### PR TITLE
Throttle values until the command can again be executed.

### DIFF
--- a/ReactiveUI.Tests/Resources/Resource.designer.cs
+++ b/ReactiveUI.Tests/Resources/Resource.designer.cs
@@ -34,6 +34,7 @@ namespace ReactiveUI.Tests
 			global::Xamarin.Android.NUnitLite.Resource.Id.ResultFullName = global::ReactiveUI.Tests.Resource.Id.ResultFullName;
 			global::Xamarin.Android.NUnitLite.Resource.Id.ResultMessage = global::ReactiveUI.Tests.Resource.Id.ResultMessage;
 			global::Xamarin.Android.NUnitLite.Resource.Id.ResultResultState = global::ReactiveUI.Tests.Resource.Id.ResultResultState;
+			global::Xamarin.Android.NUnitLite.Resource.Id.ResultRunSingleMethodTest = global::ReactiveUI.Tests.Resource.Id.ResultRunSingleMethodTest;
 			global::Xamarin.Android.NUnitLite.Resource.Id.ResultStackTrace = global::ReactiveUI.Tests.Resource.Id.ResultStackTrace;
 			global::Xamarin.Android.NUnitLite.Resource.Id.ResultsFailed = global::ReactiveUI.Tests.Resource.Id.ResultsFailed;
 			global::Xamarin.Android.NUnitLite.Resource.Id.ResultsId = global::ReactiveUI.Tests.Resource.Id.ResultsId;
@@ -91,20 +92,23 @@ namespace ReactiveUI.Tests
 			// aapt resource value: 0x7f050000
 			public const int OptionRemoteServer = 2131034112;
 			
-			// aapt resource value: 0x7f05000f
-			public const int OptionsButton = 2131034127;
-			
-			// aapt resource value: 0x7f05000a
-			public const int ResultFullName = 2131034122;
-			
-			// aapt resource value: 0x7f05000c
-			public const int ResultMessage = 2131034124;
+			// aapt resource value: 0x7f050010
+			public const int OptionsButton = 2131034128;
 			
 			// aapt resource value: 0x7f05000b
-			public const int ResultResultState = 2131034123;
+			public const int ResultFullName = 2131034123;
 			
 			// aapt resource value: 0x7f05000d
-			public const int ResultStackTrace = 2131034125;
+			public const int ResultMessage = 2131034125;
+			
+			// aapt resource value: 0x7f05000c
+			public const int ResultResultState = 2131034124;
+			
+			// aapt resource value: 0x7f05000a
+			public const int ResultRunSingleMethodTest = 2131034122;
+			
+			// aapt resource value: 0x7f05000e
+			public const int ResultStackTrace = 2131034126;
 			
 			// aapt resource value: 0x7f050006
 			public const int ResultsFailed = 2131034118;
@@ -127,11 +131,11 @@ namespace ReactiveUI.Tests
 			// aapt resource value: 0x7f050004
 			public const int ResultsResult = 2131034116;
 			
-			// aapt resource value: 0x7f05000e
-			public const int RunTestsButton = 2131034126;
+			// aapt resource value: 0x7f05000f
+			public const int RunTestsButton = 2131034127;
 			
-			// aapt resource value: 0x7f050010
-			public const int TestSuiteListView = 2131034128;
+			// aapt resource value: 0x7f050011
+			public const int TestSuiteListView = 2131034129;
 			
 			static Id()
 			{


### PR DESCRIPTION
This PR changes `InvokeCommand` to throttle produced values until the command can again be executed. Previously we would miss them and the values would never reach the command.
