### PR TITLE
RoutingState.NavigateAndReset does not work

### DIFF
--- a/ReactiveUI.Tests/RoutingState.cs
+++ b/ReactiveUI.Tests/RoutingState.cs
@@ -97,5 +97,20 @@ namespace ReactiveUI.Routing.Tests
             Assert.Equal(4, output.Count);
             Assert.Equal("A", ((TestViewModel)output.Last()).SomeProp);
         }
+        
+        [Fact]
+        public void NavigateAndResetCheckNavigationStack()
+        {
+            var fixture = new TestScreen();
+            fixture.Router = new RoutingState();
+            var viewModel = new TestViewModel();
+
+            Assert.False(fixture.Router.NavigationStack.Any());
+
+            fixture.Router.NavigateAndReset.Execute(viewModel);
+
+            Assert.True(fixture.Router.NavigationStack.Count == 1);
+            Assert.True(object.ReferenceEquals(fixture.Router.NavigationStack.First(), viewModel));
+        }
     }
 }


### PR DESCRIPTION
WPF RxUI 5.99.5 .NET4.5.
in 5.4.0 it works
