### PR TITLE
Make this.OneWayBind(x => x, ...) bindings work (#331).

### DIFF
--- a/ReactiveUI/PropertyBinding.cs
+++ b/ReactiveUI/PropertyBinding.cs
@@ -656,7 +656,7 @@ namespace ReactiveUI
             }
 
             var somethingChanged = Observable.Merge(
-                Reflection.ViewModelWhenAnyValue(viewModel, view, vmProperty).Select(_ => true),
+                Reflection.ViewModelWhenAnyValueDynamic(viewModel, view, vmPropChain).Select(_ => true),
                 signalInitialUpdate.Select(_ => true),
                 signalViewUpdate != null ? 
                     signalViewUpdate.Select(_ => false) : 
@@ -777,7 +777,6 @@ namespace ReactiveUI
         {
             var vmPropChain = Reflection.ExpressionToPropertyNames(vmProperty);
             var viewPropChain = default(string[]);
-            var vmString = String.Format("{0}.{1}", typeof (TViewModel).Name, String.Join(".", vmPropChain));
             var source = default(IObservable<TVProp>);
             var fallbackWrapper = default(Func<TVProp>);
 
@@ -794,7 +793,7 @@ namespace ReactiveUI
                 var ret = evalBindingHooks(viewModel, view, vmPropChain, viewPropChain, BindingDirection.OneWay);
                 if (!ret) return null;
 
-                source = Reflection.ViewModelWhenAnyValue(viewModel, view, vmProperty)
+                source = Reflection.ViewModelWhenAnyValueDynamic(viewModel, view, vmPropChain)
                     .SelectMany(x => {
                         object tmp;
                         if (!converter.TryConvert(x, viewType, conversionHint, out tmp)) return Observable.Empty<TVProp>();
@@ -817,7 +816,7 @@ namespace ReactiveUI
                 var ret = evalBindingHooks(viewModel, view, vmPropChain, viewPropChain, BindingDirection.OneWay);
                 if (!ret) return null;
 
-                source = Reflection.ViewModelWhenAnyValue(viewModel, view, vmProperty)
+                source = Reflection.ViewModelWhenAnyValueDynamic(viewModel, view, vmPropChain)
                     .SelectMany(x => {
                         object tmp;
                         if (!converter.TryConvert(x, typeof(TVProp), conversionHint, out tmp)) return Observable.Empty<TVProp>();
@@ -894,13 +893,13 @@ namespace ReactiveUI
                 var ret = evalBindingHooks(viewModel, view, vmPropChain, viewPropChain, BindingDirection.OneWay);
                 if (!ret) return null;
 
-                source = Reflection.ViewModelWhenAnyValue(viewModel, view, vmProperty).Select(selector);
+                source = Reflection.ViewModelWhenAnyValueDynamic(viewModel, view, vmPropChain).Select(x => (TProp)x).Select(selector);
             } else {
                 viewPropChain = Reflection.ExpressionToPropertyNames(viewProperty);
                 var ret = evalBindingHooks(viewModel, view, vmPropChain, viewPropChain, BindingDirection.OneWay);
                 if (!ret) return null;
 
-                source = Reflection.ViewModelWhenAnyValue(viewModel, view, vmProperty).Select(selector);
+                source = Reflection.ViewModelWhenAnyValueDynamic(viewModel, view, vmPropChain).Select(x => (TProp)x).Select(selector);
             }
 
             IDisposable disp = bindToDirect(source, view, viewProperty, fallbackValue);

--- a/ReactiveUI/ReactiveList.cs
+++ b/ReactiveUI/ReactiveList.cs
@@ -162,7 +162,6 @@ namespace ReactiveUI
             if (ChangeTrackingEnabled) removeItemFromPropertyTracking(item);
         }
 
-#if !SILVERLIGHT
         protected void MoveItem(int oldIndex, int newIndex)
         {
             var item = _inner[oldIndex];
@@ -186,7 +185,7 @@ namespace ReactiveUI
             _changed.OnNext(ea);
             if (_itemsMoved.IsValueCreated) _itemsMoved.Value.OnNext(mi);
         }
-#endif
+
         protected void SetItem(int index, T item)
         {
             if (_suppressionRefCount > 0) {

--- a/ReactiveUI/Reflection.cs
+++ b/ReactiveUI/Reflection.cs
@@ -285,7 +285,16 @@ namespace ReactiveUI
         {
             return view.WhenAny(x => x.ViewModel, x => x.Value)
                 .Where(x => x != null)
-                .SelectMany(x => ((TViewModel)x).WhenAny(property, y => y.Value));
+                .SelectMany(x => Reflection.ExpressionToPropertyNames(property).Length == 0 ? Observable.Return((TProp)x) : ((TViewModel)x).WhenAny(property, y => y.Value));
+        }
+
+        internal static IObservable<object> ViewModelWhenAnyValueDynamic<TView, TViewModel>(TViewModel viewModel, TView view, string[] property)
+            where TView : IViewFor
+            where TViewModel : class
+        {
+            return view.WhenAny(x => x.ViewModel, x => x.Value)
+                .Where(x => x != null)
+                .SelectMany(x => property.Length == 0 ? Observable.Return(x) : ((TViewModel)x).WhenAnyDynamic(property, y => y.Value));
         }
 
         internal static FieldInfo GetSafeField(Type type, string propertyName, BindingFlags flags)


### PR DESCRIPTION
Add ViewModelWhenAnyValueDynamic to save a call to Reflection.ExpressionToPropertyNames().

Make this.OneWayBind(x => x, ...) bindings work, fixes #331.

Remove unused directive for Silverlight.
