### PR TITLE
[Android] Add ReactiveActivity ctors for JNI ownership transfer

### DIFF
--- a/ReactiveUI/Android/ReactiveActivity.cs
+++ b/ReactiveUI/Android/ReactiveActivity.cs
@@ -32,8 +32,6 @@ namespace ReactiveUI
     public class ReactiveActivity<TViewModel> : ReactiveActivity, IViewFor<TViewModel>, ICanActivate
         where TViewModel : class
     {
-        protected ReactiveActivity() { }
-
         TViewModel _ViewModel;
         public TViewModel ViewModel {
             get { return _ViewModel; }
@@ -43,6 +41,12 @@ namespace ReactiveUI
         object IViewFor.ViewModel {
             get { return _ViewModel; }
             set { _ViewModel = (TViewModel)value; }
+        }
+
+        protected ReactiveActivity() { }
+
+        protected ReactiveActivity(IntPtr handle, JniHandleOwnership ownership) : base(handle, ownership)
+        {
         }
     }
 
@@ -85,6 +89,14 @@ namespace ReactiveUI
         /// </summary>
         public IObservable<IReactivePropertyChangedEventArgs<ReactiveActivity>> Changed {
             get { return this.getChangedObservable(); }
+        }
+
+        protected ReactiveActivity()
+        {
+        }
+
+        protected ReactiveActivity(IntPtr handle, JniHandleOwnership ownership) : base(handle, ownership)
+        {
         }
 
         /// <summary>

--- a/ReactiveUI/Android/ReactiveFragment.cs
+++ b/ReactiveUI/Android/ReactiveFragment.cs
@@ -32,6 +32,10 @@ namespace ReactiveUI
     {
         protected ReactiveFragment() { }
 
+        protected ReactiveFragment(IntPtr handle, JniHandleOwnership ownership) : base(handle, ownership)
+        {
+        }
+
         TViewModel _ViewModel;
         public TViewModel ViewModel {
             get { return _ViewModel; }
@@ -51,6 +55,10 @@ namespace ReactiveUI
     public class ReactiveFragment : Fragment, IReactiveNotifyPropertyChanged<ReactiveFragment>, IReactiveObject, IHandleObservableErrors
     {
         protected ReactiveFragment() { }
+
+        protected ReactiveFragment(IntPtr handle, JniHandleOwnership ownership) : base(handle, ownership)
+        {
+        }
 
         public event PropertyChangingEventHandler PropertyChanging {
             add { PropertyChangingEventManager.AddHandler(this, value); }


### PR DESCRIPTION
In some circumstances, the Xamarin Android framework already has a reference to an object, but needs to create it's peer MCW.  In these instances, the constructor that takes `(IntPtr, JniHandleOwnership)` is called.

This is detailed here: [Java Activation](http://developer.xamarin.com/guides/android/under_the_hood/architecture/#Java_Activation)

Also, an SO answer from @jonpryor discussing this a bit: http://stackoverflow.com/a/10603714/335675

This change adds the aforementioned constructors to both the `ReactiveActivity` and `ReactiveActivity<TViewModel>` classes.