### PR TITLE
Observable for single property, which doesn't query the value if ...

### DIFF
--- a/ReactiveUI/ReactiveNotifyPropertyChangedMixin.cs
+++ b/ReactiveUI/ReactiveNotifyPropertyChangedMixin.cs
@@ -61,7 +61,40 @@ namespace ReactiveUI
                 skipInitial);
         }
 
-        /// <summary>
+		/// <summary>
+		/// ObservableForProperty returns an Observable representing the
+		/// property change notifications for a specific property on a
+		/// ReactiveObject. This method (unlike other Observables that return
+		/// IObservedChange) guarantees that the Value property of
+		/// the IObservedChange is set.
+		/// </summary>
+		/// <param name="propertyName">A string containing the property name</param>
+		/// <param name="beforeChange">If True, the Observable will notify
+		/// immediately before a property is going to change.</param>
+		/// <returns>An Observable representing the property change
+		/// notifications for the given property.</returns>
+		public static IObservable<IObservedChange<TSender, TValue>> ObservableForProperty<TSender, TValue>(
+		    this TSender This,
+		    string propertyName,
+		    bool beforeChange = false,
+		    bool skipInitial = true)
+	    {
+			var values = notifyForProperty(This, propertyName, beforeChange);
+		    if (!skipInitial) {
+				values = values.StartWith(new ObservedChange<object, object> { Sender = This, PropertyName = propertyName });
+		    }
+
+			return values.Select(x => x.fillInValue())
+						 .Distinct(x => x.Value)
+						 .Select(x => (IObservedChange<TSender, TValue>)new ObservedChange<TSender, TValue>
+						  {
+							  Sender = This,
+							  PropertyName = propertyName,
+							  Value = (TValue)x.Value
+						  });
+	    }
+
+	    /// <summary>
         /// ObservableForPropertyDynamic returns an Observable representing the
         /// property change notifications for a specific property on a
         /// ReactiveObject. This method (unlike other Observables that return


### PR DESCRIPTION
...skipInitial is true

As described in the SO question http://stackoverflow.com/q/19958446/59371 F# doesn't like re-entrant calls from the constructor, so the ability to observe changes without first reading the property would be very helpful.

This change adds an overload which takes a single string which is the property name, and be made nicer via an F# extension method below, which has the syntax
`this.ObservableForProperty(<@ this.Source @>)`

```
module ReactiveUIExtensions

open System
open System.Linq
open ReactiveUI
open Microsoft.FSharp.Quotations
open Microsoft.FSharp.Quotations.Patterns

let toPropName(query : Expr) = 
    match query with
        | PropertyGet(a, b, list) -> b.Name
        | _ -> ""

type ReactiveUI.ReactiveObject with
    member this.ObservableForProperty (expr : Expr<'t>, ?beforeChange, ?skipInitial) =
        let propertyName = toPropName expr
        this.ObservableForProperty<_, 't>(propertyName, defaultArg beforeChange false, defaultArg skipInitial true)
```
