### PR TITLE
Warn if you don't use a platform library

### DIFF
--- a/ReactiveUI/IDependencyResolver.cs
+++ b/ReactiveUI/IDependencyResolver.cs
@@ -40,7 +40,7 @@ namespace ReactiveUI
 
             var platDllCount = platforms.Count(x => processRegistrationForNamespace(x, assmName, resolver) == true);
             if (platDllCount == 0) {
-                throw new Exception("We couldn't load a Platform DLL. This probably means you need to Install-Package ReactiveUI-Platforms on your App");
+                LogHost.Default.Warn("We couldn't load a Platform DLL. This probably means you need to Install-Package ReactiveUI-Platforms on your App");
             }
 
             extraNs.ForEach(ns => processRegistrationForNamespace(ns, assmName, resolver));


### PR DESCRIPTION
Fixes #553, stop people who get trolled by forgetting to add `ReactiveUI-Platforms` to their app
