### PR TITLE
Add caching option to ViewModelViewHost in winforms to improve performance

### DIFF
--- a/ReactiveUI.Tests/Winforms/ViewModelViewHostTests.cs
+++ b/ReactiveUI.Tests/Winforms/ViewModelViewHostTests.cs
@@ -8,6 +8,12 @@ namespace ReactiveUI.Tests.Winforms
 {
     public class ViewModelViewHostTests
     {
+
+        public ViewModelViewHostTests()
+        {
+            ViewModelViewHost.DefaultCacheViewsEnabled = true;
+        }
+
         [Fact]
         public void SettingViewModelShouldAddTheViewtoItsControls()
         {
@@ -24,8 +30,11 @@ namespace ReactiveUI.Tests.Winforms
         [Fact]
         public void ShouldDisposePreviousView()
         {
-            var viewLocator = new FakeViewLocator { LocatorFunc = t => new FakeWinformsView() };
-            var target = new ViewModelViewHost();
+            var viewLocator = new FakeViewLocator { LocatorFunc = t => new FakeWinformsView()};
+            var target = new ViewModelViewHost()
+            {
+                CacheViews = false
+            };
             target.ViewLocator = viewLocator;
 
             target.ViewModel = new FakeWinformViewModel();

--- a/ReactiveUI.Winforms/Winforms/ViewModelViewHost.cs
+++ b/ReactiveUI.Winforms/Winforms/ViewModelViewHost.cs
@@ -7,10 +7,12 @@ using System.Runtime.CompilerServices;
 using System.Windows.Forms;
 using ReactiveUI;
 
+using Splat;
+
 namespace ReactiveUI.Winforms
 {
     [DefaultProperty("ViewModel")]
-    public partial class ViewModelViewHost : UserControl, IReactiveObject
+    public partial class ViewModelViewHost : UserControl, IReactiveObject, IViewFor
     {
         readonly CompositeDisposable disposables = new CompositeDisposable();
 
@@ -21,41 +23,44 @@ namespace ReactiveUI.Winforms
 
         object content;
 
-        bool cacheViews = true;
+        public static bool DefaultCacheViewsEnabled { get; set; }
+
+        bool cacheViews;
 
         public ViewModelViewHost()
         {
             this.InitializeComponent();
+            this.cacheViews = DefaultCacheViewsEnabled;
+            foreach (var subscription in this.SetupBindings()) {
+                disposables.Add(subscription);
+            }
+        }
 
-
+        private IEnumerable<IDisposable> SetupBindings()
+        {
             var viewChanges =
-              this.WhenAnyValue(x => x.Content)
-                  .Select(x => x as Control)
-                  .Where(x => x != null)
-                  .Subscribe(x =>
-                  {
-                      //change the view in the ui
-                      this.SuspendLayout();
+                this.WhenAnyValue(x => x.Content).Select(x => x as Control).Where(x => x != null).Subscribe(x => {
+                    //change the view in the ui
+                    this.SuspendLayout();
 
-                      //clear out existing visible control view
-                      foreach (Control c in this.Controls)
-                      {
-                          c.Dispose();
-                          this.Controls.Remove(c);
-                      }
+                    //clear out existing visible control view
+                    foreach (Control c in this.Controls) {
+                        c.Dispose();
+                        this.Controls.Remove(c);
+                    }
 
-                      x.Dock = DockStyle.Fill;
-                      this.Controls.Add(x);
-                      this.ResumeLayout();
-                  });
+                    x.Dock = DockStyle.Fill;
+                    this.Controls.Add(x);
+                    this.ResumeLayout();
+                });
 
-            this.disposables.Add(viewChanges);
+            yield return viewChanges;
 
-            this.disposables.Add(this.WhenAny(x => x.DefaultContent, x => x.Value).Subscribe(x => {
+            yield return this.WhenAny(x => x.DefaultContent, x => x.Value).Subscribe(x => {
                 if (x != null && this.currentView == null) {
                     this.Content = DefaultContent;
                 }
-            }));
+            });
 
             this.ViewContractObservable = Observable.Return(default(string));
 
@@ -64,23 +69,31 @@ namespace ReactiveUI.Winforms
                     .CombineLatest(this.WhenAnyObservable(x => x.ViewContractObservable),
                         (vm, contract) => new { ViewModel = vm, Contract = contract });
 
-          
 
-            this.disposables.Add(vmAndContract.Subscribe(x => {
-                //clear all hosted controls (view or default content)
-                if (this.ViewModel == null) {
-                    if (this.DefaultContent != null) {
+
+           yield return vmAndContract.Subscribe(x =>
+            {
+
+                //set content to default when viewmodel is null
+                if (this.ViewModel == null)
+                {
+                    if (this.DefaultContent != null)
+                    {
                         this.Content = DefaultContent;
                     }
                     return;
                 }
 
-                if (CacheViews) {
+                if (CacheViews)
+                {
                     //when caching views, check the current viewmodel and type
                     var c = content as IViewFor;
                     if (c != null && c.ViewModel != null
-                        && c.ViewModel.GetType() == x.ViewModel.GetType()) {
-                            c.ViewModel = x.ViewModel;
+                        && c.ViewModel.GetType() == x.ViewModel.GetType())
+                    {
+                        c.ViewModel = x.ViewModel;
+                        //return early here after setting the viewmodel
+                        //allowing the view to update it's bindings
                         return;
                     }
                 }
@@ -90,7 +103,7 @@ namespace ReactiveUI.Winforms
                 this.Content = view;
                 view.ViewModel = x.ViewModel;
 
-            }, RxApp.DefaultExceptionHandler.OnNext));
+            }, RxApp.DefaultExceptionHandler.OnNext);
         }
 
         public event PropertyChangingEventHandler PropertyChanging


### PR DESCRIPTION
This PR adds an optional caching behavior to the Winforms `ViewModelViewHost`.

Problem:
When the ViewModelchanges often, but is always of the same type, everytime a new control (and handle) is creating and the old one is disposed. This has  a negative impact on the performance.

Solution:
By adding setting the `CacheViews` property to true on the `ViewModelViewHost`, the control presenting the viewmodel is only created new when the ViewModel Type changes

The default behavior can be set using the static `DefaultCacheViewsEnabled` property on the `ViewModelViewHost`.
