### PR TITLE
Don't reference MS-Rx in Mono projects.

### DIFF
--- a/NuGet/ReactiveUI-Core/ReactiveUI-Core.nuspec
+++ b/NuGet/ReactiveUI-Core/ReactiveUI-Core.nuspec
@@ -11,11 +11,11 @@
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
 
 		<dependencies>
-			<group>
+			<group targetFramework="Portable-Net45+WinRT45+WP8">
 				<dependency id="Rx-Main" version="2.1.30214.0" />
 			</group>
 			<group targetFramework="winrt45">
-				<dependency id="Rx-WindowStoreApps" version="2.1.30214.0" />
+				<dependency id="Rx-WindowStoreApps" version="2.1.30214.0" />				
 			</group>
 		</dependencies>
 	</metadata>

--- a/NuGet/ReactiveUI-Events/ReactiveUI-Events.nuspec
+++ b/NuGet/ReactiveUI-Events/ReactiveUI-Events.nuspec
@@ -11,12 +11,15 @@
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
 
         <dependencies>
-            <group>
-                <dependency id="Rx-Main" version="2.1.30214.0" />
-            </group>
-            <group targetFramework="winrt45">
-                <dependency id="Rx-WindowStoreApps" version="2.1.30214.0" />
-            </group>
+          <group targetFramework="net45">
+            <dependency id="Rx-Main" version="2.1.30214.0" />
+          </group>
+          <group targetFramework="wp8">
+            <dependency id="Rx-Main" version="2.1.30214.0" />
+          </group>
+          <group targetFramework="winrt45">
+            <dependency id="Rx-WindowStoreApps" version="2.1.30214.0" />				
+          </group>
         </dependencies>
     </metadata>
 </package>

--- a/NuGet/ReactiveUI-Platforms/ReactiveUI-Platforms.nuspec
+++ b/NuGet/ReactiveUI-Platforms/ReactiveUI-Platforms.nuspec
@@ -11,8 +11,27 @@
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
 
 		<dependencies>
-			<dependency id="reactiveui-core" version="[5.3.0]" />
-			<dependency id="Rx-Xaml" version="2.1.30214.0" />
+		    <group targetFramework="Monoandroid">
+          <dependency id="reactiveui-core" version="[5.3.0]" />
+		    </group>  
+		    <group targetFramework="Monomac">
+          <dependency id="reactiveui-core" version="[5.3.0]" />
+		    </group>  
+		    <group targetFramework="Monotouch">
+          <dependency id="reactiveui-core" version="[5.3.0]" />
+		    </group>  
+        <group targetFramework="net45">
+            <dependency id="reactiveui-core" version="[5.3.0]" />
+            <dependency id="Rx-Xaml" version="2.1.30214.0" />
+          </group>
+          <group targetFramework="wp8">
+            <dependency id="reactiveui-core" version="[5.3.0]" />
+            <dependency id="Rx-Xaml" version="2.1.30214.0" />
+          </group>
+          <group targetFramework="winrt45">
+            <dependency id="reactiveui-core" version="[5.3.0]" />            
+            <dependency id="Rx-Xaml" version="2.1.30214.0" />
+          </group>
 		</dependencies>
 	</metadata>
 </package>

--- a/NuGet/ReactiveUI-Testing/ReactiveUI-Testing.nuspec
+++ b/NuGet/ReactiveUI-Testing/ReactiveUI-Testing.nuspec
@@ -10,9 +10,21 @@
 		<language>en-us</language>
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
 
-		<dependencies>
-			<dependency id="reactiveui-core" version="[5.3.0]" />
-			<dependency id="Rx-Testing" version="2.1.30214.0" />
+		<dependencies>			
+			<group targetFramework="net45">
+				<dependency id="reactiveui-core" version="[5.3.0]" />
+        <dependency id="Rx-Testing" version="2.1.30214.0" />
+			</group>
+			<group targetFramework="WP8">
+				<dependency id="reactiveui-core" version="[5.3.0]" />
+        <dependency id="Rx-Testing" version="2.1.30214.0" />
+			</group>
+			<group targetFramework="monoandroid">
+				<dependency id="reactiveui-core" version="[5.3.0]" />        
+			</group>
+			<group targetFramework="monotouch">
+				<dependency id="reactiveui-core" version="[5.3.0]" />        
+			</group>
 		</dependencies>
 	</metadata>
 </package>


### PR DESCRIPTION
This should fix-up the NuGet's until Rx has Xamarin support. The Mono projects will need to use the Xamarin component store to pull in Xamarin's Rx.

This does nothing to solve the PCL incompat, but allows NuGet to add RxUI to a Xamarin.iOS/Android project w/o pulling in the wrong Rx references.
