### PR TITLE
Fix WPF ViewModelViewHost refresh behaviour

### DIFF
--- a/ReactiveUI/Xaml/ViewModelViewHost.cs
+++ b/ReactiveUI/Xaml/ViewModelViewHost.cs
@@ -82,9 +82,8 @@ namespace ReactiveUI
 
             ViewContractObservable = Observable.FromEventPattern<SizeChangedEventHandler, SizeChangedEventArgs>(x => SizeChanged += x, x => SizeChanged -= x)
                 .Select(_ => platformGetter())
-                .DistinctUntilChanged()
                 .StartWith(platformGetter())
-                .Select(x => x != null ? x.ToString() : default(string));
+                .DistinctUntilChanged();
 
             this.WhenActivated(d => {
                 d(vmAndContract.Subscribe(x => {


### PR DESCRIPTION
Hello, @paulcbetts!
ViewModelViewHost was forcing a reloading of the entire view on the first change of size even if this change didn't alter the orientation.
Also I removed the redundant Select - platformGetter() already returns a string.
Thanks.
