### PR TITLE
Provide a virtual method Validate() on ReactiveObject

### DIFF
--- a/ReactiveUI/IReactiveObject.cs
+++ b/ReactiveUI/IReactiveObject.cs
@@ -18,6 +18,8 @@ namespace ReactiveUI
         event PropertyChangingEventHandler PropertyChanging;
         event PropertyChangedEventHandler PropertyChanged;
 
+        void Validate();
+
         void RaisePropertyChanging(PropertyChangingEventArgs args);
         void RaisePropertyChanged(PropertyChangedEventArgs args);
     }
@@ -112,6 +114,7 @@ namespace ReactiveUI
 
             This.raisePropertyChanging(propertyName);
             backingField = newValue;
+            This.Validate();
             This.raisePropertyChanged(propertyName);
             return newValue;
         }
@@ -128,6 +131,7 @@ namespace ReactiveUI
         public static void RaisePropertyChanged<TSender>(this TSender This, [CallerMemberName] string propertyName = null)
             where TSender : IReactiveObject
         {
+            This.Validate();
             This.raisePropertyChanged(propertyName);
         }
 

--- a/ReactiveUI/ObservableAsPropertyHelper.cs
+++ b/ReactiveUI/ObservableAsPropertyHelper.cs
@@ -155,7 +155,10 @@ namespace ReactiveUI
 
             var name = expression.GetMemberInfo().Name;
             var ret = new ObservableAsPropertyHelper<TRet>(observable, 
-                _ => This.raisePropertyChanged(name), 
+                _ => {
+                    This.Validate();
+                    This.raisePropertyChanged(name);
+                }, 
                 _ => This.raisePropertyChanging(name),
                 initialValue, scheduler);
 

--- a/ReactiveUI/ReactiveObject.cs
+++ b/ReactiveUI/ReactiveObject.cs
@@ -67,6 +67,18 @@ namespace ReactiveUI
 #endif
 
         /// <summary>
+        /// This is a hook that can be implemented. It will be called after
+        /// a property is set but before the 'property changed event' is called.
+        /// It enables subclasses to provide custom validation logic on the entire. It
+        /// make no assumption about the type of validation you may wish to perform. It
+        /// only makes it possible that you can validate the object 'before' others
+        /// are notified of the changes. 
+        /// </summary>
+        public virtual void Validate()
+        {
+        }
+
+        /// <summary>
         /// Represents an Observable that fires *before* a property is about to
         /// be changed.
         /// </summary>


### PR DESCRIPTION
This Validate method is just a simple hook. It makes no assumptions about the method of validation you wish to employ other than you would wish to perform validation before sending out property changed events.

My use case is that I have a view model and I do something like this

    this.WhenAnyValue(p=>p.ConfigurationData.Height)
          .Where(_ => this.IsValid )
          .Subscribe( DoSomethingDangerous );

IsValid is a boolean property on my viewmodel implemented by my custom validation. It is not part of the pull request. However IsValid must be calculated before the property changed event is delivered. I could subscribe to PropertyChanged to implement the validation but then there is a race condition with the validator subscription and the WhenAnyValue subscription.

Other alternative is to add a new event __PropertyBeforeChangedEvent__ which is broadcast before the __PropertyChangedEvent__.  __WhenAnyValue__ subscribes to the __PropertyChangedEvent__ and the validator can subscribe to the __PropertyBeforeChangedEvent__. Note this new event is not the __PropertyChangingEvent__. __PropertyChangingEvent__ is delivered before the property is set. __PropertyBeforeChangedEvent__ would be sent out after the property is set but before the __PropertyChangedEvent__