### PR TITLE
Debugger support for ReactiveCollection

### DIFF
--- a/ReactiveUI/CollectionDebugView.cs
+++ b/ReactiveUI/CollectionDebugView.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace ReactiveUI
+{
+    internal sealed class CollectionDebugView<T>
+    {
+        private readonly ICollection<T> collection;
+
+        public CollectionDebugView(ICollection<T> collection)
+        {
+            if (collection == null)
+                throw new ArgumentNullException("collection", "collection is null.");
+            this.collection = collection;
+        }
+
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public T[] Items
+        {
+            get
+            {
+                T[] array = new T[this.collection.Count];
+                this.collection.CopyTo(array, 0);
+                return array;
+            }
+        }
+    }
+}

--- a/ReactiveUI/ReactiveCollection.cs
+++ b/ReactiveUI/ReactiveCollection.cs
@@ -15,9 +15,12 @@ using System.Diagnostics.Contracts;
 using System.Threading;
 using System.Reactive.Disposables;
 using System.Globalization;
+using System.Diagnostics;
 
 namespace ReactiveUI
 {
+    [DebuggerDisplay("Count = {Count}")]
+    [DebuggerTypeProxy(typeof(CollectionDebugView<>))]
     public class ReactiveCollection<T> : IList<T>, IList, IReactiveCollection<T>, INotifyPropertyChanging, INotifyPropertyChanged, IEnableLogger
     {
         public event NotifyCollectionChangedEventHandler CollectionChanging;

--- a/ReactiveUI/ReactiveUI.csproj
+++ b/ReactiveUI/ReactiveUI.csproj
@@ -144,6 +144,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="PropertyBinding.cs" />
     <Compile Include="ReactiveCollection.cs" />
+    <Compile Include="CollectionDebugView.cs" />
     <Compile Include="ReactiveCollectionMixins.cs" />
     <Compile Include="ReactiveNotifyPropertyChangedMixin.cs" />
     <Compile Include="ReactiveObject.cs" />


### PR DESCRIPTION
Added a simple collection debugger proxy for ReactiveCollection so it shows up in the VS debugger like other lists do.

Goes from this...

![Debug view of ReactiveCollection raw](http://i.imgur.com/zvjFZve.png)

... to this!

![Debug view of ReactiveCollection as a list](http://i.imgur.com/AZaE6SY.png)
