### PR TITLE
Proxy BinarySearch methods to inner list

### DIFF
--- a/ReactiveUI/ReactiveList.cs
+++ b/ReactiveUI/ReactiveList.cs
@@ -640,6 +640,25 @@ namespace ReactiveUI
         }
 
         #region Super Boring IList crap
+
+        // The BinarySearch methods aren't technically on IList<T>, they're implemented straight on List<T>
+        // but by proxying this call we can make use of the nice built in methods that operate on the internal
+        // array of the inner list instead of jumping around proxying through the index.
+        public int BinarySearch(T item)
+        {
+            return _inner.BinarySearch(item);
+        }
+
+        public int BinarySearch(T item, IComparer<T> comparer)
+        {
+            return _inner.BinarySearch(item, comparer);
+        }
+
+        public int BinarySearch(int index, int count, T item, IComparer<T> comparer)
+        {
+            return _inner.BinarySearch(index, count, item, comparer);
+        }
+
         public IEnumerator<T> GetEnumerator()
         {
             return _inner.GetEnumerator();


### PR DESCRIPTION
Being able to binary search through a sorted list is really handy at times but unfortunately `BinarySearch` isn't implemented as an extension method on IList<T> as it should be but rather as an List<T> only thing. By proxying this call we can make use of the nice built in methods that operate on the internal array of the inner list instead of implementing it ourselves and proxying through the index property.

I chose not to do the same for the derived lists since the main use case I have for this is to use it to guarantee sort on insertion and derived lists are read only.
