### PR TITLE
Update Microsoft.Bcl.Async dependency version range to [1.0.16,1.0.165]

### DIFF
--- a/NuGet/ReactiveUI-Core/ReactiveUI-Core.nuspec
+++ b/NuGet/ReactiveUI-Core/ReactiveUI-Core.nuspec
@@ -14,12 +14,12 @@
 			<group>
 				<dependency id="Rx-Main" version="2.1.30214.0" />
 				<dependency id="Microsoft.Bcl.Build" version="1.0.5" />
-				<dependency id="Microsoft.Bcl.Async" version="[1.0.16]" />
+				<dependency id="Microsoft.Bcl.Async" version="[1.0.16,1.0.165]" />
 			</group>
 			<group targetFramework="winrt45">
 				<dependency id="Rx-WindowStoreApps" version="2.1.30214.0" />
 				<dependency id="Microsoft.Bcl.Build" version="1.0.5" />
-				<dependency id="Microsoft.Bcl.Async" version="[1.0.16]" />
+				<dependency id="Microsoft.Bcl.Async" version="[1.0.16,1.0.165]" />
 			</group>
 		</dependencies>
 	</metadata>


### PR DESCRIPTION
Merging this pull request should fix issue #482.

However, I will admit that, as I do not have a Windows 8 development machine, I cannot really build the nuget packages to test that this change has the fixing effect. I have only tested that the syntax is correct (recognized by the NuGet package explorer application), and that the new specification goes high enough to include at least the current last version of the package.
