### PR TITLE
Silverlight on Windows Phone does not support Tasks.

### DIFF
--- a/ReactiveUI.Xaml/ReactiveAsyncCommand.cs
+++ b/ReactiveUI.Xaml/ReactiveAsyncCommand.cs
@@ -6,10 +6,13 @@ using System.Diagnostics.Contracts;
 using System.Reactive;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
-using System.Reactive.Threading.Tasks;
 using NLog;
 using ReactiveUI;
+
+#if !WINDOWS_PHONE
+using System.Reactive.Threading.Tasks;
 using System.Threading.Tasks;
+#endif
 
 namespace ReactiveUI.Xaml
 {
@@ -206,6 +209,7 @@ namespace ReactiveUI.Xaml
             RegisterAsyncFunction(x => { calculationFunc(x); return new Unit(); }, scheduler);
         }
 
+        #if !WINDOWS_PHONE
         /// <summary>
         /// RegisterAsyncTask registers an TPL/Async method that runs when a 
         /// Command gets executed and returns the result
@@ -232,6 +236,7 @@ namespace ReactiveUI.Xaml
             Contract.Requires(calculationFunc != null);
             return RegisterAsyncObservable(x => calculationFunc(x).ToObservable());
         }
+#endif
 
         /// <summary>
         /// RegisterAsyncObservable registers an Rx-based async method whose

--- a/ReactiveUI.Xaml/ReactiveCommand.cs
+++ b/ReactiveUI.Xaml/ReactiveCommand.cs
@@ -4,10 +4,13 @@ using System.Linq;
 using System.Reactive.Concurrency;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
-using System.Threading.Tasks;
 using System.Windows.Input;
 using NLog;
 using ReactiveUI;
+
+#if !WINDOWS_PHONE
+using System.Threading.Tasks;
+#endif
 
 namespace ReactiveUI.Xaml
 {
@@ -41,6 +44,7 @@ namespace ReactiveUI.Xaml
             ThrownExceptions = exSubject;
         }
 
+        #if !WINDOWS_PHONE
         protected ReactiveCommand(Func<object, Task<bool>> canExecuteFunc, IScheduler scheduler = null)
         {
             var canExecute = canExecuteProbed.SelectAsync(canExecuteFunc);
@@ -55,6 +59,7 @@ namespace ReactiveUI.Xaml
 
             ThrownExceptions = exSubject;
         }
+#endif
 
         protected ReactiveCommand(Func<object, bool> canExecute, IScheduler scheduler = null)
         {
@@ -87,6 +92,7 @@ namespace ReactiveUI.Xaml
             return ret;
         }
 
+#if !WINDOWS_PHONE
         /// <summary>
         /// Creates a new ReactiveCommand object in an imperative, non-Rx way,
         /// similar to RelayCommand, only via a TPL Async method
@@ -110,6 +116,7 @@ namespace ReactiveUI.Xaml
 
             return ret;
         }
+#endif
 
         public IObservable<Exception> ThrownExceptions { get; protected set; }
 

--- a/ReactiveUI/RxApp.cs
+++ b/ReactiveUI/RxApp.cs
@@ -8,11 +8,14 @@ using System.Linq.Expressions;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
-using System.Reactive.Threading.Tasks;
 using System.Reflection;
 using System.Threading;
 using NLog;
+
+#if !WINDOWS_PHONE
 using System.Threading.Tasks;
+using System.Reactive.Threading.Tasks;
+#endif
 
 #if SILVERLIGHT
 using System.Windows;
@@ -468,6 +471,7 @@ namespace ReactiveUI
         }
     }
 
+#if !WINDOWS_PHONE
     public static class TplMixins
     {
         /// <summary>
@@ -481,6 +485,7 @@ namespace ReactiveUI
             return This.SelectMany(x => selector(x).ToObservable());
         }
     }
+#endif
    
     /* TODO: Move this stuff somewhere that actually makes sense */
 


### PR DESCRIPTION
Added compiler directives to exclude Task code on Windows Phone since it is not supported.
