### PR TITLE
Fix exception when adding an element twice.

### DIFF
--- a/ReactiveUI/WeakEventManager.cs
+++ b/ReactiveUI/WeakEventManager.cs
@@ -145,6 +145,7 @@ namespace ReactiveUI
                 // clone list if we are currently delivering an event
                 if (weakHandlers.IsDeliverActive) {
                     weakHandlers = weakHandlers.Clone();
+                    this.sourceToWeakHandlers.Remove(source);
                     this.sourceToWeakHandlers.Add(source, weakHandlers);
                 }
                 weakHandlers.AddWeakHandler(source, handler);
@@ -189,6 +190,7 @@ namespace ReactiveUI
                 // clone list if we are currently delivering an event
                 if (weakHandlers.IsDeliverActive) {
                     weakHandlers = weakHandlers.Clone();
+                    this.sourceToWeakHandlers.Remove(source);
                     this.sourceToWeakHandlers.Add(source, weakHandlers);
                 }
 
@@ -239,6 +241,7 @@ namespace ReactiveUI
             if (this.sourceToWeakHandlers.TryGetValue(source, out weakHandlers)) {
                 if (weakHandlers.IsDeliverActive) {
                     weakHandlers = weakHandlers.Clone();
+                    this.sourceToWeakHandlers.Remove(source);
                     this.sourceToWeakHandlers.Add(source, weakHandlers);
                 } else {
                     weakHandlers.Purge();


### PR DESCRIPTION
This PR fixes an exception when a event handler is removed from an event backed by the WeakEventManager.
