### PR TITLE
Access template elements after template is applied

### DIFF
--- a/ReactiveUI.Xaml/TransitioningContentControl.cs
+++ b/ReactiveUI.Xaml/TransitioningContentControl.cs
@@ -53,8 +53,6 @@ namespace ReactiveUI.Xaml
         public TransitioningContentControl()
         {
             this.DefaultStyleKey = typeof (TransitioningContentControl);
-
-            this.Loaded += this.TransitioningContentControlLoaded;
         }
 
         /// <summary>
@@ -286,7 +284,7 @@ namespace ReactiveUI.Xaml
             return transition;
         }
 
-        void TransitioningContentControlLoaded(object sender, RoutedEventArgs e)
+        public override void OnApplyTemplate()
         {
             // Wire up all of the various control parts.
             this.container = (Grid) GetTemplateChild("PART_Container");


### PR DESCRIPTION
In `TransitioningContentControl` template items are accessed during the `Loaded` event.  However, `Loaded` events may be emitted _before_ the template is actually loaded, causing `ArgumentException`s. 

I hit this with nested `ViewModelViewHost` controls (i.e. a `ViewModelViewHost` loads a `UserControl` view for a view model which in turn contains `ViewModelViewHost` elements to load views for nested view models). In this case the `TransitioningContentControl` is loaded _before_ its template is applied, then the template would be applied and the control would be loaded again, but the event handler actually raises an `ArgumentException` during the first event because it can't access the template elements yet.

This patch moves the control setup from the `Loaded` event to `OnApplyTemplate()` to deal with this cause correctly.  Now the `ArgumentException`s are really only thrown if a custom template fails to provide expected template elements.
