### PR TITLE
Fix crash when checking validity of a ReactiveValidatedObject which has public static properties

### DIFF
--- a/ReactiveUI.Tests/ReactiveValidatedObjectTest.cs
+++ b/ReactiveUI.Tests/ReactiveValidatedObjectTest.cs
@@ -31,6 +31,19 @@ namespace ReactiveUI.Tests
         }
     }
 
+    public class ValidatedIgnoresStaticPropertyTestFixture : ReactiveValidatedObject
+    {
+        public static int StaticProperty
+        {
+            get { return 5; }
+        }
+
+        public string NonStaticProperty
+        {
+            get { return "A string"; }
+        }
+    }
+
     public class ReactiveValidatedObjectTest
     {
         [Fact]
@@ -59,6 +72,17 @@ namespace ReactiveUI.Tests
                 .Do(Console.WriteLine)
                 .ForEach(x => Assert.Equal(x.expected, x.actual));
              */
+        }
+
+        [Fact]
+        public void IgnoresStaticPropertiesTest()
+        {
+            var fixture = new ValidatedIgnoresStaticPropertyTestFixture();
+
+            Assert.DoesNotThrow(delegate
+            {
+                var error = fixture["NonStaticProperty"];
+            });
         }
     }
 }

--- a/ReactiveUI/Validation.cs
+++ b/ReactiveUI/Validation.cs
@@ -175,7 +175,7 @@ namespace ReactiveUI
 
         public static PropertyExtraInfo[] CreateFromType(Type type)
         {
-            return type.GetProperties()
+            return type.GetProperties(BindingFlags.Instance | BindingFlags.Public)
                 .Select(x => CreateFromTypeAndName(type, x.Name, true))
                 .Where(x => x != null)
                 .ToArray();


### PR DESCRIPTION
As discussed on the mailing list. I'm fairly sure this all works, although I don't have VS2012 so can't test that everything's right there.

ReactiveUI.PropertyExtraInfo.CreateFromType was finding all public
properties, then attempting to treat them all as instance properties in
CreateFromTypeAndName. It now filters its GetProperties call to public
instance properties only.

This commit also add a test which fails without the change to
Validation.cs.
