### PR TITLE
Only activate views when they are hit test visible.

### DIFF
--- a/ReactiveUI.Platforms/Xaml/ActivationForViewFetcher.cs
+++ b/ReactiveUI.Platforms/Xaml/ActivationForViewFetcher.cs
@@ -24,9 +24,22 @@ namespace ReactiveUI.Xaml
         public Tuple<IObservable<Unit>, IObservable<Unit>> GetActivationForView(IActivatable view)
         {
             var fe = view as FrameworkElement;
-            return Tuple.Create(
-                Observable.FromEventPattern<RoutedEventHandler, RoutedEventArgs>(x => fe.Loaded += x, x => fe.Loaded -= x).Select(_ => Unit.Default),
-                Observable.FromEventPattern<RoutedEventHandler, RoutedEventArgs>(x => fe.Unloaded += x, x => fe.Unloaded -= x).Select(_ => Unit.Default));
+
+            if (fe == null)
+                return Tuple.Create(Observable.Empty<Unit>(), Observable.Empty<Unit>());
+
+            var viewLoaded = Observable.FromEventPattern<RoutedEventHandler, RoutedEventArgs>(x => fe.Loaded += x,
+                x => fe.Loaded -= x).Select(_ => Unit.Default);
+            var viewHitTestVisible = fe.WhenAnyValue(v => v.IsHitTestVisible);
+
+            var viewActivated = viewLoaded.Zip(viewHitTestVisible, (l, h) => h)
+                .Where(v => v)
+                .Select(_ => Unit.Default);
+
+            var viewUnloaded = Observable.FromEventPattern<RoutedEventHandler, RoutedEventArgs>(x => fe.Unloaded += x,
+                x => fe.Unloaded -= x).Select(_ => Unit.Default);
+
+            return Tuple.Create(viewActivated, viewUnloaded);
         }
     }
 }


### PR DESCRIPTION
This prevents RoutedViewHost and similar controls derived from TransitioningContentControl from activating when a view gets loaded in the "previous" ContentPresenter for the purposes of displaying transitions.

Fixes #525.
