### PR TITLE
Derived collections onRemoved handler

### DIFF
--- a/ReactiveUI.Tests/ReactiveCollectionTest.cs
+++ b/ReactiveUI.Tests/ReactiveCollectionTest.cs
@@ -967,8 +967,7 @@ namespace ReactiveUI.Tests
            var fixture = new ReactiveList<TestFixture>(
                input.Select(x => new TestFixture() { IsOnlyOneWord = x }));
 
-           var output = fixture.CreateDerivedCollection(new Func<TestFixture, IDisposable>(x => Disposable.Create(() => disposed.Add(x))),
-              onRemoved: item => item.Dispose());
+           var output = fixture.CreateDerivedCollection(x => Disposable.Create(() => disposed.Add(x)), item => item.Dispose());
 
            fixture.Add(new TestFixture() { IsOnlyOneWord = "Hello" });
            Assert.Equal(5, output.Count);
@@ -1697,8 +1696,7 @@ namespace ReactiveUI.Tests
         }
 
         [Fact]
-        public void TestDelayNotifications() 
-        {
+        public void TestDelayNotifications()  {
             var maxSize = 10;
             var data = makeAsyncCollection(maxSize);
 
@@ -1708,7 +1706,6 @@ namespace ReactiveUI.Tests
 
             var derivedList = list.CreateDerivedCollection(
                 m => m.Value, m => m.HasData, (a, b) => a.Text.CompareTo(b.Text),
-                null,
                 Observable.Never(4) /*list.ShouldReset*/, 
                 scheduler: RxApp.MainThreadScheduler);
 

--- a/ReactiveUI.Winforms/Winforms/ReactiveDerivedBindingListMixins.cs
+++ b/ReactiveUI.Winforms/Winforms/ReactiveDerivedBindingListMixins.cs
@@ -105,6 +105,51 @@ namespace ReactiveUI.Winforms
         /// </summary>
         /// <param name="selector">A Select function that will be run on each
         /// item.</param>
+        /// <param name="onRemoved">An action that is called on each item when
+        /// it is removed.</param>
+        /// <param name="filter">A filter to determine whether to exclude items 
+        /// in the derived collection.</param>
+        /// <param name="orderer">A comparator method to determine the ordering of
+        /// the resulting collection.</param>
+        /// <param name="signalReset">When this Observable is signalled, 
+        /// the derived collection will be manually 
+        /// reordered/refiltered.</param>
+        /// <returns>A new collection whose items are equivalent to
+        /// Collection.Select().Where().OrderBy() and will mirror changes 
+        /// in the initial collection.</returns>
+        public static IReactiveDerivedBindingList<TNew> CreateDerivedBindingList<T, TNew, TDontCare>(
+            this IEnumerable<T> This,
+            Func<T, TNew> selector,
+            Action<TNew> removed,
+            Func<T, bool> filter = null,
+            Func<TNew, TNew, int> orderer = null,
+            IObservable<TDontCare> signalReset = null)
+        {
+            Contract.Requires(selector != null);
+
+            IObservable<Unit> reset = null;
+
+            if (signalReset != null) {
+                reset = signalReset.Select(_ => Unit.Default);
+            }
+
+            return new ReactiveDerivedBindingList<T, TNew>(This, selector, filter, orderer, removed, reset);
+        }
+
+        /// <summary>
+        /// Creates a collection whose contents will "follow" another
+        /// collection; this method is useful for creating ViewModel collections
+        /// that are automatically updated when the respective Model collection
+        /// is updated.
+        ///
+        /// Note that even though this method attaches itself to any 
+        /// IEnumerable, it will only detect changes from objects implementing
+        /// INotifyCollectionChanged (like ReactiveList). If your source
+        /// collection doesn't implement this, signalReset is the way to signal
+        /// the derived collection to reorder/refilter itself.
+        /// </summary>
+        /// <param name="selector">A Select function that will be run on each
+        /// item.</param>
         /// <param name="filter">A filter to determine whether to exclude items 
         /// in the derived collection.</param>
         /// <param name="orderer">A comparator method to determine the ordering of
@@ -120,18 +165,41 @@ namespace ReactiveUI.Winforms
             Func<T, TNew> selector,
             Func<T, bool> filter = null,
             Func<TNew, TNew, int> orderer = null,
-            Action<TNew> removed = null,
             IObservable<TDontCare> signalReset = null)
         {
-            Contract.Requires(selector != null);
+            return This.CreateDerivedBindingList(selector, null, filter, orderer, signalReset);
+        }
 
-            IObservable<Unit> reset = null;
-
-            if (signalReset != null) {
-                reset = signalReset.Select(_ => Unit.Default);
-            }
-
-            return new ReactiveDerivedBindingList<T, TNew>(This, selector, filter, orderer, removed, reset);
+        /// <summary>
+        /// Creates a collection whose contents will "follow" another
+        /// collection; this method is useful for creating ViewModel collections
+        /// that are automatically updated when the respective Model collection
+        /// is updated.
+        /// 
+        /// Be aware that this overload will result in a collection that *only* 
+        /// updates if the source implements INotifyCollectionChanged. If your
+        /// list changes but isn't a ReactiveList/ObservableCollection,
+        /// you probably want to use the other overload.
+        /// </summary>
+        /// <param name="selector">A Select function that will be run on each
+        /// item.</param>
+        /// /// <param name="onRemoved">An action that is called on each item when
+        /// it is removed.</param>
+        /// <param name="filter">A filter to determine whether to exclude items 
+        /// in the derived collection.</param>
+        /// <param name="orderer">A comparator method to determine the ordering of
+        /// the resulting collection.</param>
+        /// <returns>A new collection whose items are equivalent to
+        /// Collection.Select().Where().OrderBy() and will mirror changes 
+        /// in the initial collection.</returns>
+        public static IReactiveDerivedBindingList<TNew> CreateDerivedBindingList<T, TNew>(
+            this IEnumerable<T> This,
+            Func<T, TNew> selector,
+            Action<TNew> removed,
+            Func<T, bool> filter = null,
+            Func<TNew, TNew, int> orderer = null)
+        {
+            return This.CreateDerivedBindingList(selector, removed, filter, orderer, (IObservable<Unit>)null);
         }
 
         /// <summary>
@@ -158,10 +226,9 @@ namespace ReactiveUI.Winforms
             this IEnumerable<T> This,
             Func<T, TNew> selector,
             Func<T, bool> filter = null,
-            Action<TNew> removed = null,
             Func<TNew, TNew, int> orderer = null)
         {
-            return This.CreateDerivedBindingList(selector, filter, orderer, removed, (IObservable<Unit>)null);
+            return This.CreateDerivedBindingList(selector, null, filter, orderer, (IObservable<Unit>)null);
         }
     }
 }


### PR DESCRIPTION
This adds an optional Action onRemoved argument to the ReactiveDerivedCollection class, and a matching Action onRemoved each of the CreateDerivedCollection and CreateDerivedBindingList methods.

If the delegate is given, then it will be called whenever a derived item is removed, as well as for each item when the derived collection as a whole is disposed.

The DerviedCollectionShouldHandleItemsRemoved test is also added and passes, and all prior tests pass.

Fixes #743 
