### PR TITLE
Fix activation when IsHitTestVisible does not change.

### DIFF
--- a/ReactiveUI/Xaml/ActivationForViewFetcher.cs
+++ b/ReactiveUI/Xaml/ActivationForViewFetcher.cs
@@ -32,7 +32,7 @@ namespace ReactiveUI
                 x => fe.Loaded -= x).Select(_ => Unit.Default);
             var viewHitTestVisible = fe.WhenAnyValue(v => v.IsHitTestVisible);
 
-            var viewActivated = viewLoaded.Zip(viewHitTestVisible, (l, h) => h)
+            var viewActivated = viewLoaded.CombineLatest(viewHitTestVisible, (l, h) => h)
                 .Where(v => v)
                 .Select(_ => Unit.Default);
 


### PR DESCRIPTION
This PR fixes a bug in the default `ActivationForViewFetcher` for Xaml platforms, where views are no longer activated if IsHitTestVisible never changes.

//cc @jen20 who originally added the IsHitTestVisible stuff.
