### PR TITLE
Ensure IsExecuting is false when command completes

### DIFF
--- a/ReactiveUI.Tests/ReactiveCommandTest.cs
+++ b/ReactiveUI.Tests/ReactiveCommandTest.cs
@@ -569,5 +569,20 @@ namespace ReactiveUI.Tests
                 Assert.Equal(0, result);
             });
         }
+
+        [Fact]
+        public async Task IsExecutingIsFalseAfterAwaitingCommand()
+        {
+            var command = ReactiveCommand.CreateAsyncTask(_ => Task.Run(() => Thread.Sleep(10)));
+            var isExecutingStates = new List<bool>();
+            command.IsExecuting.Subscribe(isExecutingStates.Add);
+
+            await command.ExecuteAsync();
+
+            Assert.Equal(3, isExecutingStates.Count);
+            Assert.Equal(false, isExecutingStates[0]);
+            Assert.Equal(true, isExecutingStates[1]);
+            Assert.Equal(false, isExecutingStates[2]);
+        }
     }
 }

--- a/ReactiveUI/ReactiveCommand.cs
+++ b/ReactiveUI/ReactiveCommand.cs
@@ -377,7 +377,10 @@ namespace ReactiveUI
 
                 var disp = executeAsync(parameter)
                     .ObserveOn(scheduler)
-                    .Finally(() => decrement.Disposable = Disposable.Empty)
+                    .Do(
+                        _ => { },
+                        e => decrement.Disposable = Disposable.Empty,
+                        () => decrement.Disposable = Disposable.Empty)
                     .Do(executeResults.OnNext, exceptions.OnNext)
                     .Subscribe(subj);
 


### PR DESCRIPTION
Because `ReactiveCommand` decrements the in flight count in a `Finally` block, when we await a command's `ExecuteAsync` method, it still reports an in-flight count when the await returns. We want to not return until the in-flight count is decremented. This fixes that by putting the decrement in a `Do` statement for both the onNext block and the onError block.
