### PR TITLE
Simplify the Windows Phone ActivationForViewFetcher logic

### DIFF
--- a/ReactiveUI/Xaml/ActivationForViewFetcher.cs
+++ b/ReactiveUI/Xaml/ActivationForViewFetcher.cs
@@ -36,7 +36,7 @@ namespace ReactiveUI
 
             return viewLoaded
                 .Merge(viewUnloaded)
-                .Select(b => b ? fe.WhenAnyValue(x => x.IsHitTestVisible).Select(hv => hv && b).SkipWhile(x => !x) : Observable.Return(b))
+                .Select(b => b ? fe.WhenAnyValue(x => x.IsHitTestVisible).SkipWhile(x => !x) : Observable.Return(false))
                 .Switch()
                 .DistinctUntilChanged();
         }


### PR DESCRIPTION
While looking into https://github.com/reactiveui/ReactiveUI/issues/822, I found that the code was unnecessarily complex