### PR TITLE
By default fill in the values for IObservedChange.

### DIFF
--- a/Playground-Android/Playground-Android.csproj
+++ b/Playground-Android/Playground-Android.csproj
@@ -42,6 +42,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
+    <Reference Include="System.Runtime" />
+    <Reference Include="System.Threading.Tasks" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
     <Reference Include="Mono.Android" />

--- a/Playground-Android/ViewModels/WatchListItemViewModel.cs
+++ b/Playground-Android/ViewModels/WatchListItemViewModel.cs
@@ -96,7 +96,7 @@ namespace MobileSample_Android.ViewModels
                     DayHigh = price;
                 }
 
-                this.RaisePropertyChanged();
+                this.RaisePropertyChanged(value);
             }
         }
 

--- a/Playground-Android/ViewModels/WatchListViewModel.cs
+++ b/Playground-Android/ViewModels/WatchListViewModel.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reactive.Linq;
 using System.Text;
+using System.Threading.Tasks;
 using System.Windows.Input;
 using ReactiveUI;
 
@@ -31,18 +32,18 @@ namespace MobileSample_Android.ViewModels
 
         public WatchListViewModel()
         {
-            var openCmd = ReactiveCommand.CreateAsyncFunction(this.WhenAnyValue(vm => vm.MarketState, m => m == MarketState.Closed),
-                _ => OpenMarket(), RxApp.MainThreadScheduler);
+            var openCmd = ReactiveCommand.CreateAsyncTask(this.WhenAnyValue(vm => vm.MarketState, m => m == MarketState.Closed),
+                _ => Task.Run((Action)OpenMarket), RxApp.MainThreadScheduler);
             OpenMarketCommand = openCmd;
 
-            var closeCmd = ReactiveCommand.CreateAsyncFunction(
+            var closeCmd = ReactiveCommand.CreateAsyncTask(
                 this.WhenAnyValue(vm => vm.MarketState, m => m == MarketState.Open),
-                _ => CloseMarket(), RxApp.MainThreadScheduler);
+                _ => Task.Run((Action)CloseMarket), RxApp.MainThreadScheduler);
             CloseMarketCommand = closeCmd;
 
-            var resetCmd = ReactiveCommand.CreateAsyncFunction(
+            var resetCmd = ReactiveCommand.CreateAsyncTask(
                 this.WhenAnyValue(vm => vm.MarketState, m => m == MarketState.Closed),
-                _ => Reset(), RxApp.MainThreadScheduler);
+                _ => Task.Run((Action)Reset), RxApp.MainThreadScheduler);
             ResetCommand = resetCmd;
 
             LoadDefaultStocks();
@@ -59,7 +60,7 @@ namespace MobileSample_Android.ViewModels
             private set
             {
                 marketState = value;
-                this.RaisePropertyChanged(); // can't use ref as it's volatile
+                this.RaisePropertyChanged(value); // can't use ref as it's volatile
             }
         }
 

--- a/Playground-Android/Views/WatchListItemView.cs
+++ b/Playground-Android/Views/WatchListItemView.cs
@@ -7,7 +7,6 @@ using Android.Views;
 using Android.Widget;
 using MobileSample_Android.ViewModels;
 using ReactiveUI;
-using ReactiveUI.Android;
 
 namespace MobileSample_Android.Views
 {

--- a/Playground-Android/WatchListActivity.cs
+++ b/Playground-Android/WatchListActivity.cs
@@ -8,7 +8,6 @@ using Android.Widget;
 using MobileSample_Android.ViewModels;
 using MobileSample_Android.Views;
 using ReactiveUI;
-using ReactiveUI.Android;
 using Android.Views;
 
 namespace MobileSample_Android

--- a/ReactiveUI.Tests/Android/PropertyBindingTestViews.cs
+++ b/ReactiveUI.Tests/Android/PropertyBindingTestViews.cs
@@ -9,7 +9,6 @@ using Android;
 using Android.App;
 using Android.Widget;
 using Android.Content;
-using ReactiveUI.Android;
 using Xunit;
 
 namespace ReactiveUI.Tests

--- a/ReactiveUI.Tests/ObservedChangedMixinTest.cs
+++ b/ReactiveUI.Tests/ObservedChangedMixinTest.cs
@@ -14,7 +14,7 @@ namespace ReactiveUI.Tests
     public class ObservedChangedMixinTest
     {
         [Fact]
-        public void GetValueShouldActuallyReturnTheValue()
+        public void ValueShouldActuallyReturnTheValue()
         {
             var input = new[] {"Foo", "Bar", "Baz"};
             var output = new List<string>();
@@ -24,7 +24,7 @@ namespace ReactiveUI.Tests
                 
                 // ...whereas ObservableForProperty *is* guaranteed to.
                 fixture.ObservableForProperty(x => x.IsOnlyOneWord).Subscribe(x => {
-                    output.Add(x.GetValue());
+                    output.Add(x.Value);
                 });
 
                 foreach (var v in input) { fixture.IsOnlyOneWord = v; }
@@ -45,7 +45,7 @@ namespace ReactiveUI.Tests
             Expression<Func<HostTestFixture, string>> expression = x => x.Child.IsNotNullString;
             var fixture = new ObservedChange<HostTestFixture, string>(input, expression.Body);
 
-            Assert.Equal("Foo", fixture.GetValue());
+            Assert.Equal("Foo", fixture.Value);
         }
 
         [Fact]

--- a/ReactiveUI.Tests/Resources/Resource.designer.cs
+++ b/ReactiveUI.Tests/Resources/Resource.designer.cs
@@ -34,6 +34,7 @@ namespace ReactiveUI.Tests
 			global::Xamarin.Android.NUnitLite.Resource.Id.ResultFullName = global::ReactiveUI.Tests.Resource.Id.ResultFullName;
 			global::Xamarin.Android.NUnitLite.Resource.Id.ResultMessage = global::ReactiveUI.Tests.Resource.Id.ResultMessage;
 			global::Xamarin.Android.NUnitLite.Resource.Id.ResultResultState = global::ReactiveUI.Tests.Resource.Id.ResultResultState;
+			global::Xamarin.Android.NUnitLite.Resource.Id.ResultRunSingleMethodTest = global::ReactiveUI.Tests.Resource.Id.ResultRunSingleMethodTest;
 			global::Xamarin.Android.NUnitLite.Resource.Id.ResultStackTrace = global::ReactiveUI.Tests.Resource.Id.ResultStackTrace;
 			global::Xamarin.Android.NUnitLite.Resource.Id.ResultsFailed = global::ReactiveUI.Tests.Resource.Id.ResultsFailed;
 			global::Xamarin.Android.NUnitLite.Resource.Id.ResultsId = global::ReactiveUI.Tests.Resource.Id.ResultsId;
@@ -91,20 +92,23 @@ namespace ReactiveUI.Tests
 			// aapt resource value: 0x7f050000
 			public const int OptionRemoteServer = 2131034112;
 			
-			// aapt resource value: 0x7f05000f
-			public const int OptionsButton = 2131034127;
-			
-			// aapt resource value: 0x7f05000a
-			public const int ResultFullName = 2131034122;
-			
-			// aapt resource value: 0x7f05000c
-			public const int ResultMessage = 2131034124;
+			// aapt resource value: 0x7f050010
+			public const int OptionsButton = 2131034128;
 			
 			// aapt resource value: 0x7f05000b
-			public const int ResultResultState = 2131034123;
+			public const int ResultFullName = 2131034123;
 			
 			// aapt resource value: 0x7f05000d
-			public const int ResultStackTrace = 2131034125;
+			public const int ResultMessage = 2131034125;
+			
+			// aapt resource value: 0x7f05000c
+			public const int ResultResultState = 2131034124;
+			
+			// aapt resource value: 0x7f05000a
+			public const int ResultRunSingleMethodTest = 2131034122;
+			
+			// aapt resource value: 0x7f05000e
+			public const int ResultStackTrace = 2131034126;
 			
 			// aapt resource value: 0x7f050006
 			public const int ResultsFailed = 2131034118;
@@ -127,11 +131,11 @@ namespace ReactiveUI.Tests
 			// aapt resource value: 0x7f050004
 			public const int ResultsResult = 2131034116;
 			
-			// aapt resource value: 0x7f05000e
-			public const int RunTestsButton = 2131034126;
+			// aapt resource value: 0x7f05000f
+			public const int RunTestsButton = 2131034127;
 			
-			// aapt resource value: 0x7f050010
-			public const int TestSuiteListView = 2131034128;
+			// aapt resource value: 0x7f050011
+			public const int TestSuiteListView = 2131034129;
 			
 			static Id()
 			{

--- a/ReactiveUI.Tests/Winforms/ActivationTests.cs
+++ b/ReactiveUI.Tests/Winforms/ActivationTests.cs
@@ -11,7 +11,7 @@ namespace ReactiveUI.Tests.Winforms
         [Fact]
         public void ActivationForViewFetcherSupportsDefaultWinformsComponents()
         {
-            var target = new ActivationForViewFetcher();
+            var target = new ReactiveUI.Winforms.ActivationForViewFetcher();
             var supportedComponents = new[] { typeof(Control), typeof(UserControl), typeof(Form) };
 
             foreach (var c in supportedComponents) {
@@ -23,7 +23,7 @@ namespace ReactiveUI.Tests.Winforms
         public void CanFetchActivatorForForm()
         {
             var form = new TestForm();
-            var target = new ActivationForViewFetcher();
+            var target = new ReactiveUI.Winforms.ActivationForViewFetcher();
             var formActivator = target.GetActivationForView(form);
 
             Assert.NotNull(formActivator);
@@ -36,7 +36,7 @@ namespace ReactiveUI.Tests.Winforms
         public void CanFetchActivatorForControl()
         {
             var control = new TestControl();
-            var target = new ActivationForViewFetcher();
+            var target = new ReactiveUI.Winforms.ActivationForViewFetcher();
             var activator = target.GetActivationForView(control);
 
             Assert.NotNull(activator);
@@ -47,7 +47,7 @@ namespace ReactiveUI.Tests.Winforms
         [Fact]
         public void SmokeTestWindowsForm()
         {
-            var target = new ActivationForViewFetcher();
+            var target = new ReactiveUI.Winforms.ActivationForViewFetcher();
             using (var form = new TestForm()) {
                 var formActivator = target.GetActivationForView(form);
 
@@ -76,7 +76,7 @@ namespace ReactiveUI.Tests.Winforms
         [Fact]
         public void SmokeTestUserControl()
         {
-            var target = new ActivationForViewFetcher();
+            var target = new ReactiveUI.Winforms.ActivationForViewFetcher();
             using(var userControl = new TestControl())
             using (var parent = new TestForm()) {
                 var userControlActivator = target.GetActivationForView(userControl);

--- a/ReactiveUI/Cocoa/KVOObservableForProperty.cs
+++ b/ReactiveUI/Cocoa/KVOObservableForProperty.cs
@@ -75,8 +75,8 @@ namespace ReactiveUI
             var propertyName = expression.GetMemberInfo().Name;
 
             return Observable.Create<IObservedChange<object, object>>(subj => {
-                var bobs = new BlockObserveValueDelegate((key,s,_) => {
-                    subj.OnNext(new ObservedChange<object, object>(s, expression));
+                var bobs = new BlockObserveValueDelegate((key,s,change) => {
+                    subj.OnNext(new ObservedChange<object, object>(s, expression, beforeChanged ? change[NSDictionary.ChangeOldKey] : change[NSDictionary.ChangeNewKey]));
                 });
                 var pin = GCHandle.Alloc(bobs);
 

--- a/ReactiveUI/Cocoa/ReactiveCollectionViewSource.cs
+++ b/ReactiveUI/Cocoa/ReactiveCollectionViewSource.cs
@@ -99,9 +99,9 @@ namespace ReactiveUI
             set {
                 if (commonSource.SectionInfo == value)  return;
 
-                this.raisePropertyChanging("Data");
+                this.raisePropertyChanging("Data", value);
                 commonSource.SectionInfo = value;
-                this.raisePropertyChanged("Data");
+                this.raisePropertyChanged("Data", value);
             }
         }
 

--- a/ReactiveUI/Cocoa/ReactiveTableViewSource.cs
+++ b/ReactiveUI/Cocoa/ReactiveTableViewSource.cs
@@ -157,9 +157,9 @@ namespace ReactiveUI
             set {
                 if (commonSource.SectionInfo == value)  return;
 
-                this.raisePropertyChanging("Data");
+                this.raisePropertyChanging("Data", value);
                 commonSource.SectionInfo = value;
-                this.raisePropertyChanged("Data");
+                this.raisePropertyChanged("Data", value);
             }
         }
 

--- a/ReactiveUI/Cocoa/UIKitObservableForProperty.cs
+++ b/ReactiveUI/Cocoa/UIKitObservableForProperty.cs
@@ -16,19 +16,20 @@ namespace ReactiveUI
 
         public UIKitObservableForProperty ()
         {
-            Register(typeof(UIControl), "Value", 20, (s, p)=> ObservableFromUIControlEvent(s, p, UIControlEvent.ValueChanged));
-            Register(typeof(UITextField), "Text", 30, (s, p) => ObservableFromNotification(s, p, UITextField.TextFieldTextDidChangeNotification));
-            Register(typeof(UITextView), "Text", 30, (s, p) => ObservableFromNotification(s, p, UITextView.TextDidChangeNotification));
-            Register(typeof(UIDatePicker), "Date", 30, (s, p)=> ObservableFromUIControlEvent(s, p, UIControlEvent.ValueChanged));
-            Register(typeof(UISegmentedControl), "SelectedSegment", 30, (s, p)=> ObservableFromUIControlEvent(s, p, UIControlEvent.ValueChanged));
-            Register(typeof(UISwitch), "On", 30, (s, p)=> ObservableFromUIControlEvent(s, p, UIControlEvent.ValueChanged));
-            Register(typeof(UISegmentedControl), "SelectedSegment", 30, (s, p)=> ObservableFromUIControlEvent(s, p, UIControlEvent.ValueChanged));
+            //TODO
+            //Register(typeof(UIControl), "Value", 20, (s, p)=> ObservableFromUIControlEvent(s, p, UIControlEvent.ValueChanged, ns => ((UIControl)ns).Value));
+            Register(typeof(UITextField), "Text", 30, (s, p) => ObservableFromNotification(s, p, UITextField.TextFieldTextDidChangeNotification, ns => ((UITextField)ns).Text));
+            Register(typeof(UITextView), "Text", 30, (s, p) => ObservableFromNotification(s, p, UITextView.TextDidChangeNotification, ns => ((UITextView)ns).Text));
+            Register(typeof(UIDatePicker), "Date", 30, (s, p)=> ObservableFromUIControlEvent(s, p, UIControlEvent.ValueChanged, ns => ((UIDatePicker)ns).Date));
+            Register(typeof(UISegmentedControl), "SelectedSegment", 30, (s, p)=> ObservableFromUIControlEvent(s, p, UIControlEvent.ValueChanged, ns => ((UISegmentedControl)ns).SelectedSegment));
+            Register(typeof(UISwitch), "On", 30, (s, p)=> ObservableFromUIControlEvent(s, p, UIControlEvent.ValueChanged, ns => ((UISwitch)ns).On));
+            Register(typeof(UISegmentedControl), "SelectedSegment", 30, (s, p)=> ObservableFromUIControlEvent(s, p, UIControlEvent.ValueChanged, ns => ((UISegmentedControl)ns).SelectedSegment));
             
             // Warning: This will stomp the Control's delegate
-            Register(typeof(UITabBar), "SelectedItem", 30, (s, p) => ObservableFromEvent(s, p, "ItemSelected"));
+            Register(typeof(UITabBar), "SelectedItem", 30, (s, p) => ObservableFromEvent(s, p, "ItemSelected", ns => ((UITabBar)ns).SelectedItem));
 
             // Warning: This will stomp the Control's delegate
-            Register(typeof(UISearchBar), "Text", 30, (s, p) => ObservableFromEvent(s, p, "TextChanged"));
+            Register(typeof(UISearchBar), "Text", 30, (s, p) => ObservableFromEvent(s, p, "TextChanged", ns => ((UISearchBar)ns).Text));
         }
     }
 }

--- a/ReactiveUI/Cocoa/UIKitObservableForPropertyBase.cs
+++ b/ReactiveUI/Cocoa/UIKitObservableForPropertyBase.cs
@@ -84,11 +84,14 @@ namespace ReactiveUI
         /// <summary>
         /// Creates an Observable for a UIControl Event
         /// </summary>
-        /// <returns>An observable</returns>
         /// <param name="sender">The sender</param>
-        /// <param name="propertyName">The property name </param>
+        /// <param name="expression">The expression.</param>
         /// <param name="evt">The control event to listen for</param>
-        protected static IObservable<IObservedChange<object, object>> ObservableFromUIControlEvent(NSObject sender, Expression expression, UIControlEvent evt)
+        /// <param name="value">The value.</param>
+        /// <returns>
+        /// An observable.
+        /// </returns>
+        protected static IObservable<IObservedChange<object, object>> ObservableFromUIControlEvent(NSObject sender, Expression expression, UIControlEvent evt, Func<NSObject, object> value)
         {
             return Observable.Create<IObservedChange<object, object>>(subj =>
             {
@@ -96,7 +99,7 @@ namespace ReactiveUI
 
                 EventHandler handler = (s,e)=>
                 {
-                    subj.OnNext(new ObservedChange<object, object>(sender, expression));
+                    subj.OnNext(new ObservedChange<object, object>(sender, expression, value(sender)));
                 };
 
                 control.AddTarget(handler, evt);
@@ -111,17 +114,20 @@ namespace ReactiveUI
         /// <summary>
         /// Creates an Observable for a NSNotificationCenter notification
         /// </summary>
-        /// <returns>The from notification.</returns>
         /// <param name="sender">Sender.</param>
-        /// <param name="propertyName">Property name.</param>
+        /// <param name="expression">The expression.</param>
         /// <param name="notification">Notification.</param>
-        protected static IObservable<IObservedChange<object, object>> ObservableFromNotification(NSObject sender, Expression expression, NSString notification)
+        /// <param name="value">The value.</param>
+        /// <returns>
+        /// The from notification.
+        /// </returns>
+        protected static IObservable<IObservedChange<object, object>> ObservableFromNotification(NSObject sender, Expression expression, NSString notification, Func<NSObject, object> value)
         {
             return Observable.Create<IObservedChange<object, object>>(subj =>
             {
                 var handle = NSNotificationCenter.DefaultCenter.AddObserver (notification, (e)=>
                 {
-                    subj.OnNext(new ObservedChange<object, object>(sender, expression));
+                    subj.OnNext(new ObservedChange<object, object>(sender, expression, value(sender)));
                 }, sender);
 
                 return Disposable.Create(() =>
@@ -134,17 +140,20 @@ namespace ReactiveUI
         /// <summary>
         /// Creates an Observable for a NSNotificationCenter notification
         /// </summary>
-        /// <returns>The from notification.</returns>
         /// <param name="sender">Sender.</param>
-        /// <param name="propertyName">Property name.</param>
-        /// <param name="notification">Notification.</param>
-        protected static IObservable<IObservedChange<object, object>> ObservableFromEvent(NSObject sender, Expression expression, string eventName)
+        /// <param name="expression">The expression.</param>
+        /// <param name="eventName">Name of the event.</param>
+        /// <param name="value">The value.</param>
+        /// <returns>
+        /// The from notification.
+        /// </returns>
+        protected static IObservable<IObservedChange<object, object>> ObservableFromEvent(NSObject sender, Expression expression, string eventName, Func<NSObject, object> value)
         {
             return Observable.Create<IObservedChange<object, object>>(subj =>
             {
                 return Observable.FromEventPattern(sender, eventName).Subscribe((e) =>
                 {
-                    subj.OnNext(new ObservedChange<object, object>(sender, expression));
+                    subj.OnNext(new ObservedChange<object, object>(sender, expression, value(sender)));
                 });
             });
         }

--- a/ReactiveUI/IROObservableForProperty.cs
+++ b/ReactiveUI/IROObservableForProperty.cs
@@ -31,18 +31,18 @@ namespace ReactiveUI
             if (beforeChanged) {
                 if (expression.NodeType == ExpressionType.Index) {
                     return obs.Where(x => x.PropertyName.Equals(memberInfo.Name + "[]"))
-                        .Select(x => new ObservedChange<object, object>(sender, expression));
+                        .Select(x => new ObservedChange<object, object>(sender, expression, x.Value));
                 } else {
                     return obs.Where(x => x.PropertyName.Equals(memberInfo.Name))
-                        .Select(x => new ObservedChange<object, object>(sender, expression));
+                        .Select(x => new ObservedChange<object, object>(sender, expression, x.Value));
                 }
             } else {
                 if (expression.NodeType == ExpressionType.Index) {
                     return obs.Where(x => x.PropertyName.Equals(memberInfo.Name + "[]"))
-                        .Select(x => new ObservedChange<object, object>(sender, expression));
+                        .Select(x => new ObservedChange<object, object>(sender, expression, x.Value));
                 } else {
                     return obs.Where(x => x.PropertyName.Equals(memberInfo.Name))
-                        .Select(x => new ObservedChange<object, object>(sender, expression));
+                        .Select(x => new ObservedChange<object, object>(sender, expression, x.Value));
                 }
             }
         }

--- a/ReactiveUI/IROObservableForProperty.cs
+++ b/ReactiveUI/IROObservableForProperty.cs
@@ -31,7 +31,9 @@ namespace ReactiveUI
             if (beforeChanged) {
                 if (expression.NodeType == ExpressionType.Index) {
                     return obs.Where(x => x.PropertyName.Equals(memberInfo.Name + "[]"))
-                        .Select(x => new ObservedChange<object, object>(sender, expression, x.Value));
+                        // indexers do not know the exact position we want to get notified for,
+                        // so indexers do not fill in the value
+                        .Select(x => new ObservedChange<object, object>(sender, expression));
                 } else {
                     return obs.Where(x => x.PropertyName.Equals(memberInfo.Name))
                         .Select(x => new ObservedChange<object, object>(sender, expression, x.Value));
@@ -39,7 +41,9 @@ namespace ReactiveUI
             } else {
                 if (expression.NodeType == ExpressionType.Index) {
                     return obs.Where(x => x.PropertyName.Equals(memberInfo.Name + "[]"))
-                        .Select(x => new ObservedChange<object, object>(sender, expression, x.Value));
+                        // indexers do not know the exact position we want to get notified for,
+                        // so indexers do not fill in the value
+                        .Select(x => new ObservedChange<object, object>(sender, expression));
                 } else {
                     return obs.Where(x => x.PropertyName.Equals(memberInfo.Name))
                         .Select(x => new ObservedChange<object, object>(sender, expression, x.Value));

--- a/ReactiveUI/IReactiveObject.cs
+++ b/ReactiveUI/IReactiveObject.cs
@@ -44,22 +44,22 @@ namespace ReactiveUI
             return s.ThrownExceptions;
         }
 
-        internal static void raisePropertyChanging<TSender>(this TSender This, string propertyName) where TSender : IReactiveObject 
+        internal static void raisePropertyChanging<TSender>(this TSender This, string propertyName, object value) where TSender : IReactiveObject 
         {
             Contract.Requires(propertyName != null);
 
             var s = state.GetValue(This, key => (IExtensionState<IReactiveObject>)new ExtensionState<TSender>(This));
 
-            s.raisePropertyChanging(propertyName);
+            s.raisePropertyChanging(propertyName, value);
         }
 
-        internal static void raisePropertyChanged<TSender>(this TSender This, string propertyName) where TSender : IReactiveObject 
+        internal static void raisePropertyChanged<TSender>(this TSender This, string propertyName, object value) where TSender : IReactiveObject 
         {
             Contract.Requires(propertyName != null);
 
             var s = state.GetValue(This, key => (IExtensionState<IReactiveObject>)new ExtensionState<TSender>(This));
             
-            s.raisePropertyChanged(propertyName);
+            s.raisePropertyChanged(propertyName, value);
         }
 
         internal static IDisposable suppressChangeNotifications<TSender>(this TSender This) where TSender : IReactiveObject
@@ -102,9 +102,9 @@ namespace ReactiveUI
                 return newValue;
             }
 
-            This.raisePropertyChanging(propertyName);
+            This.raisePropertyChanging(propertyName, newValue);
             backingField = newValue;
-            This.raisePropertyChanged(propertyName);
+            This.raisePropertyChanged(propertyName, newValue);
             return newValue;
         }
 
@@ -117,9 +117,9 @@ namespace ReactiveUI
         /// A string representing the name of the property that has been changed.
         /// Leave <c>null</c> to let the runtime set to caller member name.
         /// </param>
-        public static void RaisePropertyChanged(this IReactiveObject This, [CallerMemberName] string propertyName = null)
+        public static void RaisePropertyChanged(this IReactiveObject This, object value, [CallerMemberName] string propertyName = null)
         {
-            This.raisePropertyChanged(propertyName);
+            This.raisePropertyChanged(propertyName, value);
         }
 
         /// <summary>
@@ -131,9 +131,9 @@ namespace ReactiveUI
         /// A string representing the name of the property that has been changed.
         /// Leave <c>null</c> to let the runtime set to caller member name.
         /// </param>
-        public static void RaisePropertyChanging(this IReactiveObject This, [CallerMemberName] string propertyName = null)
+        public static void RaisePropertyChanging(this IReactiveObject This, object value, [CallerMemberName] string propertyName = null)
         {
-            This.raisePropertyChanging(propertyName);
+            This.raisePropertyChanging(propertyName, value);
         }
 
         class ExtensionState<TSender> : IExtensionState<TSender> where TSender : IReactiveObject
@@ -186,23 +186,23 @@ namespace ReactiveUI
                 return Disposable.Create(() => Interlocked.Decrement(ref changeNotificationsSuppressed));
             }
 
-            public void raisePropertyChanging(string propertyName)
+            public void raisePropertyChanging(string propertyName, object value)
             {
                 if (!this.areChangeNotificationsEnabled())
                     return;
 
-                var changing = new ReactivePropertyChangingEventArgs<TSender>(sender, propertyName);
+                var changing = new ReactivePropertyChangingEventArgs<TSender>(sender, value, propertyName);
                 sender.RaisePropertyChanging(changing);
 
                 this.notifyObservable(sender, changing, this.changingSubject);
             }
 
-            public void raisePropertyChanged(string propertyName)
+            public void raisePropertyChanged(string propertyName, object value)
             {
                 if (!this.areChangeNotificationsEnabled())
                     return;
 
-                var changed = new ReactivePropertyChangedEventArgs<TSender>(sender, propertyName);
+                var changed = new ReactivePropertyChangedEventArgs<TSender>(sender, value, propertyName);
                 sender.RaisePropertyChanged(changed);
 
                 this.notifyObservable(sender, changed, this.changedSubject);
@@ -225,9 +225,9 @@ namespace ReactiveUI
 
             IObservable<IReactivePropertyChangedEventArgs<TSender>> Changed { get; }
 
-            void raisePropertyChanging(string propertyName);
+            void raisePropertyChanging(string propertyName, object value);
 
-            void raisePropertyChanged(string propertyName);
+            void raisePropertyChanged(string propertyName, object value);
 
             IObservable<Exception> ThrownExceptions { get; }
 

--- a/ReactiveUI/IReactiveObject.cs
+++ b/ReactiveUI/IReactiveObject.cs
@@ -127,10 +127,9 @@ namespace ReactiveUI
         /// properties where raiseAndSetIfChanged doesn't suffice.
         /// </summary>
         /// <param name="This">The instance of ReactiveObject on which the property has changed.</param>
-        /// <param name="propertyName">
-        /// A string representing the name of the property that has been changed.
-        /// Leave <c>null</c> to let the runtime set to caller member name.
-        /// </param>
+        /// <param name="value">The value.</param>
+        /// <param name="propertyName">A string representing the name of the property that has been changed.
+        /// Leave <c>null</c> to let the runtime set to caller member name.</param>
         public static void RaisePropertyChanging(this IReactiveObject This, object value, [CallerMemberName] string propertyName = null)
         {
             This.raisePropertyChanging(propertyName, value);

--- a/ReactiveUI/Interfaces.cs
+++ b/ReactiveUI/Interfaces.cs
@@ -42,24 +42,50 @@ namespace ReactiveUI
     /// </summary>
     public class ObservedChange<TSender, TValue> : IObservedChange<TSender, TValue>
     {
+        private bool hasValue;
+        private TValue value;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="ObservedChange{TSender, TValue}"/> class.
         /// </summary>
         /// <param name="sender">The sender.</param>
         /// <param name="expression">Expression describing the member.</param>
         /// <param name="value">The value.</param>
-        public ObservedChange(TSender sender, Expression expression, TValue value = default(TValue))
+        public ObservedChange(TSender sender, Expression expression)
         {
             this.Sender = sender;
             this.Expression = expression;
-            this.Value = value;
+            this.hasValue = false;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ObservedChange{TSender, TValue}"/> class.
+        /// </summary>
+        /// <param name="sender">The sender.</param>
+        /// <param name="expression">Expression describing the member.</param>
+        /// <param name="value">The value.</param>
+        public ObservedChange(TSender sender, Expression expression, TValue value)
+        {
+            this.Sender = sender;
+            this.Expression = expression;
+            this.value = value;
         }
 
         public TSender Sender { get; private set; }
 
         public Expression Expression { get; private set; }
 
-        public TValue Value { get; private set; }
+        public TValue Value
+        {
+            get
+            {
+                if (!hasValue) {
+                    value = this.GetValue();
+                    hasValue = true;
+                }
+                return value;
+            }
+        }
     }
 
     /// <summary>

--- a/ReactiveUI/Interfaces.cs
+++ b/ReactiveUI/Interfaces.cs
@@ -135,6 +135,11 @@ namespace ReactiveUI
         /// The object that has raised the change.
         /// </summary>
         TSender Sender { get; }
+
+        /// <summary>
+        /// Gets the value that is changed.
+        /// </summary>
+        object Value { get; }
     }
 
     public class ReactivePropertyChangingEventArgs<TSender> : PropertyChangingEventArgs, IReactivePropertyChangedEventArgs<TSender>
@@ -144,13 +149,16 @@ namespace ReactiveUI
         /// </summary>
         /// <param name="sender">The sender.</param>
         /// <param name="propertyName">Name of the property.</param>
-        public ReactivePropertyChangingEventArgs(TSender sender, string propertyName)
+        public ReactivePropertyChangingEventArgs(TSender sender, object value, string propertyName)
             : base(propertyName)
         {
             this.Sender = sender;
+            this.Value = value;
         }
 
         public TSender Sender { get; private set; }
+
+        public object Value { get; private set; }
     }
 
     public class ReactivePropertyChangedEventArgs<TSender> : PropertyChangedEventArgs, IReactivePropertyChangedEventArgs<TSender>
@@ -160,13 +168,16 @@ namespace ReactiveUI
         /// </summary>
         /// <param name="sender">The sender.</param>
         /// <param name="propertyName">Name of the property.</param>
-        public ReactivePropertyChangedEventArgs(TSender sender, string propertyName)
+        public ReactivePropertyChangedEventArgs(TSender sender, object value, string propertyName)
             : base(propertyName)
         {
             this.Sender = sender;
+            this.Value = value;
         }
 
         public TSender Sender { get; private set; }
+
+        public object Value { get; private set; }
     }
 
     /// <summary>

--- a/ReactiveUI/Interfaces.cs
+++ b/ReactiveUI/Interfaces.cs
@@ -81,8 +81,7 @@ namespace ReactiveUI
             get
             {
                 if (!hasValue) {
-                    value = this.GetValue();
-                    hasValue = true;
+                    hasValue = this.TryGetValue(out value);
                 }
                 return value;
             }

--- a/ReactiveUI/Interfaces.cs
+++ b/ReactiveUI/Interfaces.cs
@@ -69,6 +69,7 @@ namespace ReactiveUI
             this.Sender = sender;
             this.Expression = expression;
             this.value = value;
+            this.hasValue = true;
         }
 
         public TSender Sender { get; private set; }

--- a/ReactiveUI/ObservableAsPropertyHelper.cs
+++ b/ReactiveUI/ObservableAsPropertyHelper.cs
@@ -127,7 +127,7 @@ namespace ReactiveUI
             }
 
             var ret = new ObservableAsPropertyHelper<TRet>(observable, 
-                _ => This.raisePropertyChanged(expression.GetMemberInfo().Name), 
+                value => This.raisePropertyChanged(expression.GetMemberInfo().Name, value), 
                 initialValue, scheduler);
 
             return ret;

--- a/ReactiveUI/ObservedChangedMixin.cs
+++ b/ReactiveUI/ObservedChangedMixin.cs
@@ -20,20 +20,6 @@ namespace ReactiveUI
         }
 
         /// <summary>
-        /// Returns the current value of a property given a notification that
-        /// it has changed.
-        /// </summary>
-        /// <returns>The current value of the property</returns>
-        internal static TValue GetValue<TSender, TValue>(this IObservedChange<TSender, TValue> This)
-        {
-            TValue ret;
-            if (!This.TryGetValue(out ret)) {
-                throw new Exception(String.Format("One of the properties in the expression '{0}' was null", This.GetPropertyName()));
-            }
-            return ret;
-        }
-
-        /// <summary>
         /// Attempts to return the current value of a property given a 
         /// notification that it has changed. If any property in the
         /// property expression is null, false is returned.
@@ -60,7 +46,7 @@ namespace ReactiveUI
             TTarget target,
             Expression<Func<TTarget, TValue>> property)
         {
-            Reflection.TrySetValueToPropertyChain(target, Reflection.Rewrite(property.Body).GetExpressionChain(), This.GetValue());
+            Reflection.TrySetValueToPropertyChain(target, Reflection.Rewrite(property.Body).GetExpressionChain(), This.Value);
         }
 
         /// <summary>

--- a/ReactiveUI/ObservedChangedMixin.cs
+++ b/ReactiveUI/ObservedChangedMixin.cs
@@ -44,11 +44,6 @@ namespace ReactiveUI
         /// false otherwise</returns>
         internal static bool TryGetValue<TSender, TValue>(this IObservedChange<TSender, TValue> This, out TValue changeValue)
         {
-            if (!Equals(This.Value, default(TValue))) {
-                changeValue = This.Value;
-                return true;
-            }
-
             return Reflection.TryGetValueForPropertyChain(out changeValue, This.Sender, This.Expression.GetExpressionChain());
         }
 

--- a/ReactiveUI/ObservedChangedMixin.cs
+++ b/ReactiveUI/ObservedChangedMixin.cs
@@ -24,7 +24,7 @@ namespace ReactiveUI
         /// it has changed.
         /// </summary>
         /// <returns>The current value of the property</returns>
-        public static TValue GetValue<TSender, TValue>(this IObservedChange<TSender, TValue> This)
+        internal static TValue GetValue<TSender, TValue>(this IObservedChange<TSender, TValue> This)
         {
             TValue ret;
             if (!This.TryGetValue(out ret)) {
@@ -77,7 +77,7 @@ namespace ReactiveUI
         public static IObservable<TValue> Value<TSender, TValue>(
 		    this IObservable<IObservedChange<TSender, TValue>> This)
         {
-            return This.Select(GetValue);
+            return This.Select(x => x.Value);
         }
     }
 }

--- a/ReactiveUI/ReactiveList.cs
+++ b/ReactiveUI/ReactiveList.cs
@@ -586,15 +586,15 @@ namespace ReactiveUI
             this.Log().Info("Item hash: 0x{0:x}", toTrack.GetHashCode());
             var ro = toTrack as IReactiveObject;
             if (ro != null) {
-                changing = ro.getChangingObservable().Select(i => new ReactivePropertyChangingEventArgs<T>(toTrack, i.PropertyName));
-                changed = ro.getChangedObservable().Select(i => new ReactivePropertyChangedEventArgs<T>(toTrack, i.PropertyName));
+                changing = ro.getChangingObservable().Select(i => new ReactivePropertyChangingEventArgs<T>(toTrack, i.Value, i.PropertyName));
+                changed = ro.getChangedObservable().Select(i => new ReactivePropertyChangedEventArgs<T>(toTrack, i.Value, i.PropertyName));
                 goto isSetup;
             }
 
             var inpc = toTrack as INotifyPropertyChanged;
             if (inpc != null) {
                 changed = Observable.FromEventPattern<PropertyChangedEventHandler, PropertyChangedEventArgs>(x => inpc.PropertyChanged += x, x => inpc.PropertyChanged -= x)
-                    .Select(x => new ReactivePropertyChangedEventArgs<T>(toTrack, x.EventArgs.PropertyName));
+                    .Select(x => new ReactivePropertyChangedEventArgs<T>(toTrack, null, x.EventArgs.PropertyName));
                 goto isSetup;
             }
 

--- a/ReactiveUI/ReactiveList.cs
+++ b/ReactiveUI/ReactiveList.cs
@@ -123,15 +123,15 @@ namespace ReactiveUI
             // NB: ObservableCollection has a Secret Handshake with WPF where 
             // they fire an INPC notification with the token "Item[]". Emulate 
             // it here
-            CountChanging.Where(_ => this.areChangeNotificationsEnabled()).Subscribe(_ => this.RaisePropertyChanging("Count"));
+            CountChanging.Where(_ => this.areChangeNotificationsEnabled()).Subscribe(value => this.RaisePropertyChanging(value, "Count"));
 
-            CountChanged.Where(_ => this.areChangeNotificationsEnabled()).Subscribe(_ => this.RaisePropertyChanged("Count"));
+            CountChanged.Where(_ => this.areChangeNotificationsEnabled()).Subscribe(value => this.RaisePropertyChanged(value, "Count"));
 
-            IsEmptyChanged.Where(_ => this.areChangeNotificationsEnabled()).Subscribe(_ => this.RaisePropertyChanged("IsEmpty"));
+            IsEmptyChanged.Where(_ => this.areChangeNotificationsEnabled()).Subscribe(value => this.RaisePropertyChanged(value, "IsEmpty"));
 
-            Changing.Where(_ => this.areChangeNotificationsEnabled()).Subscribe(_ => this.RaisePropertyChanging("Item[]"));
+            Changing.Where(_ => this.areChangeNotificationsEnabled()).Subscribe(value => this.RaisePropertyChanging(value, "Item[]"));
 
-            Changed.Where(_ => this.areChangeNotificationsEnabled()).Subscribe(_ => this.RaisePropertyChanged("Item[]"));
+            Changed.Where(_ => this.areChangeNotificationsEnabled()).Subscribe(value => this.RaisePropertyChanged(value, "Item[]"));
         }
 
         public bool IsEmpty

--- a/ReactiveUI/Xaml/DependencyObjectObservableForProperty.cs
+++ b/ReactiveUI/Xaml/DependencyObjectObservableForProperty.cs
@@ -116,15 +116,15 @@ namespace ReactiveUI
             return null;
         }
 
-        static readonly Dictionary<Tuple<Type, string>, Tuple<DependencyProperty, Subject<object>>> attachedListener =
-            new Dictionary<Tuple<Type, string>, Tuple<DependencyProperty, Subject<object>>>();
+        static readonly Dictionary<Tuple<Type, string>, Tuple<DependencyProperty, Subject<Tuple<object, object>>>> attachedListener =
+            new Dictionary<Tuple<Type, string>, Tuple<DependencyProperty, Subject<Tuple<object, object>>>>();
 
-        Tuple<DependencyProperty, Subject<object>> createAttachedProperty(Type type, string propertyName)
+        Tuple<DependencyProperty, Subject<Tuple<object, object>>> createAttachedProperty(Type type, string propertyName)
         {
             var pair = Tuple.Create(type, propertyName);
             if (attachedListener.ContainsKey(pair)) return attachedListener[pair];
 
-            var subj = new Subject<object>();
+            var subj = new Subject<Tuple<object, object>>();
 
             // NB: There is no way to unregister an attached property, 
             // we just have to leak it. Luckily it's per-type, so it's
@@ -132,7 +132,7 @@ namespace ReactiveUI
             var dp = DependencyProperty.RegisterAttached(
                 "ListenAttached" + propertyName + this.GetHashCode().ToString("{0:x}"),
                 typeof(object), type,
-                new PropertyMetadata(null, (o, e) => subj.OnNext(o)));
+                new PropertyMetadata(null, (o, e) => subj.OnNext(Tuple.Create((object)o, e.NewValue))));
 
             var ret = Tuple.Create(dp, subj);
             attachedListener[pair] = ret;

--- a/ReactiveUI/Xaml/WpfDependencyObjectObservableForProperty.cs
+++ b/ReactiveUI/Xaml/WpfDependencyObjectObservableForProperty.cs
@@ -27,7 +27,7 @@ namespace ReactiveUI
 
             return Observable.Create<IObservedChange<object, object>>(subj => {
                 var handler = new EventHandler((o, e) => {
-                    subj.OnNext(new ObservedChange<object, object>(sender, expression));
+                    subj.OnNext(new ObservedChange<object, object>(sender, expression, dpd.GetValue(sender)));
                 });
 
                 dpd.AddValueChanged(sender, handler);


### PR DESCRIPTION
This PR changes the default behavior of `IObservedChange` and `ObservedChange` to always have their value filled in. 
## Why

With the refactorings done to the binding system, `IObservedChange` is only used for `WhenAny` and `ObservableForProperty`. These two were already guaranteed to fill in the value.

`GetValue` has been removed as you can now just use the Value property. If the value is not provided initially, it is retrieved the first time it is accessed and is cached.
## Related improvements
- `IReactiveObject` now includes the value in the change notifications, to save unnecessary reflection.
- The values coming from `DependencyObject` change notifications are now also directly propagated to `IObservedChange`.
## TODO:
- [ ] When beforeChange was set to true the `ObservedChange` previously contained the current values of the property as can be seen in the `OFPNamedPropertyTestBeforeChange` test. I think it does make more sense to include the new value in the `ObservedChange` when `beforechange` is true.
- [ ] Decide what to do with indexer change notifications. Including the value does not make sense. Including the index is more useful, but I'm not sure what to do with ranges.
- [ ] On iOS the `UIControl` does not seem to have a `Value` property. I commented it out for now, but what value do we need to return? Is this a bug?
- [ ] We need a clear policy for the `Value` property, as its value now depends on when you access it. I prefer an `It is always filled in initially` policy.
