### PR TITLE
Maximize compatibility with IoC containers by using generics first class

### DIFF
--- a/MobileSample-WP8/App.xaml.cs
+++ b/MobileSample-WP8/App.xaml.cs
@@ -47,7 +47,7 @@ namespace MobileSample_WP8
             }
 
             //TODo get rid of ugly casting
-            ((ModernDependencyResolver)RxApp.DependencyResolver).Register(() => new AppBootstrapper(), typeof(IApplicationRootState));
+            ((IMutableDependencyResolver)RxApp.DependencyResolver).Register<IApplicationRootState>(() => new AppBootstrapper());
 
             var host = RxApp.DependencyResolver.GetService<ISuspensionHost>();
             host.SetupDefaultSuspendResume();

--- a/MobileSample-WP8/MainPage.xaml
+++ b/MobileSample-WP8/MainPage.xaml
@@ -6,7 +6,7 @@
     xmlns:shell="clr-namespace:Microsoft.Phone.Shell;assembly=Microsoft.Phone"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:routing="clr-namespace:ReactiveUI.Routing;assembly=ReactiveUI.Xaml"
+    xmlns:routing="clr-namespace:ReactiveUI.Xaml;assembly=ReactiveUI.Xaml"
     mc:Ignorable="d"
     FontFamily="{StaticResource PhoneFontFamilyNormal}"
     FontSize="{StaticResource PhoneFontSizeNormal}"

--- a/MobileSample-WP8/ViewModels/TestPage1ViewModel.cs
+++ b/MobileSample-WP8/ViewModels/TestPage1ViewModel.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Runtime.Serialization;
 using ReactiveUI;
-using ReactiveUI.Routing;
 
 namespace MobileSample_WP8.ViewModels
 {

--- a/ReactiveUI.Mobile/Registrations.cs
+++ b/ReactiveUI.Mobile/Registrations.cs
@@ -8,20 +8,20 @@ namespace ReactiveUI.Mobile
 {
     public class Registrations : IWantsToRegisterStuff
     {
-        public void Register(Action<Func<object>, Type> registerFunction)
+        public void Register(IMutableDependencyResolver resolver)
         {
 #if WP8
-            registerFunction(() => new WP8SuspensionHost(), typeof (ISuspensionHost));
-            registerFunction(() => new PhoneServiceStateDriver(), typeof (ISuspensionDriver));
+            resolver.Register<ISuspensionHost>(() => new WP8SuspensionHost());
+            resolver.Register<ISuspensionDriver>(() => new PhoneServiceStateDriver());
 #elif WINRT
-            registerFunction(() => new WinRTSuspensionHost(), typeof(ISuspensionHost));
-            registerFunction(() => new WinRTAppDataDriver(), typeof(ISuspensionDriver));
+            resolver.Register<ISuspensionHost>(() => new WinRTSuspensionHost());
+            resolver.Register<ISuspensionDriver>(() => new WinRTAppDataDriver());
 #elif UIKIT
-            registerFunction(() => new CocoaSuspensionHost(), typeof(ISuspensionHost));
-            registerFunction(() => new AppSupportJsonSuspensionDriver(), typeof(ISuspensionDriver));
+            resolver.Register<ISuspensionHost>(() => new CocoaSuspensionHost());
+            resolver.Register<ISuspensionDriver>(() => new AppSupportJsonSuspensionDriver());
 #elif ANDROID
-            registerFunction(() => new AndroidSuspensionHost(), typeof(ISuspensionHost));
-            registerFunction(() => new BundleSuspensionDriver(), typeof(ISuspensionDriver));
+            resolver.Register<ISuspensionHost>(() => new AndroidSuspensionHost());
+            resolver.Register<ISuspensionDriver>(() => new BundleSuspensionDriver());
 #endif
         }
     }

--- a/ReactiveUI.NLog/Registrations.cs
+++ b/ReactiveUI.NLog/Registrations.cs
@@ -8,7 +8,7 @@ namespace ReactiveUI.NLog
 {
     public class Registrations : IWantsToRegisterStuff
     {
-        public void Register(Action<Func<object>, Type> registerFunction)
+        public void Register(IMutableDependencyResolver resolver)
         {
             RxApp.LoggerFactory = type => new NLogLogger(global::NLog.LogManager.GetLogger(type.Name));
         }

--- a/ReactiveUI.Platforms/Registrations.cs
+++ b/ReactiveUI.Platforms/Registrations.cs
@@ -32,26 +32,26 @@ namespace ReactiveUI.Xaml
     /// </summary>
     public class Registrations : IWantsToRegisterStuff
     {
-        public void Register(Action<Func<object>, Type> registerFunction)
+        public void Register(IMutableDependencyResolver resolver)
         {
 #if !WINRT && !WP8
-            registerFunction(() => new ComponentModelTypeConverter(), typeof(IBindingTypeConverter));
+            resolver.Register<IBindingTypeConverter>(() => new ComponentModelTypeConverter());
 #endif
 
 #if !MONO
-            registerFunction(() => new DependencyObjectObservableForProperty(), typeof(ICreatesObservableForProperty));
-            registerFunction(() => new XamlDefaultPropertyBinding(), typeof(IDefaultPropertyBindingProvider));
-            registerFunction(() => new CreatesCommandBindingViaCommandParameter(), typeof(ICreatesCommandBinding));
-            registerFunction(() => new CreatesCommandBindingViaEvent(), typeof(ICreatesCommandBinding));
-            registerFunction(() => new BooleanToVisibilityTypeConverter(), typeof(IBindingTypeConverter));
-            registerFunction(() => new AutoDataTemplateBindingHook(), typeof(IPropertyBindingHook));
+            resolver.Register<ICreatesObservableForProperty>(() => new DependencyObjectObservableForProperty());
+            resolver.Register<IDefaultPropertyBindingProvider>(() => new XamlDefaultPropertyBinding());
+            resolver.Register<ICreatesCommandBinding>(() => new CreatesCommandBindingViaCommandParameter());
+            resolver.Register<ICreatesCommandBinding>(() => new CreatesCommandBindingViaEvent());
+            resolver.Register<IBindingTypeConverter>(() => new BooleanToVisibilityTypeConverter());
+            resolver.Register<IPropertyBindingHook>(() => new AutoDataTemplateBindingHook());
 
 #endif
 
 #if COCOA
-            registerFunction(() => new KVOObservableForProperty(), typeof(ICreatesObservableForProperty));
-            registerFunction(() => new CocoaDefaultPropertyBinding(), typeof(IDefaultPropertyBindingProvider));
-            registerFunction(() => new TargetActionCommandBinder(), typeof(ICreatesCommandBinding));
+            resolver.Register<ICreatesObservableForProperty>(() => new KVOObservableForProperty());
+            resolver.Register<IDefaultPropertyBindingProvider>(() => new CocoaDefaultPropertyBinding());
+            resolver.Register<ICreatesCommandBinding>(() => new TargetActionCommandBinder());
 
             RxApp.DeferredScheduler = new WaitForDispatcherScheduler(() => new NSRunloopScheduler(NSApplication.SharedApplication));
 #endif

--- a/ReactiveUI.Tests/RxRouting.cs
+++ b/ReactiveUI.Tests/RxRouting.cs
@@ -65,7 +65,7 @@ namespace ReactiveUI.Routing.Tests
         public void ResolveExplicitViewType()
         {
             var resolver = new ModernDependencyResolver();
-            resolver.Register(() => new BazView(), typeof(IBazView));
+            resolver.Register<IBazView>(() => new BazView());
 
             using (resolver.WithResolver()) {
                 var vm = new BazViewModel(null);

--- a/ReactiveUI/Interfaces.cs
+++ b/ReactiveUI/Interfaces.cs
@@ -466,7 +466,7 @@ namespace ReactiveUI
 
     internal interface IWantsToRegisterStuff
     {
-        void Register(Action<Func<object>, Type> registerFunction);
+        void Register(IMutableDependencyResolver resolver);
     }
 
     // NB: This is just a name we can bolt extension methods to

--- a/ReactiveUI/Registrations.cs
+++ b/ReactiveUI/Registrations.cs
@@ -8,14 +8,14 @@ namespace ReactiveUI
 {
     public class Registrations : IWantsToRegisterStuff
     {
-        public void Register(Action<Func<object>, Type> registerFunction)
-        {            
-            registerFunction(() => new INPCObservableForProperty(), typeof(ICreatesObservableForProperty));
-            registerFunction(() => new IRNPCObservableForProperty(), typeof(ICreatesObservableForProperty));
-            registerFunction(() => new POCOObservableForProperty(), typeof(ICreatesObservableForProperty));
-            registerFunction(() => new NullDefaultPropertyBindingProvider(), typeof(IDefaultPropertyBindingProvider));
-            registerFunction(() => new EqualityTypeConverter(), typeof(IBindingTypeConverter));
-            registerFunction(() => new StringConverter(), typeof(IBindingTypeConverter));
+        public void Register(IMutableDependencyResolver resolver)
+        {
+            resolver.Register<ICreatesObservableForProperty>(() => new INPCObservableForProperty());
+            resolver.Register<ICreatesObservableForProperty>(() => new IRNPCObservableForProperty());
+            resolver.Register<ICreatesObservableForProperty>(() => new POCOObservableForProperty());
+            resolver.Register<IDefaultPropertyBindingProvider>(() => new NullDefaultPropertyBindingProvider());
+            resolver.Register<IBindingTypeConverter>(() => new EqualityTypeConverter());
+            resolver.Register<IBindingTypeConverter>(() => new StringConverter());
         }
     }
 }


### PR DESCRIPTION
as some containers don't have Register and Resolver overloads that take a Type as a parameter, but only a generic parameter.
