### PR TITLE
Replace AndroidUIScheduler with a more generalized scheduler implementation that delegates to an Android.OS.Handler

### DIFF
--- a/ReactiveUI/Android/AndroidScheduler.cs
+++ b/ReactiveUI/Android/AndroidScheduler.cs
@@ -1,71 +1,74 @@
 using System;
-using System.Linq;
-using System.Collections.Generic;
-using System.Reactive;
 using System.Reactive.Concurrency;
 using System.Reactive.Disposables;
-using ReactiveUI;
+using Android.OS;
 using Android.App;
-using Splat;
 
 namespace ReactiveUI
 {
-    /// <summary>
-    /// AndroidUIScheduler is a scheduler that schedules items on a running 
-    /// Activity's main thread. This is the moral equivalent of 
-    /// DispatcherScheduler, but since every Activity runs separately, you must
-    /// assign RxApp.MainThreadScheduler to an instance of this at the start of
-    /// every activity.
-    /// </summary>
-    public class AndroidUIScheduler : IScheduler, IEnableLogger
+    public sealed class AndroidScheduler : IScheduler
     {
-        Activity activity;
-        
-        public AndroidUIScheduler(Activity activity)
+        private readonly Handler handler;
+
+        public static IScheduler UIScheduler () 
         {
-            this.activity = activity;
+            return LooperScheduler(Looper.MainLooper);
         }
-    
+
+        public static IScheduler LooperScheduler(Looper looper)
+        {
+            return HandlerScheduler(new Handler(looper));
+        }
+
+        public static IScheduler HandlerScheduler(Handler handler) 
+        {
+            return new AndroidScheduler(handler);
+        }
+
+        private AndroidScheduler(Handler handler)
+        {
+            this.handler = handler;
+        }
+
         public DateTimeOffset Now {
             get { return DateTimeOffset.Now; }
         }
-        
+
         public IDisposable Schedule<TState>(TState state, Func<IScheduler, TState, IDisposable> action)
         {
             IDisposable innerDisp = Disposable.Empty;
-            activity.RunOnUiThread(new Action(() => innerDisp = action(this, state)));
-            
+            handler.Post (new Action (() => innerDisp = action (this, state)));
             return innerDisp;
         }
-        
+
         public IDisposable Schedule<TState>(TState state, DateTimeOffset dueTime, Func<IScheduler, TState, IDisposable> action)
         {
             if (dueTime <= Now) {
                 return Schedule(state, action);
             }
-            
+
             return Schedule(state, dueTime - Now, action);
         }
-        
+
         public IDisposable Schedule<TState>(TState state, TimeSpan dueTime, Func<IScheduler, TState, IDisposable> action)
         {
             bool isCancelled = false;
-            
-            var disp = Scheduler.TaskPool.Schedule(state, dueTime, (sched, st) => {
+
+            var disp = TaskPoolScheduler.Default.Schedule(state, dueTime, (sched, st) => {
                 IDisposable innerDisp = Disposable.Empty;
-                
+
                 if (!isCancelled) { 
-                    activity.RunOnUiThread(() => {
+                    handler.Post(() => {
                         if (!isCancelled) innerDisp = action(this, state);
                     });
                 }
-               
+
                 return Disposable.Create(() => {
                     isCancelled = true;
                     innerDisp.Dispose();
                 });    
             });
-            
+
             return Disposable.Create(() => {
                 isCancelled = true;
                 disp.Dispose();
@@ -73,5 +76,3 @@ namespace ReactiveUI
         }
     }
 }
-
-// vim: tw=120 ts=4 sw=4 et :

--- a/ReactiveUI/Android/AutoSuspendHelper.cs
+++ b/ReactiveUI/Android/AutoSuspendHelper.cs
@@ -55,7 +55,7 @@ namespace ReactiveUI
             public void OnActivityCreated(Activity activity, Bundle savedInstanceState)
             {
                 This.onCreate.OnNext(savedInstanceState);
-                RxApp.MainThreadScheduler = new WaitForDispatcherScheduler(() => new AndroidUIScheduler(activity));
+                RxApp.MainThreadScheduler = new WaitForDispatcherScheduler(() => AndroidScheduler.UIScheduler());
             }
 
             public void OnActivityResumed(Activity activity)

--- a/ReactiveUI/Android/ReactiveActivity.cs
+++ b/ReactiveUI/Android/ReactiveActivity.cs
@@ -54,7 +54,7 @@ namespace ReactiveUI
     {
         protected ReactiveActivity()
         {
-            RxApp.MainThreadScheduler = new WaitForDispatcherScheduler(() => new AndroidUIScheduler(this));
+            RxApp.MainThreadScheduler = new WaitForDispatcherScheduler(() => AndroidScheduler.UIScheduler());
         }
 
         public event PropertyChangingEventHandler PropertyChanging {

--- a/ReactiveUI/ReactiveUI_Android.csproj
+++ b/ReactiveUI/ReactiveUI_Android.csproj
@@ -72,7 +72,6 @@
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="Android\AndroidCommandBinders.cs" />
-    <Compile Include="Android\AndroidUIScheduler.cs" />
     <Compile Include="Android\ControlFetcherMixin.cs" />
     <Compile Include="Android\LinkerOverrides.cs" />
     <Compile Include="Android\ObjectExtension.cs" />
@@ -141,6 +140,7 @@
     <Compile Include="Android\BundleSuspensionDriver.cs" />
     <Compile Include="Android\AutoSuspendHelper.cs" />
     <Compile Include="Legacy\ReactiveCommand.cs" />
+    <Compile Include="Android\AndroidScheduler.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.ReactiveUI_Android.config" />


### PR DESCRIPTION
Why does ReactiveUI reassign the RxApp.MainThreadScheduler in Activity.OnCreate()? Any reason not to ifdef this once into RxApp? One of the reasons I implemented this was so that I could assign the MainThreadScheduler in Application.OnCreate(). The motivation was to allow me to use ReactiveObject throughout my app even when the app is backgrounded. For instance I have a ReactiveObject to monitor the network state, which I use to pause and automatically resume http requests when the network state changes even if the app is backgrounded.
