### PR TITLE
Fix for wrong-order index shift

### DIFF
--- a/ReactiveUI/ReactiveCollectionMixins.cs
+++ b/ReactiveUI/ReactiveCollectionMixins.cs
@@ -335,15 +335,15 @@ namespace ReactiveUI
             }
 
             if (args.OldItems != null) {
-                int removedCount = args.OldItems.Count;
-                shiftIndicesAtOrOverThreshold(args.OldStartingIndex + removedCount, -removedCount);
-                
                 for (int i = 0; i < args.OldItems.Count; i++) {
                     int destinationIndex = getIndexFromSourceIndex(args.OldStartingIndex + i);
                     if (destinationIndex != -1) {
                         internalRemoveAt(destinationIndex);
                     }
                 }
+
+                int removedCount = args.OldItems.Count;
+                shiftIndicesAtOrOverThreshold(args.OldStartingIndex + removedCount, -removedCount);
             }
 
             if (args.NewItems != null) {


### PR DESCRIPTION
Shifting indices before the removal of items can cause the wrong items in the derived collection to be removed in certain edge-cases.

Modifies existing remove unit test and adds a new regression test specific to this problem.
