### PR TITLE
Fix handling of null PropertyName values in INPCObservableForProperty

### DIFF
--- a/ReactiveUI.Tests/INPCObservableForPropertyTests.cs
+++ b/ReactiveUI.Tests/INPCObservableForPropertyTests.cs
@@ -1,0 +1,214 @@
+﻿#region Usings
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq.Expressions;
+using System.Runtime.CompilerServices;
+using Microsoft.Reactive.Testing;
+using ReactiveUI.Testing;
+using Xunit;
+
+#endregion
+
+namespace ReactiveUI.Tests
+{
+    public class INPCObservableForPropertyTests
+    {
+        [Fact]
+        public void CheckGetAffinityForObjectValues()
+        {
+            var instance = new INPCObservableForProperty();
+
+            Assert.Equal(5, instance.GetAffinityForObject(typeof(TestClassChanged), null, false));
+            Assert.Equal(0, instance.GetAffinityForObject(typeof(TestClassChanged), null, true));
+            Assert.Equal(0, instance.GetAffinityForObject(typeof(object), null, false));
+
+            Assert.Equal(5, instance.GetAffinityForObject(typeof(TestClassChanging), null, true));
+            Assert.Equal(0, instance.GetAffinityForObject(typeof(TestClassChanging), null, false));
+            Assert.Equal(0, instance.GetAffinityForObject(typeof(object), null, false));
+        }
+
+        [Fact]
+        public void NotificationOnPropertyChanged()
+        {
+            var instance = new INPCObservableForProperty();
+
+            var testClass = new TestClassChanged();
+
+            Expression<Func<TestClassChanged, string>> expr = x => x.Property1;
+            var exp = Reflection.Rewrite(expr.Body);
+
+            var changes = new List<IObservedChange<object, object>>();
+            instance.GetNotificationForProperty(testClass, exp, false).Subscribe(c => changes.Add(c));
+
+            testClass.Property1 = "test1";
+            testClass.Property1 = "test2";
+
+            Assert.Equal(2, changes.Count);
+
+            Assert.Equal(testClass, changes[0].Sender);
+            Assert.Equal(testClass, changes[1].Sender);
+        }
+
+        [Fact]
+        public void NotificationOnPropertyChanging()
+        {
+            var instance = new INPCObservableForProperty();
+
+            var testClass = new TestClassChanging();
+
+            Expression<Func<TestClassChanged, string>> expr = x => x.Property1;
+            var exp = Reflection.Rewrite(expr.Body);
+
+            var changes = new List<IObservedChange<object, object>>();
+            instance.GetNotificationForProperty(testClass, exp, true).Subscribe(c => changes.Add(c));
+
+            testClass.Property1 = "test1";
+            testClass.Property1 = "test2";
+
+            Assert.Equal(2, changes.Count);
+
+            Assert.Equal(testClass, changes[0].Sender);
+            Assert.Equal(testClass, changes[1].Sender);
+        }
+
+        [Fact]
+        public void NotificationOnWholeObjectChanged()
+        {
+            var instance = new INPCObservableForProperty();
+
+            var testClass = new TestClassChanged();
+
+            Expression<Func<TestClassChanged, string>> expr = x => x.Property1;
+            var exp = Reflection.Rewrite(expr.Body);
+
+            var changes = new List<IObservedChange<object, object>>();
+            instance.GetNotificationForProperty(testClass, exp, false).Subscribe(c => changes.Add(c));
+
+            testClass.OnPropertyChanged(null);
+            testClass.OnPropertyChanged(string.Empty);
+
+            Assert.Equal(2, changes.Count);
+
+            Assert.Equal(testClass, changes[0].Sender);
+            Assert.Equal(testClass, changes[1].Sender);
+        }
+
+        [Fact]
+        public void NotificationOnWholeObjectChanging()
+        {
+            var instance = new INPCObservableForProperty();
+
+            var testClass = new TestClassChanging();
+
+            Expression<Func<TestClassChanged, string>> expr = x => x.Property1;
+            var exp = Reflection.Rewrite(expr.Body);
+
+            var changes = new List<IObservedChange<object, object>>();
+            instance.GetNotificationForProperty(testClass, exp, true).Subscribe(c => changes.Add(c));
+
+            testClass.OnPropertyChanging(null);
+            testClass.OnPropertyChanging(string.Empty);
+
+            Assert.Equal(2, changes.Count);
+
+            Assert.Equal(testClass, changes[0].Sender);
+            Assert.Equal(testClass, changes[1].Sender);
+        }
+
+        #region Nested type: TestClassChanged
+
+        class TestClassChanged : INotifyPropertyChanged
+        {
+            string property;
+
+            string property2;
+
+            public string Property1
+            {
+                get { return property; }
+                set
+                {
+                    property = value;
+                    OnPropertyChanged();
+                }
+            }
+
+            public string Property2
+            {
+                get { return property2; }
+                set
+                {
+                    property2 = value;
+                    OnPropertyChanged();
+                }
+            }
+
+            #region INotifyPropertyChanged Members
+
+            public event PropertyChangedEventHandler PropertyChanged;
+
+            #endregion
+
+            public void OnPropertyChanged([CallerMemberName] string propertyName = null)
+            {
+                var handler = PropertyChanged;
+                if (handler != null) {
+                    handler(this, new PropertyChangedEventArgs(propertyName));
+                }
+            }
+        }
+
+        #endregion
+
+        #region Nested type: TestClassChanging
+
+        class TestClassChanging : INotifyPropertyChanging
+        {
+            string property1;
+
+            string property2;
+
+            public string Property1
+            {
+                get { return property1; }
+                set
+                {
+                    property1 = value;
+                    OnPropertyChanging();
+                }
+            }
+
+            public string Property2
+            {
+                get { return property2; }
+                set
+                {
+                    property2 = value;
+                    OnPropertyChanging();
+                }
+            }
+
+            #region INotifyPropertyChanging Members
+
+            #region Implementation of INotifyPropertyChanging
+
+            public event PropertyChangingEventHandler PropertyChanging;
+
+            #endregion
+
+            #endregion
+
+            public void OnPropertyChanging([CallerMemberName] string propertyName = null)
+            {
+                var handler = PropertyChanging;
+                if (handler != null) {
+                    handler(this, new PropertyChangingEventArgs(propertyName));
+                }
+            }
+        }
+
+        #endregion
+    }
+}

--- a/ReactiveUI.Tests/ReactiveUI.Tests_Net45.csproj
+++ b/ReactiveUI.Tests/ReactiveUI.Tests_Net45.csproj
@@ -103,6 +103,7 @@
     <Compile Include="AwaiterTest.cs" />
     <Compile Include="BindingTypeConvertersTest.cs" />
     <Compile Include="CommandBindingTests.cs" />
+    <Compile Include="INPCObservableForPropertyTests.cs" />
     <Compile Include="TestUtilsTest.cs" />
     <Compile Include="WeakEventManagerTest.cs" />
     <Compile Include="Winforms\ActivationTests.cs" />

--- a/ReactiveUI/INPCObservableForProperty.cs
+++ b/ReactiveUI/INPCObservableForProperty.cs
@@ -43,10 +43,12 @@ namespace ReactiveUI
                     x => after.PropertyChanged += x, x => after.PropertyChanged -= x);
 
                 if (expression.NodeType == ExpressionType.Index) {
-                    return obs.Where(x => x.EventArgs.PropertyName.Equals(memberInfo.Name + "[]"))
+                    return obs.Where(x => string.IsNullOrEmpty(x.EventArgs.PropertyName) 
+                        || x.EventArgs.PropertyName.Equals(memberInfo.Name + "[]"))
                     .Select(x => new ObservedChange<object, object>(sender, expression));
                 } else {
-                    return obs.Where(x => x.EventArgs.PropertyName.Equals(memberInfo.Name))
+                    return obs.Where(x => string.IsNullOrEmpty(x.EventArgs.PropertyName)
+                        || x.EventArgs.PropertyName.Equals(memberInfo.Name))
                     .Select(x => new ObservedChange<object, object>(sender, expression));
                 }
             }

--- a/ReactiveUI/INPCObservableForProperty.cs
+++ b/ReactiveUI/INPCObservableForProperty.cs
@@ -32,10 +32,12 @@ namespace ReactiveUI
                     x => before.PropertyChanging += x, x => before.PropertyChanging -= x);
 
                 if (expression.NodeType == ExpressionType.Index) {
-                    return obs.Where(x => x.EventArgs.PropertyName.Equals(memberInfo.Name + "[]"))
+                    return obs.Where(x => string.IsNullOrEmpty(x.EventArgs.PropertyName)
+                        || x.EventArgs.PropertyName.Equals(memberInfo.Name + "[]"))
                         .Select(x => new ObservedChange<object, object>(sender, expression));
                 } else {
-                    return obs.Where(x => x.EventArgs.PropertyName.Equals(memberInfo.Name))
+                    return obs.Where(x => string.IsNullOrEmpty(x.EventArgs.PropertyName)
+                        || x.EventArgs.PropertyName.Equals(memberInfo.Name))
                     .Select(x => new ObservedChange<object, object>(sender, expression));
                 }
             } else {


### PR DESCRIPTION
The documentation for [INotifyPropertyChanged.PropertyChanged](https://msdn.microsoft.com/en-us/library/system.componentmodel.inotifypropertychanged.propertychanged.aspx) says that `null` and `string.Empty` are valid values for the PropertyName and indicate that the whole object has changed. The current version of `INPCObservableForProperty` ignores such values.
This pull request adds support for these values and also adds tests for the `INPCObservableForProperty` class.