### PR TITLE
Allow multiple cell types to be specified for a given section.

### DIFF
--- a/ReactiveUI.Platforms/Cocoa/CommonReactiveSource.cs
+++ b/ReactiveUI.Platforms/Cocoa/CommonReactiveSource.cs
@@ -30,7 +30,7 @@ namespace ReactiveUI.Cocoa
     interface ISectionInformation<TUIView, TUIViewCell>
     {
         IReactiveNotifyCollectionChanged Collection { get; }
-        NSString CellKey { get; }
+        Func<object, NSString> CellKeySelector { get; }
         Action<TUIViewCell> InitializeCellAction { get; }
     }
 
@@ -167,12 +167,13 @@ namespace ReactiveUI.Cocoa
         public TUIViewCell GetCell(NSIndexPath indexPath) 
         {
             var section = SectionInfo[indexPath.Section];
-            var cell = adapter.DequeueReusableCell(section.CellKey, indexPath);
+            var vm = ((IList)section.Collection) [indexPath.Row];
+            var cell = adapter.DequeueReusableCell(section.CellKeySelector(vm), indexPath);
             var view = cell as IViewFor;
 
             if (view != null) {
                 this.Log().Debug("GetCell: Setting vm for Row: " + indexPath.Row);
-                view.ViewModel = ((IList)section.Collection) [indexPath.Row];
+                view.ViewModel = vm;
             }
 
             (section.InitializeCellAction ?? (_ => {}))(cell);

--- a/ReactiveUI.Platforms/Cocoa/ReactiveCollectionViewSource.cs
+++ b/ReactiveUI.Platforms/Cocoa/ReactiveCollectionViewSource.cs
@@ -22,20 +22,25 @@ namespace ReactiveUI.Cocoa
     {
         public IReactiveNotifyCollectionChanged Collection { get; protected set; }
         public Action<UICollectionViewCell> InitializeCellAction { get; protected set; }
-        public NSString CellKey { get; protected set; }
+        public Func<object, NSString> CellKeySelector { get; protected set; }
     }
 
     public class CollectionViewSectionInformation<TCell> : CollectionViewSectionInformation
         where TCell : UICollectionViewCell
     {
-        public CollectionViewSectionInformation(IReactiveNotifyCollectionChanged collection, NSString cellKey, Action<TCell> initializeCellAction = null)
+        public CollectionViewSectionInformation(IReactiveNotifyCollectionChanged collection, Func<object, NSString> cellKeySelector, Action<TCell> initializeCellAction = null)
         {
             Collection = collection;
-            CellKey = cellKey;
+            CellKeySelector = cellKeySelector;
 
             if (initializeCellAction != null) {
                 InitializeCellAction = cell => initializeCellAction((TCell)cell);
             }
+        }
+
+        public CollectionViewSectionInformation(IReactiveNotifyCollectionChanged collection, NSString cellKey, Action<TCell> initializeCellAction = null)
+            : this(collection, _ => cellKey, initializeCellAction)
+        {
         }
     }
 

--- a/ReactiveUI.Platforms/Cocoa/ReactiveTableViewSource.cs
+++ b/ReactiveUI.Platforms/Cocoa/ReactiveTableViewSource.cs
@@ -22,7 +22,7 @@ namespace ReactiveUI.Cocoa
     {
         public IReactiveNotifyCollectionChanged Collection { get; protected set; }
         public Action<UITableViewCell> InitializeCellAction { get; protected set; }
-        public NSString CellKey { get; protected set; }
+        public Func<object, NSString> CellKeySelector { get; protected set; }
         public float SizeHint { get; protected set; }
 
         /// <summary>
@@ -41,13 +41,18 @@ namespace ReactiveUI.Cocoa
     public class TableSectionInformation<TCell> : TableSectionInformation
         where TCell : UITableViewCell
     {
-        public TableSectionInformation(IReactiveNotifyCollectionChanged collection, NSString cellKey, float sizeHint, Action<TCell> initializeCellAction = null)
+        public TableSectionInformation(IReactiveNotifyCollectionChanged collection, Func<object, NSString> cellKeySelector, float sizeHint, Action<TCell>initializeCellAction = null)
         {
             Collection = collection;
-            CellKey = cellKey;
             SizeHint = sizeHint;
+            CellKeySelector = cellKeySelector;
             if (initializeCellAction != null)
                 InitializeCellAction = cell => initializeCellAction((TCell)cell);
+        }
+
+        public TableSectionInformation(IReactiveNotifyCollectionChanged collection, NSString cellKey, float sizeHint, Action<TCell> initializeCellAction = null)
+            : this(collection, _ => cellKey, sizeHint, initializeCellAction)
+        {
         }
     }
 


### PR DESCRIPTION
This changes the interface to use a Func<object, NSString> as a cell key selector instead of a single NSString, which enables different cell types in a single section.

@meteficha paul mentioned I should cc you, as this is your baby, what do you think?
