### PR TITLE
Fix for GetService() implementation of FuncDependencyResolver

### DIFF
--- a/ReactiveUI/IDependencyResolver.cs
+++ b/ReactiveUI/IDependencyResolver.cs
@@ -137,7 +137,7 @@ namespace ReactiveUI
 
         public object GetService(Type serviceType, string contract = null)
         {
-            return (GetServices(serviceType, contract) ?? Enumerable.Empty<object>()).FirstOrDefault();
+            return (GetServices(serviceType, contract) ?? Enumerable.Empty<object>()).LastOrDefault();
         }
 
         public IEnumerable<object> GetServices(Type serviceType, string contract = null)


### PR DESCRIPTION
I use FuncDependencyResolver with my 3rd party IoC and I'm unable to overwrite default registration of DebugLogger with my ILogger implementation, this PR fixes it
