### PR TITLE
Changed Cocoa activation to trigger on WillAppear instead of DidAppear.

### DIFF
--- a/ReactiveUI/Cocoa/ReactiveCollectionViewController.cs
+++ b/ReactiveUI/Cocoa/ReactiveCollectionViewController.cs
@@ -93,9 +93,9 @@ namespace ReactiveUI
         Subject<Unit> deactivated = new Subject<Unit>();
         public IObservable<Unit> Deactivated { get { return deactivated; } }
 
-        public override void ViewDidAppear(bool animated)
+        public override void ViewWillAppear(bool animated)
         {
-            base.ViewDidAppear(animated);
+            base.ViewWillAppear(animated);
             activated.OnNext(Unit.Default);
             this.ActivateSubviews(true);
         }

--- a/ReactiveUI/Cocoa/ReactiveNSViewController.cs
+++ b/ReactiveUI/Cocoa/ReactiveNSViewController.cs
@@ -114,9 +114,9 @@ namespace ReactiveUI
         Subject<Unit> deactivated = new Subject<Unit>();
         public IObservable<Unit> Deactivated { get { return deactivated; } }
 
-        public override void ViewDidAppear(bool animated)
+        public override void ViewWillAppear(bool animated)
         {
-            base.ViewDidAppear(animated);
+            base.ViewWillAppear(animated);
             activated.OnNext(Unit.Default);
             this.ActivateSubviews(true);
         }

--- a/ReactiveUI/Cocoa/ReactivePageViewController.cs
+++ b/ReactiveUI/Cocoa/ReactivePageViewController.cs
@@ -96,9 +96,9 @@ namespace ReactiveUI
         Subject<Unit> deactivated = new Subject<Unit>();
         public IObservable<Unit> Deactivated { get { return deactivated; } }
 
-        public override void ViewDidAppear(bool animated)
+        public override void ViewWillAppear(bool animated)
         {
-            base.ViewDidAppear(animated);
+            base.ViewWillAppear(animated);
             activated.OnNext(Unit.Default);
             this.ActivateSubviews(true);
         }

--- a/ReactiveUI/Cocoa/ReactiveTabBarController.cs
+++ b/ReactiveUI/Cocoa/ReactiveTabBarController.cs
@@ -92,9 +92,9 @@ namespace ReactiveUI
         Subject<Unit> deactivated = new Subject<Unit>();
         public IObservable<Unit> Deactivated { get { return deactivated; } }
 
-        public override void ViewDidAppear(bool animated)
+        public override void ViewWillAppear(bool animated)
         {
-            base.ViewDidAppear(animated);
+            base.ViewWillAppear(animated);
             activated.OnNext(Unit.Default);
             this.ActivateSubviews(true);
         }

--- a/ReactiveUI/Cocoa/ReactiveTableViewController.cs
+++ b/ReactiveUI/Cocoa/ReactiveTableViewController.cs
@@ -97,9 +97,9 @@ namespace ReactiveUI
         Subject<Unit> deactivated = new Subject<Unit>();
         public IObservable<Unit> Deactivated { get { return deactivated; } }
 
-        public override void ViewDidAppear(bool animated)
+        public override void ViewWillAppear(bool animated)
         {
-            base.ViewDidAppear(animated);
+            base.ViewWillAppear(animated);
             activated.OnNext(Unit.Default);
             this.ActivateSubviews(true);
         }


### PR DESCRIPTION
My original thought was that activation/deactivation should trigger off of the `Will` events instead of the `Did`. However, I think the deactivation makes sense to keep on the `Did` since you don't technically want to deactivate a component that may be animating offscreen - It has the potential to look weird if deactivation is tied to some visual component.

Fixes #778
