### PR TITLE
Added ReactiveNavigationController

### DIFF
--- a/ReactiveUI/Cocoa/ReactiveNavigationController.cs
+++ b/ReactiveUI/Cocoa/ReactiveNavigationController.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using ReactiveUI;
+using System.Runtime.Serialization;
+using System.ComponentModel;
+using System.Reflection;
+using System.Reactive;
+using System.Reactive.Subjects;
+using System.Reactive.Concurrency;
+using System.Linq;
+using System.Threading;
+using System.Reactive.Disposables;
+using System.Diagnostics.Contracts;
+using System.Runtime.CompilerServices;
+using System.Collections.Generic;
+using System.Drawing;
+using Splat;
+
+#if UNIFIED
+using Foundation;
+using UIKit;
+#else
+using MonoTouch.Foundation;
+using MonoTouch.UIKit;
+#endif
+
+namespace ReactiveUI
+{
+    public abstract class ReactiveNavigationController : UINavigationController,
+    IReactiveNotifyPropertyChanged<ReactiveNavigationController>, IHandleObservableErrors, IReactiveObject, ICanActivate
+    {
+        protected ReactiveNavigationController(UIViewController rootViewController) : base(rootViewController) { setupRxObj(); }
+        protected ReactiveNavigationController(Type navigationBarType, Type toolbarType) : base(navigationBarType, toolbarType) { setupRxObj(); }
+        protected ReactiveNavigationController(string nibName, NSBundle bundle) : base(nibName, bundle) { setupRxObj(); }
+        protected ReactiveNavigationController(IntPtr handle) : base(handle) { setupRxObj(); }
+        protected ReactiveNavigationController(NSObjectFlag t) : base(t) { setupRxObj(); }
+        protected ReactiveNavigationController(NSCoder coder) : base(coder) { setupRxObj(); }
+        protected ReactiveNavigationController() { setupRxObj(); }
+
+        public event PropertyChangingEventHandler PropertyChanging {
+            add { PropertyChangingEventManager.AddHandler(this, value); }
+            remove { PropertyChangingEventManager.RemoveHandler(this, value); }
+        }
+
+        void IReactiveObject.RaisePropertyChanging(PropertyChangingEventArgs args)
+        {
+            PropertyChangingEventManager.DeliverEvent(this, args);
+        }
+
+        public event PropertyChangedEventHandler PropertyChanged {
+            add { PropertyChangedEventManager.AddHandler(this, value); }
+            remove { PropertyChangedEventManager.RemoveHandler(this, value); }
+        }
+
+        void IReactiveObject.RaisePropertyChanged(PropertyChangedEventArgs args)
+        {
+            PropertyChangedEventManager.DeliverEvent(this, args);
+        }
+
+        /// <summary>
+        /// Represents an Observable that fires *before* a property is about to
+        /// be changed.         
+        /// </summary>
+        public IObservable<IReactivePropertyChangedEventArgs<ReactiveNavigationController>> Changing {
+            get { return this.getChangingObservable(); }
+        }
+
+        /// <summary>
+        /// Represents an Observable that fires *after* a property has changed.
+        /// </summary>
+        public IObservable<IReactivePropertyChangedEventArgs<ReactiveNavigationController>> Changed {
+            get { return this.getChangedObservable(); }
+        }
+
+        public IObservable<Exception> ThrownExceptions { get { return this.getThrownExceptionsObservable(); } }
+
+        void setupRxObj()
+        {
+        }
+
+        /// <summary>
+        /// When this method is called, an object will not fire change
+        /// notifications (neither traditional nor Observable notifications)
+        /// until the return value is disposed.
+        /// </summary>
+        /// <returns>An object that, when disposed, reenables change
+        /// notifications.</returns>
+        public IDisposable SuppressChangeNotifications()
+        {
+            return this.suppressChangeNotifications();
+        }
+
+        Subject<Unit> activated = new Subject<Unit>();
+        public IObservable<Unit> Activated { get { return activated; } }
+        Subject<Unit> deactivated = new Subject<Unit>();
+        public IObservable<Unit> Deactivated { get { return deactivated; } }
+
+        public override void ViewWillAppear(bool animated)
+        {
+            base.ViewWillAppear(animated);
+            activated.OnNext(Unit.Default);
+            this.ActivateSubviews(true);
+        }
+
+        public override void ViewDidDisappear(bool animated)
+        {
+            base.ViewDidDisappear(animated);
+            deactivated.OnNext(Unit.Default);
+            this.ActivateSubviews(false);
+        }
+    }
+}
+

--- a/ReactiveUI/ReactiveUI_iOS.csproj
+++ b/ReactiveUI/ReactiveUI_iOS.csproj
@@ -159,6 +159,7 @@
     <Compile Include="Cocoa\AutoSuspendHelper.cs" />
     <Compile Include="Legacy\ReactiveCommand.cs" />
     <Compile Include="Cocoa\ReactiveTabBarController.cs" />
+    <Compile Include="Cocoa\ReactiveNavigationController.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.ReactiveUI_iOS.config" />


### PR DESCRIPTION
I copied ReactiveTabBarController to make this, but changed the activation to be on ViewWillAppear instead of ViewDidAppear to line up with pull request #779.

Not sure if nobody has needed/wanted this yet or if it just a bad idea to make UINavigationController reactive.