### PR TITLE
Added implementation of IViewFor<T> for XAML

### DIFF
--- a/docs/basics/bindings.md
+++ b/docs/basics/bindings.md
@@ -24,6 +24,35 @@ implement it differently:
   RaiseAndSetIfChanged, *or* implement `INotifyPropertyChanged` on your View and
   ensure that ViewModel signals changes.
 
+```csharp
+public partial class NotificationsListViewController : ReactiveTableViewController, IViewFor<NotificationsListViewModel>
+{
+    public NotificationsListViewController()
+    {
+    }
+
+    public override void ViewDidLoad()
+    {
+        base.ViewDidLoad();
+        ViewModel = new NotificationsListViewModel();
+        // ... view stuff
+    }
+
+    NotificationsListViewModel _ViewModel;
+    public NotificationsListViewModel ViewModel
+    {
+        get { return _ViewModel; }
+        set { this.RaiseAndSetIfChanged(ref _ViewModel, value); }
+    }
+
+    object IViewFor.ViewModel
+    {
+        get { return _ViewModel; }
+        set { ViewModel = (NotificationsListViewModel)value; }
+    }
+}
+```
+
 * **Android:** - change your base class to one of the Reactive Activity /
   Fragment classes (i.e. ReactiveActivity<T>), *or* implement
   `INotifyPropertyChanged` on your View and ensure that ViewModel signals

--- a/docs/basics/bindings.md
+++ b/docs/basics/bindings.md
@@ -32,6 +32,32 @@ implement it differently:
 * **Xaml-based:** - Implement `IViewFor<T>` by hand and ensure that ViewModel
   is a DependencyProperty.
 
+```csharp
+public partial class ShellView : IViewFor<ShellViewModel>
+{
+    public ShellView()
+    {
+        InitializeComponent();
+        ViewModel = new ShellViewModel();
+    }
+
+    object IViewFor.ViewModel
+    {
+        get { return ViewModel; }
+        set { ViewModel = (ShellViewModel)value; }
+    }
+
+    public ShellViewModel ViewModel
+    {
+        get { return (ShellViewModel)GetValue(ViewModelProperty); }
+        set { SetValue(ViewModelProperty, value); }
+    }
+
+    public static readonly DependencyProperty ViewModelProperty =
+        DependencyProperty.Register("ViewModel", typeof(ShellViewModel), typeof(ShellView));
+}
+```
+
 ### Types of Bindings
 
 Once you implement `IViewFor<T>`, binding methods are now available as

--- a/docs/basics/bindings.md
+++ b/docs/basics/bindings.md
@@ -58,6 +58,38 @@ public partial class NotificationsListViewController : ReactiveTableViewControll
   `INotifyPropertyChanged` on your View and ensure that ViewModel signals
   changes.
 
+```csharp
+[Activity (Label = "RxUISample-Android", MainLauncher = true)]
+public class TestActivity : ReactiveActivity, IViewFor<TestViewModel>
+{
+    protected override async void OnCreate(Bundle bundle)
+    {
+        base.OnCreate(bundle);
+        BlobCache.ApplicationName = "RxUISample";
+
+        // Set our view from the "main" layout resource
+        SetContentView(Resource.Layout.Main);
+
+        ViewModel = await BlobCache.LocalMachine.GetOrCreateObject("TestViewModel", () => {
+            return new TestViewModel();
+        });
+    }
+
+    TestViewModel _ViewModel;
+    public TestViewModel ViewModel
+    {
+        get { return _ViewModel; }
+        set { this.RaiseAndSetIfChanged(ref _ViewModel, value); }
+    }
+
+    object IViewFor.ViewModel
+    {
+        get { return ViewModel; }
+        set { ViewModel = (TestViewModel)value; }
+    }
+}
+```
+
 * **Xaml-based:** - Implement `IViewFor<T>` by hand and ensure that ViewModel
   is a DependencyProperty.
 


### PR DESCRIPTION
I think things will be much clearer with an example of each platform's implementation of `IViewFor<T>`. I've provided the one for WPF. I assume it works equally well for the other XAML based platforms.

I would provide the other two as well, but I don't have much experience in them. If some one can leave a comment on this pull request, I'd be glad to add them to my changes.