### PR TITLE
Add note about IRoutingState -> RoutingState

### DIFF
--- a/docs/migrating-from-rxui5.md
+++ b/docs/migrating-from-rxui5.md
@@ -108,6 +108,9 @@ that your app provides.
 
 * MemoizingMRUCache is now in Splat
 
+* The `Router` property on `IScreen` is now of type `RoutingState` instead of
+  `IRoutingState`.
+
 ### Find-and-replace changes
 
 * RxApp.DependencyResolver => Locator.Current


### PR DESCRIPTION
This was the only thing I found missing from the guide whilst migrating a reasonably large app across from RXUI 5 to RXUI 6.0.1 - not a big one but may save someone a few mins in future.
