### PR TITLE
WinForms command binding return higher affinity than XAML

### DIFF
--- a/ReactiveUI.Platforms/Winforms/CreatesCommandBinding.cs
+++ b/ReactiveUI.Platforms/Winforms/CreatesCommandBinding.cs
@@ -28,12 +28,12 @@ namespace ReactiveUI.Winforms
 
             if (isWinformControl) return 10;
 
-            if (hasEventTarget) return 5;
+            if (hasEventTarget) return 6;
 
             return defaultEventsToBind.Any(x =>{
                 var ei = type.GetEvent(x.Item1, BindingFlags.Public | BindingFlags.FlattenHierarchy | BindingFlags.Instance);
                 return ei != null;
-            }) ? 3 : 0;
+            }) ? 4 : 0;
         }
 
         public IDisposable BindCommandToObject(ICommand command, object target, IObservable<object> commandParameter)


### PR DESCRIPTION
There exist System.ComponentModel.Component subclasses which would be useful for binding as a command e.g. MenuItem, NotifyIcon, ToolBarButton, however others are not e.g. Timer, Process, SerialPort.

This change ensures that falling back onto hasEventTarget or defaultEventsToBind for the useful ones won't result in ReactiveUI.Platforms/Xaml/CreatesCommandBinding.cs (which returns equal affinities for these cases) attempting to handle binding instead.
