### PR TITLE
Fixed ReactiveList.SetItem

### DIFF
--- a/ReactiveUI/ReactiveList.cs
+++ b/ReactiveUI/ReactiveList.cs
@@ -268,12 +268,12 @@ namespace ReactiveUI
         protected void SetItem(int index, T item)
         {
             if (!this.areChangeNotificationsEnabled()) {
-                _inner[index] = item;
-
+                
                 if (ChangeTrackingEnabled) {
                     removeItemFromPropertyTracking(_inner[index]);
                     addItemToPropertyTracking(item);
                 }
+                _inner[index] = item;
 
                 return;
             }


### PR DESCRIPTION
Fixed the ReactiveList SetItem method when change notification is
surpressed. The new item is used instead of the old item when attempting
to remove the old from property change tracking.
