### PR TITLE
fix absolute urls to github pages

### DIFF
--- a/docs/basics/reactive-object.md
+++ b/docs/basics/reactive-object.md
@@ -38,8 +38,8 @@ Because ViewModels do not explicitly reference UI frameworks or controls, this
 means that ViewModels can often be *reused across platforms*. This is a very
 powerful pattern that can drastically reduce the time required to port to a
 new platform, especially in conjunction with portable libraries designed to
-help in this task, such as [Splat](github.com/paulcbetts/splat) and
-[Akavache](github.com/akavache/Akavache). The majority of your application's
+help in this task, such as [Splat](http://github.com/paulcbetts/splat) and
+[Akavache](http://github.com/akavache/Akavache). The majority of your application's
 interesting code (models / network handling / caching / image loading /
 viewmodels) can be used on all platforms, and only the View-related classes
 need to be rewritten.


### PR DESCRIPTION
currently looks for Splat/Akavache at https://github.com/reactiveui/ReactiveUI/blob/docs/docs/basics/github.com/paulcbetts/splat when browsing the markup on github, specified http:// scheme to fix
