### PR TITLE
Bugfixes in derived collections (rxui5)

### DIFF
--- a/ReactiveUI.Tests/ReactiveCollectionTest.cs
+++ b/ReactiveUI.Tests/ReactiveCollectionTest.cs
@@ -655,6 +655,27 @@ namespace ReactiveUI.Tests
 
 #if !SILVERLIGHT
         [Fact]
+        public void DerivedCollectionShouldNotSignalRedundantMoveSignals()
+        {
+            var sanity = new List<string> { "a", "b", "c", "d", "e", "f" };
+            var source = new System.Collections.ObjectModel.ObservableCollection<string> {
+                "a", "b", "c", "d", "e", "f"
+            };
+
+            var derived = source.CreateDerivedCollection(x => x, x => x == "d" || x == "e");
+
+            var derivedNotification = new List<NotifyCollectionChangedEventArgs>();
+            derived.Changed.Subscribe(derivedNotification.Add);
+
+            Assert.Equal("d", source[3]);
+            source.Move(3, 0);
+
+            Assert.Equal(0, derivedNotification.Count);
+        }
+#endif
+
+#if !SILVERLIGHT
+        [Fact]
         public void DerivedCollectionShouldHandleMovesWhenOnlyContainingOneItem()
         {
             // This test is here to verify a bug in where newPositionForItem would return an incorrect

--- a/ReactiveUI/ReactiveCollectionMixins.cs
+++ b/ReactiveUI/ReactiveCollectionMixins.cs
@@ -311,6 +311,9 @@ namespace ReactiveUI
                                 int newDestinationIndex = newPositionForExistingItem(
                                     sourceIndex, currentDestinationIndex, newItem);
 
+                                Debug.Assert(newDestinationIndex != currentDestinationIndex,
+                                    "This can't be, canItemStayAtPosition said it this couldn't happen");
+
                                 indexToSourceIndexMap.RemoveAt(currentDestinationIndex);
                                 indexToSourceIndexMap.Insert(newDestinationIndex, sourceIndex);
 
@@ -437,10 +440,17 @@ namespace ReactiveUI
                     int newDestinationIndex = newPositionForExistingItem(
                         indexToSourceIndexMap, newSourceIndex, currentDestinationIndex);
 
-                    indexToSourceIndexMap.RemoveAt(currentDestinationIndex);
-                    indexToSourceIndexMap.Insert(newDestinationIndex, newSourceIndex);
+                    if (newDestinationIndex != currentDestinationIndex)
+                    {
+                        indexToSourceIndexMap.RemoveAt(currentDestinationIndex);
+                        indexToSourceIndexMap.Insert(newDestinationIndex, newSourceIndex);
 
-                    base.internalMove(currentDestinationIndex, newDestinationIndex);
+                        base.internalMove(currentDestinationIndex, newDestinationIndex);
+                    }
+                    else
+                    {
+                        indexToSourceIndexMap[currentDestinationIndex] = newSourceIndex;
+                    }
                 } else {
                     // TODO: Conceptually I feel like we shouldn't concern ourselves with ordering when we 
                     // receive a Move notification. If it affects ordering it should be picked up by the


### PR DESCRIPTION
This fixes two issues with the recent move support (#327) in derived collections. The first is a typo or a copy-paste-fail on my part. When newPositionForItem receives a list with a single item in it there's nowhere that the item can move so it should return index 0 but instead returned 1.

The second part is that derived collections with a filter but no orderer may publish a move notification with the same source and destination index (ie a noop move).
