### PR TITLE
NLog should use full type name for logger name

### DIFF
--- a/ReactiveUI.NLog/Registrations.cs
+++ b/ReactiveUI.NLog/Registrations.cs
@@ -11,7 +11,7 @@ namespace ReactiveUI.NLog
     {
         public IFullLogger GetLogger(Type type)
         {
-            return new NLogLogger(global::NLog.LogManager.GetLogger(type.Name));
+            return new NLogLogger(global::NLog.LogManager.GetLogger(type.FullName));
         }
     }
 


### PR DESCRIPTION
When using the nlog logging component, things are logged with just the class name, such as ReactiveObject, CachingMRU, etc.  This makes it hard to create  nlog rules to redirect all the ReactiveUI messages somewhere as they have no common prefix.  Using fullname in the nlog GetLogger() call will change this behavior such that the logger will be called ReactiveUI.ReactiveObject, etc, making it possible to filter on ReactiveUI.\* or similar
