### PR TITLE
Fix source item removals in sorted derived cols

### DIFF
--- a/ReactiveUI.Tests/ReactiveCollectionTest.cs
+++ b/ReactiveUI.Tests/ReactiveCollectionTest.cs
@@ -662,6 +662,40 @@ namespace ReactiveUI.Tests
                 Assert.Equal(2, onlyVisible.Count);
                 Assert.True(onlyVisible.SequenceEqual(new[] { "***", "***" }));
             }
+
+            [Fact]
+            public void DerivedCollectionShouldHandleRemovesOfFilteredItems()
+            {
+                var a = new ReactiveVisibilityItem<string>("A", true);
+                var b = new ReactiveVisibilityItem<string>("B", true);
+                var c = new ReactiveVisibilityItem<string>("C", true);
+
+                var items = new ReactiveCollection<ReactiveVisibilityItem<string>>(new[] { a, b, c })
+                {
+                    ChangeTrackingEnabled = true
+                };
+
+                var onlyVisible = items.CreateDerivedCollection(
+                    x => x.Value,
+                    x => x.IsVisible,
+                    OrderedComparer<string>.OrderByDescending(x => x).Compare
+                );
+
+                Assert.True(onlyVisible.SequenceEqual(new[] { "C", "B", "A" }, StringComparer.Ordinal));
+                Assert.Equal(3, onlyVisible.Count);
+
+                c.IsVisible = false;
+                Assert.Equal(2, onlyVisible.Count);
+                Assert.True(onlyVisible.SequenceEqual(new[] { "B", "A" }, StringComparer.Ordinal));
+
+                items.Remove(c);
+                Assert.Equal(2, onlyVisible.Count);
+                Assert.True(onlyVisible.SequenceEqual(new[] { "B", "A" }, StringComparer.Ordinal));
+
+                items.Remove(b);
+                Assert.Equal(1, onlyVisible.Count);
+                Assert.True(onlyVisible.SequenceEqual(new[] { "A" }, StringComparer.Ordinal));
+            }
         }
 
         [Fact]
@@ -766,7 +800,6 @@ namespace ReactiveUI.Tests
             collection.Add(3);
             Assert.Equal(2, orderedCollection.Count);
         }
-
 
         [Fact]
         public void IListTSmokeTest() {

--- a/ReactiveUI/ReactiveCollectionMixins.cs
+++ b/ReactiveUI/ReactiveCollectionMixins.cs
@@ -337,10 +337,11 @@ namespace ReactiveUI
             if (args.OldItems != null) {
                 int removedCount = args.OldItems.Count;
                 shiftIndicesAtOrOverThreshold(args.OldStartingIndex + removedCount, -removedCount);
-
+                
                 for (int i = 0; i < args.OldItems.Count; i++) {
-                    if (filter((TSource)args.OldItems[i])) {
-                        internalRemoveAt(args.OldStartingIndex + i);
+                    int destinationIndex = getIndexFromSourceIndex(args.OldStartingIndex + i);
+                    if (destinationIndex != -1) {
+                        internalRemoveAt(destinationIndex);
                     }
                 }
             }


### PR DESCRIPTION
The test contained is kind of contrived and it could probably be simplified a lot. Any way, this is a stupid bug and it's all on me. It's not possible to use filter as the test for whether or not to include an item when handling removes since the state of the item might have changed since it was added (or not added).

I also used sourceIndex where I should have been using destinationIndex which caused the wrong items to get removed.

Now it'll actually check if the item is included (by going through the mapping list) instead.
