### PR TITLE
False positives in RealUnitTestDetector

### DIFF
--- a/ReactiveUI.Tests/RxAppTest.cs
+++ b/ReactiveUI.Tests/RxAppTest.cs
@@ -25,5 +25,61 @@ namespace ReactiveUI.Tests
             Console.WriteLine(RxApp.DeferredScheduler.GetType().FullName);
             Assert.Equal(Scheduler.Immediate, RxApp.DeferredScheduler);
         }
+
+        [Fact]
+        public void UnitTestDetectorIdentifiesThisTestAsAnXUnitTest()
+        {
+            string[] testAssemblies = new[] {
+                "CSUNIT",
+                "NUNIT",
+                "XUNIT",
+                "MBUNIT",
+                "TESTDRIVEN",
+                "QUALITYTOOLS.TIPS.UNITTEST.ADAPTER",
+                "QUALITYTOOLS.UNITTESTING.SILVERLIGHT",
+                "PEX",
+                "MSBUILD",
+                "NBEHAVE",
+                "TESTPLATFORM",
+            };
+
+            string[] designEnvironments = new[] {
+                "BLEND.EXE",
+                "MONODEVELOP",
+                "SHARPDEVELOP.EXE",
+            };
+
+            var isInUnitTestRunner = RealUnitTestDetector.InUnitTestRunner(testAssemblies, designEnvironments);
+
+            Assert.True(isInUnitTestRunner);
+        }
+
+        [Fact]
+        public void UnitTestDetectorDoesNotIdentifyThisTestWhenXUnitAssemblyNotChecked()
+        {
+            // XUnit assembly name removed
+            string[] testAssembliesWithoutNunit = new[] {
+                "CSUNIT",
+                "NUNIT",
+                "MBUNIT",
+                "TESTDRIVEN",
+                "QUALITYTOOLS.TIPS.UNITTEST.ADAPTER",
+                "QUALITYTOOLS.UNITTESTING.SILVERLIGHT",
+                "PEX",
+                "MSBUILD",
+                "NBEHAVE",
+                "TESTPLATFORM",
+            };
+
+            string[] designEnvironments = new[] {
+                "BLEND.EXE",
+                "MONODEVELOP",
+                "SHARPDEVELOP.EXE",
+            };
+
+            var isInUnitTestRunner = RealUnitTestDetector.InUnitTestRunner(testAssembliesWithoutNunit, designEnvironments);
+
+            Assert.False(isInUnitTestRunner);
+        }
     }
 }

--- a/ReactiveUI/RxApp.cs
+++ b/ReactiveUI/RxApp.cs
@@ -427,30 +427,8 @@ namespace ReactiveUI
 
     internal static class RealUnitTestDetector
     {
-        public static bool InUnitTestRunner()
+        public static bool InUnitTestRunner(string[] testAssemblies, string[] designEnvironments)
         {
-            // XXX: This is hacky and evil, but I can't think of any better way
-            // to do this
-            string[] testAssemblies = new[] {
-                "CSUNIT",
-                "NUNIT",
-                "XUNIT",
-                "MBUNIT",
-                "TESTDRIVEN",
-                "QUALITYTOOLS.TIPS.UNITTEST.ADAPTER",
-                "QUALITYTOOLS.UNITTESTING.SILVERLIGHT",
-                "PEX",
-                "MSBUILD",
-                "NBEHAVE",
-                "TESTPLATFORM",
-            };
-
-            string[] designEnvironments = new[] {
-                "BLEND.EXE",
-                "MONODEVELOP",
-                "SHARPDEVELOP.EXE",
-            };
-
 #if SILVERLIGHT
             // NB: Deployment.Current.Parts throws an exception when accessed in Blend
             try {
@@ -492,13 +470,41 @@ namespace ReactiveUI
             // without access to any WPF references :-/
             var entry = Assembly.GetEntryAssembly();
             var exeName = (entry != null ? entry.Location.ToUpperInvariant() : "");
-            if (designEnvironments.Any(x => x.Contains(exeName))) {
+            if (designEnvironments.Any(x => x.Contains(exeName)))
+            {
                 return true;
             }
 
             return AppDomain.CurrentDomain.GetAssemblies().Any(x =>
                 testAssemblies.Any(name => x.FullName.ToUpperInvariant().Contains(name)));
 #endif
+        }
+
+        public static bool InUnitTestRunner()
+        {
+            // XXX: This is hacky and evil, but I can't think of any better way
+            // to do this
+            string[] testAssemblies = new[] {
+                "CSUNIT",
+                "NUNIT",
+                "XUNIT",
+                "MBUNIT",
+                "TESTDRIVEN",
+                "QUALITYTOOLS.TIPS.UNITTEST.ADAPTER",
+                "QUALITYTOOLS.UNITTESTING.SILVERLIGHT",
+                "PEX",
+                "MSBUILD",
+                "NBEHAVE",
+                "TESTPLATFORM",
+            };
+
+            string[] designEnvironments = new[] {
+                "BLEND.EXE",
+                "MONODEVELOP",
+                "SHARPDEVELOP.EXE",
+            };
+
+            return InUnitTestRunner(testAssemblies, designEnvironments);
         }
 
     }


### PR DESCRIPTION
Hi, I've run into an issue using ReactiveUI in a WPF project that is hosted within an Office application. Some methods, that update the UI were being called from background threads causing the usual InvalidOperationExceptions.

Example code (running in a background thread):

``` C#
MessageBus.Listen<SomeMessage>()
          .ObserveOn(RxApp.DeferredScheduler)
          .Subscribe(UpdateCustomerList);
```

UpdateCustomerList would end up running on the same background thread that had created the subscription. Turned out `RxApp.DeferredScheduler` in the Office host was returning the Immediate scheduler as it thinks the Office host is a test runner / designer. The offending code is:

``` csharp
var entry = Assembly.GetEntryAssembly();
var exeName = (entry != null ? entry.Location.ToUpperInvariant() : "");
if (designEnvironments.Any(x => x.Contains(exeName)))
{
    return true;
}
```

`Assembly.GetEntryAssembly()` returns null in the Office host, which causes `designEnvironments.Any(x => x.Contains(exeName))` to always match, returning true.

I tried fixing it by returning false if `entry` was null, but that caused many of ReactiveUI's unit tests to fail. Debugged a test and broke on the line `Assembly.GetEntryAssembly()` and realised, it returns null under XUnit also. So it looks like XUnit is detected because there's no EntryAssembly rather than a match against the string array containing the XUnit assembly name.

I'm going to try against another test runner or two to see if they have the same behaviour.
I'm not that familiar with how test runners execute tests, maybe in the absence of an EntryAssembly there might some clues in the AppDomain or ProcessName.
