### PR TITLE
OnDeserialized throws MethodAccessException on Windows Phone because method is not public.

### DIFF
--- a/ReactiveUI.Routing/RoutingState.cs
+++ b/ReactiveUI.Routing/RoutingState.cs
@@ -58,6 +58,9 @@ namespace ReactiveUI.Routing
         }
 
         [OnDeserialized]
+#if WINDOWS_PHONE
+        public
+#endif
         void setupRx(StreamingContext sc) { setupRx();  }
         void setupRx()
         {

--- a/ReactiveUI/ReactiveCollection.cs
+++ b/ReactiveUI/ReactiveCollection.cs
@@ -37,6 +37,9 @@ namespace ReactiveUI
         public ReactiveCollection(IEnumerable<T> list) { setupRx(list); }
 
         [OnDeserialized]
+#if WINDOWS_PHONE
+		public
+#endif
         void setupRx(StreamingContext _) { setupRx(); }
 
         void setupRx(IEnumerable<T> List = null)

--- a/ReactiveUI/ReactiveObject.cs
+++ b/ReactiveUI/ReactiveObject.cs
@@ -76,6 +76,9 @@ namespace ReactiveUI
         }
 
         [OnDeserialized]
+#if WINDOWS_PHONE
+        public
+#endif
         void setupRxObj(StreamingContext sc) { setupRxObj(); }
 
         void setupRxObj()


### PR DESCRIPTION
On Windows Phone OnDerialized only works for public methods. Otherwise it throws a MethodAccessException.
