### PR TITLE
Fix for issue #131

### DIFF
--- a/ReactiveUI.Tests/BindingTypeConvertersTest.cs
+++ b/ReactiveUI.Tests/BindingTypeConvertersTest.cs
@@ -1,0 +1,23 @@
+﻿using Xunit;
+
+namespace ReactiveUI.Tests
+{
+    public class BindingTypeConvertersTest
+    {
+        [Fact]
+        public void EqualityTypeConverterDoReferenceCastShouldConvertNullableValues()
+        {
+            double? nullableDouble = 0.0;
+            var result = EqualityTypeConverter.DoReferenceCast<double?>(nullableDouble);
+            Assert.Equal(nullableDouble, result);
+        }
+
+        [Fact]
+        public void EqualityTypeConverterDoReferenceCastShouldConvertValueTypes()
+        {
+            double doubleValue = 0.0;
+            var result = EqualityTypeConverter.DoReferenceCast<double>(doubleValue);
+            Assert.Equal(doubleValue, result);
+        }
+    }
+}

--- a/ReactiveUI.Tests/ReactiveUI.Tests.csproj
+++ b/ReactiveUI.Tests/ReactiveUI.Tests.csproj
@@ -93,6 +93,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="BindingTypeConvertersTest.cs" />
     <Compile Include="CommandBindingTests.cs" />
     <Compile Include="DependencyObjectObservableForPropertyTest.cs" />
     <Compile Include="ErrorsTest.cs" />

--- a/ReactiveUI/BindingTypeConverters.cs
+++ b/ReactiveUI/BindingTypeConverters.cs
@@ -42,16 +42,18 @@ namespace ReactiveUI
 
         public static object DoReferenceCast<T>(object from)
         {
-#if WINRT
-            bool isValueType = typeof (T).GetTypeInfo().IsValueType;
-#else
-            bool isValueType = typeof (T).IsValueType;
-#endif
-            if (isValueType) {
-                return System.Convert.ChangeType(from, typeof (T), null);
-            } else {
-                return (T) from;
+            var t = typeof (T);
+            var u = Nullable.GetUnderlyingType(t);
+
+            if (u == null) {
+                return (T) Convert.ChangeType(@from, t);
             }
+
+            if (@from == null) {
+                return default(T);
+            }
+
+            return (T) Convert.ChangeType(@from, u);
         }
     }
 


### PR DESCRIPTION
BindingTypeConverters EqualityTypeConverter.DoReferenceCast doesn't handle nullable values

Implemented type conversion according to this Stack Overflow answer:

http://stackoverflow.com/a/793893/265848
