### PR TITLE
Add special sauce to prevent the MT linker from stripping out properties...

### DIFF
--- a/ReactiveUI.Platforms/Cocoa/LinkerOverrides.cs
+++ b/ReactiveUI.Platforms/Cocoa/LinkerOverrides.cs
@@ -14,7 +14,7 @@ namespace ReactiveUI.Cocoa.Cocoa
     /// This class exists to force the MT linker to include properties called by RxUI via reflection
     /// </summary>
     [Preserve]
-    class Magic
+    class LinkerOverrides
     {
 
         private void KeepMe()

--- a/ReactiveUI.Platforms/ReactiveUI.Cocoa_Monotouch.csproj
+++ b/ReactiveUI.Platforms/ReactiveUI.Cocoa_Monotouch.csproj
@@ -65,7 +65,7 @@
   <ItemGroup>
     <Compile Include="Cocoa\CocoaDefaultPropertyBinding.cs" />
     <Compile Include="Cocoa\KVOObservableForProperty.cs" />
-    <Compile Include="Cocoa\Magic.cs" />
+    <Compile Include="Cocoa\LinkerOverrides.cs" />
     <Compile Include="Cocoa\NSRunloopScheduler.cs" />
     <Compile Include="Cocoa\Properties\AssemblyInfo.cs" />
     <Compile Include="Cocoa\RoutedViewHost.cs" />


### PR DESCRIPTION
..., events and methods we use via reflection

This may not be an exhaustive list yet, but it's a good starting point.

The goal is to cover the methods and properties invoked via reflection so that the MT linker doesn't strip them out.
