### PR TITLE
Add read only interfaces for reactive collections

### DIFF
--- a/ReactiveUI/Interfaces.cs
+++ b/ReactiveUI/Interfaces.cs
@@ -211,6 +211,18 @@ namespace ReactiveUI
         IObservable<Unit> ShouldReset { get; }
     }
 
+    public interface IReadOnlyReactiveCollection<T> : IReadOnlyCollection<T>, IReactiveCollection
+    {
+    }
+
+    public interface IReadOnlyReactiveList<T> : IReadOnlyList<T>, IReadOnlyReactiveCollection<T>
+    {
+    }
+
+    public interface IReactiveDerivedList<T> : IReadOnlyReactiveList<T>, IDisposable
+    {
+    }
+
     /// <summary>
     /// IReactiveCollection of T is the typed version of IReactiveCollection and
     /// adds type-specified versions of Observables
@@ -254,6 +266,7 @@ namespace ReactiveUI
         /// ChangeTrackingEnabled is set to True.
         /// </summary>
         IObservable<IObservedChange<T, object>> ItemChanged { get; }
+
     }
 
     /// <summary>

--- a/ReactiveUI/ReactiveCollectionMixins.cs
+++ b/ReactiveUI/ReactiveCollectionMixins.cs
@@ -11,7 +11,7 @@ using System.Threading;
 
 namespace ReactiveUI
 {
-    public abstract class ReactiveDerivedCollection<TValue> : ReactiveList<TValue>, IDisposable
+    public abstract class ReactiveDerivedCollection<TValue> : ReactiveList<TValue>, IReactiveDerivedList<TValue>
     {
         const string readonlyExceptionMessage = "Derived collections cannot be modified.";
 
@@ -151,7 +151,7 @@ namespace ReactiveUI
         public virtual void Dispose(bool disposing) { }
     }
 
-    public sealed class ReactiveDerivedCollection<TSource, TValue> : ReactiveDerivedCollection<TValue>, IDisposable
+    public sealed class ReactiveDerivedCollection<TSource, TValue> : ReactiveDerivedCollection<TValue>
     {
         readonly IEnumerable<TSource> source;
         readonly Func<TSource, TValue> selector;
@@ -504,7 +504,7 @@ namespace ReactiveUI
         }
     }
 
-    internal class ReactiveDerivedCollectionFromObservable<T>: ReactiveDerivedCollection<T>
+    internal class ReactiveDerivedCollectionFromObservable<T> : ReactiveDerivedCollection<T>
     {
         SingleAssignmentDisposable inner;
 
@@ -573,7 +573,7 @@ namespace ReactiveUI
         /// collection no faster than the delay provided.</param>
         /// <returns>A new collection which will be populated with the
         /// Observable.</returns>
-        public static ReactiveDerivedCollection<T> CreateCollection<T>(
+        public static IReactiveDerivedList<T> CreateCollection<T>(
             this IObservable<T> fromObservable, 
             TimeSpan? withDelay = null,
             Action<Exception> onError = null)
@@ -596,7 +596,7 @@ namespace ReactiveUI
         /// collection no faster than the delay provided.</param>
         /// <returns>A new collection which will be populated with the
         /// Observable.</returns>
-        public static ReactiveDerivedCollection<TRet> CreateCollection<T, TRet>(
+        public static IReactiveDerivedList<TRet> CreateCollection<T, TRet>(
             this IObservable<T> fromObservable,
             Func<T, TRet> selector,
             TimeSpan? withDelay = null)
@@ -632,7 +632,7 @@ namespace ReactiveUI
         /// <returns>A new collection whose items are equivalent to
         /// Collection.Select().Where().OrderBy() and will mirror changes 
         /// in the initial collection.</returns>
-        public static ReactiveDerivedCollection<TNew> CreateDerivedCollection<T, TNew, TDontCare>(
+        public static IReactiveDerivedList<TNew> CreateDerivedCollection<T, TNew, TDontCare>(
             this IEnumerable<T> This,
             Func<T, TNew> selector,
             Func<T, bool> filter = null,
@@ -670,7 +670,7 @@ namespace ReactiveUI
         /// <returns>A new collection whose items are equivalent to
         /// Collection.Select().Where().OrderBy() and will mirror changes 
         /// in the initial collection.</returns>
-        public static ReactiveDerivedCollection<TNew> CreateDerivedCollection<T, TNew>(
+        public static IReactiveDerivedList<TNew> CreateDerivedCollection<T, TNew>(
             this IEnumerable<T> This,
             Func<T, TNew> selector,
             Func<T, bool> filter = null,


### PR DESCRIPTION
fixes #267 

This is a first cut at the read only interfaces. I simply changed the methods that return a derived collection to return the interface `IReactiveDerivedList`. It's possible to cast it to the underlying `ReactiveDerivedCollection` abstract base class and call the `Add` method, for example, but that'll throw a `NotImplementedException` so we're covered.

This helps people fall into the pit of success as the derived collection they get will not have any mutating methods on it. :)
