### PR TITLE
Remove the IList from IReactiveList<T>

### DIFF
--- a/ReactiveUI.Tests/ReactiveCollectionTest.cs
+++ b/ReactiveUI.Tests/ReactiveCollectionTest.cs
@@ -19,6 +19,26 @@ namespace ReactiveUI.Tests
     public class ReactiveCollectionTest
     {
         [Fact]
+        public void CountPropertyIsNotAmbiguous()
+        {
+            IReactiveList<int> reactiveList = new ReactiveList<int>();
+            Assert.Equal(0, reactiveList.Count);
+            IList<int> list = reactiveList;
+            Assert.Equal(0, list.Count);
+
+            ICollection collection = new ReactiveList<int>();
+            var l = (IList) collection;
+            Assert.Same(collection, l);
+        }
+
+        [Fact]
+        public void IndexerIsNotAmbiguous()
+        {
+            IReactiveList<int> reactiveList = new ReactiveList<int> { 0, 1 };
+            Assert.Equal(0, reactiveList[0]);
+        }
+
+        [Fact]
         public void CollectionCountChangedTest()
         {
             var fixture = new ReactiveList<int>();

--- a/ReactiveUI/Interfaces.cs
+++ b/ReactiveUI/Interfaces.cs
@@ -166,7 +166,7 @@ namespace ReactiveUI
     /// IReactiveNotifyPropertyChanged semantically as "Fire when *anything* in
     /// the collection or any of its items have changed, in any way".
     /// </summary>
-    public interface IReactiveCollection : IReactiveNotifyCollectionChanged, IReactiveNotifyCollectionItemChanged, ICollection, INotifyPropertyChanging, INotifyPropertyChanged, IEnableLogger
+    public interface IReactiveCollection : IReactiveNotifyCollectionChanged, IReactiveNotifyCollectionItemChanged, INotifyPropertyChanging, INotifyPropertyChanged, IEnableLogger, IEnumerable
     {
     }
 
@@ -362,7 +362,7 @@ namespace ReactiveUI
     /// IReactiveNotifyPropertyChanged semantically as "Fire when *anything* in
     /// the collection or any of its items have changed, in any way".
     /// </summary>
-    public interface IReactiveList<T> : IReactiveCollection<T>, IList<T>, IList
+    public interface IReactiveList<T> : IReactiveCollection<T>, IList<T>
     {
     }
 

--- a/ReactiveUI/ReactiveList.cs
+++ b/ReactiveUI/ReactiveList.cs
@@ -20,7 +20,7 @@ namespace ReactiveUI
 {
     [DebuggerDisplay("Count = {Count}")]
     [DebuggerTypeProxy(typeof(CollectionDebugView<>))]
-    public class ReactiveList<T> : IReactiveList<T>, IReadOnlyReactiveList<T>
+    public class ReactiveList<T> : IReactiveList<T>, IReadOnlyReactiveList<T>, IList<T>, IList
     {
         public event NotifyCollectionChangedEventHandler CollectionChanging;
         public event NotifyCollectionChangedEventHandler CollectionChanged;


### PR DESCRIPTION
This should not have been on the generic interface. It only belongs to
the generic implementation.

Fixes #427
