### PR TITLE
#145 An alternate way to handle DP WhenAny

### DIFF
--- a/ReactiveUI.Tests/DependencyObjectObservableForPropertyTest.cs
+++ b/ReactiveUI.Tests/DependencyObjectObservableForPropertyTest.cs
@@ -5,18 +5,77 @@ using System.Text;
 using System.Windows;
 using ReactiveUI.Xaml;
 using Xunit;
+using System.Windows.Controls;
 
 namespace ReactiveUI.Tests
 {
-    public class DepObjFixture : FrameworkElement
-    {
-        public static readonly DependencyProperty TestStringProperty = 
-            DependencyProperty.Register("TestString", typeof(string), typeof(DepObjFixture), new PropertyMetadata(null));
+    public class ViewModelClass : ReactiveObject{
+        string _TestString;
+        public string TestString
+        {
+            get { return _TestString; }
+            set { this.RaiseAndSetIfChanged(value); }
+        }
 
-        public string TestString {
+        string _TestString1;
+        public string TestString1
+        {
+            get { return _TestString1; }
+            set { this.RaiseAndSetIfChanged(value); }
+        }
+    }
+
+    public class DepObjFixture : UserControl, IViewFor<ViewModelClass>
+    {
+
+        public string TestString
+        {
             get { return (string)GetValue(TestStringProperty); }
             set { SetValue(TestStringProperty, value); }
         }
+
+        // Using a DependencyProperty as the backing store for TestString.  This enables animation, styling, binding, etc...
+        public static readonly DependencyProperty TestStringProperty =
+            DependencyProperty.Register
+            ("TestString",
+            typeof(string), 
+            typeof(DepObjFixture ), 
+            new FrameworkPropertyMetadata(
+                null, 
+                FrameworkPropertyMetadataOptions.BindsTwoWayByDefault ));
+
+        public string TestString2
+        {
+            get { return (string)GetValue(TestString2Property); }
+            set { SetValue(TestString2Property, value); }
+        }
+
+        // Using a DependencyProperty as the backing store for TestString2.  This enables animation, styling, binding, etc...
+        public static readonly DependencyProperty TestString2Property =
+            DependencyProperty.Register
+            ("TestString2",
+            typeof(string), 
+            typeof(DepObjFixture ), 
+            new FrameworkPropertyMetadata(
+                null, 
+                FrameworkPropertyMetadataOptions.BindsTwoWayByDefault ));
+
+        #region IViewFor<ViewModelClass>
+        public ViewModelClass ViewModel
+        {
+            get { return (ViewModelClass)GetValue(ViewModelProperty); }
+            set { SetValue(ViewModelProperty, value); }
+        }
+        public static readonly DependencyProperty ViewModelProperty =
+            DependencyProperty.Register("ViewModel", typeof(ViewModelClass), typeof(DepObjFixture ), new PropertyMetadata(null));
+
+        object IViewFor.ViewModel
+        {
+            get { return ViewModel; }
+            set { ViewModel = (ViewModelClass)value; }
+        }
+        #endregion
+
     }
 
     public class DependencyObjectObservableForPropertyTest
@@ -48,11 +107,95 @@ namespace ReactiveUI.Tests
             var fixture = new DepObjFixture();
 
             var outputs = fixture.WhenAny(x => x.TestString, x => x.Value).CreateCollection();
+            var outputs2 = fixture.WhenAny(x => x.TestString2, x => x.Value).CreateCollection();
+
+            inputs.ForEach(x => fixture.TestString2 = x);
             inputs.ForEach(x => fixture.TestString = x);
 
             Assert.Null(outputs.First());
+            Assert.Null(outputs2.First());
             Assert.Equal(4, outputs.Count);
+            Assert.Equal(4, outputs2.Count);
             Assert.True(inputs.Zip(outputs.Skip(1), (expected, actual) => expected == actual).All(x => x));
+            Assert.True(inputs.Zip(outputs2.Skip(1), (expected, actual) => expected == actual).All(x => x));
         }
+
+        [Fact]
+        public void WhenAnyWithDependencyObject2()
+        {
+            var fixture = new DepObjFixture();
+            var o0 = fixture.WhenAny(x => x.TestString, x => x.Value);
+
+            int c0 = 0;
+            Assert.Equal(0,c0);
+
+            o0.Subscribe(x => c0++);
+
+            Assert.Equal(1,c0);
+
+            fixture.TestString = "hello";
+            Assert.Equal(2,c0);
+
+            fixture.TestString = "hello1";
+            Assert.Equal(3,c0);
+
+            fixture.TestString = "hello2";
+            Assert.Equal(4,c0);
+
+            fixture.TestString = "hello3";
+            Assert.Equal(5,c0);
+            
+        }
+
+        [Fact]
+        public void WhenAnyWithDependencyObject3()
+        {
+            var fixture = new DepObjFixture();
+            var o0 = fixture.WhenAny(x => x.TestString, x => x.Value);
+            var o1 = fixture.WhenAny(x => x.TestString2, x => x.Value);
+
+            int c0 = 0;
+            int c1 = 0;
+            int c2 = 0;
+            Assert.Equal(0,c0);
+            Assert.Equal(0,c1);
+
+            o0.Subscribe(x => c0++);
+            o1.Subscribe(x => c1++);
+            o1.Subscribe(x => c2++);
+
+            Assert.Equal(1,c0);
+            Assert.Equal(1,c1);
+
+            fixture.TestString = "hello";
+            Assert.Equal(2,c0);
+            Assert.Equal(1,c1);
+
+            fixture.TestString2 = "hello";
+            Assert.Equal(2,c0);
+            Assert.Equal(2,c1);
+
+            fixture.TestString2 = "hello1";
+            Assert.Equal(2,c0);
+            Assert.Equal(3,c1);
+
+            fixture.TestString = "hello1";
+            Assert.Equal(3,c0);
+            Assert.Equal(3,c1);
+
+            fixture.TestString = "hello2";
+            Assert.Equal(4,c0);
+            Assert.Equal(3,c1);
+
+            fixture.TestString = "hello3";
+            Assert.Equal(5,c0);
+            Assert.Equal(3,c1);
+
+            fixture.TestString2 = "hello3";
+            Assert.Equal(5,c0);
+            Assert.Equal(4,c1);
+            
+        }
+
     }
 }


### PR DESCRIPTION
Why: It's possible that the AddHandler method with DP's is buggy and
it is not used very much. Replace it with a more common idiom that is
used often and more robust

How: Inject a proxy DependencyObject with a single DependencyProperty
called value between the source object and the WhenAny operation. The
proxy object implements a standard DP callback which then calls onNext
on a standard Rx Subject which in turn is hooked into the WhenAny
architecture

Does This Fix The Problem: Not sure yet as I haven't tested it against
my failing code and I can't replicate the error in the tests even though
I've made the test more robust.
