### PR TITLE
Addresses issue #209.

### DIFF
--- a/ReactiveUI.Routing/RoutedViewHost.cs
+++ b/ReactiveUI.Routing/RoutedViewHost.cs
@@ -52,6 +52,8 @@ namespace ReactiveUI.Routing
             HorizontalContentAlignment = HorizontalAlignment.Stretch;
             VerticalContentAlignment = VerticalAlignment.Stretch;
 
+            if (RxApp.InUnitTestRunner()) return;
+
             this.WhenAny(x => x.Router.NavigationStack, x => x.Value)
                 .SelectMany(x => x.CollectionCountChanged.StartWith(x.Count).Select(_ => x.LastOrDefault()))
                 .Subscribe(vm => {

--- a/ReactiveUI/RxApp.cs
+++ b/ReactiveUI/RxApp.cs
@@ -476,7 +476,7 @@ namespace ReactiveUI
             // without access to any WPF references :-/
             var entry = Assembly.GetEntryAssembly();
             if (entry != null) {
-                var exeName = entry.Location.ToUpperInvariant(); 
+                var exeName = (new FileInfo(entry.Location)).Name.ToUpperInvariant(); 
 
                 if (designEnvironments.Any(x => x.Contains(exeName))) {
                     return true;
@@ -510,6 +510,7 @@ namespace ReactiveUI
                 "BLEND.EXE",
                 "MONODEVELOP",
                 "SHARPDEVELOP.EXE",
+                "XDESPROC.EXE",
             };
 
             return InUnitTestRunner(testAssemblies, designEnvironments);


### PR DESCRIPTION
```
Exit early in RoutedViewHost when in Design Mode.
Added "XDESPROC.EXE" (VS2012 Design Mode) to RxApp list of design environments.
Also fixed an issue in RxApp where checking for design mode was testing against full path of assembly instead of just the assembly name.
```

It looks like the test for Design Mode is the same set of tests for Unit Test mode (InUnitTestRunner). Wondering if it would be better to break them apart or is the end result the same?
