### PR TITLE
Fix Xamarin.Forms navigation so we don't go forward, backward, forward.

### DIFF
--- a/ReactiveUI.XamForms/XamForms/RoutedViewHost.cs
+++ b/ReactiveUI.XamForms/XamForms/RoutedViewHost.cs
@@ -23,21 +23,21 @@ namespace ReactiveUI.XamForms
             this.WhenActivated(new Action<Action<IDisposable>>(d => {
                 bool currentlyPopping = false;
 
-                d(this.WhenAnyObservable(x => x.Router.Navigate)
-                    .SelectMany(_ => pageForViewModel(Router.GetCurrentViewModel()))
-                    .SelectMany(x => this.PushAsync(x).ToObservable())
-                    .Subscribe());
-
-                d(this.WhenAnyObservable(x => x.Router.NavigateAndReset)
-                    .SelectMany(_ => pageForViewModel(Router.GetCurrentViewModel()))
-                    .SelectMany(async x => {
+                d (this.WhenAnyObservable (x => x.Router.NavigationStack.Changed)
+                    .Where(_ => Router.NavigationStack.IsEmpty)
+                    .SelectMany (_ => pageForViewModel (Router.GetCurrentViewModel ()))
+                    .SelectMany (async x => {
                         currentlyPopping = true;
-                        await this.PopToRootAsync();
-                        await this.PushAsync(x);
+                        await this.PopToRootAsync ();
                         currentlyPopping = false;
 
                         return x;
                     })
+                    .Subscribe ());
+
+                d(this.WhenAnyObservable(x => x.Router.Navigate)
+                    .SelectMany(_ => pageForViewModel(Router.GetCurrentViewModel()))
+                    .SelectMany(x => this.PushAsync(x).ToObservable())
                     .Subscribe());
 
                 d(this.WhenAnyObservable(x => x.Router.NavigateBack)


### PR DESCRIPTION
The problem is that RoutingState sets up NavigateAndReset to call Navigate.ExecuteAsync(). The Xam.Forms view host listens for NavigateAndReset, then calls PopToRootAsync() and then PushAsync().
This causes us to push the new page, pop to root, then push the new page again.

Instead of listening to NavigateAndReset in the view host, listen for the navigation stack to change to 0 and then call PopToRootAsync(), and let RoutingState execute Navigate as usual.

So, I haven't managed to build ReactiveUI itself yet. What I did was kind of janky I guess, but I copied `RoutedViewHost` into my own app and renamed the class and made these changes to it. I hope I haven't missed anything here. I'll try again to build ReactiveUI tomorrow so I can test this more properly.