### PR TITLE
Remove opportunistic scheduling in Cocoa

### DIFF
--- a/ReactiveUI/Cocoa/NSRunloopScheduler.cs
+++ b/ReactiveUI/Cocoa/NSRunloopScheduler.cs
@@ -29,8 +29,6 @@ namespace ReactiveUI
 
         public IDisposable Schedule<TState>(TState state, Func<IScheduler, TState, IDisposable> action)
         {
-            if (NSThread.IsMain) return action(this, state);
-
             var innerDisp = new SingleAssignmentDisposable();
 
             DispatchQueue.MainQueue.DispatchAsync(new NSAction(() => {


### PR DESCRIPTION
You can get things out of order, and it almost always slows down animations.
