### PR TITLE
Avoid implicit uses of RxApp.MainThreadScheduler

### DIFF
--- a/ReactiveUI/Legacy/ReactiveCommand.cs
+++ b/ReactiveUI/Legacy/ReactiveCommand.cs
@@ -27,12 +27,12 @@ namespace ReactiveUI.Legacy
         /// ObservableFromProperty, that defines when the Command can
         /// execute.</param>
         /// <param name="scheduler">The scheduler to publish events on - default
-        /// is RxApp.MainThreadScheduler.</param>
+        /// is Scheduler.Immediate.</param>
         /// <param name="initialCondition">Initial CanExecute state</param>
         public ReactiveCommand(IObservable<bool> canExecute = null, IScheduler scheduler = null, bool initialCondition = true)
         {
             canExecute = canExecute ?? Observable.Return(true).Concat(Observable.Never<bool>());
-            canExecute = canExecute.ObserveOn(scheduler ?? RxApp.MainThreadScheduler);
+            canExecute = canExecute.ObserveOn(scheduler ?? Scheduler.Immediate);
             commonCtor(scheduler, initialCondition);
 
             _inner = canExecute.Subscribe(
@@ -69,7 +69,7 @@ namespace ReactiveUI.Legacy
         /// <param name="executed">A method that will be invoked when the
         /// Execute method is invoked.</param>
         /// <param name="scheduler">The scheduler to publish events on - default
-        /// is RxApp.MainThreadScheduler.</param>
+        /// is Scheduler.Immediate.</param>
         /// <returns>A new ReactiveCommand object.</returns>
         public static ReactiveCommand Create(
             Func<object, bool> canExecute, 
@@ -93,7 +93,7 @@ namespace ReactiveUI.Legacy
         /// <param name="executed">A method that will be invoked when the
         /// Execute method is invoked.</param>
         /// <param name="scheduler">The scheduler to publish events on - default
-        /// is RxApp.MainThreadScheduler.</param>
+        /// is Scheduler.Immediate.</param>
         /// <returns>A new ReactiveCommand object.</returns>
         public static ReactiveCommand Create(
             Func<object, Task<bool>> canExecute, 

--- a/ReactiveUI/MessageBus.cs
+++ b/ReactiveUI/MessageBus.cs
@@ -169,7 +169,7 @@ namespace ReactiveUI
         {
             IScheduler scheduler;
             schedulerMappings.TryGetValue(tuple, out scheduler);
-            return scheduler ?? RxApp.MainThreadScheduler;
+            return scheduler ?? Scheduler.Immediate;
         }
     }
 

--- a/ReactiveUI/ObservableAsPropertyHelper.cs
+++ b/ReactiveUI/ObservableAsPropertyHelper.cs
@@ -46,7 +46,7 @@ namespace ReactiveUI
             Contract.Requires(observable != null);
             Contract.Requires(onChanged != null);
 
-            scheduler = scheduler ?? RxApp.MainThreadScheduler;
+            scheduler = scheduler ?? Scheduler.Immediate;
             _lastValue = initialValue;
 
             var subj = new ScheduledSubject<T>(scheduler);

--- a/ReactiveUI/POCOObservableForProperty.cs
+++ b/ReactiveUI/POCOObservableForProperty.cs
@@ -29,7 +29,7 @@ namespace ReactiveUI
 
             return Observable.Return((IObservedChange<object, object>) new ObservedChange<object, object>() {
                 Sender = sender, PropertyName = propertyName
-            }, RxApp.MainThreadScheduler)
+            })
                 .Concat(Observable.Never<IObservedChange<object, object>>());
         }
     }

--- a/ReactiveUI/ReactiveCollectionMixins.cs
+++ b/ReactiveUI/ReactiveCollectionMixins.cs
@@ -763,9 +763,7 @@ namespace ReactiveUI
             inner.Disposable = disconnect;
 
             // When new items come in from the observable, stuff them in the queue.
-            // Using the MainThreadScheduler guarantees we'll always access the queue
-            // from the same thread.
-            observable.ObserveOn(RxApp.MainThreadScheduler).Subscribe(queue.Enqueue, onError);
+            observable.Subscribe(queue.Enqueue, onError);
 
             // This is a bit clever - keep a running count of the items actually 
             // added and compare them to the final count of items provided by the

--- a/ReactiveUI/ReactiveCommand.cs
+++ b/ReactiveUI/ReactiveCommand.cs
@@ -34,7 +34,7 @@ namespace ReactiveUI
         public ReactiveCommand(IObservable<bool> canExecute, bool allowsConcurrentExecution, IScheduler scheduler, bool initialCondition = true)
         {
             canExecute = canExecute ?? Observable.Return(true);
-            defaultScheduler = scheduler ?? RxApp.MainThreadScheduler;
+            defaultScheduler = scheduler ?? Scheduler.Immediate;
             AllowsConcurrentExecution = allowsConcurrentExecution;
 
             canExecute = canExecute.Catch<bool, Exception>(ex => {
@@ -212,7 +212,7 @@ namespace ReactiveUI
         /// ReactiveCommand based on an existing Observable chain.
         /// </summary>
         /// <param name="scheduler">The scheduler to publish events on - default
-        /// is RxApp.MainThreadScheduler.</param>
+        /// is Scheduler.Immediate.</param>
         /// <returns>A new ReactiveCommand whose CanExecute Observable is the
         /// current object.</returns>
         public static ReactiveCommand ToCommand(this IObservable<bool> This, bool allowsConcurrentExecution = false, IScheduler scheduler = null)
@@ -230,7 +230,7 @@ namespace ReactiveUI
         /// from the command.</returns>
         public static IDisposable InvokeCommand<T>(this IObservable<T> This, ICommand command)
         {
-            return This.ObserveOn(RxApp.MainThreadScheduler).Subscribe(x => {
+            return This.Subscribe(x => {
                 if (!command.CanExecute(x)) {
                     return;
                 }
@@ -250,7 +250,6 @@ namespace ReactiveUI
         public static IDisposable InvokeCommand<T, TTarget>(this IObservable<T> This, TTarget target, Expression<Func<TTarget, ICommand>> commandProperty)
         {
             return This.CombineLatest(target.WhenAnyValue(commandProperty), (val, cmd) => new { val, cmd })
-                .ObserveOn(RxApp.MainThreadScheduler)
                 .Subscribe(x => {
                     if (!x.cmd.CanExecute(x.val)) {
                         return;

--- a/ReactiveUI/RegisterableInterfaces.cs
+++ b/ReactiveUI/RegisterableInterfaces.cs
@@ -38,7 +38,7 @@ namespace ReactiveUI
         /// <typeparam name="T">The type of the message to listen to.</typeparam>
         /// <param name="scheduler">The scheduler on which to post the
         /// notifications for the specified type and contract.
-        /// RxApp.MainThreadScheduler by default.</param>
+        /// Scheduler.Immediate by default.</param>
         /// <param name="contract">A unique string to distinguish messages with
         /// identical types (i.e. "MyCoolViewModel") - if the message type is
         /// only used for one purpose, leave this as null.</param>


### PR DESCRIPTION
This pull request currently is meant to foster discussion about which are the implications of this kind of change, and whether it would be better or worse for ReactiveUI.

My first ramblings can be found at #425. 

Right now this branch works perfectly on the simulator for everything I've tried (of my code, obviously), and fails even to start the app on the device.
