### PR TITLE
Changes ref to out

### DIFF
--- a/docs/basics/reactive-command-async.md
+++ b/docs/basics/reactive-command-async.md
@@ -46,7 +46,7 @@ LoadUsersAndAvatars = ReactiveCommand.CreateAsyncTask(async _ => {
     return users;
 });
 
-LoadUsersAndAvatars.ToProperty(this, x => x.Users, ref users);
+LoadUsersAndAvatars.ToProperty(this, x => x.Users, out users);
 
 LoadUsersAndAvatars.ThrownExceptions
     .Subscribe(ex => this.Log().WarnException("Failed to load users", ex));


### PR DESCRIPTION
The documentation seems to outdated, I was having compile error when trying to convert a command to property based on this example and realized that I should use `out` instead of `ref`