### PR TITLE
Cast section info list to the matching IReactiveNotifyCollectionChanged

### DIFF
--- a/ReactiveUI/Cocoa/CommonReactiveSource.cs
+++ b/ReactiveUI/Cocoa/CommonReactiveSource.cs
@@ -241,7 +241,7 @@ namespace ReactiveUI.Cocoa
             disp.Add(subscrDisp);
 
             // Decide when we should check for section changes.
-            var reactiveSectionInfo = newSectionInfo as IReactiveNotifyCollectionChanged<TSource>;
+            var reactiveSectionInfo = newSectionInfo as IReactiveNotifyCollectionChanged<TSectionInfo>;
 
             var sectionChanging = reactiveSectionInfo == null ? Observable.Never<Unit>() : reactiveSectionInfo
                 .Changing


### PR DESCRIPTION
Otherwise this always disables change notifications for section lists.
