### PR TITLE
Fix for #175

### DIFF
--- a/ReactiveUI.Xaml/ReactiveAsyncCommand.cs
+++ b/ReactiveUI.Xaml/ReactiveAsyncCommand.cs
@@ -114,7 +114,7 @@ namespace ReactiveUI.Xaml
             });
 
             if (canExecute != null) {
-                canExecute.Subscribe(_canExecuteSubject.OnNext, _exSubject.OnNext);
+                _inner = canExecute.Subscribe(_canExecuteSubject.OnNext, _exSubject.OnNext);
             }
 
             _maximumConcurrent = maximumConcurrent;


### PR DESCRIPTION
ReactiveAsyncCommand subscribes to _canExecute observable but never
unsubscribes from it in IDisposable
