### PR TITLE
Correct XML namespace for AutoDataTemplateBindingHook

### DIFF
--- a/ReactiveUI.Platforms/Xaml/AutoDataTemplateBindingHook.cs
+++ b/ReactiveUI.Platforms/Xaml/AutoDataTemplateBindingHook.cs
@@ -25,14 +25,14 @@ namespace ReactiveUI.Xaml
     {
         public static Lazy<DataTemplate> DefaultItemTemplate = new Lazy<DataTemplate>(() => {
 #if WINRT
-            const string template = "<DataTemplate xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation' xmlns:routing='using:ReactiveUI.Routing'>" +
-                "<routing:ViewModelViewHost ViewModel=\"{Binding}\" VerticalContentAlignment=\"Stretch\" HorizontalContentAlignment=\"Stretch\" IsTabStop=\"False\" />" +
+            const string template = "<DataTemplate xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation' xmlns:xaml='using:ReactiveUI.Xaml'>" +
+                "<xaml:ViewModelViewHost ViewModel=\"{Binding}\" VerticalContentAlignment=\"Stretch\" HorizontalContentAlignment=\"Stretch\" IsTabStop=\"False\" />" +
             "</DataTemplate>";
             var assemblyName = "";
 #else
             const string template = "<DataTemplate xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation' " +
-                    "xmlns:routing='clr-namespace:ReactiveUI.Routing;assembly=__ASSEMBLYNAME__'> " +
-                "<routing:ViewModelViewHost ViewModel=\"{Binding}\" VerticalContentAlignment=\"Stretch\" HorizontalContentAlignment=\"Stretch\" IsTabStop=\"False\" />" +
+                    "xmlns:xaml='clr-namespace:ReactiveUI.Xaml;assembly=__ASSEMBLYNAME__'> " +
+                "<xaml:ViewModelViewHost ViewModel=\"{Binding}\" VerticalContentAlignment=\"Stretch\" HorizontalContentAlignment=\"Stretch\" IsTabStop=\"False\" />" +
             "</DataTemplate>";
             var assemblyName = typeof(AutoDataTemplateBindingHook).Assembly.FullName;
             assemblyName = assemblyName.Substring(0, assemblyName.IndexOf(','));


### PR DESCRIPTION
It looks like the automatic DataTemplate creation wasn't updated from RxUI 4 so it was pointing to the ReactiveUI.Routing namespace where as it is now in ReactiveUI.Xaml.

This pull request just points it to the correct namespace.
