### PR TITLE
ReactiveCommand can set initial CanExecute state

### DIFF
--- a/ReactiveUI.Tests/ReactiveCommandTest.cs
+++ b/ReactiveUI.Tests/ReactiveCommandTest.cs
@@ -21,6 +21,18 @@ namespace ReactiveUI.Tests
         }
 
         [Fact]
+        public void CommandInitialConditionShouldBeAdjustable()
+        {
+            var sub = new Subject<bool>();
+            var cmd = new ReactiveCommand(sub);
+            Assert.Equal(true, cmd.CanExecute(null));
+
+            var cmd2 = new ReactiveCommand(sub, false);
+            Assert.Equal(false, cmd2.CanExecute(null));
+
+        }
+
+        [Fact]
         public void CompletelyDefaultReactiveCommandShouldFire()
         {
             var sched = new TestScheduler();

--- a/ReactiveUI/ReactiveCommand.cs
+++ b/ReactiveUI/ReactiveCommand.cs
@@ -28,9 +28,9 @@ namespace ReactiveUI
         readonly IScheduler defaultScheduler;
 
         public ReactiveCommand() : this(null, false, null) { }
-        public ReactiveCommand(IObservable<bool> canExecute) : this(canExecute, false, null) { }
+        public ReactiveCommand(IObservable<bool> canExecute, bool initialCondition = true) : this(canExecute, false, null, initialCondition) { }
 
-        public ReactiveCommand(IObservable<bool> canExecute, bool allowsConcurrentExecution, IScheduler scheduler)
+        public ReactiveCommand(IObservable<bool> canExecute, bool allowsConcurrentExecution, IScheduler scheduler, bool initialCondition = true)
         {
             canExecute = canExecute ?? Observable.Return(true);
             defaultScheduler = scheduler ?? RxApp.MainThreadScheduler;
@@ -54,7 +54,7 @@ namespace ReactiveUI
             var canExecuteAndNotBusy = Observable.CombineLatest(canExecute, isBusy, (ce, b) => ce && !b);
 
             var canExecuteObs = canExecuteAndNotBusy
-                .Publish(true)
+                .Publish(initialCondition)
                 .RefCount();
 
             CanExecuteObservable = canExecuteObs


### PR DESCRIPTION
ReactiveCommand's should be able to set the initial CanExecute state.  The currently version sets the state to true until your canExecute observable tells it otherwise.  It is of course possible to forced the state to false before binding it to anything, but this removes that necessity. This is identical to a pull request that was merged into the old ReactiveCommand and ReactiveAsyncCommand back in version 4.6.2 I think.

The basic issue is that when it defaults to true, and the observable that we pull the state from doesn't immediately tell it different, the command, and hence the button bound to it, will report that it is executable.  Once something in the GUI such as a load completes then the canExecute observable will announce false and disable the button, but the result is often a flickering button at start up.  
