### PR TITLE
Part two of INotifyCollectionChanged warning PR

### DIFF
--- a/ReactiveUI/ReactiveCollectionMixins.cs
+++ b/ReactiveUI/ReactiveCollectionMixins.cs
@@ -201,7 +201,8 @@ namespace ReactiveUI
                 lock (hasWarned) {
                     if (!hasWarned.ContainsKey(type)) {
                         this.Log().Warn(
-                            "{0} doesn't implement INotifyCollectionChanged, derived collection will only update on reset",
+                            "{0} doesn't implement INotifyCollectionChanged, derived collection will only update " +
+                            "when the Reset() method is invoked manually or the reset observable is signalled.",
                             type.FullName);
                         hasWarned.Add(type, true);
                     }


### PR DESCRIPTION
See #283 for the first part that got accidentally merged. This fixes the non-synchronized access issue and contains a second attempt at wording the warning message.

Refs #280 
