### PR TITLE
Calls to NotifyDataSetChanged should be on the main thread

### DIFF
--- a/ReactiveUI/Android/ReactiveListAdapter.cs
+++ b/ReactiveUI/Android/ReactiveListAdapter.cs
@@ -26,7 +26,7 @@ namespace ReactiveUI
             this.viewCreator = viewCreator;
             this.viewInitializer = viewInitializer;
 
-            _inner = this.list.Changed.Subscribe(_ => NotifyDataSetChanged());
+            _inner = this.list.Changed.ObserveOn(RxApp.MainThreadScheduler).Subscribe(_ => NotifyDataSetChanged());
         }
 
         public override TViewModel this[int index] {


### PR DESCRIPTION
If this is not called and this is fired off from a background thread, it will result in the following error "Only the original thread that created a view hierarchy can touch its views."
