### PR TITLE
Enable the Debug Logger to work

### DIFF
--- a/ReactiveUI/Logging-iOS.cs
+++ b/ReactiveUI/Logging-iOS.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#define DEBUG // enable the debug logger to work even when this lib is compiled in release mode
+
+using System;
 using System.ComponentModel;
 using System.Reactive.Linq;
 using System.Reflection;

--- a/ReactiveUI/Logging.cs
+++ b/ReactiveUI/Logging.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#define DEBUG // enable the debug logger to work even when this lib is compiled in release mode
+
+using System;
 using System.ComponentModel;
 using System.Reactive.Linq;
 using System.Reflection;


### PR DESCRIPTION
Enable the Debug Logger to work even when RxUI is compiled in release mode
