### PR TITLE
Added two failing tests for ReactiveCommand

### DIFF
--- a/ReactiveUI.Tests/ReactiveCommandTest.cs
+++ b/ReactiveUI.Tests/ReactiveCommandTest.cs
@@ -89,6 +89,26 @@ namespace ReactiveUI.Tests
         }
 
         [Fact]
+        public void ObservableCanExecuteIsNotNullAfterCanExecuteCalled()
+        {
+            var fixture = createCommand(null);
+
+            fixture.CanExecute(null);
+
+            Assert.NotNull(fixture.CanExecuteObservable);
+        }
+
+        [Fact]
+        public void ObservableCanExecuteIsNotNullAfterCanExecuteChangedEventAdded()
+        {
+            var fixture = createCommand(null);
+
+            fixture.CanExecuteChanged += (sender, args) => { };
+
+            Assert.NotNull(fixture.CanExecuteObservable);
+        }
+
+        [Fact]
         public void MultipleSubscribesShouldntResultInMultipleNotifications()
         {
             var input = new[] {1, 2, 1, 2};


### PR DESCRIPTION
`CanExecuteObservable` always returns null if either `CanExecute()` is called before or something subscribes to the `CanExecuteChanged` event.

I guess this isn't the intended behavior?
