### PR TITLE
Setup WinRTAutoSuspendApplication to also be watching the app.Resuming for the IsUnPausing behavior on AutoSuspendHelper because of how Fast Resume works

### DIFF
--- a/ReactiveUI/Xaml/WinRTAutoSuspendApplication.cs
+++ b/ReactiveUI/Xaml/WinRTAutoSuspendApplication.cs
@@ -30,14 +30,14 @@ namespace ReactiveUI
                 .Where(x => x.PreviousExecutionState == ApplicationExecutionState.Terminated)
                 .Select(_ => Unit.Default);
 
-			var fastResuming = new Subject<ApplicationExecutionState>();
-			app.Resuming += (o, e) => fastResuming.OnNext(ApplicationExecutionState.Suspended);
-			var unpausing = new[] { ApplicationExecutionState.Suspended, ApplicationExecutionState.Running, };
-			RxApp.SuspensionHost.IsUnpausing = _launched
-				.Select(x => x.PreviousExecutionState)
-				.Merge(fastResuming)
-				.Where(x => unpausing.Contains(x))
-				.Select(_ => Unit.Default);
+            var fastResuming = new Subject<ApplicationExecutionState>();
+            app.Resuming += (o, e) => fastResuming.OnNext(ApplicationExecutionState.Suspended);
+            var unpausing = new[] { ApplicationExecutionState.Suspended, ApplicationExecutionState.Running, };
+            RxApp.SuspensionHost.IsUnpausing = _launched
+                .Select(x => x.PreviousExecutionState)
+                .Merge(fastResuming)
+                .Where(x => unpausing.Contains(x))
+                .Select(_ => Unit.Default);
 
             var shouldPersistState = new Subject<SuspendingEventArgs>();
             app.Suspending += (o, e) => shouldPersistState.OnNext(e);

--- a/ReactiveUI/Xaml/WinRTAutoSuspendApplication.cs
+++ b/ReactiveUI/Xaml/WinRTAutoSuspendApplication.cs
@@ -30,10 +30,14 @@ namespace ReactiveUI
                 .Where(x => x.PreviousExecutionState == ApplicationExecutionState.Terminated)
                 .Select(_ => Unit.Default);
 
-            var unpausing = new[] { ApplicationExecutionState.Suspended, ApplicationExecutionState.Running, };
-            RxApp.SuspensionHost.IsUnpausing = _launched
-                .Where(x => unpausing.Contains(x.PreviousExecutionState))
-                .Select(_ => Unit.Default);
+			var fastResuming = new Subject<ApplicationExecutionState>();
+			app.Resuming += (o, e) => fastResuming.OnNext(ApplicationExecutionState.Suspended);
+			var unpausing = new[] { ApplicationExecutionState.Suspended, ApplicationExecutionState.Running, };
+			RxApp.SuspensionHost.IsUnpausing = _launched
+				.Select(x => x.PreviousExecutionState)
+				.Merge(fastResuming)
+				.Where(x => unpausing.Contains(x))
+				.Select(_ => Unit.Default);
 
             var shouldPersistState = new Subject<SuspendingEventArgs>();
             app.Suspending += (o, e) => shouldPersistState.OnNext(e);


### PR DESCRIPTION
As it stands now I can't get IsUnpausing to fire which I'm pretty sure is caused by the fact that the Fast Resume features of Win 8.1 means App.OnLaunched is never called because "resuming" in WinRT isn't really the same as :"Launching" ..  As I understand it a Suspended WinRT application stays in memory (with limited functionality) unless it's actually terminated and will usually just stay in memory for awhile unless memory pressures dictate otherwise...  The info on it (https://msdn.microsoft.com/en-us/library/windows/apps/hh464925.aspx) says it might just sit there in memory suspended for days

Hopefully that makes sense... The language in RxUI doesn't correlate to WinRT's names for things (not saying it should) but that might make what I'm saying confusing :-x  

Here's my stab at the modification that seems to work when I tested it in the PlayGround projects

```
            var fastResuming = new Subject<ApplicationExecutionState>();
            app.Resuming += (o, e) => fastResuming.OnNext(ApplicationExecutionState.Suspended);
            var unpausing = new[] { ApplicationExecutionState.Suspended, ApplicationExecutionState.Running, };
            RxApp.SuspensionHost.IsUnpausing = _launched
                .Select(x=> x.PreviousExecutionState)
                .Merge(fastResuming)
                .Where(x => unpausing.Contains(x))
                .Select(_ => Unit.Default);

```

Suspended in WinRT still means you're entering a limited state of functionality (for example you can't get GPS location) so it's not like it's just same behavior but not visible it's still "suspended" so it's a good thing to be able to wire into....    Which is why I ran into this :-)  Because I need to suspend some GPS/network stuff going on if the user "suspends" the app and then start those things back up with the app enters the foreground
