### PR TITLE
Prevent reset notification from firing twice

### DIFF
--- a/ReactiveUI/ReactiveCollectionMixins.cs
+++ b/ReactiveUI/ReactiveCollectionMixins.cs
@@ -188,7 +188,6 @@ namespace ReactiveUI
                         enumerable.ForEach(ret.Add);
                     }
 
-                    ret.Reset();
                     return;
                 }
 


### PR DESCRIPTION
Reset is called from SuppressChangeNotifications so we don't need to explicitly do it from the derived collection.

``` c#
public IDisposable SuppressChangeNotifications()
{
    Interlocked.Increment(ref _suppressionRefCount);

    if (!_hasWhinedAboutNoResetSub && _resetSubCount == 0) {
        LogHost.Default.Warn("SuppressChangeNotifications was called (perhaps via AddRange), yet you do not");
        LogHost.Default.Warn("have a subscription to ShouldReset. This probably isn't what you want, as ItemsAdded");
        LogHost.Default.Warn("and friends will appear to 'miss' items");
        _hasWhinedAboutNoResetSub = true;
    }

    return Disposable.Create(() => {
        if (Interlocked.Decrement(ref _suppressionRefCount) == 0) {
            Reset();
        }
    });
}
```

Includes a tiny test to verify.
