### PR TITLE
Actually get actually throws on WinRT should fix #563

### DIFF
--- a/ReactiveUI.Platforms/Xaml/DependencyObjectObservableForProperty.cs
+++ b/ReactiveUI.Platforms/Xaml/DependencyObjectObservableForProperty.cs
@@ -93,7 +93,7 @@ namespace ReactiveUI.Xaml
                 var ret = typeInfo.GetDeclaredProperty(propertyName);
                 if (ret != null && ret.IsStatic()) return ret;
 
-                current = current.BaseType.GetTypeInfo();
+                current = current.BaseType != null ? current.BaseType.GetTypeInfo() : null;
             }
 
             return null;
@@ -106,7 +106,7 @@ namespace ReactiveUI.Xaml
                 var ret = typeInfo.GetDeclaredField(propertyName);
                 if (ret != null && ret.IsStatic) return ret;
 
-                current = current.BaseType.GetTypeInfo();
+                current = current.BaseType != null ? current.BaseType.GetTypeInfo() : null;
             }
 
             return null;


### PR DESCRIPTION
The change introduced by 1f9d5307 to fix dependency properties defined in base classes fails to catch an edge case causing WinRT apps to blow up on binding (as the code digs through looking for ways to convert types).

Adding a test for current.BaseType being null to the two methods prevents the exception and looks to me like it shouldn't affect anything else as a null return is a valid result.

I can't see how to easily write a test, however without the fix the MobileSample_WinRT throws and with the fix it doesn't and _appears_ to run successfully (he said taking note of comments about the nature of said application).
