### PR TITLE
Use an AutoResetEvent instead of a Monitor in TestScheduler.WithScheduler

### DIFF
--- a/ReactiveUI.Testing/TestUtils.cs
+++ b/ReactiveUI.Testing/TestUtils.cs
@@ -12,7 +12,7 @@ namespace ReactiveUI.Testing
 {
     public static class TestUtils
     {
-        static readonly object schedGate = 42;
+        static readonly AutoResetEvent schedGate = new AutoResetEvent(true);
         static readonly object mbGate = 42;
 
         /// <summary>
@@ -26,7 +26,7 @@ namespace ReactiveUI.Testing
         /// schedulers.</returns>
         public static IDisposable WithScheduler(IScheduler sched)
         {
-            Monitor.Enter(schedGate);
+            schedGate.WaitOne();
             var prevDef = RxApp.MainThreadScheduler;
             var prevTask = RxApp.TaskpoolScheduler;
 
@@ -36,7 +36,7 @@ namespace ReactiveUI.Testing
             return Disposable.Create(() => {
                 RxApp.MainThreadScheduler = prevDef;
                 RxApp.TaskpoolScheduler = prevTask;
-                Monitor.Exit(schedGate);
+                schedGate.Set();
             });
         }
 

--- a/ReactiveUI.Tests/ReactiveUI.Tests_Net45.csproj
+++ b/ReactiveUI.Tests/ReactiveUI.Tests_Net45.csproj
@@ -103,6 +103,7 @@
     <Compile Include="AwaiterTest.cs" />
     <Compile Include="BindingTypeConvertersTest.cs" />
     <Compile Include="CommandBindingTests.cs" />
+    <Compile Include="TestUtilsTest.cs" />
     <Compile Include="WeakEventManagerTest.cs" />
     <Compile Include="Winforms\ActivationTests.cs" />
     <Compile Include="Winforms\CommandBindingTests.cs">

--- a/ReactiveUI.Tests/TestUtilsTest.cs
+++ b/ReactiveUI.Tests/TestUtilsTest.cs
@@ -1,0 +1,16 @@
+﻿using System.Threading.Tasks;
+using Microsoft.Reactive.Testing;
+using ReactiveUI.Testing;
+using Xunit;
+
+namespace ReactiveUI.Tests
+{
+    public class TestUtilsTest
+    {
+        [Fact]
+        public async Task WithAsyncScheduler()
+        {
+            await new TestScheduler().WithAsync(_ => Task.Run(() => { }));
+        }
+    }
+}


### PR DESCRIPTION
This prevents `TestScheduler.WithAsync` from throwing a SynchronizationLockExceptionObject exception, because we can't `await` inside a Monitor