### PR TITLE
Make Cocoa view sources non-generic

### DIFF
--- a/ReactiveUI.Platforms/Cocoa/CommonReactiveSource.cs
+++ b/ReactiveUI.Platforms/Cocoa/CommonReactiveSource.cs
@@ -28,9 +28,9 @@ namespace ReactiveUI.Cocoa
         TUIViewCell DequeueReusableCell(NSString cellKey, NSIndexPath path);
     }
 
-    interface ISectionInformation<TSource, TUIView, TUIViewCell>
+    interface ISectionInformation<TUIView, TUIViewCell>
     {
-        IReactiveNotifyCollectionChanged<TSource> Collection { get; }
+        IReactiveNotifyCollectionChanged<object> Collection { get; }
         Func<object, NSString> CellKeySelector { get; }
         Action<TUIViewCell> InitializeCellAction { get; }
     }
@@ -39,8 +39,8 @@ namespace ReactiveUI.Cocoa
     /// Internal class containing the common code between <see cref="ReactiveTableViewSource"/>
     /// and <see cref="ReactiveCollectionViewSource"/>.
     /// </summary>
-    sealed class CommonReactiveSource<TSource, TUIView, TUIViewCell, TSectionInfo> : ReactiveObject, IDisposable, IEnableLogger
-        where TSectionInfo : ISectionInformation<TSource, TUIView, TUIViewCell>
+    sealed class CommonReactiveSource<TUIView, TUIViewCell, TSectionInfo> : ReactiveObject, IDisposable, IEnableLogger
+        where TSectionInfo : ISectionInformation<TUIView, TUIViewCell>
     {
         /// <summary>
         /// Main disposable which is disposed when this object is disposed.
@@ -241,7 +241,7 @@ namespace ReactiveUI.Cocoa
             disp.Add(subscrDisp);
 
             // Decide when we should check for section changes.
-            var reactiveSectionInfo = newSectionInfo as IReactiveNotifyCollectionChanged<TSource>;
+            var reactiveSectionInfo = newSectionInfo as IReactiveNotifyCollectionChanged<object>;
 
             var sectionChanging = reactiveSectionInfo == null ? Observable.Never<Unit>() : reactiveSectionInfo
                 .Changing


### PR DESCRIPTION
While the design in #448 is far-and-away better from a code perspective, it doesn't work because Cocoa objects can't be generic (i.e. anything that exposes an interface to Objective C). Peep http://docs.xamarin.com/guides/ios/advanced_topics/limitations for the details.

/cc @jlaanstra who fought the good fight but didn't realize how much Objective C sucks
