### PR TITLE
On WinRT there is no requirement for EventArgs to be of type EventArgs. ...

### DIFF
--- a/ReactiveUI.Xaml/CreatesCommandBinding.cs
+++ b/ReactiveUI.Xaml/CreatesCommandBinding.cs
@@ -58,7 +58,9 @@ namespace ReactiveUI.Xaml
         }
 
         public IDisposable BindCommandToObject<TEventArgs>(ICommand command, object target, IObservable<object> commandParameter, string eventName)
-            where TEventArgs : EventArgs
+#if !WINRT
+            where TEventArgs : EventArgs            
+#endif
         {
             var ret = new CompositeDisposable();
 


### PR DESCRIPTION
...Drop the requirement for WinRT just like Rx does.

Fixes #194
