### PR TITLE
Set content to default if unable to resolve view with view locator

### DIFF
--- a/ReactiveUI.Platforms/Xaml/RoutedViewHost.cs
+++ b/ReactiveUI.Platforms/Xaml/RoutedViewHost.cs
@@ -92,8 +92,7 @@ namespace ReactiveUI.Xaml
                 var view = viewLocator.ResolveView(x.Item1, x.Item2) ?? viewLocator.ResolveView(x.Item1, null);
 
                 if (view == null) {
-                    Content = DefaultContent;
-                    return;
+                    throw new Exception(string.Format("Couldn't find view for '{0}'.", x.Item1));
                 }
 
                 view.ViewModel = x.Item1;


### PR DESCRIPTION
Handle case where ViewLocator is configured incorrectly, and returns a null view.
If view is null, content is set to default content.

related to https://github.com/reactiveui/ReactiveUI/issues/357
