### PR TITLE
Fix the type forwarding of INotifyPropertyChanging

### DIFF
--- a/ReactiveUI/ContractStubs.cs
+++ b/ReactiveUI/ContractStubs.cs
@@ -3,7 +3,7 @@ using System.Collections.Specialized;
 
 #if UIKIT || PORTABLE || WINRT || ANDROID
 
-namespace ReactiveUI
+namespace System.ComponentModel
 {
     public class PropertyChangingEventArgs : EventArgs
     {

--- a/ReactiveUI/Properties/AssemblyInfo.cs
+++ b/ReactiveUI/Properties/AssemblyInfo.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
@@ -23,3 +24,7 @@ using System.Windows;
 [assembly: InternalsVisibleTo("ReactiveUI.Winforms")]
 [assembly: InternalsVisibleTo("ReactiveUI.XamForms")]
 [assembly: InternalsVisibleTo("ReactiveUI.AndroidSupport")]
+
+#if NET_45 || WP8 || MONO
+[assembly: TypeForwardedTo(typeof(INotifyPropertyChanging))]
+#endif


### PR DESCRIPTION
I'm not 100% sure this is the correct approach, but it fixes the `TypeLoadException` for `INotifyPropertyChanging` for me.

I had to change the namespace of `INotifyPropertyChanging` from `ReactiveUI` to `System.ComponentModel` I think type forwarding doesn't work if the type moves to a different namespace, please correct me if I'm wrong.

I'm also not 100% sure I've included all of the correct platforms, I can't test on a Mac or iOS
