### PR TITLE
Make FollowObservableStateBehavior more flexible

### DIFF
--- a/ReactiveUI.Blend/FollowObservableStateBehavior.cs
+++ b/ReactiveUI.Blend/FollowObservableStateBehavior.cs
@@ -67,7 +67,17 @@ namespace ReactiveUI.Blend
             }
 
             This.watcher = ((IObservable<string>)e.NewValue).ObserveOn(RxApp.DeferredScheduler).Subscribe(
-                x => VisualStateManager.GoToState(This.TargetObject ?? This.AssociatedObject, x, true),
+                x => {
+                    var target = This.TargetObject ?? This.AssociatedObject;
+#if SILVERLIGHT
+                    VisualStateManager.GoToState(target, x, true);
+#else
+                    if (target is Control)
+                        VisualStateManager.GoToState(target, x, true);
+                    else
+                        VisualStateManager.GoToElementState(target, x, true);
+#endif
+                },
                 ex => {
                     if (!This.AutoResubscribeOnError)
                         return;


### PR DESCRIPTION
VisualStateManager.GoToElementState should be used when the target is not a Control (e.g. your visual states are on a Window) as per [MSDN](http://msdn.microsoft.com/en-us/library/system.windows.visualstatemanager.gotoelementstate.aspx).
