### PR TITLE
Property/Collection changed events on the dispatcher

### DIFF
--- a/ReactiveUI/ReactiveCollection.cs
+++ b/ReactiveUI/ReactiveCollection.cs
@@ -456,7 +456,7 @@ namespace ReactiveUI
             NotifyCollectionChangedEventHandler handler = CollectionChanged;
 
             if (handler != null) {
-                handler(this, e);
+                RxApp.DeferredScheduler.Schedule(() => handler(this, e));
             }
         }
 
@@ -465,7 +465,7 @@ namespace ReactiveUI
             PropertyChangedEventHandler handler = _propertyChangedEventHandler;
 
             if (handler != null) {
-                handler(this, e);
+                RxApp.DeferredScheduler.Schedule(() => handler(this, e));
             }
         }
 #endif


### PR DESCRIPTION
The IObservables publish items on the dispatcher but the events were raised on whichever thread caused the change. This was a confusing behavior. In addition if you had a derived collection its events would be raised on whatever thread changed the source collection without giving the developer the ability to change which thread the events would be raised on.
