### PR TITLE
Added support for binding to properties of Component (WinForms)

### DIFF
--- a/ReactiveUI.Tests/Winforms/DefaultPropertyBindingTests.cs
+++ b/ReactiveUI.Tests/Winforms/DefaultPropertyBindingTests.cs
@@ -33,6 +33,30 @@ namespace ReactiveUI.Tests.Winforms
         }
 
         [Fact]
+        public void WinformsCreatesObservableForPropertyWorksForComponents()
+        {
+            var input = new ToolStripButton(); // ToolStripButton is a Component, not a Control
+            var fixture = new WinformsCreatesObservableForProperty();
+
+            Assert.NotEqual(0, fixture.GetAffinityForObject(typeof(ToolStripButton), "Checked"));
+
+            Expression<Func<ToolStripButton, bool>> expression = x => x.Checked;
+            var output = fixture.GetNotificationForProperty(input, expression.Body).CreateCollection();
+            Assert.Equal(0, output.Count);
+
+            input.Checked = true;
+            Assert.Equal(1, output.Count);
+            Assert.Equal(input, output[0].Sender);
+            Assert.Equal("Checked", output[0].GetPropertyName());
+
+            output.Dispose();
+
+            // Since we disposed the derived list, we should no longer receive updates
+            input.Checked = false;
+            Assert.Equal(1, output.Count);
+        }
+
+        [Fact]
         public void WinformsCreatesObservableForPropertyWorksForThirdPartyControls()
         {
             var input = new AThirdPartyNamespace.ThirdPartyControl();

--- a/ReactiveUI.Winforms/Winforms/WinformsCreatesObservableForProperty.cs
+++ b/ReactiveUI.Winforms/Winforms/WinformsCreatesObservableForProperty.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reactive.Disposables;
@@ -18,7 +19,7 @@ namespace ReactiveUI.Winforms
 
         public int GetAffinityForObject(Type type, string propertyName, bool beforeChanged = false)
         {
-            bool supportsTypeBinding = typeof(Control).IsAssignableFrom(type);
+            bool supportsTypeBinding = typeof(Component).IsAssignableFrom(type);
             if (!supportsTypeBinding) return 0;
 
             lock (eventInfoCache) {


### PR DESCRIPTION
This is related to my [previous pull request](https://github.com/reactiveui/ReactiveUI/pull/720). You can only bind one-way to properties of WinForms Components: the property will be set upon ViewModel changes, but no notifications are received for changes to the Component. This problem does not occur with Controls, because notifications are triggered for changes to Control properties correctly.

There are properties of Components that are very suitable for two-way binding however, such as ToolStripButton.Checked. This pull request remedies the problem by adding change nofications for properties of a Component.

The test WinformsCreatesObservableForPropertyWorksForComponents illustrates the problem. The one-word change to WinformsCreatesObservableForProperty makes the test pass.
