### PR TITLE
Support property changes in derived collections

### DIFF
--- a/ReactiveUI.Tests/ReactiveCollectionTest.cs
+++ b/ReactiveUI.Tests/ReactiveCollectionTest.cs
@@ -12,6 +12,7 @@ using Microsoft.Reactive.Testing;
 using System.Collections.Specialized;
 using System.Reactive.Subjects;
 using System.Reactive;
+using System.Diagnostics;
 
 namespace ReactiveUI.Tests
 {
@@ -368,6 +369,285 @@ namespace ReactiveUI.Tests
 
             Assert.Equal(1, changeNotifications.Count);
             Assert.Equal(2, derived.Count);
+        }
+
+        public class DerivedPropertyChanges
+        {
+            private class ReactiveVisibilityItem<T> : ReactiveObject
+            {
+                private T _Value;
+
+                public T Value
+                {
+                    get { return _Value; }
+                    set { this.RaiseAndSetIfChanged(value); }
+                }
+
+                private bool _IsVisible;
+                public bool IsVisible
+                {
+                    get { return _IsVisible; }
+                    set { this.RaiseAndSetIfChanged(value); }
+                }
+
+                public ReactiveVisibilityItem(T item1, bool isVisible)
+                {
+                    this._Value = item1;
+                    this._IsVisible = isVisible;
+                }
+
+            }
+
+            [DebuggerDisplay("{Name} is {Age} years old and makes ${Salary}")]
+            private class ReactiveEmployee : ReactiveObject
+            {
+                string _Name;
+                public string Name
+                {
+                    get { return _Name; }
+                    set { this.RaiseAndSetIfChanged(ref _Name, value); }
+                }
+
+                int _Age;
+                public int Age
+                {
+                    get { return _Age; }
+                    set { this.RaiseAndSetIfChanged(ref _Age, value); }
+                }
+
+                int _Salary;
+                public int Salary
+                {
+                    get { return _Salary; }
+                    set { this.RaiseAndSetIfChanged(ref _Salary, value); }
+                }
+            }
+
+            public class DerivedCollectionTestContainer
+            {
+                public static DerivedCollectionTestContainer<TSource, TValue> Create<TSource, TValue>(
+                    IEnumerable<TSource> source,
+                    Func<TSource, TValue> selector,
+                    Func<TSource, bool> filter = null,
+                    IComparer<TValue> orderer = null)
+                {
+                    var derived = source.CreateDerivedCollection(selector, filter, orderer == null ? (Func<TValue, TValue, int>)null : orderer.Compare);
+
+                    return new DerivedCollectionTestContainer<TSource, TValue>
+                    {
+                        Source = source,
+                        Selector = selector,
+                        Derived = derived,
+                        Filter = filter,
+                        Orderer = orderer
+                    };
+                }
+
+                public virtual void Test() { }
+            }
+
+            public class DerivedCollectionTestContainer<TSource, TValue> : DerivedCollectionTestContainer
+            {
+                public IEnumerable<TSource> Source { get; set; }
+                public ReactiveDerivedCollection<TValue> Derived { get; set; }
+                public Func<TSource, TValue> Selector { get; set; }
+                public Func<TSource, bool> Filter { get; set; }
+                public IComparer<TValue> Orderer { get; set; }
+
+                public override void Test()
+                {
+                    var filtered = Source;
+
+                    if (Filter != null)
+                        filtered = filtered.Where(Filter);
+
+                    var projected = filtered.Select(Selector);
+
+                    var ordered = projected;
+
+                    if (Orderer != null)
+                        ordered = ordered.OrderBy(x => x, Orderer);
+
+                    var shouldBe = ordered;
+                    var isEqual = Derived.SequenceEqual(shouldBe);
+
+                    Assert.True(isEqual);
+                }
+            }
+
+            [Fact]
+            public void DerivedCollectionsSmokeTest()
+            {
+                var adam = new ReactiveEmployee { Name = "Adam", Age = 20, Salary = 100 };
+                var bob = new ReactiveEmployee { Name = "Bob", Age = 30, Salary = 150 };
+                var carol = new ReactiveEmployee { Name = "Carol", Age = 40, Salary = 200 };
+                var dan = new ReactiveEmployee { Name = "Dan", Age = 50, Salary = 250 };
+                var eve = new ReactiveEmployee { Name = "Eve", Age = 60, Salary = 300 };
+
+                var start = new[] { adam, bob, carol, dan, eve };
+
+                var employees = new ReactiveCollection<ReactiveEmployee>(start)
+                {
+                    ChangeTrackingEnabled = true
+                };
+
+                var employeesByName = DerivedCollectionTestContainer.Create(
+                    employees,
+                    selector: x => x,
+                    orderer: OrderedComparer<ReactiveEmployee>.OrderBy(x => x.Name)
+                );
+
+                var employeesByAge = DerivedCollectionTestContainer.Create(
+                    employees,
+                    selector: x => x,
+                    orderer: OrderedComparer<ReactiveEmployee>.OrderBy(x => x.Age)
+                );
+
+                var employeesBySalary = DerivedCollectionTestContainer.Create(
+                    employees,
+                    selector: x => x,
+                    orderer: OrderedComparer<ReactiveEmployee>.OrderBy(x => x.Salary)
+                );
+
+                // special
+
+                // filtered, ordered, reference
+                var oldEmployeesByAge = DerivedCollectionTestContainer.Create(
+                    employees,
+                    selector: x => x,
+                    filter: x => x.Age >= 50,
+                    orderer: OrderedComparer<ReactiveEmployee>.OrderBy(x => x.Age)
+                );
+
+                // ordered, not reference
+                var employeeSalaries = DerivedCollectionTestContainer.Create(
+                    employees,
+                    selector: x => x.Salary,
+                    orderer: Comparer<int>.Default
+                );
+
+                // not filtered (derived filter), not reference, not ordered (derived order)
+                oldEmployeesByAge.Derived.ChangeTrackingEnabled = true;
+                var oldEmployeesSalariesByAge = DerivedCollectionTestContainer.Create(
+                    oldEmployeesByAge.Derived,
+                    selector: x => x.Salary
+                );
+
+                var containers = new List<DerivedCollectionTestContainer> {
+                    employeesByName, employeesByAge, employeesBySalary, oldEmployeesByAge, 
+                    employeeSalaries, oldEmployeesSalariesByAge
+                };
+
+                Action<Action> testAll = a => { a(); containers.ForEach(x => x.Test()); };
+
+                containers.ForEach(x => x.Test());
+
+                // if (isIncluded && !shouldBeIncluded)
+                testAll(() => { dan.Age = 49; });
+
+                // else if (!isIncluded && shouldBeIncluded)
+                testAll(() => { dan.Age = eve.Age + 1; });
+
+                // else if (isIncluded && shouldBeIncluded)
+                testAll(() => { adam.Salary = 350; });
+                
+                testAll(() => { dan.Age = 50; });
+                testAll(() => { dan.Age = 51; });
+            }
+
+            [Fact]
+            public void FilteredDerivedCollectionsShouldReactToPropertyChanges()
+            {
+                // Naturally this isn't done by magic, it only works if the source implements IReactiveCollection.
+
+                var a = new ReactiveVisibilityItem<string>("a", true);
+                var b = new ReactiveVisibilityItem<string>("b", true);
+                var c = new ReactiveVisibilityItem<string>("c", true);
+
+                var items = new ReactiveCollection<ReactiveVisibilityItem<string>>(new[] { a, b, c })
+                {
+                    ChangeTrackingEnabled = true
+                };
+
+                var onlyVisible = items.CreateDerivedCollection(x => x.Value, x => x.IsVisible, StringComparer.Ordinal.Compare);
+                var onlyNonVisible = items.CreateDerivedCollection(x => x.Value, x => !x.IsVisible, StringComparer.Ordinal.Compare);
+
+                var onlVisibleStartingWithB = items.CreateDerivedCollection(x => x.Value, x => x.IsVisible && x.Value.StartsWith("b"), StringComparer.Ordinal.Compare);
+
+                Assert.Equal(3, onlyVisible.Count);
+                Assert.Equal(0, onlyNonVisible.Count);
+                Assert.Equal(1, onlVisibleStartingWithB.Count);
+
+                a.IsVisible = false;
+
+                Assert.Equal(2, onlyVisible.Count);
+                Assert.Equal(1, onlyNonVisible.Count);
+                Assert.Equal(1, onlVisibleStartingWithB.Count);
+
+                b.Value = "D";
+
+                Assert.Equal(0, onlVisibleStartingWithB.Count);
+            }
+
+            [Fact]
+            public void FilteredProjectedDerivedCollectionsShouldReactToPropertyChanges()
+            {
+                // This differs from the FilteredDerivedCollectionsShouldReactToPropertyChanges as it tests providing a 
+                // non-identity selector (ie x=>x.Value).
+
+                var a = new ReactiveVisibilityItem<string>("a", true);
+                var b = new ReactiveVisibilityItem<string>("b", true);
+                var c = new ReactiveVisibilityItem<string>("c", true);
+
+                var items = new ReactiveCollection<ReactiveVisibilityItem<string>>(new[] { a, b, c })
+                {
+                    ChangeTrackingEnabled = true
+                };
+
+                var onlyVisible = items.CreateDerivedCollection(
+                    x => x.Value.ToUpper(), // Note, not an identity function.
+                    x => x.IsVisible,
+                    StringComparer.Ordinal.Compare
+                );
+
+                Assert.Equal(3, onlyVisible.Count);
+                Assert.True(onlyVisible.SequenceEqual(new[] { "A", "B", "C" }));
+
+                a.IsVisible = false;
+
+                Assert.Equal(2, onlyVisible.Count);
+                Assert.True(onlyVisible.SequenceEqual(new[] { "B", "C" }));
+            }
+
+            [Fact]
+            public void DerivedCollectionsShouldReactToPropertyChanges()
+            {
+                // This differs from the FilteredDerivedCollectionsShouldReactToPropertyChanges as it tests providing a 
+                // non-identity selector (ie x=>x.Value).
+
+                var foo = new ReactiveVisibilityItem<string>("Foo", true);
+                var bar = new ReactiveVisibilityItem<string>("Bar", true);
+                var baz = new ReactiveVisibilityItem<string>("Baz", true);
+
+                var items = new ReactiveCollection<ReactiveVisibilityItem<string>>(new[] { foo, bar, baz })
+                {
+                    ChangeTrackingEnabled = true
+                };
+
+                var onlyVisible = items.CreateDerivedCollection(
+                    x => new string('*', x.Value.Length), // Note, not an identity function.
+                    x => x.IsVisible,
+                    StringComparer.Ordinal.Compare
+                );
+
+                Assert.Equal(3, onlyVisible.Count);
+                Assert.True(onlyVisible.SequenceEqual(new[] { "***", "***", "***" }));
+
+                foo.IsVisible = false;
+
+                Assert.Equal(2, onlyVisible.Count);
+                Assert.True(onlyVisible.SequenceEqual(new[] { "***", "***" }));
+            }
         }
 
         [Fact]

--- a/ReactiveUI/ReactiveCollection.cs
+++ b/ReactiveUI/ReactiveCollection.cs
@@ -229,12 +229,12 @@ namespace ReactiveUI
 
         public double ResetChangeThreshold { get; set; }
 
-        public void AddRange(IEnumerable<T> collection)
+        public virtual void AddRange(IEnumerable<T> collection)
         {
             InsertRange(_inner.Count, collection);
         }
 
-        public void InsertRange(int index, IEnumerable<T> collection)
+        public virtual void InsertRange(int index, IEnumerable<T> collection)
         {
             var arr = collection.ToArray();
             var disp = isLengthAboveResetThreshold(arr.Length) ?
@@ -249,7 +249,7 @@ namespace ReactiveUI
             }
         }
 
-        public void RemoveRange(int index, int count)
+        public virtual void RemoveRange(int index, int count)
         {
             var disp = isLengthAboveResetThreshold(count) ?
                 SuppressChangeNotifications() : Disposable.Empty;
@@ -263,7 +263,7 @@ namespace ReactiveUI
             }
         }
 
-        public void RemoveAll(IEnumerable<T> items)
+        public virtual void RemoveAll(IEnumerable<T> items)
         {
             Contract.Requires(items != null);
 
@@ -279,25 +279,30 @@ namespace ReactiveUI
             }
         }
 
-        public void Sort(int index, int count, IComparer<T> comparer)
+        public virtual void Sort(int index, int count, IComparer<T> comparer)
         {
             _inner.Sort(index, count, comparer);
-            Reset();
+            Reset(true);
         }
 
-        public void Sort(Comparison<T> comparison)
+        public virtual void Sort(Comparison<T> comparison)
         {
             _inner.Sort(comparison);
-            Reset();
+            Reset(true);
         }
 
-        public void Sort(IComparer<T> comparer = null)
+        public virtual void Sort(IComparer<T> comparer = null)
         {
             _inner.Sort(comparer ?? Comparer<T>.Default);
-            Reset();
+            Reset(true);
         }
 
-        public void Reset()
+        public virtual void Reset()
+        {
+            Reset(true);
+        }
+
+        protected virtual void Reset(bool resetting)
         {
             var ea = new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset);
             _changing.OnNext(ea);
@@ -344,7 +349,7 @@ namespace ReactiveUI
 
             return Disposable.Create(() => {
                 if (Interlocked.Decrement(ref _suppressionRefCount) == 0) {
-                    Reset();
+                    Reset(true);
                 }
             });
         }
@@ -499,7 +504,7 @@ namespace ReactiveUI
             InsertItem(_inner.Count, item);
         }
 
-        public void Clear()
+        public virtual void Clear()
         {
             ClearItems();
         }
@@ -514,7 +519,7 @@ namespace ReactiveUI
             _inner.CopyTo(array, arrayIndex);
         }
 
-        public bool Remove(T item)
+        public virtual bool Remove(T item)
         {
             int index = _inner.IndexOf(item);
             if (index < 0) return false;
@@ -525,29 +530,29 @@ namespace ReactiveUI
 
         public int Count { get { return _inner.Count; } }
 
-        public bool IsReadOnly { get { return false; } }
+        public virtual bool IsReadOnly { get { return false; } }
 
         public int IndexOf(T item)
         {
             return _inner.IndexOf(item);
         }
 
-        public void Insert(int index, T item)
+        public virtual void Insert(int index, T item)
         {
             InsertItem(index, item);
         }
 
-        public void RemoveAt(int index)
+        public virtual void RemoveAt(int index)
         {
             RemoveItem(index);
         }
 
-        public T this[int index] {
+        public virtual T this[int index] {
             get { return _inner[index]; }
             set { SetItem(index, value); }
         }
 
-        public int Add(object value)
+        public virtual int Add(object value)
         {
             Add((T)value);
             return Count - 1;

--- a/ReactiveUI/ReactiveCollectionMixins.cs
+++ b/ReactiveUI/ReactiveCollectionMixins.cs
@@ -1,32 +1,424 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Reactive;
-using System.Reactive.Linq;
-using System.Diagnostics.Contracts;
 using System.Collections.Specialized;
-using System.Reactive.Subjects;
-using System.Globalization;
-using System.Threading;
+using System.Diagnostics.Contracts;
+using System.Reactive;
 using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Runtime.CompilerServices;
+using System.Threading;
 
 namespace ReactiveUI
 {
-    public sealed class ReactiveDerivedCollection<T> : ReactiveCollection<T>, IDisposable
+    public abstract class ReactiveDerivedCollection<TValue> : ReactiveCollection<TValue>, IDisposable
     {
-        IDisposable inner = null;
+        public abstract void Dispose();
+    }
 
-        public ReactiveDerivedCollection(IDisposable disposable) : base()
+    public sealed class ReactiveDerivedCollection<TSource, TValue> : ReactiveDerivedCollection<TValue>, IDisposable
+    {
+        const string readonlyExceptionMessage = "Derived collections cannot be modified.";
+
+        IEnumerable<TSource> source;
+        Func<TSource, TValue> selector;
+        Func<TSource, bool> filter;
+        Func<TValue, TValue, int> orderer;
+        IObservable<Unit> signalReset;
+
+        // This list maps indices in this collection to their corresponding indices in the source collection.
+        List<int> indexToSourceIndexMap;
+        CompositeDisposable inner;
+
+        public override bool IsReadOnly { get { return true; } }
+
+        public ReactiveDerivedCollection(
+            IEnumerable<TSource> source,
+            Func<TSource, TValue> selector,
+            Func<TSource, bool> filter,
+            Func<TValue, TValue, int> orderer,
+            IObservable<Unit> signalReset)
         {
-            inner = disposable ?? Disposable.Empty;
+            Contract.Requires(source != null);
+            Contract.Requires(selector != null);
+
+            if (filter == null)
+                filter = x => true;
+
+            this.source = source;
+            this.selector = selector;
+            this.filter = filter;
+            this.orderer = orderer;
+            this.signalReset = signalReset;
+
+            this.inner = new CompositeDisposable();
+            this.indexToSourceIndexMap = new List<int>();
+
+            this.Reset();
+            this.wireUpChangeNotifications();
         }
 
-        public ReactiveDerivedCollection(IEnumerable<T> items, IDisposable disposable) : base(items)
+        private void wireUpChangeNotifications()
         {
-            inner = disposable;
+            var incc = source as INotifyCollectionChanged;
+
+            var collChanged = new Subject<NotifyCollectionChangedEventArgs>();
+
+            var connObs = Observable
+                .FromEventPattern<NotifyCollectionChangedEventHandler, NotifyCollectionChangedEventArgs>(
+                    x => incc.CollectionChanged += x,
+                    x => incc.CollectionChanged -= x
+                )
+                .Select(x => x.EventArgs)
+                .Multicast(collChanged);
+
+            inner.Add(collChanged.Subscribe(onSourceCollectionChanged));
+            inner.Add(connObs.Connect());
+
+            var irc = source as IReactiveCollection;
+
+            if (irc != null) {
+                inner.Add(irc.ItemChanged.Select(x => (TSource)x.Sender).Subscribe(onItemChanged));
+            }
+
+            if (signalReset != null) {
+                inner.Add(signalReset.Subscribe(x => this.Reset()));
+            }
         }
 
-        public void Dispose()
+        private void onItemChanged(TSource changedItem)
+        {
+            // If you've implemented INotifyPropertyChanged on a struct then you're doint it wrong(TM) and change
+            // tracking won't work in derived collections (change tracking for value types makes no sense any way)
+            // NB: It's possible the sender exists in multiple places in the source collection.
+            var sourceIndices = indexOfAll(source, changedItem, ReferenceEqualityComparer<TSource>.Default);
+
+            var shouldBeIncluded = filter(changedItem);
+
+            foreach (int sourceIndex in sourceIndices) {
+
+                int destinationIndex = getIndexFromSourceIndex(sourceIndex);
+                bool isIncluded = destinationIndex >= 0;
+
+                if (isIncluded && !shouldBeIncluded) {
+                    internalRemoveAt(sourceIndex, destinationIndex);
+                } else if (!isIncluded && shouldBeIncluded) {
+                    internalInsert(sourceIndex, selector(changedItem));
+                }
+                else if (isIncluded && shouldBeIncluded) {
+                    // The item is already included and it should stay there but it's possible that the change that
+                    // caused this event affects the ordering. This gets a little tricky so let's be verbose.
+
+                    TValue newItem = selector(changedItem);
+
+                    if (orderer == null) {
+                        // We don't have an orderer so we're currently using the source collection index for sorting 
+                        // meaning that no item change will affect ordering. Look at our current item and see if it's
+                        // the exact (reference-wise) same object. If it is then we're done, if it's not (for example if
+                        // it's an integer) we'll issue a replace event so that subscribers get the new value.
+                        if (!object.ReferenceEquals(newItem, this[destinationIndex])) {
+                            internalReplace(destinationIndex, newItem);
+                        }
+                    } else {
+                        // Don't be tempted to just use the orderer to compare the new item with the previous since
+                        // they'll almost certainly be equal (for reference types). We need to test whether or not the
+                        // new item can stay in the same position that the current item is in without comparing them.
+                        if (canItemStayAtPosition(newItem, destinationIndex)) {
+                            // The new item should be in the same position as the current but there's no need to signal
+                            // that in case they are the same object.
+                            if (!object.ReferenceEquals(newItem, this[destinationIndex])) {
+                                internalReplace(destinationIndex, newItem);
+                            }
+                        } else {
+                            // The change is forcing us to reorder, implemented as a remove and insert.
+                            internalRemoveAt(sourceIndex, destinationIndex);
+                            internalInsert(sourceIndex, newItem);
+                        }
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether or not the item fits (sort-wise) at the provided index. The determination
+        /// is made by checking whether or not it's considered larger than or equal to the preceeding item and if
+        /// it's less than or equal to the succeeding item.
+        /// </summary>
+        private bool canItemStayAtPosition(TValue item, int currentIndex)
+        {
+            bool hasPreceedingItem = currentIndex > 0;
+            bool hasSucceedingItem = currentIndex < this.Count - 1;
+
+            bool isGreaterThanOrEqualToPreceedingItem = hasPreceedingItem 
+                ? (orderer(item, this[currentIndex - 1]) >= 0) 
+                : true;
+
+            bool isLessThanOrEqualToSucceedingItem = hasSucceedingItem 
+                ? (orderer(item, this[currentIndex + 1]) <= 0) 
+                : true;
+
+            return isGreaterThanOrEqualToPreceedingItem && isLessThanOrEqualToSucceedingItem;
+        }
+
+        private void internalReplace(int destinationIndex, TValue newItem)
+        {
+            base[destinationIndex] = newItem;
+        }
+
+        /// <summary>
+        /// Gets the index of the dervived item based on it's originating element index in the source collection.
+        /// </summary>
+        private int getIndexFromSourceIndex(int sourceIndex)
+        {
+            return this.indexToSourceIndexMap.IndexOf(sourceIndex);
+        }
+
+        /// <summary>
+        /// Returns one or more positions in the source collection where the given item is found based on the
+        /// provided equality comparer.
+        /// </summary>
+        private IEnumerable<int> indexOfAll(IEnumerable<TSource> source, TSource item,
+            IEqualityComparer<TSource> equalityComparer)
+        {
+            int sourceIndex = 0;
+            foreach (var x in source) {
+
+                if (equalityComparer.Equals(x, item)) {
+                    yield return sourceIndex;
+                }
+
+                sourceIndex++;
+            }
+        }
+
+        private void onSourceCollectionChanged(NotifyCollectionChangedEventArgs args)
+        {
+            if (args.Action == NotifyCollectionChangedAction.Reset) {
+                this.Reset();
+                return;
+            }
+
+            if (args.OldItems != null) {
+                int removedCount = args.OldItems.Count;
+                shiftIndicesAtOrOverThreshold(args.OldStartingIndex + removedCount, -removedCount);
+
+                for (int i = 0; i < args.OldItems.Count; i++) {
+                    if (filter((TSource)args.OldItems[i])) {
+                        internalRemoveAt(args.OldStartingIndex + i);
+                    }
+                }
+            }
+
+            if (args.NewItems != null) {
+                shiftIndicesAtOrOverThreshold(args.NewStartingIndex, args.NewItems.Count);
+
+                for (int i = 0; i < args.NewItems.Count; i++) {
+                    var sourceItem = (TSource)args.NewItems[i];
+
+                    if (!filter(sourceItem)) {
+                        continue;
+                    }
+
+                    var destinationItem = selector(sourceItem);
+                    internalInsert(args.NewStartingIndex + i, destinationItem);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Increases (or decreases) all source indices equal to or higher than the threshold. Represents an
+        /// insert or remove of one or more items in the source list thus causing all subsequent items to shift
+        /// up or down.
+        /// </summary>
+        private void shiftIndicesAtOrOverThreshold(int threshold, int value)
+        {
+            for (int i = 0; i < indexToSourceIndexMap.Count; i++) {
+                if (indexToSourceIndexMap[i] >= threshold) {
+                    indexToSourceIndexMap[i] += value;
+                }
+            }
+        }
+
+        public override void Reset()
+        {
+            using (base.SuppressChangeNotifications())
+            {
+                if (this.Count > 0)
+                    internalClear();
+
+                int sourceIndex = 0;
+
+                foreach (TSource sourceItem in source) {
+                    if (filter(sourceItem)) {
+                        var destinationItem = selector(sourceItem);
+                        internalInsert(sourceIndex, destinationItem);
+                    }
+
+                    sourceIndex++;
+                }
+            }
+        }
+
+        private void internalClear()
+        {
+            indexToSourceIndexMap.Clear();
+            base.Clear();
+        }
+
+        private void internalInsert(int sourceIndex, TValue value)
+        {
+            int destinationIndex = positionForNewItem(sourceIndex, value);
+
+            internalInsert(sourceIndex, destinationIndex, value);
+        }
+
+        private void internalInsert(int sourceIndex, int destinationIndex, TValue value)
+        {
+            indexToSourceIndexMap.Insert(destinationIndex, sourceIndex);
+            base.Insert(destinationIndex, value);
+        }
+
+        private void internalRemoveAt(int sourceIndex)
+        {
+            int destinationIndex = indexToSourceIndexMap.IndexOf(sourceIndex);
+            internalRemoveAt(sourceIndex, destinationIndex);
+        }
+
+        private void internalRemoveAt(int sourceIndex, int destinationIndex)
+        {
+            indexToSourceIndexMap.RemoveAt(destinationIndex);
+            base.RemoveAt(destinationIndex);
+        }
+
+        public override int Add(object value)
+        {
+            throw new InvalidOperationException(readonlyExceptionMessage);
+        }
+
+        public override void AddRange(IEnumerable<TValue> collection)
+        {
+            throw new InvalidOperationException(readonlyExceptionMessage);
+        }
+
+        public override void Clear()
+        {
+            throw new InvalidOperationException(readonlyExceptionMessage);
+        }
+
+        public override void Insert(int index, TValue item)
+        {
+            throw new InvalidOperationException(readonlyExceptionMessage);
+        }
+
+        public override void InsertRange(int index, IEnumerable<TValue> collection)
+        {
+            throw new InvalidOperationException(readonlyExceptionMessage);
+        }
+
+        public override bool Remove(TValue item)
+        {
+            throw new InvalidOperationException(readonlyExceptionMessage);
+        }
+
+        public override void RemoveAll(IEnumerable<TValue> items)
+        {
+            throw new InvalidOperationException(readonlyExceptionMessage);
+        }
+
+        public override void RemoveAt(int index)
+        {
+            throw new InvalidOperationException(readonlyExceptionMessage);
+        }
+
+        public override void RemoveRange(int index, int count)
+        {
+            throw new InvalidOperationException(readonlyExceptionMessage);
+        }
+
+        public override void Sort(Comparison<TValue> comparison)
+        {
+            throw new InvalidOperationException(readonlyExceptionMessage);
+        }
+
+        public override void Sort(IComparer<TValue> comparer = null)
+        {
+            throw new InvalidOperationException(readonlyExceptionMessage);
+        }
+
+        public override void Sort(int index, int count, IComparer<TValue> comparer)
+        {
+            throw new InvalidOperationException(readonlyExceptionMessage);
+        }
+
+        public override TValue this[int index]
+        {
+            get { return base[index]; }
+            set { throw new InvalidOperationException(readonlyExceptionMessage); }
+        }
+
+        /// <summary>
+        /// Internal equality comparer used for looking up the source object of a property change notification in
+        /// the source list.
+        /// </summary>
+        class ReferenceEqualityComparer<T> : IEqualityComparer<T>
+        {
+            public static readonly ReferenceEqualityComparer<T> Default = new ReferenceEqualityComparer<T>();
+
+            public bool Equals(T x, T y)
+            {
+                return object.ReferenceEquals(x, y);
+            }
+
+            public int GetHashCode(T obj)
+            {
+                return RuntimeHelpers.GetHashCode(obj);
+            }
+        }
+
+        private int positionForNewItem(int sourceIndex, TValue value)
+        {
+            // If we haven't got an orderer we'll simply match our items to that of the source collection.
+            int destinationIndex = orderer == null
+                ? positionForNewItem(this.indexToSourceIndexMap, sourceIndex, (x, y) => x.CompareTo(y))
+                : positionForNewItem(this, value, orderer);
+
+            return destinationIndex;
+        }
+
+        static int positionForNewItem<T>(IList<T> list, T item, Func<T, T, int> orderer)
+        {
+            if (list.Count == 0) {
+                return 0;
+            }
+
+            if (list.Count == 1) {
+                return orderer(list[0], item) >= 0 ? 0 : 1;
+            }
+
+            if (orderer(list[0], item) >= 1) return 0;
+
+            // NB: This is the most tart way to do this possible
+            int? prevCmp = null;
+            int cmp;
+
+            for (int i = 0; i < list.Count; i++) {
+                cmp = sign(orderer(list[i], item));
+                if (prevCmp.HasValue && cmp != prevCmp) {
+                    return i;
+                }
+
+                prevCmp = cmp;
+            }
+
+            return list.Count;
+        }
+
+        static int sign(int i)
+        {
+            return (i == 0 ? 0 : i / Math.Abs(i));
+        }
+
+        public override void Dispose()
         {
             var disp = Interlocked.Exchange(ref inner, null);
             if (disp == null) return;
@@ -57,6 +449,8 @@ namespace ReactiveUI
             TimeSpan? withDelay = null,
             Action<Exception> onError = null)
         {
+            throw new NotImplementedException();
+            /*
             var disp = new SingleAssignmentDisposable();
             var ret = new ReactiveDerivedCollection<T>(disp);
 
@@ -90,6 +484,7 @@ namespace ReactiveUI
                 (l,r) => (l == r)).Where(x => x).Subscribe(_ => disconnect.Dispose());
 
             return ret;
+            */
         }
 
         /// <summary>
@@ -108,8 +503,8 @@ namespace ReactiveUI
         /// <returns>A new collection which will be populated with the
         /// Observable.</returns>
         public static ReactiveDerivedCollection<TRet> CreateCollection<T, TRet>(
-            this IObservable<T> fromObservable, 
-            Func<T, TRet> selector, 
+            this IObservable<T> fromObservable,
+            Func<T, TRet> selector,
             TimeSpan? withDelay = null)
         {
             Contract.Requires(selector != null);
@@ -152,85 +547,12 @@ namespace ReactiveUI
         {
             Contract.Requires(selector != null);
 
-            var disp = new CompositeDisposable();
-            var collChanged = new Subject<NotifyCollectionChangedEventArgs>();
+            IObservable<Unit> reset = null;
 
-            if (selector == null) {
-                selector = (x => (TNew)Convert.ChangeType(x, typeof(TNew), CultureInfo.CurrentCulture));
-            }
+            if (signalReset != null)
+                reset = signalReset.Select(_ => Unit.Default);
 
-            var origEnum = This;
-            origEnum = (filter != null ? origEnum.Where(filter) : origEnum);
-            var enumerable = origEnum.Select(selector);
-            enumerable = (orderer != null ? enumerable.OrderBy(x => x, new FuncComparator<TNew>(orderer)) : enumerable);
-
-            var ret = new ReactiveDerivedCollection<TNew>(enumerable, disp);
-
-            var incc = This as INotifyCollectionChanged;
-            if (incc != null) {
-                var connObs = Observable.FromEventPattern<NotifyCollectionChangedEventHandler, NotifyCollectionChangedEventArgs>(x => incc.CollectionChanged += x, x => incc.CollectionChanged -= x)
-                    .Select(x => x.EventArgs)
-                    .Multicast(collChanged);
-
-                disp.Add(connObs.Connect());
-            }
-
-            if (filter != null && orderer == null) {
-                throw new Exception("If you specify a filter, you must also specify an ordering function");
-            }
-
-            disp.Add(signalReset.Subscribe(_ => collChanged.OnNext(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset))));
-
-            disp.Add(collChanged.Subscribe(args => {
-                if (args.Action == NotifyCollectionChangedAction.Reset) {
-                    using(ret.SuppressChangeNotifications()) {
-                        ret.Clear();
-                        enumerable.ForEach(ret.Add);
-                    }
-
-                    return;
-                }
-
-                int oldIndex = (args.Action == NotifyCollectionChangedAction.Replace ?
-                    args.NewStartingIndex : args.OldStartingIndex);
-
-                if (args.OldItems != null) {
-                    // NB: Tracking removes gets hard, because unless the items
-                    // are objects, we have trouble telling them apart. This code
-                    // is also tart, but it works.
-                    foreach(T x in args.OldItems) {
-                        if (filter != null && !filter(x)) {
-                            continue;
-                        }
-                        if (orderer == null) {
-                            ret.RemoveAt(oldIndex);
-                            continue;
-                        }
-                        for(int i = 0; i < ret.Count; i++) {
-                            if (orderer(ret[i], selector(x)) == 0) {
-                                ret.RemoveAt(i);
-                            }
-                        }
-                    }
-                }
-
-                if (args.NewItems != null) {
-                    foreach(T x in args.NewItems) {
-                        if (filter != null && !filter(x)) {
-                            continue;
-                        }
-                        if (orderer == null) {
-                            ret.Insert(args.NewStartingIndex, selector(x));
-                            continue;
-                        }
-
-                        var toAdd = selector(x);
-                        ret.Insert(positionForNewItem(ret, toAdd, orderer), toAdd);
-                    }
-                }
-            }));
-
-            return ret;
+            return new ReactiveDerivedCollection<T, TNew>(This, selector, filter, orderer, reset);
         }
 
         /// <summary>
@@ -259,55 +581,7 @@ namespace ReactiveUI
             Func<T, bool> filter = null,
             Func<TNew, TNew, int> orderer = null)
         {
-            return This.CreateDerivedCollection(selector, filter, orderer, Observable.Empty<Unit>());
-        }
-
-        static int positionForNewItem<T>(IList<T> list, T item, Func<T, T, int> orderer)
-        {
-            if (list.Count == 0) {
-                return 0;
-            }
-
-            if (list.Count == 1) {
-                return orderer(list[0], item) >= 0 ? 0 : 1;
-            }
-
-            if (orderer(list[0], item) >= 1) return 0;
-
-            // NB: This is the most tart way to do this possible
-            int? prevCmp = null;
-            int cmp;
-
-            for (int i = 0; i < list.Count; i++) {
-                cmp = sign(orderer(list[i], item));
-                if (prevCmp.HasValue && cmp != prevCmp) {
-                    return i;
-                }
-
-                prevCmp = cmp;
-            }
-
-            return list.Count;
-        }
-
-        static int sign(int i)
-        {
-            return (i == 0 ? 0 : i / Math.Abs(i));
-        }
-        
-        class FuncComparator<T> : IComparer<T>
-        {
-            Func<T, T, int> _inner;
-
-            public FuncComparator(Func<T, T, int> comparer)
-            {
-                _inner = comparer;
-            }
-
-            public int Compare(T x, T y)
-            {
-                return _inner(x, y);
-            }
+            return This.CreateDerivedCollection(selector, filter, orderer, (IObservable<Unit>)null);
         }
     }
 }


### PR DESCRIPTION
### What does this do?

Suppose you have a simple container class with two properties, Visible and Value. Both properties raise change notification events. Say that you'd like to have a derived collection where only the visible items are included, you'd do something like this.

``` c#
var items = new ReactiveCollection(...) { ChangeTrackingEnabled = true };
var visibleItems = items.CreateDerivedCollection(x => x, x => x.IsVisible);

items[0].Visible = false; // This won't update the derived collection.

```

The problem is that the derived collections doesn't support item change notifications propagated through the source collection so you have to provide the derived collection with a reset signal.

``` c#
var rst = items.ItemChanged.Where(x=> x.PropertyName == "IsVisible");
var visibleItems = items.CreateDerivedCollection(x => x, x => x.IsVisible, signalReset: rst);
```

This works but it will force the derived collection to completely reset every time an item raises a notification event for the IsVisible property.

The PR aims to add support for updating derived collections when items in the source collection changes (provided it has change tracking enabled) and have the first scenario just work(TM) without a complete reset. 
### What has changed?

Changes to source items can result in items being added to or removed from the derived collection as well as items changing places (due to new sort conditions).

In order to make this possible I've moved all of the synchronization logic into the RDC class itself and the class has been split into two parts. The RDC<T> class is exposed to callers of CreateDerivedCollection (for backwards compatibility and sanity) and RDC<TSource,TValue> which contains the magic ingredient TSource (the type of the source collection items).

In order to support all scenarios of value and reference types, orderers and no orderers filters and what not RDC now maintains a map between the item indices and their corresponding indices in the source collection allowing it to track and map changes in the origin collection to their projected counterparts regardless of type and value/reference type changes.

Also supports items existing in multiple places in the source collection whether or not the selector is an identity function or if they're mapped to value types.
### Breaking changes

This PR is a breaking change (and thus opened against rxui5-master)  for the following reasons:
- RDC constructor no longer accepts an IDisposable.
- RDC is now explicitly read only (modifying a derived collection makes no sense and now it's enforced. All modifying methods throws and the IsReadOnly property is set to true.

The behavior of `ReactiveCollectionMixins.CreateDerivedCollection` is maintained and all code using it to create derived collection will continue to work the same.
### TODO:
- [ ] `ReactiveCollectionMixins.CreateCollection` is currently broken. I don't think it will be hard to fix it but I want to get some feedback on this change first.
- [ ] One possible performance optimization would be to maintain an inverse map of source indices to destination indices which would allow for quicker lookups. Needs to be measured and weighed against increase complexity. Could also enable binary search for reverse lookup.
- [ ] Another possible perf gain is to use binary search for `positionForNewItem`.
