### PR TITLE
Fix issue with overwriting subjects

### DIFF
--- a/ReactiveUI.Routing/RoutingState.cs
+++ b/ReactiveUI.Routing/RoutingState.cs
@@ -17,6 +17,8 @@ namespace ReactiveUI.Routing
     [DataContract]
     public class RoutingState : ReactiveObject, IRoutingState
     {
+        [field: IgnoreDataMember]
+        bool rxObjectsSetup = false;
         [IgnoreDataMember] ReactiveCollection<IRoutableViewModel> _NavigationStack;
 
         /// <summary>
@@ -64,6 +66,8 @@ namespace ReactiveUI.Routing
         void setupRx(StreamingContext sc) { setupRx();  }
         void setupRx()
         {
+            if (rxObjectsSetup) return;
+
             NavigateBack = new ReactiveCommand(
                 NavigationStack.CollectionCountChanged.StartWith(_NavigationStack.Count).Select(x => x > 0));
             NavigateBack.Subscribe(_ =>
@@ -84,6 +88,8 @@ namespace ReactiveUI.Routing
                 NavigationStack.Clear();
                 Navigate.Execute(x);
             });
+
+            rxObjectsSetup = true;
         }
     }
 

--- a/ReactiveUI/ReactiveCollection.cs
+++ b/ReactiveUI/ReactiveCollection.cs
@@ -26,6 +26,8 @@ namespace ReactiveUI
         public event PropertyChangingEventHandler PropertyChanging;
         public event PropertyChangedEventHandler PropertyChanged;
 
+        [field: IgnoreDataMember]
+        bool rxObjectsSetup = false;
         [IgnoreDataMember] Subject<NotifyCollectionChangedEventArgs> _changing;
         [IgnoreDataMember] Subject<NotifyCollectionChangedEventArgs> _changed;
         
@@ -61,6 +63,8 @@ namespace ReactiveUI
 
         void setupRx(IEnumerable<T> initialContents = null, IScheduler scheduler = null, double resetChangeThreshold = 0.3)
         {
+            if (rxObjectsSetup) return; 
+
             scheduler = scheduler ?? RxApp.DeferredScheduler;
             _inner = _inner ?? new List<T>();
 
@@ -101,6 +105,8 @@ namespace ReactiveUI
             Changed.Subscribe(_ => {
                 if (PropertyChanged != null) PropertyChanged(this, new PropertyChangedEventArgs("Item[]"));
             });
+
+            rxObjectsSetup = true;
         }
 
 

--- a/ReactiveUI/ReactiveObject.cs
+++ b/ReactiveUI/ReactiveObject.cs
@@ -26,6 +26,9 @@ namespace ReactiveUI
     [DataContract]
     public class ReactiveObject : IReactiveNotifyPropertyChanged
     {
+        [field: IgnoreDataMember]
+        bool rxObjectsSetup = false;
+
         [field:IgnoreDataMember]
         public event PropertyChangingEventHandler PropertyChanging;
 
@@ -80,10 +83,14 @@ namespace ReactiveUI
 
         void setupRxObj()
         {
+            if (rxObjectsSetup) return;
+
             changingSubject = new Subject<IObservedChange<object, object>>();
             changedSubject = new Subject<IObservedChange<object, object>>();
             allPublicProperties = new Lazy<PropertyInfo[]>(() =>
                 GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance).ToArray());
+
+            rxObjectsSetup = true;
         }
 
         /// <summary>


### PR DESCRIPTION
The commit 980107f55cad makes sure the `changingSubject` and `changedSubject` are created when deserialized. However, some deserializers (notably JSON.NET) may still end up calling the `ctor` during deserialization and then call `OnDeserialized` which would end up overwriting
the already initialized subjects losing information.

This fixes the `WhenAny` not firing problem I was running into.
