### PR TITLE
Possible fix for issue #746

### DIFF
--- a/ReactiveUI/WeakEventManager.cs
+++ b/ReactiveUI/WeakEventManager.cs
@@ -279,7 +279,11 @@ namespace ReactiveUI
                 return this.source != null && 
                     Object.ReferenceEquals(this.source.Target, source) && 
                     this.originalHandler != null && 
-                    Object.ReferenceEquals(this.originalHandler.Target, handler);
+                    (Object.ReferenceEquals(this.originalHandler.Target, handler) ||
+                    (this.originalHandler.Target is PropertyChangedEventHandler &&
+                    handler is PropertyChangedEventHandler &&
+                    object.Equals((this.originalHandler.Target as PropertyChangedEventHandler).Target,
+                        (handler as PropertyChangedEventHandler).Target)));
             }
         }
 


### PR DESCRIPTION
This took a while to find but the number of handlers grows into the thousands when using Entry.Text bound to a string. This seems to have fixed the issue and greatly speeds up ReactiveUI.

See comments on the issue thread.