### PR TITLE
Added support for binding to thirdparty winforms controls

### DIFF
--- a/ReactiveUI.Platforms/Winforms/WinformsCreatesObservableForProperty.cs
+++ b/ReactiveUI.Platforms/Winforms/WinformsCreatesObservableForProperty.cs
@@ -1,14 +1,14 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
+using System.Windows.Forms;
 
 namespace ReactiveUI.Winforms
 {
+  
+
     public class WinformsCreatesObservableForProperty : ICreatesObservableForProperty
     {
         static readonly MemoizingMRUCache<Tuple<Type, string>, EventInfo> eventInfoCache = new MemoizingMRUCache<Tuple<Type, string>, EventInfo>((pair, _) => {
@@ -18,7 +18,8 @@ namespace ReactiveUI.Winforms
 
         public int GetAffinityForObject(Type type, string propertyName, bool beforeChanged = false)
         {
-            if (!type.FullName.ToLowerInvariant().StartsWith("system.windows.forms")) return 0;
+            bool supportsTypeBinding = typeof(Control).IsAssignableFrom(type);
+            if (!supportsTypeBinding) return 0;
 
             lock (eventInfoCache) {
                 var ei = eventInfoCache.Get(Tuple.Create(type, propertyName));


### PR DESCRIPTION
Modified `GetAffinityForObject` to look at System.Windows.Forms.Control inheritors instead of namespace checking.
This way ReactiveUI supports 3rd party control libraries by default (if they adhere to common winforms patterns)
