### PR TITLE
Fix bug in Fsharp-friendly ObservableForProperty

### DIFF
--- a/ReactiveUI.Tests/ReactiveNotifyPropertyChangedMixinTest.cs
+++ b/ReactiveUI.Tests/ReactiveNotifyPropertyChangedMixinTest.cs
@@ -553,6 +553,35 @@ namespace ReactiveUI.Tests
                 changes.Select(x => x.Value).AssertAreEqual(new[] { "Pre", "Foo" });
             });
         }
+
+        [Fact]
+        public void OFPNamedPropertyTestRepeats()
+        {
+            (new TestScheduler()).With(sched => {
+                var fixture = new TestFixture();
+                var changes = fixture.ObservableForProperty<TestFixture, string>("IsOnlyOneWord").CreateCollection();
+
+                fixture.IsOnlyOneWord = "Foo";
+                sched.Start();
+                Assert.Equal(1, changes.Count);
+
+                fixture.IsOnlyOneWord = "Bar";
+                sched.Start();
+                Assert.Equal(2, changes.Count);
+
+                fixture.IsOnlyOneWord = "Bar";
+                sched.Start();
+                Assert.Equal(2, changes.Count);
+
+                fixture.IsOnlyOneWord = "Foo";
+                sched.Start();
+                Assert.Equal(3, changes.Count);
+
+                Assert.True(changes.All(x => x.Sender == fixture));
+                Assert.True(changes.All(x => x.PropertyName == "IsOnlyOneWord"));
+                changes.Select(x => x.Value).AssertAreEqual(new[] { "Foo", "Bar", "Foo" });
+            });
+        }
     }
 
     public class WhenAnyObservableTests

--- a/ReactiveUI/ReactiveNotifyPropertyChangedMixin.cs
+++ b/ReactiveUI/ReactiveNotifyPropertyChangedMixin.cs
@@ -86,7 +86,7 @@ namespace ReactiveUI
             }
 
             return values.Select(x => x.fillInValue())
-                 .Distinct(x => x.Value)
+                 .DistinctUntilChanged(x => x.Value)
                  .Select(x => (IObservedChange<TSender,TValue>) new ObservedChange<TSender, TValue> {
                       Sender = This,
                       PropertyName = propertyName,


### PR DESCRIPTION
Fix a dumb bug in the code I submitted for the F# friendly overload for ObservableForProperty.
Would only notify previously unseen property values, due to the use of Distinct instead of DistinctUntilChanged. 
