### PR TITLE
Allow templates for TCC not to have previous site

### DIFF
--- a/ReactiveUI.Platforms/Xaml/TransitioningContentControl.cs
+++ b/ReactiveUI.Platforms/Xaml/TransitioningContentControl.cs
@@ -261,6 +261,9 @@ namespace ReactiveUI.Xaml
                     this.RaiseTransitionStarted();
                     VisualStateManager.GoToState(this, startingTransitionName, false);
                 }
+            } else {
+                if (this.currentContentPresentationSite != null)
+                    this.currentContentPresentationSite.Content = newContent;
             }
         }
 
@@ -300,9 +303,6 @@ namespace ReactiveUI.Xaml
 
             this.previousContentPresentationSite =
                 (ContentPresenter) GetTemplateChild("PART_PreviousContentPresentationSite");
-            if (this.previousContentPresentationSite == null) {
-                throw new ArgumentException("PART_PreviousContentPresentationSite not found.");
-            }
 
             // Set the current content site to the first piece of content.
             this.currentContentPresentationSite.Content = Content;


### PR DESCRIPTION
This pull request allows `ViewModelViewHost` and `RoutedViewHost` to have a template which does not include the previous content site, which can be used for fixing airspace issues in WPF.
