### PR TITLE
Fixed the Android Playground build

### DIFF
--- a/Playground-Android/App.cs
+++ b/Playground-Android/App.cs
@@ -10,7 +10,7 @@ namespace MobileSample_Android
     {
         AutoSuspendHelper suspendHelper;
 
-        //App(IntPtr handle, JniHandleOwnership owner) : base(handle, owner) { }
+        App(IntPtr handle, JniHandleOwnership owner) : base(handle, owner) { }
 
         public override void OnCreate()
         {

--- a/Playground-Android/ViewModels/WatchListViewModel.cs
+++ b/Playground-Android/ViewModels/WatchListViewModel.cs
@@ -31,18 +31,18 @@ namespace MobileSample_Android.ViewModels
 
         public WatchListViewModel()
         {
-            var openCmd = ReactiveCommand.CreateAsyncFunction(this.WhenAnyValue(vm => vm.MarketState, m => m == MarketState.Closed),
-                _ => OpenMarket(), RxApp.MainThreadScheduler);
+            var openCmd = ReactiveCommand.CreateAsyncObservable(this.WhenAnyValue(vm => vm.MarketState, m => m == MarketState.Closed),
+                _ => Observable.Start(OpenMarket), RxApp.MainThreadScheduler);
             OpenMarketCommand = openCmd;
 
-            var closeCmd = ReactiveCommand.CreateAsyncFunction(
+            var closeCmd = ReactiveCommand.CreateAsyncObservable(
                 this.WhenAnyValue(vm => vm.MarketState, m => m == MarketState.Open),
-                _ => CloseMarket(), RxApp.MainThreadScheduler);
+                _ => Observable.Start(CloseMarket), RxApp.MainThreadScheduler);
             CloseMarketCommand = closeCmd;
 
-            var resetCmd = ReactiveCommand.CreateAsyncFunction(
+            var resetCmd = ReactiveCommand.CreateAsyncObservable(
                 this.WhenAnyValue(vm => vm.MarketState, m => m == MarketState.Closed),
-                _ => Reset(), RxApp.MainThreadScheduler);
+                _ => Observable.Start(Reset), RxApp.MainThreadScheduler);
             ResetCommand = resetCmd;
 
             LoadDefaultStocks();

--- a/Playground-Android/Views/WatchListItemView.cs
+++ b/Playground-Android/Views/WatchListItemView.cs
@@ -7,7 +7,6 @@ using Android.Views;
 using Android.Widget;
 using MobileSample_Android.ViewModels;
 using ReactiveUI;
-using ReactiveUI.Android;
 
 namespace MobileSample_Android.Views
 {

--- a/Playground-Android/WatchListActivity.cs
+++ b/Playground-Android/WatchListActivity.cs
@@ -8,7 +8,6 @@ using Android.Widget;
 using MobileSample_Android.ViewModels;
 using MobileSample_Android.Views;
 using ReactiveUI;
-using ReactiveUI.Android;
 using Android.Views;
 
 namespace MobileSample_Android


### PR DESCRIPTION
This also reveals a strange issue when starting the Playground app, it throws a

```
NotSupportedException: "Unsupported expression type: 'Convert'"
```

at https://github.com/reactiveui/ReactiveUI/blob/master/ReactiveUI/Platform/Registrations.cs#L46

that I can also reproduce in my apps that I upgraded to RxUI 6
