### PR TITLE
Avoid breaking bindings when deserializing ReactiveObjects

### DIFF
--- a/ReactiveUI/ReactiveObject.cs
+++ b/ReactiveUI/ReactiveObject.cs
@@ -74,11 +74,12 @@ namespace ReactiveUI
 
         void setupRxObj()
         {
-            changingSubject = new Subject<IObservedChange<object, object>>();
-            changedSubject = new Subject<IObservedChange<object, object>>();
+            changingSubject = changingSubject ?? new Subject<IObservedChange<object, object>>();
+            changedSubject  = changedSubject  ?? new Subject<IObservedChange<object, object>>();
 
-            allPublicProperties = new Lazy<PropertyInfo[]>(() =>
-                GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance).ToArray());
+            allPublicProperties = allPublicProperties ??
+                new Lazy<PropertyInfo[]>(() =>
+                    GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance).ToArray());
         }
 
         /// <summary>


### PR DESCRIPTION
Since changingSubject and changedSubject were being overwritten, if
you had any binding on the constructor it would just vanish into thin
air whenever your subclass of ReactiveObject was deserialized.

An workaround would be to setup all your bindings on a [OnDeserialized]
method, however that is subpar when your deserializer supports running
constructors since it will lead to harder to read code and will spend
time creating the bindings twice (which is not cheap!).

This commit will avoid recreating these attributes while still supporting
deserializers that do not call constructors.

See also: https://github.com/reactiveui/ReactiveUI/commit/980107f55cadac02e14e10bb1c94d9b6dc5f05b5#commitcomment-4697090
