### PR TITLE
Make events do The Right Thing automatically when awaited

### DIFF
--- a/ReactiveUI.Events/Events.mustache
+++ b/ReactiveUI.Events/Events.mustache
@@ -57,7 +57,7 @@ namespace {{Name}}.Rx
     public {{Abstract}} partial class {{Name}}Rx : {{Name}}
     {
 {{#ZeroParameterMethods}}
-        protected readonly Subject<Unit> _{{Name}} = new Subject<Unit>();
+        protected readonly SingleAwaitSubject<Unit> _{{Name}} = new SingleAwaitSubject<Unit>();
         public IObservable<Unit> {{Name}}Obs { get { return _{{Name}}; } }
         public override void {{Name}}()
         {
@@ -66,7 +66,7 @@ namespace {{Name}}.Rx
 
 {{/ZeroParameterMethods}}
 {{#SingleParameterMethods}}
-        protected readonly Subject<{{ParameterType}}> _{{Name}} = new Subject<{{ParameterType}}>();
+        protected readonly SingleAwaitSubject<{{ParameterType}}> _{{Name}} = new SingleAwaitSubject<{{ParameterType}}>();
         public IObservable<{{ParameterType}}> {{Name}}Obs { get { return _{{Name}}; } }
         public override void {{Name}}({{ParameterType}} {{ParameterName}})
         {
@@ -75,7 +75,7 @@ namespace {{Name}}.Rx
 
 {{/SingleParameterMethods}}
 {{#MultiParameterMethods}}
-        protected readonly Subject<Tuple<{{ParameterTypeList}}>> _{{Name}} = new Subject<Tuple<{{ParameterTypeList}}>>();
+        protected readonly SingleAwaitSubject<Tuple<{{ParameterTypeList}}>> _{{Name}} = new SingleAwaitSubject<Tuple<{{ParameterTypeList}}>>();
         public IObservable<Tuple<{{ParameterTypeList}}>> {{Name}}Obs { get { return _{{Name}}; } }
         public override void {{Name}}({{ParameterList}})
         {

--- a/ReactiveUI.Events/ReactiveUI.Events_Android.csproj
+++ b/ReactiveUI.Events/ReactiveUI.Events_Android.csproj
@@ -62,6 +62,7 @@
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="Events_Android.cs" />
+    <Compile Include="SingleAwaitSubject.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />

--- a/ReactiveUI.Events/ReactiveUI.Events_Monodroid_XS.csproj
+++ b/ReactiveUI.Events/ReactiveUI.Events_Monodroid_XS.csproj
@@ -69,6 +69,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Events.cs" />
+    <Compile Include="SingleAwaitSubject.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />

--- a/ReactiveUI.Events/ReactiveUI.Events_Monomac.csproj
+++ b/ReactiveUI.Events/ReactiveUI.Events_Monomac.csproj
@@ -153,6 +153,7 @@
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Events.cs" />
+    <Compile Include="SingleAwaitSubject.cs" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />

--- a/ReactiveUI.Events/ReactiveUI.Events_Monotouch_XS.csproj
+++ b/ReactiveUI.Events/ReactiveUI.Events_Monotouch_XS.csproj
@@ -88,6 +88,7 @@
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Events.cs" />
+    <Compile Include="SingleAwaitSubject.cs" />
   </ItemGroup>
   <ItemGroup>
   </ItemGroup>

--- a/ReactiveUI.Events/ReactiveUI.Events_Net45.csproj
+++ b/ReactiveUI.Events/ReactiveUI.Events_Net45.csproj
@@ -65,6 +65,7 @@
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="Events.cs" />
+    <Compile Include="SingleAwaitSubject.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <AppDesigner Include="Properties\" />
   </ItemGroup>

--- a/ReactiveUI.Events/ReactiveUI.Events_WP8.csproj
+++ b/ReactiveUI.Events/ReactiveUI.Events_WP8.csproj
@@ -143,6 +143,7 @@
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="Events_WP8.cs" />
+    <Compile Include="SingleAwaitSubject.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/ReactiveUI.Events/ReactiveUI.Events_WinRT.csproj
+++ b/ReactiveUI.Events/ReactiveUI.Events_WinRT.csproj
@@ -45,6 +45,7 @@
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="Events_WinRT.cs" />
+    <Compile Include="SingleAwaitSubject.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/ReactiveUI.Events/ReactiveUI.Events_WinRT80.csproj
+++ b/ReactiveUI.Events/ReactiveUI.Events_WinRT80.csproj
@@ -42,6 +42,7 @@
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="Events_WinRT80.cs" />
+    <Compile Include="SingleAwaitSubject.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/ReactiveUI.Events/ReactiveUI.Events_iOS.csproj
+++ b/ReactiveUI.Events/ReactiveUI.Events_iOS.csproj
@@ -43,6 +43,7 @@
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="Events_iOS.cs" />
+    <Compile Include="SingleAwaitSubject.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/ReactiveUI.Events/SingleAwaitSubject.cs
+++ b/ReactiveUI.Events/SingleAwaitSubject.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+
+namespace ReactiveUI.Events
+{
+    public class SingleAwaitSubject<T> : ISubject<T>
+    {
+        readonly Subject<T> inner = new Subject<T>();
+
+        public AsyncSubject<T> GetAwaiter()
+        {
+            return inner.Take(1).GetAwaiter();
+        }
+
+        public void OnNext(T value) { inner.OnNext(value); }
+        public void OnError(Exception error) { inner.OnError(error); }
+        public void OnCompleted() { inner.OnCompleted(); }
+
+        public IDisposable Subscribe(IObserver<T> observer)
+        {
+            return inner.Subscribe(observer);
+        }
+    }
+}
+


### PR DESCRIPTION
Consider the following (incorrect) code:

``` cs
    await myWindow.Events().KeyUpObservable;
```

This code deadlocks because we're awaiting an Event which will never complete. This PR overrides the awaiter, so that if _and only if_ you directly await the event, you will get an implicit Take(1).  This means that existing code won't break:

``` cs
    // Since the return type of Select isn't SingleAwaitSubject, our rigged
    // awaiter doesn't apply, they get the default one.
    await myWindow.Events().KeyUpObservable
        .Skip(2)
    .Select(x => x.Key);
```
