### PR TITLE
Adding Activation Support for WinForms Views. (ref #604)

### DIFF
--- a/ReactiveUI.Tests/ReactiveUI.Tests_Net45.csproj
+++ b/ReactiveUI.Tests/ReactiveUI.Tests_Net45.csproj
@@ -112,6 +112,7 @@
     <Compile Include="BindingTypeConvertersTest.cs" />
     <Compile Include="CommandBindingTests.cs" />
     <Compile Include="WeakEventManagerTest.cs" />
+    <Compile Include="Winforms\ActivationTests.cs" />
     <Compile Include="Winforms\CommandBindingTests.cs">
       <SubType>Component</SubType>
     </Compile>

--- a/ReactiveUI.Tests/Winforms/ActivationTests.cs
+++ b/ReactiveUI.Tests/Winforms/ActivationTests.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using System.Windows.Forms;
+
+using ReactiveUI.Winforms;
+
+using Xunit;
+
+namespace ReactiveUI.Tests.Winforms
+{
+    public class ActivationTests
+    {
+        [Fact]
+        public void ActivationForViewFetcherSupportsDefaultWinformsComponents()
+        {
+            var target = new ActivationForViewFetcher();
+            var supportedComponents = new[] { typeof(Control), typeof(UserControl), typeof(Form) };
+            foreach (var c in supportedComponents) {
+                Assert.Equal(10, target.GetAffinityForView(c));
+            }
+        }
+
+        [Fact]
+        public void CanFetchActivatorForForm()
+        {
+            var form = new TestForm();
+            var target = new ActivationForViewFetcher();
+            var formActivator = target.GetActivationForView(form);
+
+            Assert.NotNull(formActivator);
+            Assert.NotNull(formActivator.Item1);
+            Assert.NotNull(formActivator.Item2);
+        }
+      
+
+        [Fact]
+        public void CanFetchActivatorForControl()
+        {
+            var control = new TestControl();
+            var target = new ActivationForViewFetcher();
+            var activator = target.GetActivationForView(control);
+
+            Assert.NotNull(activator);
+            Assert.NotNull(activator.Item1);
+            Assert.NotNull(activator.Item2);
+        }
+
+        [Fact]
+        public void SmokeTestWindowsForm()
+        {
+            var target = new ActivationForViewFetcher();
+            using (var form = new TestForm()) {
+                var formActivator = target.GetActivationForView(form);
+
+                int formActivateCount = 0, formDeActivateCount = 0;
+                formActivator.Item1.Subscribe(_ => formActivateCount++);
+                formActivator.Item2.Subscribe(_ => formDeActivateCount++);
+
+                Assert.Equal(0, formActivateCount);
+                Assert.Equal(0, formDeActivateCount);
+
+                form.Visible = true;
+                Assert.Equal(1, formActivateCount);
+
+                form.Visible = false;
+                Assert.Equal(1, formActivateCount);
+                Assert.Equal(1, formDeActivateCount);
+
+                form.Visible = true;
+                Assert.Equal(2, formActivateCount);
+
+                form.Close();
+                Assert.Equal(2, formDeActivateCount);
+            }
+        }
+
+        [Fact]
+        public void SmokeTestUserControl()
+        {
+            var target = new ActivationForViewFetcher();
+            using(var userControl = new TestControl())
+            using (var parent = new TestForm()) {
+
+                var userControlActivator = target.GetActivationForView(userControl);
+
+                int userControlActivateCount = 0, userControlDeActivateCount = 0;
+                userControlActivator.Item1.Subscribe(_ => userControlActivateCount++);
+                userControlActivator.Item2.Subscribe(_ => userControlDeActivateCount++);
+
+
+                parent.Visible = true;
+                parent.Controls.Add(userControl);
+
+                userControl.Visible = true;
+                Assert.Equal(1, userControlActivateCount);
+                userControl.Visible = false;
+                Assert.Equal(1, userControlDeActivateCount);
+
+                userControl.Visible = true;
+                Assert.Equal(2, userControlActivateCount);
+
+                //closing the form deactivated the usercontrol
+                parent.Close();
+                Assert.Equal(2, userControlDeActivateCount);
+            }
+        }
+
+        class TestControl : System.Windows.Forms.Control, IActivatable { }
+
+        class TestForm : System.Windows.Forms.Form, IActivatable { }
+    }
+}

--- a/ReactiveUI.Winforms/ReactiveUI.Winforms_Net45.csproj
+++ b/ReactiveUI.Winforms/ReactiveUI.Winforms_Net45.csproj
@@ -132,6 +132,7 @@
     <Compile Include="..\CommonAssemblyInfo.cs">
       <Link>Winforms\Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="Winforms\ActivationForViewFetcher.cs" />
     <Compile Include="Winforms\ObservableCollectionChangedToListChangedTransformer.cs" />
     <Compile Include="Winforms\ReactiveDerivedBindingListMixins.cs" />
     <Compile Include="Winforms\RoutedViewHost.cs">

--- a/ReactiveUI.Winforms/Winforms/ActivationForViewFetcher.cs
+++ b/ReactiveUI.Winforms/Winforms/ActivationForViewFetcher.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reflection;
+using System.Windows.Forms;
+
+using Splat;
+
+namespace ReactiveUI.Winforms
+{
+    public class ActivationForViewFetcher : IActivationForViewFetcher, IEnableLogger
+    {
+
+        public int GetAffinityForView(Type view)
+        {
+            return (typeof(Control).GetTypeInfo().IsAssignableFrom(view.GetTypeInfo())) ? 10 : 0;
+        }
+
+        public Tuple<IObservable<Unit>, IObservable<Unit>> GetActivationForView(IActivatable view)
+        {
+            var control = view as Control;
+            if (control == null) {
+                //show a friendly warning in the log that this view will never be activated
+                this.Log().Warn("Expected a view of type System.Windows.Forms.Control but it is {0}.\r\nYou need to implement your own IActivationForViewFetcher for {0}.", view.GetType());
+                return Tuple.Create(Observable.Empty<Unit>(), Observable.Empty<Unit>());
+            }
+
+            // create an observable stream of booleans
+            // true representing the control is active, false representing the control is not active
+            // by using DistinctUntilChanged, a control can either be active or not active
+            // this should also fix #610 for winforms
+
+            var controlVisible = Observable.FromEventPattern(control, "VisibleChanged").Select(_ => control.Visible);
+            var handleDestroyed = Observable.FromEventPattern(control, "HandleDestroyed").Select(_ => false);
+            var handleCreated = Observable.FromEventPattern(control, "HandleCreated").Select(_ => true);
+
+            var controlActive = Observable.Merge(controlVisible, handleDestroyed, handleCreated)
+                .DistinctUntilChanged();
+
+
+            var controlActivated = controlActive.Where(x => x).Select(_ => Unit.Default);
+            var controlDeactivated = controlActive.Where(x => !x).Select(_ => Unit.Default);
+
+            var form = view as Form;
+            if (form != null) {
+                var formActive = Observable.FromEventPattern(form, "Closed").Select(_ => false);
+                var formDeactivated = controlActive.Merge(formActive).DistinctUntilChanged().Where(x => !x).Select(_ => Unit.Default);
+                return Tuple.Create(controlActivated, formDeactivated);
+            }
+
+
+
+            return Tuple.Create(controlActivated, controlDeactivated);
+        }
+    }
+}

--- a/ReactiveUI.Winforms/Winforms/Registrations.cs
+++ b/ReactiveUI.Winforms/Winforms/Registrations.cs
@@ -28,6 +28,7 @@ namespace ReactiveUI.Winforms
             registerFunction(() => new WinformsDefaultPropertyBinding(), typeof(IDefaultPropertyBindingProvider));
             registerFunction(() => new CreatesWinformsCommandBinding(), typeof(ICreatesCommandBinding));
             registerFunction(() => new WinformsCreatesObservableForProperty(), typeof(ICreatesObservableForProperty));
+            registerFunction(() => new ActivationForViewFetcher(), typeof(IActivationForViewFetcher));
 
             if (!ModeDetector.InUnitTestRunner()) {
                 WindowsFormsSynchronizationContext.AutoInstall = true;


### PR DESCRIPTION
This PR adds basic winforms activation support.

ViewActivation is based on several events:
- Visible changed
- Closed (when control is a form)
- HandleCreated
- HandleDestroyed

the ActivationForViewFetcher creates a observable stream of booleans where true=active and false=not active.

Using DistinctUntilChanged for the actived and deactivated observables, a view can only be active  or not active.

Please note that WinForms users are better off implementing the ICanActivate in their views for more control over activation. e.g. when a parent (or grandparent etc) of a usercontrol is hidden, the VisibleChanged of the child is not raised. As a result, the view stays active but it is not painted.
If anyone has Idea's how to implement this into a nice Rx way... all hints are welcome.
