### PR TITLE
Check length of resulting string before removing the last '.'

### DIFF
--- a/ReactiveUI/Reflection.cs
+++ b/ReactiveUI/Reflection.cs
@@ -48,7 +48,10 @@ namespace ReactiveUI
                 sb.Append('.');
             }
 
-            sb.Remove(sb.Length - 1, 1);
+            if (sb.Length > 0) {
+                sb.Remove(sb.Length - 1, 1);
+            }
+
             return sb.ToString();
         }
 


### PR DESCRIPTION
The resulting string could be empty when `expression.GetExpressionChain` returns an empty list.
This happens e.g. when the method is called with an expression like `x => x`
