### PR TITLE
Fix for Issue #130

### DIFF
--- a/ReactiveUI/Validation.cs
+++ b/ReactiveUI/Validation.cs
@@ -21,7 +21,7 @@ namespace ReactiveUI
         /// </summary>
         public ReactiveValidatedObject()
         {
-            this.Changed.Subscribe(x => {
+            this.Changing.Subscribe(x => {
                 if (x.Sender != this) {
                     return;
                 }


### PR DESCRIPTION
Have ReactiveValidatedObject remove the cache entry when the Changing
event happens rather than Changed.
