### PR TITLE
Fix for #339 - Move WPF check before Silverlight.

### DIFF
--- a/ReactiveUI/DesignModeDetector.cs
+++ b/ReactiveUI/DesignModeDetector.cs
@@ -24,22 +24,20 @@ namespace ReactiveUI
         {
             if (!isInDesignMode.HasValue)
             {
-                // Check Silverlight Design Mode
-                var type = Type.GetType("System.ComponentModel.DesignerProperties, System.Windows, Version=2.0.5.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e", false);
-                if (type != null)
-                {
+                // Check WPF Design Mode
+                var type = Type.GetType("System.ComponentModel.DesignerProperties, PresentationFramework, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35", false);
+                if (type != null) {
                     MethodInfo mInfo = type.GetMethod("GetIsInDesignMode");
-                    Type dependencyObject = Type.GetType("System.Windows.Controls.Border, System.Windows, Version=2.0.5.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e", false);
-                    if (dependencyObject != null)
-                    {
+	                Type dependencyObject = Type.GetType("System.Windows.DependencyObject, WindowsBase, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35", false); 
+                    if (dependencyObject != null) {
                         isInDesignMode = (bool)mInfo.Invoke(null, new object[] { Activator.CreateInstance(dependencyObject) });
                     }
-                } else if((type = Type.GetType("System.ComponentModel.DesignerProperties, PresentationFramework, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35", false)) != null) {
-                    // loaded the assembly, could be .net 
+
+                } else if((type = Type.GetType("System.ComponentModel.DesignerProperties, System.Windows, Version=2.0.5.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e", false)) != null) {
+                    // Check Silverlight Design Mode
                     MethodInfo mInfo = type.GetMethod("GetIsInDesignMode");
-                    Type dependencyObject = Type.GetType("System.Windows.DependencyObject, WindowsBase, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35", false);
-                    if (dependencyObject != null)
-                    {
+                    Type dependencyObject = Type.GetType("System.Windows.Controls.Border, System.Windows, Version=2.0.5.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e", false);
+                    if (dependencyObject != null) {
                         isInDesignMode = (bool)mInfo.Invoke(null, new object[] { Activator.CreateInstance(dependencyObject) });
                     }
                 } else if ((type = Type.GetType("Windows.ApplicationModel.DesignMode, Windows, ContentType=WindowsRuntime", false)) != null) {


### PR DESCRIPTION
If the Silverlight (Windows Phone in this case really) check happens before the WPF one, the WPF designer can not load any control that checks design mode because an exception is thrown.

I've uploaded a [Test Project](https://github.com/ChrisWay/RxTest), to show that it works in WPF, Phone and RT projects.
