### PR TITLE
Ensure thread safety for RxUI objects

### DIFF
--- a/ReactiveUI.Xaml/CommandBinding.cs
+++ b/ReactiveUI.Xaml/CommandBinding.cs
@@ -286,8 +286,13 @@ namespace ReactiveUI.Xaml
 
         public static IDisposable BindCommandToObject(ICommand command, object target, IObservable<object> commandParameter)
         {
+            var binder = default(ICreatesCommandBinding);
             var type = target.GetType();
-            var binder = bindCommandCache.Get(type);
+
+            lock(bindCommandCache) {
+                binder = bindCommandCache.Get(type);
+            }
+
             if (binder == null) {
                 throw new Exception(String.Format("Couldn't find a Command Binder for {0}", type.FullName));
             }

--- a/ReactiveUI/BindingTypeConverters.cs
+++ b/ReactiveUI/BindingTypeConverters.cs
@@ -45,7 +45,11 @@ namespace ReactiveUI
         {
             Contract.Requires(toType != null);
 
-            var mi = referenceCastCache.Get(toType);
+            var mi = default(MethodInfo);
+            lock (referenceCastCache) {
+                mi = referenceCastCache.Get(toType);
+            }
+
             try {
                 result = mi.Invoke(null, new[] {from});
             } catch (Exception ex) {

--- a/ReactiveUI/PropertyBinding.cs
+++ b/ReactiveUI/PropertyBinding.cs
@@ -481,7 +481,9 @@ namespace ReactiveUI
 
         IBindingTypeConverter getConverterForTypes(Type lhs, Type rhs)
         {
-            return typeConverterCache.Get(Tuple.Create(lhs, rhs));
+            lock (typeConverterCache) {
+                return typeConverterCache.Get(Tuple.Create(lhs, rhs));
+            }
         }
     }
 

--- a/ReactiveUI/ReactiveNotifyPropertyChangedMixin.cs
+++ b/ReactiveUI/ReactiveNotifyPropertyChangedMixin.cs
@@ -248,7 +248,11 @@ namespace ReactiveUI
 
         static IObservable<IObservedChange<object, object>> notifyForProperty(object sender, string propertyName, bool beforeChange)
         {
-            var result = notifyFactoryCache.Get(Tuple.Create(sender.GetType(), beforeChange));
+            var result = default(ICreatesObservableForProperty);
+            lock (notifyFactoryCache) {
+                result = notifyFactoryCache.Get(Tuple.Create(sender.GetType(), beforeChange));
+            }
+
             if (result == null) {
                 throw new Exception(
                     String.Format("Couldn't find a ICreatesObservableForProperty for {0}. This should never happen, your service locator is probably broken.", 


### PR DESCRIPTION
Make sure that internal property / implementation caches we use to avoid repeated lookups are appropriately synchronized.

This situation normally doesn't occur since most ViewModels are created on the UI thread, but should you end up creating a lot of them on various worker threads, you could end up hitting the crash that this fixes.
