### PR TITLE
Fixes #830.

### DIFF
--- a/ReactiveUI.Tests/ReactiveNotifyPropertyChangedMixinTest.cs
+++ b/ReactiveUI.Tests/ReactiveNotifyPropertyChangedMixinTest.cs
@@ -23,8 +23,8 @@ namespace ReactiveUI.Tests
 {
     public class TestWhenAnyObsViewModel : ReactiveObject
     {
-        public ReactiveCommand<object> Command1 { get; protected set; }
-        public ReactiveCommand<object> Command2 { get; protected set; }
+        public ReactiveCommand<object> Command1 { get; set; }
+        public ReactiveCommand<object> Command2 { get; set; }
 
         ReactiveList<int> myListOfInts;
         public ReactiveList<int> MyListOfInts {
@@ -647,6 +647,25 @@ namespace ReactiveUI.Tests
 
             fixture.MyListOfInts = null;
             Assert.Equal(1, output.Count);
+        }
+
+        [Fact]
+        public void NullObservablesDoNotCauseExceptions()
+        {
+            var fixture = new TestWhenAnyObsViewModel();
+            fixture.Command1 = null;
+
+            fixture.WhenAnyObservable(x => x.Command1).Subscribe();
+            fixture.WhenAnyObservable(x => x.Command1, x => x.Command1).Subscribe();
+            fixture.WhenAnyObservable(x => x.Command1, x => x.Command1, x => x.Command1).Subscribe();
+            fixture.WhenAnyObservable(x => x.Command1, x => x.Command1, x => x.Command1, x => x.Command1).Subscribe();
+            fixture.WhenAnyObservable(x => x.Command1, x => x.Command1, x => x.Command1, x => x.Command1, x => x.Command1).Subscribe();
+            fixture.WhenAnyObservable(x => x.Command1, x => x.Command1, x => x.Command1, x => x.Command1, x => x.Command1, x => x.Command1).Subscribe();
+            fixture.WhenAnyObservable(x => x.Command1, x => x.Command1, x => x.Command1, x => x.Command1, x => x.Command1, x => x.Command1, x => x.Command1).Subscribe();
+            fixture.WhenAnyObservable(x => x.Command1, x => x.Command1, x => x.Command1, x => x.Command1, x => x.Command1, x => x.Command1, x => x.Command1, x => x.Command1).Subscribe();
+            fixture.WhenAnyObservable(x => x.Command1, x => x.Command1, x => x.Command1, x => x.Command1, x => x.Command1, x => x.Command1, x => x.Command1, x => x.Command1, x => x.Command1).Subscribe();
+            fixture.WhenAnyObservable(x => x.Command1, x => x.Command1, x => x.Command1, x => x.Command1, x => x.Command1, x => x.Command1, x => x.Command1, x => x.Command1, x => x.Command1, x => x.Command1).Subscribe();
+            fixture.WhenAnyObservable(x => x.Command1, x => x.Command1, x => x.Command1, x => x.Command1, x => x.Command1, x => x.Command1, x => x.Command1, x => x.Command1, x => x.Command1, x => x.Command1, x => x.Command1).Subscribe();
         }
     }
 

--- a/ReactiveUI/VariadicTemplates.cs
+++ b/ReactiveUI/VariadicTemplates.cs
@@ -1169,63 +1169,71 @@ namespace ReactiveUI
     {
         public static IObservable<TRet> WhenAnyObservable<TSender, TRet>(this TSender This, Expression<Func<TSender, IObservable<TRet>>> obs1)
         {
-            return This.WhenAny(obs1, x => x.Value).Switch();
+            return This.WhenAny(obs1, x => x.Value.EmptyIfNull()).Switch();
         }
 
         public static IObservable<TRet> WhenAnyObservable<TSender, TRet>(this TSender This, Expression<Func<TSender, IObservable<TRet>>> obs1, Expression<Func<TSender, IObservable<TRet>>> obs2)
         {
-            return This.WhenAny(obs1, obs2, (o1, o2) => new[] {o1.Value, o2.Value})
+            return This.WhenAny(obs1, obs2, (o1, o2) => new[] {o1.Value.EmptyIfNull(), o2.Value.EmptyIfNull() })
                 .Select(x => x.Merge()).Switch();
         }
         public static IObservable<TRet> WhenAnyObservable<TSender, TRet>(this TSender This, Expression<Func<TSender, IObservable<TRet>>> obs1, Expression<Func<TSender, IObservable<TRet>>> obs2, Expression<Func<TSender, IObservable<TRet>>> obs3)
         {
-            return This.WhenAny(obs1, obs2, obs3, (o1, o2, o3) => new[] {o1.Value, o2.Value, o3.Value})
+            return This.WhenAny(obs1, obs2, obs3, (o1, o2, o3) => new[] {o1.Value.EmptyIfNull(), o2.Value.EmptyIfNull(), o3.Value.EmptyIfNull() })
                 .Select(x => x.Merge()).Switch();
         }
         public static IObservable<TRet> WhenAnyObservable<TSender, TRet>(this TSender This, Expression<Func<TSender, IObservable<TRet>>> obs1, Expression<Func<TSender, IObservable<TRet>>> obs2, Expression<Func<TSender, IObservable<TRet>>> obs3, Expression<Func<TSender, IObservable<TRet>>> obs4)
         {
-            return This.WhenAny(obs1, obs2, obs3, obs4, (o1, o2, o3, o4) => new[] {o1.Value, o2.Value, o3.Value, o4.Value})
+            return This.WhenAny(obs1, obs2, obs3, obs4, (o1, o2, o3, o4) => new[] {o1.Value.EmptyIfNull(), o2.Value.EmptyIfNull(), o3.Value.EmptyIfNull(), o4.Value.EmptyIfNull() })
                 .Select(x => x.Merge()).Switch();
         }
         public static IObservable<TRet> WhenAnyObservable<TSender, TRet>(this TSender This, Expression<Func<TSender, IObservable<TRet>>> obs1, Expression<Func<TSender, IObservable<TRet>>> obs2, Expression<Func<TSender, IObservable<TRet>>> obs3, Expression<Func<TSender, IObservable<TRet>>> obs4, Expression<Func<TSender, IObservable<TRet>>> obs5)
         {
-            return This.WhenAny(obs1, obs2, obs3, obs4, obs5, (o1, o2, o3, o4, o5) => new[] {o1.Value, o2.Value, o3.Value, o4.Value, o5.Value})
+            return This.WhenAny(obs1, obs2, obs3, obs4, obs5, (o1, o2, o3, o4, o5) => new[] {o1.Value.EmptyIfNull(), o2.Value.EmptyIfNull(), o3.Value.EmptyIfNull(), o4.Value.EmptyIfNull(), o5.Value.EmptyIfNull() })
                 .Select(x => x.Merge()).Switch();
         }
         public static IObservable<TRet> WhenAnyObservable<TSender, TRet>(this TSender This, Expression<Func<TSender, IObservable<TRet>>> obs1, Expression<Func<TSender, IObservable<TRet>>> obs2, Expression<Func<TSender, IObservable<TRet>>> obs3, Expression<Func<TSender, IObservable<TRet>>> obs4, Expression<Func<TSender, IObservable<TRet>>> obs5, Expression<Func<TSender, IObservable<TRet>>> obs6)
         {
-            return This.WhenAny(obs1, obs2, obs3, obs4, obs5, obs6, (o1, o2, o3, o4, o5, o6) => new[] {o1.Value, o2.Value, o3.Value, o4.Value, o5.Value, o6.Value})
+            return This.WhenAny(obs1, obs2, obs3, obs4, obs5, obs6, (o1, o2, o3, o4, o5, o6) => new[] {o1.Value.EmptyIfNull(), o2.Value.EmptyIfNull(), o3.Value.EmptyIfNull(), o4.Value.EmptyIfNull(), o5.Value.EmptyIfNull(), o6.Value.EmptyIfNull() })
                 .Select(x => x.Merge()).Switch();
         }
         public static IObservable<TRet> WhenAnyObservable<TSender, TRet>(this TSender This, Expression<Func<TSender, IObservable<TRet>>> obs1, Expression<Func<TSender, IObservable<TRet>>> obs2, Expression<Func<TSender, IObservable<TRet>>> obs3, Expression<Func<TSender, IObservable<TRet>>> obs4, Expression<Func<TSender, IObservable<TRet>>> obs5, Expression<Func<TSender, IObservable<TRet>>> obs6, Expression<Func<TSender, IObservable<TRet>>> obs7)
         {
-            return This.WhenAny(obs1, obs2, obs3, obs4, obs5, obs6, obs7, (o1, o2, o3, o4, o5, o6, o7) => new[] {o1.Value, o2.Value, o3.Value, o4.Value, o5.Value, o6.Value, o7.Value})
+            return This.WhenAny(obs1, obs2, obs3, obs4, obs5, obs6, obs7, (o1, o2, o3, o4, o5, o6, o7) => new[] {o1.Value.EmptyIfNull(), o2.Value.EmptyIfNull(), o3.Value.EmptyIfNull(), o4.Value.EmptyIfNull(), o5.Value.EmptyIfNull(), o6.Value.EmptyIfNull(), o7.Value.EmptyIfNull() })
                 .Select(x => x.Merge()).Switch();
         }
         public static IObservable<TRet> WhenAnyObservable<TSender, TRet>(this TSender This, Expression<Func<TSender, IObservable<TRet>>> obs1, Expression<Func<TSender, IObservable<TRet>>> obs2, Expression<Func<TSender, IObservable<TRet>>> obs3, Expression<Func<TSender, IObservable<TRet>>> obs4, Expression<Func<TSender, IObservable<TRet>>> obs5, Expression<Func<TSender, IObservable<TRet>>> obs6, Expression<Func<TSender, IObservable<TRet>>> obs7, Expression<Func<TSender, IObservable<TRet>>> obs8)
         {
-            return This.WhenAny(obs1, obs2, obs3, obs4, obs5, obs6, obs7, obs8, (o1, o2, o3, o4, o5, o6, o7, o8) => new[] {o1.Value, o2.Value, o3.Value, o4.Value, o5.Value, o6.Value, o7.Value, o8.Value})
+            return This.WhenAny(obs1, obs2, obs3, obs4, obs5, obs6, obs7, obs8, (o1, o2, o3, o4, o5, o6, o7, o8) => new[] {o1.Value.EmptyIfNull(), o2.Value.EmptyIfNull(), o3.Value.EmptyIfNull(), o4.Value.EmptyIfNull(), o5.Value.EmptyIfNull(), o6.Value.EmptyIfNull(), o7.Value.EmptyIfNull(), o8.Value.EmptyIfNull() })
                 .Select(x => x.Merge()).Switch();
         }
         public static IObservable<TRet> WhenAnyObservable<TSender, TRet>(this TSender This, Expression<Func<TSender, IObservable<TRet>>> obs1, Expression<Func<TSender, IObservable<TRet>>> obs2, Expression<Func<TSender, IObservable<TRet>>> obs3, Expression<Func<TSender, IObservable<TRet>>> obs4, Expression<Func<TSender, IObservable<TRet>>> obs5, Expression<Func<TSender, IObservable<TRet>>> obs6, Expression<Func<TSender, IObservable<TRet>>> obs7, Expression<Func<TSender, IObservable<TRet>>> obs8, Expression<Func<TSender, IObservable<TRet>>> obs9)
         {
-            return This.WhenAny(obs1, obs2, obs3, obs4, obs5, obs6, obs7, obs8, obs9, (o1, o2, o3, o4, o5, o6, o7, o8, o9) => new[] {o1.Value, o2.Value, o3.Value, o4.Value, o5.Value, o6.Value, o7.Value, o8.Value, o9.Value})
+            return This.WhenAny(obs1, obs2, obs3, obs4, obs5, obs6, obs7, obs8, obs9, (o1, o2, o3, o4, o5, o6, o7, o8, o9) => new[] {o1.Value.EmptyIfNull(), o2.Value.EmptyIfNull(), o3.Value.EmptyIfNull(), o4.Value.EmptyIfNull(), o5.Value.EmptyIfNull(), o6.Value.EmptyIfNull(), o7.Value.EmptyIfNull(), o8.Value.EmptyIfNull(), o9.Value.EmptyIfNull() })
                 .Select(x => x.Merge()).Switch();
         }
         public static IObservable<TRet> WhenAnyObservable<TSender, TRet>(this TSender This, Expression<Func<TSender, IObservable<TRet>>> obs1, Expression<Func<TSender, IObservable<TRet>>> obs2, Expression<Func<TSender, IObservable<TRet>>> obs3, Expression<Func<TSender, IObservable<TRet>>> obs4, Expression<Func<TSender, IObservable<TRet>>> obs5, Expression<Func<TSender, IObservable<TRet>>> obs6, Expression<Func<TSender, IObservable<TRet>>> obs7, Expression<Func<TSender, IObservable<TRet>>> obs8, Expression<Func<TSender, IObservable<TRet>>> obs9, Expression<Func<TSender, IObservable<TRet>>> obs10)
         {
-            return This.WhenAny(obs1, obs2, obs3, obs4, obs5, obs6, obs7, obs8, obs9, obs10, (o1, o2, o3, o4, o5, o6, o7, o8, o9, o10) => new[] {o1.Value, o2.Value, o3.Value, o4.Value, o5.Value, o6.Value, o7.Value, o8.Value, o9.Value, o10.Value})
+            return This.WhenAny(obs1, obs2, obs3, obs4, obs5, obs6, obs7, obs8, obs9, obs10, (o1, o2, o3, o4, o5, o6, o7, o8, o9, o10) => new[] {o1.Value.EmptyIfNull(), o2.Value.EmptyIfNull(), o3.Value.EmptyIfNull(), o4.Value.EmptyIfNull(), o5.Value.EmptyIfNull(), o6.Value.EmptyIfNull(), o7.Value.EmptyIfNull(), o8.Value.EmptyIfNull(), o9.Value.EmptyIfNull(), o10.Value.EmptyIfNull() })
                 .Select(x => x.Merge()).Switch();
         }
         public static IObservable<TRet> WhenAnyObservable<TSender, TRet>(this TSender This, Expression<Func<TSender, IObservable<TRet>>> obs1, Expression<Func<TSender, IObservable<TRet>>> obs2, Expression<Func<TSender, IObservable<TRet>>> obs3, Expression<Func<TSender, IObservable<TRet>>> obs4, Expression<Func<TSender, IObservable<TRet>>> obs5, Expression<Func<TSender, IObservable<TRet>>> obs6, Expression<Func<TSender, IObservable<TRet>>> obs7, Expression<Func<TSender, IObservable<TRet>>> obs8, Expression<Func<TSender, IObservable<TRet>>> obs9, Expression<Func<TSender, IObservable<TRet>>> obs10, Expression<Func<TSender, IObservable<TRet>>> obs11)
         {
-            return This.WhenAny(obs1, obs2, obs3, obs4, obs5, obs6, obs7, obs8, obs9, obs10, obs11, (o1, o2, o3, o4, o5, o6, o7, o8, o9, o10, o11) => new[] {o1.Value, o2.Value, o3.Value, o4.Value, o5.Value, o6.Value, o7.Value, o8.Value, o9.Value, o10.Value, o11.Value})
+            return This.WhenAny(obs1, obs2, obs3, obs4, obs5, obs6, obs7, obs8, obs9, obs10, obs11, (o1, o2, o3, o4, o5, o6, o7, o8, o9, o10, o11) => new[] {o1.Value.EmptyIfNull(), o2.Value.EmptyIfNull(), o3.Value.EmptyIfNull(), o4.Value.EmptyIfNull(), o5.Value.EmptyIfNull(), o6.Value.EmptyIfNull(), o7.Value.EmptyIfNull(), o8.Value.EmptyIfNull(), o9.Value.EmptyIfNull(), o10.Value.EmptyIfNull(), o11.Value.EmptyIfNull() })
                 .Select(x => x.Merge()).Switch();
         }
         public static IObservable<TRet> WhenAnyObservable<TSender, TRet>(this TSender This, Expression<Func<TSender, IObservable<TRet>>> obs1, Expression<Func<TSender, IObservable<TRet>>> obs2, Expression<Func<TSender, IObservable<TRet>>> obs3, Expression<Func<TSender, IObservable<TRet>>> obs4, Expression<Func<TSender, IObservable<TRet>>> obs5, Expression<Func<TSender, IObservable<TRet>>> obs6, Expression<Func<TSender, IObservable<TRet>>> obs7, Expression<Func<TSender, IObservable<TRet>>> obs8, Expression<Func<TSender, IObservable<TRet>>> obs9, Expression<Func<TSender, IObservable<TRet>>> obs10, Expression<Func<TSender, IObservable<TRet>>> obs11, Expression<Func<TSender, IObservable<TRet>>> obs12)
         {
-            return This.WhenAny(obs1, obs2, obs3, obs4, obs5, obs6, obs7, obs8, obs9, obs10, obs11, obs12, (o1, o2, o3, o4, o5, o6, o7, o8, o9, o10, o11, o12) => new[] {o1.Value, o2.Value, o3.Value, o4.Value, o5.Value, o6.Value, o7.Value, o8.Value, o9.Value, o10.Value, o11.Value, o12.Value})
+            return This.WhenAny(obs1, obs2, obs3, obs4, obs5, obs6, obs7, obs8, obs9, obs10, obs11, obs12, (o1, o2, o3, o4, o5, o6, o7, o8, o9, o10, o11, o12) => new[] {o1.Value.EmptyIfNull(), o2.Value.EmptyIfNull(), o3.Value.EmptyIfNull(), o4.Value.EmptyIfNull(), o5.Value.EmptyIfNull(), o6.Value.EmptyIfNull(), o7.Value.EmptyIfNull(), o8.Value.EmptyIfNull(), o9.Value.EmptyIfNull(), o10.Value.EmptyIfNull(), o11.Value.EmptyIfNull(), o12.Value.EmptyIfNull() })
                 .Select(x => x.Merge()).Switch();
+        }
+    }
+
+    internal static class ObservableExtensions
+    {
+        public static IObservable<T> EmptyIfNull<T>(this IObservable<T> @this)
+        {
+            return @this ?? Observable.Empty<T>();
         }
     }
 }


### PR DESCRIPTION
Whenever a property chain returns a `null` observable, an instance of `Observable.Empty<TRet>` is swapped in.

Happy to rearrange as you see fit. In particular, I wasn't sure about where I should put the `ObservableExtensions` helper class.