### PR TITLE
Bump dependencies

### DIFF
--- a/NuGet/ReactiveUI-AndroidSupport/ReactiveUI-AndroidSupport.nuspec
+++ b/NuGet/ReactiveUI-AndroidSupport/ReactiveUI-AndroidSupport.nuspec
@@ -12,8 +12,8 @@
 
     <dependencies>
       <dependency id="reactiveui-core" version="[6.4.0.1]" />
-      <dependency id="Xamarin.Android.Support.v4" version="20.0.0.3" />
-      <dependency id="Xamarin.Android.Support.v7.AppCompat" version="21.0.3.0" />
+      <dependency id="Xamarin.Android.Support.v4" version="22.1.1.1" />
+      <dependency id="Xamarin.Android.Support.v7.AppCompat" version="22.1.1.1" />
     </dependencies>
   </metadata>
 </package>

--- a/NuGet/ReactiveUI-Core/ReactiveUI-Core.nuspec
+++ b/NuGet/ReactiveUI-Core/ReactiveUI-Core.nuspec
@@ -12,28 +12,28 @@
     <dependencies>
       <group>
         <dependency id="Rx-Main" version="2.2.5" />
-        <dependency id="Splat" version="1.6.0" />
+        <dependency id="Splat" version="1.6.2" />
       </group>
       <group targetFramework="win8">
         <dependency id="Rx-Main" version="2.2.5" />
-        <dependency id="Splat" version="1.6.0" />
+        <dependency id="Splat" version="1.6.2" />
         <dependency id="Rx-Xaml" version="2.2.5" />
         <dependency id="Rx-WinRT" version="2.2.5" />
       </group>
 	  <group targetFramework="wp8">
         <dependency id="Rx-Main" version="2.2.5" />
-        <dependency id="Splat" version="1.6.0" />
+        <dependency id="Splat" version="1.6.2" />
         <dependency id="Rx-Xaml" version="2.2.5" />
         <dependency id="Rx-WinRT" version="2.2.5" />
       </group>
 	  <group targetFramework="net45">
         <dependency id="Rx-Main" version="2.2.5" />
-        <dependency id="Splat" version="1.6.0" />
+        <dependency id="Splat" version="1.6.2" />
         <dependency id="Rx-Xaml" version="2.2.5" />
       </group>
 	  <group targetFramework="Portable-Win81+Wpa81">
         <dependency id="Rx-Main" version="2.2.5" />
-        <dependency id="Splat" version="1.6.0" />
+        <dependency id="Splat" version="1.6.2" />
         <dependency id="Rx-Xaml" version="2.2.5" />
         <dependency id="Rx-WinRT" version="2.2.5" />
       </group>	  

--- a/NuGet/ReactiveUI-Core/ReactiveUI-Core.nuspec
+++ b/NuGet/ReactiveUI-Core/ReactiveUI-Core.nuspec
@@ -12,28 +12,28 @@
     <dependencies>
       <group>
         <dependency id="Rx-Main" version="2.2.5" />
-        <dependency id="Splat" version="1.6.2" />
+        <dependency id="Splat" version="[1,2)" />
       </group>
       <group targetFramework="win8">
         <dependency id="Rx-Main" version="2.2.5" />
-        <dependency id="Splat" version="1.6.2" />
+        <dependency id="Splat" version="[1,2)" />
         <dependency id="Rx-Xaml" version="2.2.5" />
         <dependency id="Rx-WinRT" version="2.2.5" />
       </group>
 	  <group targetFramework="wp8">
         <dependency id="Rx-Main" version="2.2.5" />
-        <dependency id="Splat" version="1.6.2" />
+        <dependency id="Splat" version="[1,2)" />
         <dependency id="Rx-Xaml" version="2.2.5" />
         <dependency id="Rx-WinRT" version="2.2.5" />
       </group>
 	  <group targetFramework="net45">
         <dependency id="Rx-Main" version="2.2.5" />
-        <dependency id="Splat" version="1.6.2" />
+        <dependency id="Splat" version="[1,2)" />
         <dependency id="Rx-Xaml" version="2.2.5" />
       </group>
 	  <group targetFramework="Portable-Win81+Wpa81">
         <dependency id="Rx-Main" version="2.2.5" />
-        <dependency id="Splat" version="1.6.2" />
+        <dependency id="Splat" version="[1,2)" />
         <dependency id="Rx-Xaml" version="2.2.5" />
         <dependency id="Rx-WinRT" version="2.2.5" />
       </group>	  

--- a/NuGet/ReactiveUI-XamForms/ReactiveUI-XamForms.nuspec
+++ b/NuGet/ReactiveUI-XamForms/ReactiveUI-XamForms.nuspec
@@ -12,7 +12,7 @@
 
     <dependencies>
       <dependency id="reactiveui-core" version="[6.4.0.1]" />
-      <dependency id="Xamarin.Forms" version="1.4.0.6341" />
+      <dependency id="Xamarin.Forms" version="1.4.2.6359" />
     </dependencies>
   </metadata>
 </package>

--- a/PerfConsoleRunner/PerfConsoleRunner.csproj
+++ b/PerfConsoleRunner/PerfConsoleRunner.csproj
@@ -48,15 +48,6 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="xunit.abstractions">
-      <HintPath>..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
-    </Reference>
-    <Reference Include="xunit.assert">
-      <HintPath>..\packages\xunit.assert.2.1.0-beta1-build2945\lib\portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.assert.dll</HintPath>
-    </Reference>
-    <Reference Include="xunit.core">
-      <HintPath>..\packages\xunit.extensibility.core.2.1.0-beta1-build2945\lib\portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Program.cs" />

--- a/PerfConsoleRunner/packages.config
+++ b/PerfConsoleRunner/packages.config
@@ -1,8 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="xunit" version="2.1.0-beta1-build2945" targetFramework="net45" />
-  <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.assert" version="2.1.0-beta1-build2945" targetFramework="net45" />
   <package id="xunit.core" version="2.1.0-beta1-build2945" targetFramework="net45" />
-  <package id="xunit.extensibility.core" version="2.1.0-beta1-build2945" targetFramework="net45" />
 </packages>

--- a/Playground-Android/Playground-Android.csproj
+++ b/Playground-Android/Playground-Android.csproj
@@ -5,7 +5,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{D444AA58-1C6B-4CEE-B5F5-761.6.0B86E5}</ProjectGuid>
+    <ProjectGuid>{D444AA58-1C6B-4CEE-B5F5-761A650B86E5}</ProjectGuid>
     <ProjectTypeGuids>{EFBA0AD7-5A72-4C68-AF49-83D382785DCF};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
@@ -43,7 +43,7 @@
   <ItemGroup>
     <Reference Include="Splat">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Splat.1.6.0\lib\monoandroid\Splat.dll</HintPath>
+      <HintPath>..\packages\Splat.1.6.2\lib\monoandroid\Splat.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Reactive.Core, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/Playground-Android/packages.config
+++ b/Playground-Android/packages.config
@@ -5,5 +5,5 @@
   <package id="Rx-Linq" version="2.2.5" targetFramework="MonoAndroid403" />
   <package id="Rx-Main" version="2.2.5" targetFramework="MonoAndroid403" />
   <package id="Rx-PlatformServices" version="2.2.5" targetFramework="MonoAndroid403" />
-  <package id="Splat" version="1.6.0" targetFramework="MonoAndroid403" />
+  <package id="Splat" version="1.6.2" targetFramework="MonoAndroid403" />
 </packages>

--- a/Playground-Wpa81/Playground-Wpa81.Windows/Playground-Wpa81.Windows.csproj
+++ b/Playground-Wpa81/Playground-Wpa81.Windows/Playground-Wpa81.Windows.csproj
@@ -130,9 +130,9 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Splat, Version=1.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="Splat, Version=1.6.2.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Splat.1.6.0\lib\NetCore45\Splat.dll</HintPath>
+      <HintPath>..\..\packages\Splat.1.6.2\lib\NetCore45\Splat.dll</HintPath>
     </Reference>
     <Reference Include="System.Reactive.Core, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/Playground-Wpa81/Playground-Wpa81.Windows/packages.config
+++ b/Playground-Wpa81/Playground-Wpa81.Windows/packages.config
@@ -7,5 +7,5 @@
   <package id="Rx-PlatformServices" version="2.2.5" targetFramework="win81" />
   <package id="Rx-WinRT" version="2.2.5" targetFramework="win81" />
   <package id="Rx-Xaml" version="2.2.5" targetFramework="win81" />
-  <package id="Splat" version="1.6.0" targetFramework="win81" />
+  <package id="Splat" version="1.6.2" targetFramework="win81" />
 </packages>

--- a/Playground-Wpa81/Playground-Wpa81.WindowsPhone/Playground-Wpa81.WindowsPhone.csproj
+++ b/Playground-Wpa81/Playground-Wpa81.WindowsPhone/Playground-Wpa81.WindowsPhone.csproj
@@ -109,7 +109,7 @@
   <ItemGroup>
     <Reference Include="Splat, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Splat.1.6.0\lib\Portable-Win81+Wpa81\Splat.dll</HintPath>
+      <HintPath>..\..\packages\Splat.1.6.2\lib\Portable-Win81+Wpa81\Splat.dll</HintPath>
     </Reference>
     <Reference Include="System.Reactive.Core, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/Playground-Wpa81/Playground-Wpa81.WindowsPhone/packages.config
+++ b/Playground-Wpa81/Playground-Wpa81.WindowsPhone/packages.config
@@ -7,5 +7,5 @@
   <package id="Rx-PlatformServices" version="2.2.5" targetFramework="wpa81" />
   <package id="Rx-WinRT" version="2.2.5" targetFramework="wpa81" />
   <package id="Rx-Xaml" version="2.2.5" targetFramework="wpa81" />
-  <package id="Splat" version="1.6.0" targetFramework="wpa81" />
+  <package id="Splat" version="1.6.2" targetFramework="wpa81" />
 </packages>

--- a/Playground-XamForms.Android/Playground-XamForms.Android.csproj
+++ b/Playground-XamForms.Android/Playground-XamForms.Android.csproj
@@ -55,7 +55,7 @@
       <HintPath>..\packages\Xamarin.Forms.1.4.0.6341\lib\MonoAndroid10\Xamarin.Forms.Xaml.dll</HintPath>
     </Reference>
     <Reference Include="Splat">
-      <HintPath>..\packages\Splat.1.6.0\lib\monoandroid\Splat.dll</HintPath>
+      <HintPath>..\packages\Splat.1.6.2\lib\monoandroid\Splat.dll</HintPath>
     </Reference>
     <Reference Include="System.Reactive.Interfaces">
       <HintPath>..\packages\Rx-Interfaces.2.2.5\lib\portable-windows8+net45+wp8\System.Reactive.Interfaces.dll</HintPath>

--- a/Playground-XamForms.Android/Playground-XamForms.Android.csproj
+++ b/Playground-XamForms.Android/Playground-XamForms.Android.csproj
@@ -46,13 +46,13 @@
     <Reference Include="System.Core" />
     <Reference Include="Mono.Android" />
     <Reference Include="Xamarin.Forms.Platform.Android">
-      <HintPath>..\packages\Xamarin.Forms.1.4.0.6341\lib\MonoAndroid10\Xamarin.Forms.Platform.Android.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.1.4.2.6359\lib\MonoAndroid10\Xamarin.Forms.Platform.Android.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Core">
-      <HintPath>..\packages\Xamarin.Forms.1.4.0.6341\lib\MonoAndroid10\Xamarin.Forms.Core.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.1.4.2.6359\lib\MonoAndroid10\Xamarin.Forms.Core.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Xaml">
-      <HintPath>..\packages\Xamarin.Forms.1.4.0.6341\lib\MonoAndroid10\Xamarin.Forms.Xaml.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.1.4.2.6359\lib\MonoAndroid10\Xamarin.Forms.Xaml.dll</HintPath>
     </Reference>
     <Reference Include="Splat">
       <HintPath>..\packages\Splat.1.6.2\lib\monoandroid\Splat.dll</HintPath>
@@ -113,5 +113,5 @@
     <AndroidResource Include="Resources\drawable\Icon.png" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Novell\Novell.MonoDroid.CSharp.targets" />
-  <Import Project="../packages/Xamarin.Forms.1.4.0.6341/build/portable-win+net45+wp80+MonoAndroid10+MonoTouch10/Xamarin.Forms.targets" />
+  <Import Project="../packages/Xamarin.Forms.1.4.2.6359/build/portable-win+net45+wp80+MonoAndroid10+MonoTouch10/Xamarin.Forms.targets" />
 </Project>

--- a/Playground-XamForms.Android/packages.config
+++ b/Playground-XamForms.Android/packages.config
@@ -5,7 +5,7 @@
   <package id="Rx-Linq" version="2.2.5" targetFramework="MonoAndroid403" />
   <package id="Rx-Main" version="2.2.5" targetFramework="MonoAndroid403" />
   <package id="Rx-PlatformServices" version="2.2.5" targetFramework="MonoAndroid403" />
-  <package id="Splat" version="1.6.0" targetFramework="MonoAndroid403" />
+  <package id="Splat" version="1.6.2" targetFramework="MonoAndroid403" />
   <package id="Xamarin.Android.Support.v4" version="19.0.2" targetFramework="MonoAndroid403" />
   <package id="Xamarin.Forms" version="1.4.0.6341" targetFramework="MonoAndroid403" />
 </packages>

--- a/Playground-XamForms.Android/packages.config
+++ b/Playground-XamForms.Android/packages.config
@@ -7,5 +7,5 @@
   <package id="Rx-PlatformServices" version="2.2.5" targetFramework="MonoAndroid403" />
   <package id="Splat" version="1.6.2" targetFramework="MonoAndroid403" />
   <package id="Xamarin.Android.Support.v4" version="19.0.2" targetFramework="MonoAndroid403" />
-  <package id="Xamarin.Forms" version="1.4.0.6341" targetFramework="MonoAndroid403" />
+  <package id="Xamarin.Forms" version="1.4.2.6359" targetFramework="MonoAndroid403" />
 </packages>

--- a/Playground-XamForms.iOS/Playground-XamForms.iOS.csproj
+++ b/Playground-XamForms.iOS/Playground-XamForms.iOS.csproj
@@ -128,7 +128,7 @@
       <HintPath>..\packages\Xamarin.Forms.1.4.0.6341\lib\MonoTouch10\Xamarin.Forms.Xaml.dll</HintPath>
     </Reference>
     <Reference Include="Splat">
-      <HintPath>..\packages\Splat.1.6.0\lib\Xamarin.iOS10\Splat.dll</HintPath>
+      <HintPath>..\packages\Splat.1.6.2\lib\Xamarin.iOS10\Splat.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Playground-XamForms.iOS/Playground-XamForms.iOS.csproj
+++ b/Playground-XamForms.iOS/Playground-XamForms.iOS.csproj
@@ -119,13 +119,13 @@
     </Reference>
     <Reference Include="Xamarin.iOS" />
     <Reference Include="Xamarin.Forms.Core">
-      <HintPath>..\packages\Xamarin.Forms.1.4.0.6341\lib\Xamarin.iOS10\Xamarin.Forms.Core.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.1.4.2.6359\lib\Xamarin.iOS10\Xamarin.Forms.Core.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Platform.iOS">
-      <HintPath>..\packages\Xamarin.Forms.1.4.0.6341\lib\Xamarin.iOS10\Xamarin.Forms.Platform.iOS.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.1.4.2.6359\lib\Xamarin.iOS10\Xamarin.Forms.Platform.iOS.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Xaml">
-      <HintPath>..\packages\Xamarin.Forms.1.4.0.6341\lib\MonoTouch10\Xamarin.Forms.Xaml.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.1.4.2.6359\lib\MonoTouch10\Xamarin.Forms.Xaml.dll</HintPath>
     </Reference>
     <Reference Include="Splat">
       <HintPath>..\packages\Splat.1.6.2\lib\Xamarin.iOS10\Splat.dll</HintPath>
@@ -165,6 +165,6 @@
     <Compile Include="Main.cs" />
     <Compile Include="AppDelegate.cs" />
   </ItemGroup>
-  <Import Project="../packages/Xamarin.Forms.1.4.0.6341/build/portable-win+net45+wp80+MonoAndroid10+MonoTouch10+Xamarin.iOS10/Xamarin.Forms.targets" />
+  <Import Project="../packages/Xamarin.Forms.1.4.2.6359/build/portable-win+net45+wp80+MonoAndroid10+MonoTouch10+Xamarin.iOS10/Xamarin.Forms.targets" />
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
 </Project>

--- a/Playground-XamForms.iOS/packages.config
+++ b/Playground-XamForms.iOS/packages.config
@@ -5,6 +5,6 @@
   <package id="Rx-Linq" version="2.2.5" targetFramework="MonoTouch10" />
   <package id="Rx-Main" version="2.2.5" targetFramework="MonoTouch10" />
   <package id="Rx-PlatformServices" version="2.2.5" targetFramework="MonoTouch10" />
-  <package id="Splat" version="1.6.0" targetFramework="MonoTouch10" />
+  <package id="Splat" version="1.6.2" targetFramework="MonoTouch10" />
   <package id="Xamarin.Forms" version="1.4.0.6341" targetFramework="MonoTouch10" />
 </packages>

--- a/Playground-XamForms.iOS/packages.config
+++ b/Playground-XamForms.iOS/packages.config
@@ -6,5 +6,5 @@
   <package id="Rx-Main" version="2.2.5" targetFramework="MonoTouch10" />
   <package id="Rx-PlatformServices" version="2.2.5" targetFramework="MonoTouch10" />
   <package id="Splat" version="1.6.2" targetFramework="MonoTouch10" />
-  <package id="Xamarin.Forms" version="1.4.0.6341" targetFramework="MonoTouch10" />
+  <package id="Xamarin.Forms" version="1.4.2.6359" targetFramework="MonoTouch10" />
 </packages>

--- a/Playground-XamForms/Playground-XamForms.csproj
+++ b/Playground-XamForms/Playground-XamForms.csproj
@@ -49,7 +49,7 @@
     </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
-  <Import Project="../packages/Xamarin.Forms.1.4.0.6341/build/portable-win+net45+wp80+MonoAndroid10+MonoTouch10+Xamarin.iOS10/Xamarin.Forms.targets" />
+  <Import Project="../packages/Xamarin.Forms.1.4.2.6359/build/portable-win+net45+wp80+MonoAndroid10+MonoTouch10+Xamarin.iOS10/Xamarin.Forms.targets" />
   <ItemGroup>
     <Reference Include="Splat">
       <HintPath>..\packages\Splat.1.6.2\lib\Portable-net45+win+wpa81+wp80\Splat.dll</HintPath>
@@ -67,10 +67,10 @@
       <HintPath>..\packages\Rx-PlatformServices.2.2.5\lib\portable-windows8+net45+wp8\System.Reactive.PlatformServices.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Core">
-      <HintPath>..\packages\Xamarin.Forms.1.4.0.6341\lib\portable-win+net45+wp80+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.Core.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.1.4.2.6359\lib\portable-win+net45+wp80+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.Core.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Xaml">
-      <HintPath>..\packages\Xamarin.Forms.1.4.0.6341\lib\portable-win+net45+wp80+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.Xaml.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.1.4.2.6359\lib\portable-win+net45+wp80+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.Xaml.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Playground-XamForms/Playground-XamForms.csproj
+++ b/Playground-XamForms/Playground-XamForms.csproj
@@ -52,7 +52,7 @@
   <Import Project="../packages/Xamarin.Forms.1.4.0.6341/build/portable-win+net45+wp80+MonoAndroid10+MonoTouch10+Xamarin.iOS10/Xamarin.Forms.targets" />
   <ItemGroup>
     <Reference Include="Splat">
-      <HintPath>..\packages\Splat.1.6.0\lib\Portable-net45+win+wpa81+wp80\Splat.dll</HintPath>
+      <HintPath>..\packages\Splat.1.6.2\lib\Portable-net45+win+wpa81+wp80\Splat.dll</HintPath>
     </Reference>
     <Reference Include="System.Reactive.Interfaces">
       <HintPath>..\packages\Rx-Interfaces.2.2.5\lib\portable-windows8+net45+wp8\System.Reactive.Interfaces.dll</HintPath>

--- a/Playground-XamForms/packages.config
+++ b/Playground-XamForms/packages.config
@@ -5,6 +5,6 @@
   <package id="Rx-Linq" version="2.2.5" targetFramework="portable-net45+win+wp80+MonoAndroid10+MonoTouch10" />
   <package id="Rx-Main" version="2.2.5" targetFramework="portable-net45+win+wp80+MonoAndroid10+MonoTouch10" />
   <package id="Rx-PlatformServices" version="2.2.5" targetFramework="portable-net45+win+wp80+MonoAndroid10+MonoTouch10" />
-  <package id="Splat" version="1.6.0" targetFramework="portable-net45+win+wp80+MonoAndroid10+MonoTouch10" />
+  <package id="Splat" version="1.6.2" targetFramework="portable-net45+win+wp80+MonoAndroid10+MonoTouch10" />
   <package id="Xamarin.Forms" version="1.4.0.6341" targetFramework="portable-net45+win+wp80+MonoAndroid10+MonoTouch10" />
 </packages>

--- a/Playground-XamForms/packages.config
+++ b/Playground-XamForms/packages.config
@@ -6,5 +6,5 @@
   <package id="Rx-Main" version="2.2.5" targetFramework="portable-net45+win+wp80+MonoAndroid10+MonoTouch10" />
   <package id="Rx-PlatformServices" version="2.2.5" targetFramework="portable-net45+win+wp80+MonoAndroid10+MonoTouch10" />
   <package id="Splat" version="1.6.2" targetFramework="portable-net45+win+wp80+MonoAndroid10+MonoTouch10" />
-  <package id="Xamarin.Forms" version="1.4.0.6341" targetFramework="portable-net45+win+wp80+MonoAndroid10+MonoTouch10" />
+  <package id="Xamarin.Forms" version="1.4.2.6359" targetFramework="portable-net45+win+wp80+MonoAndroid10+MonoTouch10" />
 </packages>

--- a/Playground-iOS/Playground-iOS.csproj
+++ b/Playground-iOS/Playground-iOS.csproj
@@ -90,7 +90,7 @@
   <ItemGroup>
     <Reference Include="Splat, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Splat.1.6.0\lib\monotouch\Splat.dll</HintPath>
+      <HintPath>..\packages\Splat.1.6.2\lib\monotouch\Splat.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Reactive.Core, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/Playground-iOS/packages.config
+++ b/Playground-iOS/packages.config
@@ -5,5 +5,5 @@
   <package id="Rx-Linq" version="2.2.5" targetFramework="MonoTouch10" />
   <package id="Rx-Main" version="2.2.5" targetFramework="MonoTouch10" />
   <package id="Rx-PlatformServices" version="2.2.5" targetFramework="MonoTouch10" />
-  <package id="Splat" version="1.6.0" targetFramework="MonoTouch10" />
+  <package id="Splat" version="1.6.2" targetFramework="MonoTouch10" />
 </packages>

--- a/ReactiveUI.AndroidSupport/ReactiveUI.AndroidSupport.csproj
+++ b/ReactiveUI.AndroidSupport/ReactiveUI.AndroidSupport.csproj
@@ -64,10 +64,10 @@
       <HintPath>..\packages\Rx-PlatformServices.2.2.5\lib\portable-windows8+net45+wp8\System.Reactive.PlatformServices.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Android.Support.v4">
-      <HintPath>..\packages\Xamarin.Android.Support.v4.21.0.3.0\lib\MonoAndroid10\Xamarin.Android.Support.v4.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Android.Support.v4.22.1.1.1\lib\MonoAndroid403\Xamarin.Android.Support.v4.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Android.Support.v7.AppCompat">
-      <HintPath>..\packages\Xamarin.Android.Support.v7.AppCompat.21.0.3.0\lib\MonoAndroid403\Xamarin.Android.Support.v7.AppCompat.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Android.Support.v7.AppCompat.22.1.1.1\lib\MonoAndroid403\Xamarin.Android.Support.v7.AppCompat.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/ReactiveUI.AndroidSupport/ReactiveUI.AndroidSupport.csproj
+++ b/ReactiveUI.AndroidSupport/ReactiveUI.AndroidSupport.csproj
@@ -49,7 +49,7 @@
     <Reference Include="Mono.Android" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="Splat">
-      <HintPath>..\packages\Splat.1.6.0\lib\monoandroid\Splat.dll</HintPath>
+      <HintPath>..\packages\Splat.1.6.2\lib\monoandroid\Splat.dll</HintPath>
     </Reference>
     <Reference Include="System.Reactive.Core">
       <HintPath>..\packages\Rx-Core.2.2.5\lib\portable-windows8+net45+wp8\System.Reactive.Core.dll</HintPath>

--- a/ReactiveUI.AndroidSupport/packages.config
+++ b/ReactiveUI.AndroidSupport/packages.config
@@ -5,7 +5,7 @@
   <package id="Rx-Linq" version="2.2.5" targetFramework="MonoAndroid403" />
   <package id="Rx-Main" version="2.2.5" targetFramework="MonoAndroid403" />
   <package id="Rx-PlatformServices" version="2.2.5" targetFramework="MonoAndroid403" />
-  <package id="Splat" version="1.6.0" targetFramework="MonoAndroid403" />
+  <package id="Splat" version="1.6.2" targetFramework="MonoAndroid403" />
   <package id="Xamarin.Android.Support.v4" version="21.0.3.0" targetFramework="MonoAndroid403" />
   <package id="Xamarin.Android.Support.v7.AppCompat" version="21.0.3.0" targetFramework="MonoAndroid403" />
 </packages>

--- a/ReactiveUI.AndroidSupport/packages.config
+++ b/ReactiveUI.AndroidSupport/packages.config
@@ -6,6 +6,6 @@
   <package id="Rx-Main" version="2.2.5" targetFramework="MonoAndroid403" />
   <package id="Rx-PlatformServices" version="2.2.5" targetFramework="MonoAndroid403" />
   <package id="Splat" version="1.6.2" targetFramework="MonoAndroid403" />
-  <package id="Xamarin.Android.Support.v4" version="21.0.3.0" targetFramework="MonoAndroid403" />
-  <package id="Xamarin.Android.Support.v7.AppCompat" version="21.0.3.0" targetFramework="MonoAndroid403" />
+  <package id="Xamarin.Android.Support.v4" version="22.1.1.1" targetFramework="MonoAndroid403" />
+  <package id="Xamarin.Android.Support.v7.AppCompat" version="22.1.1.1" targetFramework="MonoAndroid403" />
 </packages>

--- a/ReactiveUI.Blend/ReactiveUI.Blend_Net45.csproj
+++ b/ReactiveUI.Blend/ReactiveUI.Blend_Net45.csproj
@@ -49,9 +49,9 @@
     <Reference Include="Microsoft.Expression.Interactions, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
-    <Reference Include="Splat, Version=1.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="Splat, Version=1.6.2.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Splat.1.6.0\lib\Net45\Splat.dll</HintPath>
+      <HintPath>..\packages\Splat.1.6.2\lib\Net45\Splat.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/ReactiveUI.Blend/ReactiveUI.Blend_WP8.csproj
+++ b/ReactiveUI.Blend/ReactiveUI.Blend_WP8.csproj
@@ -91,9 +91,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="mscorlib.Extensions" />
-    <Reference Include="Splat, Version=1.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="Splat, Version=1.6.2.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Splat.1.6.0\lib\wp8\Splat.dll</HintPath>
+      <HintPath>..\packages\Splat.1.6.2\lib\wp8\Splat.dll</HintPath>
     </Reference>
     <Reference Include="System.Observable" />
     <Reference Include="System.Reactive.Core, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/ReactiveUI.Blend/ReactiveUI.Blend_WinRT.csproj
+++ b/ReactiveUI.Blend/ReactiveUI.Blend_WinRT.csproj
@@ -51,7 +51,7 @@
       <HintPath>C:\Program Files (x86)\Microsoft SDKs\Windows\v8.1\ExtensionSDKs\BehaviorsXamlSDKManaged\12.0\References\CommonConfiguration\Neutral\Microsoft.Xaml.Interactivity.dll</HintPath>
     </Reference>
     <Reference Include="Splat">
-      <HintPath>..\packages\Splat.1.6.0\lib\Portable-Win81+Wpa81\Splat.dll</HintPath>
+      <HintPath>..\packages\Splat.1.6.2\lib\Portable-Win81+Wpa81\Splat.dll</HintPath>
     </Reference>
     <Reference Include="System.Reactive.Core">
       <HintPath>..\packages\Rx-Core.2.2.5\lib\portable-win81+wpa81\System.Reactive.Core.dll</HintPath>

--- a/ReactiveUI.Blend/packages.ReactiveUI.Blend_Net45.config
+++ b/ReactiveUI.Blend/packages.ReactiveUI.Blend_Net45.config
@@ -6,5 +6,5 @@
   <package id="Rx-Main" version="2.2.5" targetFramework="net45" />
   <package id="Rx-PlatformServices" version="2.2.5" targetFramework="net45" />
   <package id="Rx-Xaml" version="2.2.5" targetFramework="net45" />
-  <package id="Splat" version="1.6.0" targetFramework="net45" />
+  <package id="Splat" version="1.6.2" targetFramework="net45" />
 </packages>

--- a/ReactiveUI.Blend/packages.ReactiveUI.Blend_WP8.config
+++ b/ReactiveUI.Blend/packages.ReactiveUI.Blend_WP8.config
@@ -7,5 +7,5 @@
   <package id="Rx-PlatformServices" version="2.2.5" targetFramework="wp80" />
   <package id="Rx-WinRT" version="2.2.5" targetFramework="wp80" />
   <package id="Rx-Xaml" version="2.2.5" targetFramework="wp80" />
-  <package id="Splat" version="1.6.0" targetFramework="wp80" />
+  <package id="Splat" version="1.6.2" targetFramework="wp80" />
 </packages>

--- a/ReactiveUI.Blend/packages.ReactiveUI.Blend_WinRT.config
+++ b/ReactiveUI.Blend/packages.ReactiveUI.Blend_WinRT.config
@@ -7,5 +7,5 @@
   <package id="Rx-PlatformServices" version="2.2.5" targetFramework="portable-win81+wpa81" />
   <package id="Rx-WinRT" version="2.2.5" targetFramework="portable-win81+wpa81" />
   <package id="Rx-Xaml" version="2.2.5" targetFramework="portable-win81+wpa81" />
-  <package id="Splat" version="1.6.0" targetFramework="portable-win81+wpa81" />
+  <package id="Splat" version="1.6.2" targetFramework="portable-win81+wpa81" />
 </packages>

--- a/ReactiveUI.Events/ReactiveUI.Events_Android.csproj
+++ b/ReactiveUI.Events/ReactiveUI.Events_Android.csproj
@@ -45,7 +45,7 @@
     <Reference Include="mscorlib" />
     <Reference Include="Splat, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Splat.1.6.0\lib\monoandroid\Splat.dll</HintPath>
+      <HintPath>..\packages\Splat.1.6.2\lib\monoandroid\Splat.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/ReactiveUI.Events/ReactiveUI.Events_Net45.csproj
+++ b/ReactiveUI.Events/ReactiveUI.Events_Net45.csproj
@@ -37,9 +37,9 @@
     <DocumentationFile>bin\Release\Net45\ReactiveUI.Events.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Splat, Version=1.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="Splat, Version=1.6.2.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Splat.1.6.0\lib\Net45\Splat.dll</HintPath>
+      <HintPath>..\packages\Splat.1.6.2\lib\Net45\Splat.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/ReactiveUI.Events/ReactiveUI.Events_WP8.csproj
+++ b/ReactiveUI.Events/ReactiveUI.Events_WP8.csproj
@@ -91,9 +91,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="mscorlib.Extensions" />
-    <Reference Include="Splat, Version=1.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="Splat, Version=1.6.2.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Splat.1.6.0\lib\wp8\Splat.dll</HintPath>
+      <HintPath>..\packages\Splat.1.6.2\lib\wp8\Splat.dll</HintPath>
     </Reference>
     <Reference Include="System.Observable" />
     <Reference Include="System.Reactive.Core, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/ReactiveUI.Events/ReactiveUI.Events_WP81.csproj
+++ b/ReactiveUI.Events/ReactiveUI.Events_WP81.csproj
@@ -98,9 +98,9 @@
     <PlatformTarget />
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Splat, Version=1.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="Splat, Version=1.6.2.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Splat.1.6.0\lib\wp8\Splat.dll</HintPath>
+      <HintPath>..\packages\Splat.1.6.2\lib\wp8\Splat.dll</HintPath>
     </Reference>
     <Reference Include="System.Reactive.Core, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/ReactiveUI.Events/ReactiveUI.Events_WPA81.csproj
+++ b/ReactiveUI.Events/ReactiveUI.Events_WPA81.csproj
@@ -54,7 +54,7 @@
   <ItemGroup>
     <Reference Include="Splat, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Splat.1.6.0\lib\Portable-Win81+Wpa81\Splat.dll</HintPath>
+      <HintPath>..\packages\Splat.1.6.2\lib\Portable-Win81+Wpa81\Splat.dll</HintPath>
     </Reference>
     <Reference Include="System.Reactive.Core, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/ReactiveUI.Events/ReactiveUI.Events_WinRT.csproj
+++ b/ReactiveUI.Events/ReactiveUI.Events_WinRT.csproj
@@ -52,9 +52,9 @@
     <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Splat, Version=1.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="Splat, Version=1.6.2.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Splat.1.6.0\lib\NetCore45\Splat.dll</HintPath>
+      <HintPath>..\packages\Splat.1.6.2\lib\NetCore45\Splat.dll</HintPath>
     </Reference>
     <Reference Include="System.Reactive.Core, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/ReactiveUI.Events/ReactiveUI.Events_WinRT80.csproj
+++ b/ReactiveUI.Events/ReactiveUI.Events_WinRT80.csproj
@@ -49,9 +49,9 @@
     <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Splat, Version=1.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="Splat, Version=1.6.2.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Splat.1.6.0\lib\NetCore45\Splat.dll</HintPath>
+      <HintPath>..\packages\Splat.1.6.2\lib\NetCore45\Splat.dll</HintPath>
     </Reference>
     <Reference Include="System.Reactive.Core, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/ReactiveUI.Events/ReactiveUI.Events_XamForms_XS.csproj
+++ b/ReactiveUI.Events/ReactiveUI.Events_XamForms_XS.csproj
@@ -53,7 +53,7 @@
     <Reference Include="System.Xml.Linq" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Splat">
-      <HintPath>..\packages\Splat.1.6.0\lib\Portable-net45+win+wpa81+wp80\Splat.dll</HintPath>
+      <HintPath>..\packages\Splat.1.6.2\lib\Portable-net45+win+wpa81+wp80\Splat.dll</HintPath>
     </Reference>
     <Reference Include="System.Reactive.Core">
       <HintPath>..\packages\Rx-Core.2.2.5\lib\portable-windows8+net45+wp8\System.Reactive.Core.dll</HintPath>

--- a/ReactiveUI.Events/ReactiveUI.Events_XamForms_XS.csproj
+++ b/ReactiveUI.Events/ReactiveUI.Events_XamForms_XS.csproj
@@ -20,7 +20,7 @@
     <SchemaVersion>2.0</SchemaVersion>
     <CustomCommands>
       <CustomCommands>
-        <Command type="BeforeBuild" command="/usr/bin/env ruby ${ProjectDir}/generate_events.rb ${ProjectDir}/../packages/Xamarin.Forms.1.4.0.6341/lib/portable-win+net45+wp80+MonoAndroid10+MonoTouch10/Xamarin.Forms.Core.dll" workingdir="${ProjectDir}" />
+        <Command type="BeforeBuild" command="/usr/bin/env ruby ${ProjectDir}/generate_events.rb ${ProjectDir}/../packages/Xamarin.Forms.1.4.2.6359/lib/portable-win+net45+wp80+MonoAndroid10+MonoTouch10/Xamarin.Forms.Core.dll" workingdir="${ProjectDir}" />
       </CustomCommands>
     </CustomCommands>
   </PropertyGroup>
@@ -68,10 +68,10 @@
       <HintPath>..\packages\Rx-PlatformServices.2.2.5\lib\portable-windows8+net45+wp8\System.Reactive.PlatformServices.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Core">
-      <HintPath>..\packages\Xamarin.Forms.1.4.0.6341\lib\portable-win+net45+wp80+MonoAndroid10+MonoTouch10\Xamarin.Forms.Core.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.1.4.2.6359\lib\portable-win+net45+wp80+MonoAndroid10+MonoTouch10\Xamarin.Forms.Core.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Xaml">
-      <HintPath>..\packages\Xamarin.Forms.1.4.0.6341\lib\portable-win+net45+wp80+MonoAndroid10+MonoTouch10\Xamarin.Forms.Xaml.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.1.4.2.6359\lib\portable-win+net45+wp80+MonoAndroid10+MonoTouch10\Xamarin.Forms.Xaml.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/ReactiveUI.Events/ReactiveUI.Events_iOS.csproj
+++ b/ReactiveUI.Events/ReactiveUI.Events_iOS.csproj
@@ -50,7 +50,7 @@
   <ItemGroup>
     <Reference Include="Splat, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Splat.1.6.0\lib\monotouch\Splat.dll</HintPath>
+      <HintPath>..\packages\Splat.1.6.2\lib\monotouch\Splat.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Reactive.Core, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/ReactiveUI.Events/ReactiveUI.Events_iOS64.csproj
+++ b/ReactiveUI.Events/ReactiveUI.Events_iOS64.csproj
@@ -54,7 +54,7 @@
     <Reference Include="System.Core" />
     <Reference Include="Xamarin.iOS" />
     <Reference Include="Splat">
-      <HintPath>..\packages\Splat.1.6.0\lib\Xamarin.iOS10\Splat.dll</HintPath>
+      <HintPath>..\packages\Splat.1.6.2\lib\Xamarin.iOS10\Splat.dll</HintPath>
     </Reference>
     <Reference Include="System.Reactive.Core">
       <HintPath>..\packages\Rx-Core.2.2.5\lib\portable-windows8+net45+wp8\System.Reactive.Core.dll</HintPath>

--- a/ReactiveUI.Events/ReactiveUI.Events_iOS_XS.csproj
+++ b/ReactiveUI.Events/ReactiveUI.Events_iOS_XS.csproj
@@ -94,7 +94,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Splat">
-      <HintPath>..\packages\Splat.1.6.0\lib\monotouch\Splat.dll</HintPath>
+      <HintPath>..\packages\Splat.1.6.2\lib\monotouch\Splat.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Xml" />

--- a/ReactiveUI.Events/packages.ReactiveUI.Events_Android.config
+++ b/ReactiveUI.Events/packages.ReactiveUI.Events_Android.config
@@ -5,5 +5,5 @@
   <package id="Rx-Linq" version="2.2.5" targetFramework="MonoAndroid403" />
   <package id="Rx-Main" version="2.2.5" targetFramework="MonoAndroid403" />
   <package id="Rx-PlatformServices" version="2.2.5" targetFramework="MonoAndroid403" />
-  <package id="Splat" version="1.6.0" targetFramework="MonoAndroid403" />
+  <package id="Splat" version="1.6.2" targetFramework="MonoAndroid403" />
 </packages>

--- a/ReactiveUI.Events/packages.ReactiveUI.Events_Android_XS.config
+++ b/ReactiveUI.Events/packages.ReactiveUI.Events_Android_XS.config
@@ -5,5 +5,5 @@
   <package id="Rx-Linq" version="2.2.5" targetFramework="MonoAndroid403" />
   <package id="Rx-Main" version="2.2.5" targetFramework="MonoAndroid403" />
   <package id="Rx-PlatformServices" version="2.2.5" targetFramework="MonoAndroid403" />
-  <package id="Splat" version="1.6.0" targetFramework="MonoAndroid403" />
+  <package id="Splat" version="1.6.2" targetFramework="MonoAndroid403" />
 </packages>

--- a/ReactiveUI.Events/packages.ReactiveUI.Events_Net45.config
+++ b/ReactiveUI.Events/packages.ReactiveUI.Events_Net45.config
@@ -6,5 +6,5 @@
   <package id="Rx-Main" version="2.2.5" targetFramework="net45" />
   <package id="Rx-PlatformServices" version="2.2.5" targetFramework="net45" />
   <package id="Rx-Xaml" version="2.2.5" targetFramework="net45" />
-  <package id="Splat" version="1.6.0" targetFramework="net45" />
+  <package id="Splat" version="1.6.2" targetFramework="net45" />
 </packages>

--- a/ReactiveUI.Events/packages.ReactiveUI.Events_WP8.config
+++ b/ReactiveUI.Events/packages.ReactiveUI.Events_WP8.config
@@ -7,5 +7,5 @@
   <package id="Rx-PlatformServices" version="2.2.5" targetFramework="wp80" />
   <package id="Rx-WinRT" version="2.2.5" targetFramework="wp80" />
   <package id="Rx-Xaml" version="2.2.5" targetFramework="wp80" />
-  <package id="Splat" version="1.6.0" targetFramework="wp80" />
+  <package id="Splat" version="1.6.2" targetFramework="wp80" />
 </packages>

--- a/ReactiveUI.Events/packages.ReactiveUI.Events_WP81.config
+++ b/ReactiveUI.Events/packages.ReactiveUI.Events_WP81.config
@@ -7,5 +7,5 @@
   <package id="Rx-PlatformServices" version="2.2.5" targetFramework="wp81" />
   <package id="Rx-WinRT" version="2.2.5" targetFramework="wp81" />
   <package id="Rx-Xaml" version="2.2.5" targetFramework="wp81" />
-  <package id="Splat" version="1.6.0" targetFramework="wp81" />
+  <package id="Splat" version="1.6.2" targetFramework="wp81" />
 </packages>

--- a/ReactiveUI.Events/packages.ReactiveUI.Events_WPA81.config
+++ b/ReactiveUI.Events/packages.ReactiveUI.Events_WPA81.config
@@ -7,5 +7,5 @@
   <package id="Rx-PlatformServices" version="2.2.5" targetFramework="wpa81" />
   <package id="Rx-WinRT" version="2.2.5" targetFramework="wpa81" />
   <package id="Rx-Xaml" version="2.2.5" targetFramework="wpa81" />
-  <package id="Splat" version="1.6.0" targetFramework="wpa81" />
+  <package id="Splat" version="1.6.2" targetFramework="wpa81" />
 </packages>

--- a/ReactiveUI.Events/packages.ReactiveUI.Events_WinRT.config
+++ b/ReactiveUI.Events/packages.ReactiveUI.Events_WinRT.config
@@ -7,5 +7,5 @@
   <package id="Rx-PlatformServices" version="2.2.5" targetFramework="win81" />
   <package id="Rx-WinRT" version="2.2.5" targetFramework="win81" />
   <package id="Rx-Xaml" version="2.2.5" targetFramework="win81" />
-  <package id="Splat" version="1.6.0" targetFramework="win81" />
+  <package id="Splat" version="1.6.2" targetFramework="win81" />
 </packages>

--- a/ReactiveUI.Events/packages.ReactiveUI.Events_WinRT80.config
+++ b/ReactiveUI.Events/packages.ReactiveUI.Events_WinRT80.config
@@ -7,5 +7,5 @@
   <package id="Rx-PlatformServices" version="2.2.5" targetFramework="win" />
   <package id="Rx-WinRT" version="2.2.5" targetFramework="win" />
   <package id="Rx-Xaml" version="2.2.5" targetFramework="win" />
-  <package id="Splat" version="1.6.0" targetFramework="win" />
+  <package id="Splat" version="1.6.2" targetFramework="win" />
 </packages>

--- a/ReactiveUI.Events/packages.ReactiveUI.Events_iOS.config
+++ b/ReactiveUI.Events/packages.ReactiveUI.Events_iOS.config
@@ -5,5 +5,5 @@
   <package id="Rx-Linq" version="2.2.5" targetFramework="MonoTouch10" />
   <package id="Rx-Main" version="2.2.5" targetFramework="MonoTouch10" />
   <package id="Rx-PlatformServices" version="2.2.5" targetFramework="MonoTouch10" />
-  <package id="Splat" version="1.6.0" targetFramework="MonoTouch10" />
+  <package id="Splat" version="1.6.2" targetFramework="MonoTouch10" />
 </packages>

--- a/ReactiveUI.Events/packages.ReactiveUI.Events_iOS64.config
+++ b/ReactiveUI.Events/packages.ReactiveUI.Events_iOS64.config
@@ -5,5 +5,5 @@
   <package id="Rx-Linq" version="2.2.5" targetFramework="MonoTouch10" />
   <package id="Rx-Main" version="2.2.5" targetFramework="MonoTouch10" />
   <package id="Rx-PlatformServices" version="2.2.5" targetFramework="MonoTouch10" />
-  <package id="Splat" version="1.6.0" targetFramework="MonoTouch10" />
+  <package id="Splat" version="1.6.2" targetFramework="MonoTouch10" />
 </packages>

--- a/ReactiveUI.Events/packages.ReactiveUI.Events_iOS_XS.config
+++ b/ReactiveUI.Events/packages.ReactiveUI.Events_iOS_XS.config
@@ -5,5 +5,5 @@
   <package id="Rx-Linq" version="2.2.5" targetFramework="MonoTouch10" />
   <package id="Rx-Main" version="2.2.5" targetFramework="MonoTouch10" />
   <package id="Rx-PlatformServices" version="2.2.5" targetFramework="MonoTouch10" />
-  <package id="Splat" version="1.6.0" targetFramework="MonoTouch10" />
+  <package id="Splat" version="1.6.2" targetFramework="MonoTouch10" />
 </packages>

--- a/ReactiveUI.Testing/ReactiveUI.Testing_Android.csproj
+++ b/ReactiveUI.Testing/ReactiveUI.Testing_Android.csproj
@@ -51,7 +51,7 @@
     <Reference Include="Mono.Android" />
     <Reference Include="Xamarin.Android.NUnitLite" />
     <Reference Include="Splat">
-      <HintPath>..\packages\Splat.1.6.0\lib\monoandroid\Splat.dll</HintPath>
+      <HintPath>..\packages\Splat.1.6.2\lib\monoandroid\Splat.dll</HintPath>
     </Reference>
     <Reference Include="System.Reactive.Core">
       <HintPath>..\packages\Rx-Core.2.2.5\lib\portable-windows8+net45+wp8\System.Reactive.Core.dll</HintPath>

--- a/ReactiveUI.Testing/ReactiveUI.Testing_Mac.csproj
+++ b/ReactiveUI.Testing/ReactiveUI.Testing_Mac.csproj
@@ -51,7 +51,7 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Xml" />
     <Reference Include="Splat">
-      <HintPath>..\packages\Splat.1.6.0\lib\MonoMac\Splat.dll</HintPath>
+      <HintPath>..\packages\Splat.1.6.2\lib\MonoMac\Splat.dll</HintPath>
     </Reference>
     <Reference Include="System.Reactive.Core">
       <HintPath>..\packages\Rx-Core.2.2.5\lib\net45\System.Reactive.Core.dll</HintPath>

--- a/ReactiveUI.Testing/ReactiveUI.Testing_Net45.csproj
+++ b/ReactiveUI.Testing/ReactiveUI.Testing_Net45.csproj
@@ -52,9 +52,9 @@
       <HintPath>..\packages\Rx-Testing.2.2.5\lib\net45\Microsoft.Reactive.Testing.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-    <Reference Include="Splat, Version=1.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="Splat, Version=1.6.2.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Splat.1.6.0\lib\Net45\Splat.dll</HintPath>
+      <HintPath>..\packages\Splat.1.6.2\lib\Net45\Splat.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/ReactiveUI.Testing/ReactiveUI.Testing_WP8.csproj
+++ b/ReactiveUI.Testing/ReactiveUI.Testing_WP8.csproj
@@ -94,9 +94,9 @@
       <HintPath>..\packages\Rx-Testing.2.2.5\lib\windowsphone8\Microsoft.Reactive.Testing.dll</HintPath>
     </Reference>
     <Reference Include="mscorlib.Extensions" />
-    <Reference Include="Splat, Version=1.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="Splat, Version=1.6.2.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Splat.1.6.0\lib\wp8\Splat.dll</HintPath>
+      <HintPath>..\packages\Splat.1.6.2\lib\wp8\Splat.dll</HintPath>
     </Reference>
     <Reference Include="System.Observable" />
     <Reference Include="System.Reactive.Core, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/ReactiveUI.Testing/ReactiveUI.Testing_WinRT.csproj
+++ b/ReactiveUI.Testing/ReactiveUI.Testing_WinRT.csproj
@@ -52,7 +52,7 @@
       <HintPath>..\packages\Rx-Testing.2.2.5\lib\windows8\Microsoft.Reactive.Testing.dll</HintPath>
     </Reference>
     <Reference Include="Splat">
-      <HintPath>..\packages\Splat.1.6.0\lib\Portable-Win81+Wpa81\Splat.dll</HintPath>
+      <HintPath>..\packages\Splat.1.6.2\lib\Portable-Win81+Wpa81\Splat.dll</HintPath>
     </Reference>
     <Reference Include="System.Reactive.Core">
       <HintPath>..\packages\Rx-Core.2.2.5\lib\portable-win81+wpa81\System.Reactive.Core.dll</HintPath>

--- a/ReactiveUI.Testing/ReactiveUI.Testing_WinRT80.csproj
+++ b/ReactiveUI.Testing/ReactiveUI.Testing_WinRT80.csproj
@@ -47,9 +47,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Rx-Testing.2.2.5\lib\windows8\Microsoft.Reactive.Testing.dll</HintPath>
     </Reference>
-    <Reference Include="Splat, Version=1.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="Splat, Version=1.6.2.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Splat.1.6.0\lib\NetCore45\Splat.dll</HintPath>
+      <HintPath>..\packages\Splat.1.6.2\lib\NetCore45\Splat.dll</HintPath>
     </Reference>
     <Reference Include="System.Reactive.Core, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/ReactiveUI.Testing/ReactiveUI.Testing_iOS.csproj
+++ b/ReactiveUI.Testing/ReactiveUI.Testing_iOS.csproj
@@ -47,7 +47,7 @@
     <Reference Include="monotouch" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="Splat">
-      <HintPath>..\packages\Splat.1.6.0\lib\monotouch\Splat.dll</HintPath>
+      <HintPath>..\packages\Splat.1.6.2\lib\monotouch\Splat.dll</HintPath>
     </Reference>
     <Reference Include="System.Reactive.Core">
       <HintPath>..\packages\Rx-Core.2.2.5\lib\portable-windows8+net45+wp8\System.Reactive.Core.dll</HintPath>

--- a/ReactiveUI.Testing/ReactiveUI.Testing_iOS64.csproj
+++ b/ReactiveUI.Testing/ReactiveUI.Testing_iOS64.csproj
@@ -47,7 +47,7 @@
     <Reference Include="Xamarin.iOS" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="Splat">
-      <HintPath>..\packages\Splat.1.6.0\lib\Xamarin.iOS10\Splat.dll</HintPath>
+      <HintPath>..\packages\Splat.1.6.2\lib\Xamarin.iOS10\Splat.dll</HintPath>
     </Reference>
     <Reference Include="System.Reactive.Core">
       <HintPath>..\packages\Rx-Core.2.2.5\lib\portable-windows8+net45+wp8\System.Reactive.Core.dll</HintPath>

--- a/ReactiveUI.Testing/packages.ReactiveUI.Testing_Android.config
+++ b/ReactiveUI.Testing/packages.ReactiveUI.Testing_Android.config
@@ -5,5 +5,5 @@
   <package id="Rx-Linq" version="2.2.5" targetFramework="MonoAndroid403" />
   <package id="Rx-Main" version="2.2.5" targetFramework="MonoAndroid403" />
   <package id="Rx-PlatformServices" version="2.2.5" targetFramework="MonoAndroid403" />
-  <package id="Splat" version="1.6.0" targetFramework="MonoAndroid403" />
+  <package id="Splat" version="1.6.2" targetFramework="MonoAndroid403" />
 </packages>

--- a/ReactiveUI.Testing/packages.ReactiveUI.Testing_Net45.config
+++ b/ReactiveUI.Testing/packages.ReactiveUI.Testing_Net45.config
@@ -7,5 +7,5 @@
   <package id="Rx-PlatformServices" version="2.2.5" targetFramework="net45" />
   <package id="Rx-Testing" version="2.2.5" targetFramework="net45" />
   <package id="Rx-Xaml" version="2.2.5" targetFramework="net45" />
-  <package id="Splat" version="1.6.0" targetFramework="net45" />
+  <package id="Splat" version="1.6.2" targetFramework="net45" />
 </packages>

--- a/ReactiveUI.Testing/packages.ReactiveUI.Testing_WP8.config
+++ b/ReactiveUI.Testing/packages.ReactiveUI.Testing_WP8.config
@@ -7,5 +7,5 @@
   <package id="Rx-PlatformServices" version="2.2.5" targetFramework="wp80" />
   <package id="Rx-WinRT" version="2.2.5" targetFramework="wp80" />
   <package id="Rx-Xaml" version="2.2.5" targetFramework="wp80" />
-  <package id="Splat" version="1.6.0" targetFramework="wp80" />
+  <package id="Splat" version="1.6.2" targetFramework="wp80" />
 </packages>

--- a/ReactiveUI.Testing/packages.ReactiveUI.Testing_WinRT.config
+++ b/ReactiveUI.Testing/packages.ReactiveUI.Testing_WinRT.config
@@ -7,5 +7,5 @@
   <package id="Rx-PlatformServices" version="2.2.5" targetFramework="portable-win81+wpa81" />
   <package id="Rx-WinRT" version="2.2.5" targetFramework="portable-win81+wpa81" />
   <package id="Rx-Xaml" version="2.2.5" targetFramework="portable-win81+wpa81" />
-  <package id="Splat" version="1.6.0" targetFramework="portable-win81+wpa81" />
+  <package id="Splat" version="1.6.2" targetFramework="portable-win81+wpa81" />
 </packages>

--- a/ReactiveUI.Testing/packages.ReactiveUI.Testing_WinRT80.config
+++ b/ReactiveUI.Testing/packages.ReactiveUI.Testing_WinRT80.config
@@ -8,5 +8,5 @@
   <package id="Rx-Testing" version="2.2.5" targetFramework="win" />
   <package id="Rx-WinRT" version="2.2.5" targetFramework="win" />
   <package id="Rx-Xaml" version="2.2.5" targetFramework="win" />
-  <package id="Splat" version="1.6.0" targetFramework="win" />
+  <package id="Splat" version="1.6.2" targetFramework="win" />
 </packages>

--- a/ReactiveUI.Testing/packages.ReactiveUI.Testing_iOS.config
+++ b/ReactiveUI.Testing/packages.ReactiveUI.Testing_iOS.config
@@ -5,5 +5,5 @@
   <package id="Rx-Linq" version="2.2.5" targetFramework="MonoTouch10" />
   <package id="Rx-Main" version="2.2.5" targetFramework="MonoTouch10" />
   <package id="Rx-PlatformServices" version="2.2.5" targetFramework="MonoTouch10" />
-  <package id="Splat" version="1.6.0" targetFramework="MonoTouch10" />
+  <package id="Splat" version="1.6.2" targetFramework="MonoTouch10" />
 </packages>

--- a/ReactiveUI.Testing/packages.ReactiveUI.Testing_iOS64.config
+++ b/ReactiveUI.Testing/packages.ReactiveUI.Testing_iOS64.config
@@ -5,5 +5,5 @@
   <package id="Rx-Linq" version="2.2.5" targetFramework="Xamarin.iOS10" />
   <package id="Rx-Main" version="2.2.5" targetFramework="Xamarin.iOS10" />
   <package id="Rx-PlatformServices" version="2.2.5" targetFramework="Xamarin.iOS10" />
-  <package id="Splat" version="1.6.0" targetFramework="Xamarin.iOS10" />
+  <package id="Splat" version="1.6.2" targetFramework="Xamarin.iOS10" />
 </packages>

--- a/ReactiveUI.Tests/ReactiveUI.Tests_Android.csproj
+++ b/ReactiveUI.Tests/ReactiveUI.Tests_Android.csproj
@@ -79,10 +79,10 @@
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="Xamarin.Android.Support.v4">
-      <HintPath>..\packages\Xamarin.Android.Support.v4.21.0.3.0\lib\MonoAndroid10\Xamarin.Android.Support.v4.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Android.Support.v4.22.1.1.1\lib\MonoAndroid403\Xamarin.Android.Support.v4.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Android.Support.v7.AppCompat">
-      <HintPath>..\packages\Xamarin.Android.Support.v7.AppCompat.21.0.3.0\lib\MonoAndroid403\Xamarin.Android.Support.v7.AppCompat.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Android.Support.v7.AppCompat.22.1.1.1\lib\MonoAndroid403\Xamarin.Android.Support.v7.AppCompat.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/ReactiveUI.Tests/ReactiveUI.Tests_Android.csproj
+++ b/ReactiveUI.Tests/ReactiveUI.Tests_Android.csproj
@@ -57,7 +57,7 @@
       <HintPath>..\packages\Rx-PlatformServices.2.2.5\lib\portable-windows8+net45+wp8\System.Reactive.PlatformServices.dll</HintPath>
     </Reference>
     <Reference Include="Splat">
-      <HintPath>..\packages\Splat.1.6.0\lib\monoandroid\Splat.dll</HintPath>
+      <HintPath>..\packages\Splat.1.6.2\lib\monoandroid\Splat.dll</HintPath>
     </Reference>
     <Reference Include="xunit.abstractions">
       <HintPath>..\packages\xunit.abstractions.2.0.0-beta-build2700\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid\xunit.abstractions.dll</HintPath>

--- a/ReactiveUI.Tests/ReactiveUI.Tests_Net45.csproj
+++ b/ReactiveUI.Tests/ReactiveUI.Tests_Net45.csproj
@@ -50,9 +50,9 @@
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
-    <Reference Include="Splat, Version=1.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="Splat, Version=1.6.2.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Splat.1.6.0\lib\Net45\Splat.dll</HintPath>
+      <HintPath>..\packages\Splat.1.6.2\lib\Net45\Splat.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/ReactiveUI.Tests/ReactiveUI.Tests_iOS.csproj
+++ b/ReactiveUI.Tests/ReactiveUI.Tests_iOS.csproj
@@ -110,7 +110,7 @@
       <HintPath>..\packages\Rx-PlatformServices.2.2.5\lib\portable-windows8+net45+wp8\System.Reactive.PlatformServices.dll</HintPath>
     </Reference>
     <Reference Include="Splat">
-      <HintPath>..\packages\Splat.1.6.0\lib\monotouch\Splat.dll</HintPath>
+      <HintPath>..\packages\Splat.1.6.2\lib\monotouch\Splat.dll</HintPath>
     </Reference>
     <Reference Include="xunit.abstractions">
       <HintPath>..\packages\xunit.abstractions.2.0.0-beta-build2700\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid\xunit.abstractions.dll</HintPath>

--- a/ReactiveUI.Tests/Resources/Resource.designer.cs
+++ b/ReactiveUI.Tests/Resources/Resource.designer.cs
@@ -73,16 +73,28 @@ namespace ReactiveUI.Tests
 			public const int abc_fade_out = 2130968577;
 			
 			// aapt resource value: 0x7f040002
-			public const int abc_slide_in_bottom = 2130968578;
+			public const int abc_grow_fade_in_from_bottom = 2130968578;
 			
 			// aapt resource value: 0x7f040003
-			public const int abc_slide_in_top = 2130968579;
+			public const int abc_popup_enter = 2130968579;
 			
 			// aapt resource value: 0x7f040004
-			public const int abc_slide_out_bottom = 2130968580;
+			public const int abc_popup_exit = 2130968580;
 			
 			// aapt resource value: 0x7f040005
-			public const int abc_slide_out_top = 2130968581;
+			public const int abc_shrink_fade_out_from_bottom = 2130968581;
+			
+			// aapt resource value: 0x7f040006
+			public const int abc_slide_in_bottom = 2130968582;
+			
+			// aapt resource value: 0x7f040007
+			public const int abc_slide_in_top = 2130968583;
+			
+			// aapt resource value: 0x7f040008
+			public const int abc_slide_out_bottom = 2130968584;
+			
+			// aapt resource value: 0x7f040009
+			public const int abc_slide_out_top = 2130968585;
 			
 			static Animation()
 			{
@@ -97,107 +109,122 @@ namespace ReactiveUI.Tests
 		public partial class Attribute
 		{
 			
-			// aapt resource value: 0x7f01005a
-			public const int actionBarDivider = 2130772058;
-			
-			// aapt resource value: 0x7f01005b
-			public const int actionBarItemBackground = 2130772059;
-			
-			// aapt resource value: 0x7f010054
-			public const int actionBarPopupTheme = 2130772052;
-			
-			// aapt resource value: 0x7f010059
-			public const int actionBarSize = 2130772057;
-			
-			// aapt resource value: 0x7f010056
-			public const int actionBarSplitStyle = 2130772054;
-			
-			// aapt resource value: 0x7f010055
-			public const int actionBarStyle = 2130772053;
-			
-			// aapt resource value: 0x7f010050
-			public const int actionBarTabBarStyle = 2130772048;
-			
-			// aapt resource value: 0x7f01004f
-			public const int actionBarTabStyle = 2130772047;
-			
-			// aapt resource value: 0x7f010051
-			public const int actionBarTabTextStyle = 2130772049;
-			
-			// aapt resource value: 0x7f010057
-			public const int actionBarTheme = 2130772055;
-			
-			// aapt resource value: 0x7f010058
-			public const int actionBarWidgetTheme = 2130772056;
-			
-			// aapt resource value: 0x7f010072
-			public const int actionButtonStyle = 2130772082;
-			
-			// aapt resource value: 0x7f01006d
-			public const int actionDropDownStyle = 2130772077;
-			
-			// aapt resource value: 0x7f01002c
-			public const int actionLayout = 2130772012;
-			
-			// aapt resource value: 0x7f01005c
-			public const int actionMenuTextAppearance = 2130772060;
-			
-			// aapt resource value: 0x7f01005d
-			public const int actionMenuTextColor = 2130772061;
-			
-			// aapt resource value: 0x7f010060
-			public const int actionModeBackground = 2130772064;
-			
-			// aapt resource value: 0x7f01005f
-			public const int actionModeCloseButtonStyle = 2130772063;
-			
-			// aapt resource value: 0x7f010062
-			public const int actionModeCloseDrawable = 2130772066;
+			// aapt resource value: 0x7f010063
+			public const int actionBarDivider = 2130772067;
 			
 			// aapt resource value: 0x7f010064
-			public const int actionModeCopyDrawable = 2130772068;
+			public const int actionBarItemBackground = 2130772068;
 			
-			// aapt resource value: 0x7f010063
-			public const int actionModeCutDrawable = 2130772067;
+			// aapt resource value: 0x7f01005d
+			public const int actionBarPopupTheme = 2130772061;
 			
-			// aapt resource value: 0x7f010068
-			public const int actionModeFindDrawable = 2130772072;
+			// aapt resource value: 0x7f010062
+			public const int actionBarSize = 2130772066;
 			
-			// aapt resource value: 0x7f010065
-			public const int actionModePasteDrawable = 2130772069;
-			
-			// aapt resource value: 0x7f01006a
-			public const int actionModePopupWindowStyle = 2130772074;
-			
-			// aapt resource value: 0x7f010066
-			public const int actionModeSelectAllDrawable = 2130772070;
-			
-			// aapt resource value: 0x7f010067
-			public const int actionModeShareDrawable = 2130772071;
-			
-			// aapt resource value: 0x7f010061
-			public const int actionModeSplitBackground = 2130772065;
+			// aapt resource value: 0x7f01005f
+			public const int actionBarSplitStyle = 2130772063;
 			
 			// aapt resource value: 0x7f01005e
-			public const int actionModeStyle = 2130772062;
+			public const int actionBarStyle = 2130772062;
 			
-			// aapt resource value: 0x7f010069
-			public const int actionModeWebSearchDrawable = 2130772073;
+			// aapt resource value: 0x7f010059
+			public const int actionBarTabBarStyle = 2130772057;
 			
-			// aapt resource value: 0x7f010052
-			public const int actionOverflowButtonStyle = 2130772050;
+			// aapt resource value: 0x7f010058
+			public const int actionBarTabStyle = 2130772056;
 			
-			// aapt resource value: 0x7f010053
-			public const int actionOverflowMenuStyle = 2130772051;
+			// aapt resource value: 0x7f01005a
+			public const int actionBarTabTextStyle = 2130772058;
 			
-			// aapt resource value: 0x7f01002e
-			public const int actionProviderClass = 2130772014;
+			// aapt resource value: 0x7f010060
+			public const int actionBarTheme = 2130772064;
 			
-			// aapt resource value: 0x7f01002d
-			public const int actionViewClass = 2130772013;
+			// aapt resource value: 0x7f010061
+			public const int actionBarWidgetTheme = 2130772065;
+			
+			// aapt resource value: 0x7f01007d
+			public const int actionButtonStyle = 2130772093;
 			
 			// aapt resource value: 0x7f010079
-			public const int activityChooserViewStyle = 2130772089;
+			public const int actionDropDownStyle = 2130772089;
+			
+			// aapt resource value: 0x7f010031
+			public const int actionLayout = 2130772017;
+			
+			// aapt resource value: 0x7f010065
+			public const int actionMenuTextAppearance = 2130772069;
+			
+			// aapt resource value: 0x7f010066
+			public const int actionMenuTextColor = 2130772070;
+			
+			// aapt resource value: 0x7f010069
+			public const int actionModeBackground = 2130772073;
+			
+			// aapt resource value: 0x7f010068
+			public const int actionModeCloseButtonStyle = 2130772072;
+			
+			// aapt resource value: 0x7f01006b
+			public const int actionModeCloseDrawable = 2130772075;
+			
+			// aapt resource value: 0x7f01006d
+			public const int actionModeCopyDrawable = 2130772077;
+			
+			// aapt resource value: 0x7f01006c
+			public const int actionModeCutDrawable = 2130772076;
+			
+			// aapt resource value: 0x7f010071
+			public const int actionModeFindDrawable = 2130772081;
+			
+			// aapt resource value: 0x7f01006e
+			public const int actionModePasteDrawable = 2130772078;
+			
+			// aapt resource value: 0x7f010073
+			public const int actionModePopupWindowStyle = 2130772083;
+			
+			// aapt resource value: 0x7f01006f
+			public const int actionModeSelectAllDrawable = 2130772079;
+			
+			// aapt resource value: 0x7f010070
+			public const int actionModeShareDrawable = 2130772080;
+			
+			// aapt resource value: 0x7f01006a
+			public const int actionModeSplitBackground = 2130772074;
+			
+			// aapt resource value: 0x7f010067
+			public const int actionModeStyle = 2130772071;
+			
+			// aapt resource value: 0x7f010072
+			public const int actionModeWebSearchDrawable = 2130772082;
+			
+			// aapt resource value: 0x7f01005b
+			public const int actionOverflowButtonStyle = 2130772059;
+			
+			// aapt resource value: 0x7f01005c
+			public const int actionOverflowMenuStyle = 2130772060;
+			
+			// aapt resource value: 0x7f010033
+			public const int actionProviderClass = 2130772019;
+			
+			// aapt resource value: 0x7f010032
+			public const int actionViewClass = 2130772018;
+			
+			// aapt resource value: 0x7f010084
+			public const int activityChooserViewStyle = 2130772100;
+			
+			// aapt resource value: 0x7f0100a5
+			public const int alertDialogButtonGroupStyle = 2130772133;
+			
+			// aapt resource value: 0x7f0100a6
+			public const int alertDialogCenterButtons = 2130772134;
+			
+			// aapt resource value: 0x7f0100a4
+			public const int alertDialogStyle = 2130772132;
+			
+			// aapt resource value: 0x7f0100a7
+			public const int alertDialogTheme = 2130772135;
+			
+			// aapt resource value: 0x7f0100ac
+			public const int autoCompleteTextViewStyle = 2130772140;
 			
 			// aapt resource value: 0x7f01000c
 			public const int background = 2130771980;
@@ -208,56 +235,86 @@ namespace ReactiveUI.Tests
 			// aapt resource value: 0x7f01000d
 			public const int backgroundStacked = 2130771981;
 			
-			// aapt resource value: 0x7f010026
-			public const int barSize = 2130772006;
+			// aapt resource value: 0x7f0100c5
+			public const int backgroundTint = 2130772165;
 			
-			// aapt resource value: 0x7f010074
-			public const int buttonBarButtonStyle = 2130772084;
+			// aapt resource value: 0x7f0100c6
+			public const int backgroundTintMode = 2130772166;
 			
-			// aapt resource value: 0x7f010073
-			public const int buttonBarStyle = 2130772083;
+			// aapt resource value: 0x7f01002b
+			public const int barSize = 2130772011;
 			
-			// aapt resource value: 0x7f010035
-			public const int closeIcon = 2130772021;
+			// aapt resource value: 0x7f01007f
+			public const int buttonBarButtonStyle = 2130772095;
+			
+			// aapt resource value: 0x7f0100aa
+			public const int buttonBarNegativeButtonStyle = 2130772138;
+			
+			// aapt resource value: 0x7f0100ab
+			public const int buttonBarNeutralButtonStyle = 2130772139;
+			
+			// aapt resource value: 0x7f0100a9
+			public const int buttonBarPositiveButtonStyle = 2130772137;
+			
+			// aapt resource value: 0x7f01007e
+			public const int buttonBarStyle = 2130772094;
+			
+			// aapt resource value: 0x7f01001f
+			public const int buttonPanelSideLayout = 2130771999;
+			
+			// aapt resource value: 0x7f0100ad
+			public const int buttonStyle = 2130772141;
+			
+			// aapt resource value: 0x7f0100ae
+			public const int buttonStyleSmall = 2130772142;
+			
+			// aapt resource value: 0x7f0100af
+			public const int checkboxStyle = 2130772143;
+			
+			// aapt resource value: 0x7f0100b0
+			public const int checkedTextViewStyle = 2130772144;
+			
+			// aapt resource value: 0x7f01003a
+			public const int closeIcon = 2130772026;
 			
 			// aapt resource value: 0x7f01001c
 			public const int closeItemLayout = 2130771996;
 			
-			// aapt resource value: 0x7f0100a4
-			public const int collapseContentDescription = 2130772132;
+			// aapt resource value: 0x7f0100bf
+			public const int collapseContentDescription = 2130772159;
+			
+			// aapt resource value: 0x7f0100be
+			public const int collapseIcon = 2130772158;
+			
+			// aapt resource value: 0x7f010025
+			public const int color = 2130772005;
+			
+			// aapt resource value: 0x7f01009e
+			public const int colorAccent = 2130772126;
+			
+			// aapt resource value: 0x7f0100a2
+			public const int colorButtonNormal = 2130772130;
+			
+			// aapt resource value: 0x7f0100a0
+			public const int colorControlActivated = 2130772128;
+			
+			// aapt resource value: 0x7f0100a1
+			public const int colorControlHighlight = 2130772129;
+			
+			// aapt resource value: 0x7f01009f
+			public const int colorControlNormal = 2130772127;
+			
+			// aapt resource value: 0x7f01009c
+			public const int colorPrimary = 2130772124;
+			
+			// aapt resource value: 0x7f01009d
+			public const int colorPrimaryDark = 2130772125;
 			
 			// aapt resource value: 0x7f0100a3
-			public const int collapseIcon = 2130772131;
+			public const int colorSwitchThumbNormal = 2130772131;
 			
-			// aapt resource value: 0x7f010020
-			public const int color = 2130772000;
-			
-			// aapt resource value: 0x7f010094
-			public const int colorAccent = 2130772116;
-			
-			// aapt resource value: 0x7f010098
-			public const int colorButtonNormal = 2130772120;
-			
-			// aapt resource value: 0x7f010096
-			public const int colorControlActivated = 2130772118;
-			
-			// aapt resource value: 0x7f010097
-			public const int colorControlHighlight = 2130772119;
-			
-			// aapt resource value: 0x7f010095
-			public const int colorControlNormal = 2130772117;
-			
-			// aapt resource value: 0x7f010092
-			public const int colorPrimary = 2130772114;
-			
-			// aapt resource value: 0x7f010093
-			public const int colorPrimaryDark = 2130772115;
-			
-			// aapt resource value: 0x7f010099
-			public const int colorSwitchThumbNormal = 2130772121;
-			
-			// aapt resource value: 0x7f010039
-			public const int commitIcon = 2130772025;
+			// aapt resource value: 0x7f01003f
+			public const int commitIcon = 2130772031;
 			
 			// aapt resource value: 0x7f010017
 			public const int contentInsetEnd = 2130771991;
@@ -274,8 +331,14 @@ namespace ReactiveUI.Tests
 			// aapt resource value: 0x7f01000f
 			public const int customNavigationLayout = 2130771983;
 			
-			// aapt resource value: 0x7f010040
-			public const int disableChildrenWhenDisabled = 2130772032;
+			// aapt resource value: 0x7f010077
+			public const int dialogPreferredPadding = 2130772087;
+			
+			// aapt resource value: 0x7f010076
+			public const int dialogTheme = 2130772086;
+			
+			// aapt resource value: 0x7f010046
+			public const int disableChildrenWhenDisabled = 2130772038;
 			
 			// aapt resource value: 0x7f010005
 			public const int displayOptions = 2130771973;
@@ -283,32 +346,35 @@ namespace ReactiveUI.Tests
 			// aapt resource value: 0x7f01000b
 			public const int divider = 2130771979;
 			
-			// aapt resource value: 0x7f010078
-			public const int dividerHorizontal = 2130772088;
+			// aapt resource value: 0x7f010083
+			public const int dividerHorizontal = 2130772099;
 			
-			// aapt resource value: 0x7f01002a
-			public const int dividerPadding = 2130772010;
+			// aapt resource value: 0x7f01002f
+			public const int dividerPadding = 2130772015;
 			
-			// aapt resource value: 0x7f010077
-			public const int dividerVertical = 2130772087;
+			// aapt resource value: 0x7f010082
+			public const int dividerVertical = 2130772098;
 			
-			// aapt resource value: 0x7f010022
-			public const int drawableSize = 2130772002;
+			// aapt resource value: 0x7f010027
+			public const int drawableSize = 2130772007;
 			
 			// aapt resource value: 0x7f010000
 			public const int drawerArrowStyle = 2130771968;
 			
+			// aapt resource value: 0x7f010094
+			public const int dropDownListViewStyle = 2130772116;
+			
+			// aapt resource value: 0x7f01007a
+			public const int dropdownListPreferredItemHeight = 2130772090;
+			
 			// aapt resource value: 0x7f01008a
-			public const int dropDownListViewStyle = 2130772106;
+			public const int editTextBackground = 2130772106;
 			
-			// aapt resource value: 0x7f01006e
-			public const int dropdownListPreferredItemHeight = 2130772078;
+			// aapt resource value: 0x7f010089
+			public const int editTextColor = 2130772105;
 			
-			// aapt resource value: 0x7f01007f
-			public const int editTextBackground = 2130772095;
-			
-			// aapt resource value: 0x7f01007e
-			public const int editTextColor = 2130772094;
+			// aapt resource value: 0x7f0100b1
+			public const int editTextStyle = 2130772145;
 			
 			// aapt resource value: 0x7f01001a
 			public const int elevation = 2130771994;
@@ -316,11 +382,11 @@ namespace ReactiveUI.Tests
 			// aapt resource value: 0x7f01001e
 			public const int expandActivityOverflowButtonDrawable = 2130771998;
 			
-			// aapt resource value: 0x7f010023
-			public const int gapBetweenBars = 2130772003;
+			// aapt resource value: 0x7f010028
+			public const int gapBetweenBars = 2130772008;
 			
-			// aapt resource value: 0x7f010036
-			public const int goIcon = 2130772022;
+			// aapt resource value: 0x7f01003b
+			public const int goIcon = 2130772027;
 			
 			// aapt resource value: 0x7f010001
 			public const int height = 2130771969;
@@ -328,8 +394,8 @@ namespace ReactiveUI.Tests
 			// aapt resource value: 0x7f010015
 			public const int hideOnContentScroll = 2130771989;
 			
-			// aapt resource value: 0x7f010071
-			public const int homeAsUpIndicator = 2130772081;
+			// aapt resource value: 0x7f01007c
+			public const int homeAsUpIndicator = 2130772092;
 			
 			// aapt resource value: 0x7f010010
 			public const int homeLayout = 2130771984;
@@ -337,8 +403,8 @@ namespace ReactiveUI.Tests
 			// aapt resource value: 0x7f010009
 			public const int icon = 2130771977;
 			
-			// aapt resource value: 0x7f010033
-			public const int iconifiedByDefault = 2130772019;
+			// aapt resource value: 0x7f010038
+			public const int iconifiedByDefault = 2130772024;
 			
 			// aapt resource value: 0x7f010012
 			public const int indeterminateProgressStyle = 2130771986;
@@ -352,83 +418,95 @@ namespace ReactiveUI.Tests
 			// aapt resource value: 0x7f010014
 			public const int itemPadding = 2130771988;
 			
-			// aapt resource value: 0x7f010032
-			public const int layout = 2130772018;
+			// aapt resource value: 0x7f010037
+			public const int layout = 2130772023;
+			
+			// aapt resource value: 0x7f01009b
+			public const int listChoiceBackgroundIndicator = 2130772123;
+			
+			// aapt resource value: 0x7f010078
+			public const int listDividerAlertDialog = 2130772088;
+			
+			// aapt resource value: 0x7f010023
+			public const int listItemLayout = 2130772003;
+			
+			// aapt resource value: 0x7f010020
+			public const int listLayout = 2130772000;
+			
+			// aapt resource value: 0x7f010095
+			public const int listPopupWindowStyle = 2130772117;
+			
+			// aapt resource value: 0x7f01008f
+			public const int listPreferredItemHeight = 2130772111;
 			
 			// aapt resource value: 0x7f010091
-			public const int listChoiceBackgroundIndicator = 2130772113;
+			public const int listPreferredItemHeightLarge = 2130772113;
 			
-			// aapt resource value: 0x7f01008b
-			public const int listPopupWindowStyle = 2130772107;
+			// aapt resource value: 0x7f010090
+			public const int listPreferredItemHeightSmall = 2130772112;
 			
-			// aapt resource value: 0x7f010085
-			public const int listPreferredItemHeight = 2130772101;
+			// aapt resource value: 0x7f010092
+			public const int listPreferredItemPaddingLeft = 2130772114;
 			
-			// aapt resource value: 0x7f010087
-			public const int listPreferredItemHeightLarge = 2130772103;
-			
-			// aapt resource value: 0x7f010086
-			public const int listPreferredItemHeightSmall = 2130772102;
-			
-			// aapt resource value: 0x7f010088
-			public const int listPreferredItemPaddingLeft = 2130772104;
-			
-			// aapt resource value: 0x7f010089
-			public const int listPreferredItemPaddingRight = 2130772105;
+			// aapt resource value: 0x7f010093
+			public const int listPreferredItemPaddingRight = 2130772115;
 			
 			// aapt resource value: 0x7f01000a
 			public const int logo = 2130771978;
 			
-			// aapt resource value: 0x7f0100a1
-			public const int maxButtonHeight = 2130772129;
+			// aapt resource value: 0x7f0100bd
+			public const int maxButtonHeight = 2130772157;
 			
-			// aapt resource value: 0x7f010028
-			public const int measureWithLargestChild = 2130772008;
+			// aapt resource value: 0x7f01002d
+			public const int measureWithLargestChild = 2130772013;
 			
-			// aapt resource value: 0x7f010025
-			public const int middleBarArrowSize = 2130772005;
+			// aapt resource value: 0x7f01002a
+			public const int middleBarArrowSize = 2130772010;
 			
-			// aapt resource value: 0x7f0100a6
-			public const int navigationContentDescription = 2130772134;
+			// aapt resource value: 0x7f010021
+			public const int multiChoiceItemLayout = 2130772001;
 			
-			// aapt resource value: 0x7f0100a5
-			public const int navigationIcon = 2130772133;
+			// aapt resource value: 0x7f0100c1
+			public const int navigationContentDescription = 2130772161;
+			
+			// aapt resource value: 0x7f0100c0
+			public const int navigationIcon = 2130772160;
 			
 			// aapt resource value: 0x7f010004
 			public const int navigationMode = 2130771972;
 			
-			// aapt resource value: 0x7f010030
-			public const int overlapAnchor = 2130772016;
+			// aapt resource value: 0x7f010035
+			public const int overlapAnchor = 2130772021;
 			
-			// aapt resource value: 0x7f0100a8
-			public const int paddingEnd = 2130772136;
+			// aapt resource value: 0x7f0100c3
+			public const int paddingEnd = 2130772163;
 			
-			// aapt resource value: 0x7f0100a7
-			public const int paddingStart = 2130772135;
+			// aapt resource value: 0x7f0100c2
+			public const int paddingStart = 2130772162;
 			
-			// aapt resource value: 0x7f01008e
-			public const int panelBackground = 2130772110;
+			// aapt resource value: 0x7f010098
+			public const int panelBackground = 2130772120;
 			
-			// aapt resource value: 0x7f010090
-			public const int panelMenuListTheme = 2130772112;
+			// aapt resource value: 0x7f01009a
+			public const int panelMenuListTheme = 2130772122;
 			
-			// aapt resource value: 0x7f01008f
-			public const int panelMenuListWidth = 2130772111;
+			// aapt resource value: 0x7f010099
+			public const int panelMenuListWidth = 2130772121;
 			
-			// aapt resource value: 0x7f01007c
-			public const int popupMenuStyle = 2130772092;
+			// aapt resource value: 0x7f010087
+			public const int popupMenuStyle = 2130772103;
 			
-			// aapt resource value: 0x7f01003f
-			public const int popupPromptView = 2130772031;
+			// aapt resource value: 0x7f010045
+			public const int popupPromptView = 2130772037;
 			
 			// aapt resource value: 0x7f01001b
 			public const int popupTheme = 2130771995;
 			
-			// aapt resource value: 0x7f01007d
-			public const int popupWindowStyle = 2130772093;
+			// aapt resource value: 0x7f010088
+			public const int popupWindowStyle = 2130772104;
 			
-			// aapt resource value: 0x7f01002f
-			public const int preserveIconSpacing = 2130772015;
+			// aapt resource value: 0x7f010034
+			public const int preserveIconSpacing = 2130772020;
 			
 			// aapt resource value: 0x7f010013
 			public const int progressBarPadding = 2130771987;
@@ -436,173 +514,197 @@ namespace ReactiveUI.Tests
 			// aapt resource value: 0x7f010011
 			public const int progressBarStyle = 2130771985;
 			
+			// aapt resource value: 0x7f010043
+			public const int prompt = 2130772035;
+			
+			// aapt resource value: 0x7f010041
+			public const int queryBackground = 2130772033;
+			
+			// aapt resource value: 0x7f010039
+			public const int queryHint = 2130772025;
+			
+			// aapt resource value: 0x7f0100b2
+			public const int radioButtonStyle = 2130772146;
+			
+			// aapt resource value: 0x7f0100b3
+			public const int ratingBarStyle = 2130772147;
+			
 			// aapt resource value: 0x7f01003d
-			public const int prompt = 2130772029;
-			
-			// aapt resource value: 0x7f01003b
-			public const int queryBackground = 2130772027;
-			
-			// aapt resource value: 0x7f010034
-			public const int queryHint = 2130772020;
-			
-			// aapt resource value: 0x7f010037
-			public const int searchIcon = 2130772023;
-			
-			// aapt resource value: 0x7f010084
-			public const int searchViewStyle = 2130772100;
-			
-			// aapt resource value: 0x7f010075
-			public const int selectableItemBackground = 2130772085;
-			
-			// aapt resource value: 0x7f010076
-			public const int selectableItemBackgroundBorderless = 2130772086;
-			
-			// aapt resource value: 0x7f01002b
-			public const int showAsAction = 2130772011;
-			
-			// aapt resource value: 0x7f010029
-			public const int showDividers = 2130772009;
-			
-			// aapt resource value: 0x7f010047
-			public const int showText = 2130772039;
-			
-			// aapt resource value: 0x7f010021
-			public const int spinBars = 2130772001;
-			
-			// aapt resource value: 0x7f010070
-			public const int spinnerDropDownItemStyle = 2130772080;
-			
-			// aapt resource value: 0x7f01003e
-			public const int spinnerMode = 2130772030;
-			
-			// aapt resource value: 0x7f01006f
-			public const int spinnerStyle = 2130772079;
-			
-			// aapt resource value: 0x7f010046
-			public const int splitTrack = 2130772038;
-			
-			// aapt resource value: 0x7f010031
-			public const int state_above_anchor = 2130772017;
+			public const int searchHintIcon = 2130772029;
 			
 			// aapt resource value: 0x7f01003c
-			public const int submitBackground = 2130772028;
+			public const int searchIcon = 2130772028;
+			
+			// aapt resource value: 0x7f01008e
+			public const int searchViewStyle = 2130772110;
+			
+			// aapt resource value: 0x7f010080
+			public const int selectableItemBackground = 2130772096;
+			
+			// aapt resource value: 0x7f010081
+			public const int selectableItemBackgroundBorderless = 2130772097;
+			
+			// aapt resource value: 0x7f010030
+			public const int showAsAction = 2130772016;
+			
+			// aapt resource value: 0x7f01002e
+			public const int showDividers = 2130772014;
+			
+			// aapt resource value: 0x7f01004d
+			public const int showText = 2130772045;
+			
+			// aapt resource value: 0x7f010022
+			public const int singleChoiceItemLayout = 2130772002;
+			
+			// aapt resource value: 0x7f010026
+			public const int spinBars = 2130772006;
+			
+			// aapt resource value: 0x7f01007b
+			public const int spinnerDropDownItemStyle = 2130772091;
+			
+			// aapt resource value: 0x7f010044
+			public const int spinnerMode = 2130772036;
+			
+			// aapt resource value: 0x7f0100b4
+			public const int spinnerStyle = 2130772148;
+			
+			// aapt resource value: 0x7f01004c
+			public const int splitTrack = 2130772044;
+			
+			// aapt resource value: 0x7f010036
+			public const int state_above_anchor = 2130772022;
+			
+			// aapt resource value: 0x7f010042
+			public const int submitBackground = 2130772034;
 			
 			// aapt resource value: 0x7f010006
 			public const int subtitle = 2130771974;
 			
-			// aapt resource value: 0x7f01009b
-			public const int subtitleTextAppearance = 2130772123;
+			// aapt resource value: 0x7f0100b7
+			public const int subtitleTextAppearance = 2130772151;
 			
 			// aapt resource value: 0x7f010008
 			public const int subtitleTextStyle = 2130771976;
 			
-			// aapt resource value: 0x7f01003a
-			public const int suggestionRowLayout = 2130772026;
+			// aapt resource value: 0x7f010040
+			public const int suggestionRowLayout = 2130772032;
 			
-			// aapt resource value: 0x7f010044
-			public const int switchMinWidth = 2130772036;
+			// aapt resource value: 0x7f01004a
+			public const int switchMinWidth = 2130772042;
 			
-			// aapt resource value: 0x7f010045
-			public const int switchPadding = 2130772037;
+			// aapt resource value: 0x7f01004b
+			public const int switchPadding = 2130772043;
 			
-			// aapt resource value: 0x7f010080
-			public const int switchStyle = 2130772096;
+			// aapt resource value: 0x7f0100b5
+			public const int switchStyle = 2130772149;
 			
-			// aapt resource value: 0x7f010043
-			public const int switchTextAppearance = 2130772035;
+			// aapt resource value: 0x7f010049
+			public const int switchTextAppearance = 2130772041;
 			
-			// aapt resource value: 0x7f01001f
-			public const int textAllCaps = 2130771999;
+			// aapt resource value: 0x7f010024
+			public const int textAllCaps = 2130772004;
 			
-			// aapt resource value: 0x7f01006b
-			public const int textAppearanceLargePopupMenu = 2130772075;
+			// aapt resource value: 0x7f010074
+			public const int textAppearanceLargePopupMenu = 2130772084;
+			
+			// aapt resource value: 0x7f010096
+			public const int textAppearanceListItem = 2130772118;
+			
+			// aapt resource value: 0x7f010097
+			public const int textAppearanceListItemSmall = 2130772119;
 			
 			// aapt resource value: 0x7f01008c
-			public const int textAppearanceListItem = 2130772108;
+			public const int textAppearanceSearchResultSubtitle = 2130772108;
+			
+			// aapt resource value: 0x7f01008b
+			public const int textAppearanceSearchResultTitle = 2130772107;
+			
+			// aapt resource value: 0x7f010075
+			public const int textAppearanceSmallPopupMenu = 2130772085;
+			
+			// aapt resource value: 0x7f0100a8
+			public const int textColorAlertDialogListItem = 2130772136;
 			
 			// aapt resource value: 0x7f01008d
-			public const int textAppearanceListItemSmall = 2130772109;
+			public const int textColorSearchUrl = 2130772109;
 			
-			// aapt resource value: 0x7f010082
-			public const int textAppearanceSearchResultSubtitle = 2130772098;
+			// aapt resource value: 0x7f0100c4
+			public const int theme = 2130772164;
 			
-			// aapt resource value: 0x7f010081
-			public const int textAppearanceSearchResultTitle = 2130772097;
+			// aapt resource value: 0x7f01002c
+			public const int thickness = 2130772012;
 			
-			// aapt resource value: 0x7f01006c
-			public const int textAppearanceSmallPopupMenu = 2130772076;
-			
-			// aapt resource value: 0x7f010083
-			public const int textColorSearchUrl = 2130772099;
-			
-			// aapt resource value: 0x7f0100a2
-			public const int theme = 2130772130;
-			
-			// aapt resource value: 0x7f010027
-			public const int thickness = 2130772007;
-			
-			// aapt resource value: 0x7f010042
-			public const int thumbTextPadding = 2130772034;
+			// aapt resource value: 0x7f010048
+			public const int thumbTextPadding = 2130772040;
 			
 			// aapt resource value: 0x7f010003
 			public const int title = 2130771971;
 			
-			// aapt resource value: 0x7f0100a0
-			public const int titleMarginBottom = 2130772128;
+			// aapt resource value: 0x7f0100bc
+			public const int titleMarginBottom = 2130772156;
 			
-			// aapt resource value: 0x7f01009e
-			public const int titleMarginEnd = 2130772126;
+			// aapt resource value: 0x7f0100ba
+			public const int titleMarginEnd = 2130772154;
 			
-			// aapt resource value: 0x7f01009d
-			public const int titleMarginStart = 2130772125;
+			// aapt resource value: 0x7f0100b9
+			public const int titleMarginStart = 2130772153;
 			
-			// aapt resource value: 0x7f01009f
-			public const int titleMarginTop = 2130772127;
+			// aapt resource value: 0x7f0100bb
+			public const int titleMarginTop = 2130772155;
 			
-			// aapt resource value: 0x7f01009c
-			public const int titleMargins = 2130772124;
+			// aapt resource value: 0x7f0100b8
+			public const int titleMargins = 2130772152;
 			
-			// aapt resource value: 0x7f01009a
-			public const int titleTextAppearance = 2130772122;
+			// aapt resource value: 0x7f0100b6
+			public const int titleTextAppearance = 2130772150;
 			
 			// aapt resource value: 0x7f010007
 			public const int titleTextStyle = 2130771975;
 			
-			// aapt resource value: 0x7f01007b
-			public const int toolbarNavigationButtonStyle = 2130772091;
+			// aapt resource value: 0x7f010086
+			public const int toolbarNavigationButtonStyle = 2130772102;
 			
-			// aapt resource value: 0x7f01007a
-			public const int toolbarStyle = 2130772090;
+			// aapt resource value: 0x7f010085
+			public const int toolbarStyle = 2130772101;
 			
-			// aapt resource value: 0x7f010024
-			public const int topBottomBarArrowSize = 2130772004;
+			// aapt resource value: 0x7f010029
+			public const int topBottomBarArrowSize = 2130772009;
 			
-			// aapt resource value: 0x7f010041
-			public const int track = 2130772033;
+			// aapt resource value: 0x7f010047
+			public const int track = 2130772039;
 			
-			// aapt resource value: 0x7f010038
-			public const int voiceIcon = 2130772024;
-			
-			// aapt resource value: 0x7f010048
-			public const int windowActionBar = 2130772040;
-			
-			// aapt resource value: 0x7f010049
-			public const int windowActionBarOverlay = 2130772041;
-			
-			// aapt resource value: 0x7f01004a
-			public const int windowActionModeOverlay = 2130772042;
+			// aapt resource value: 0x7f01003e
+			public const int voiceIcon = 2130772030;
 			
 			// aapt resource value: 0x7f01004e
-			public const int windowFixedHeightMajor = 2130772046;
+			public const int windowActionBar = 2130772046;
 			
-			// aapt resource value: 0x7f01004c
-			public const int windowFixedHeightMinor = 2130772044;
+			// aapt resource value: 0x7f010050
+			public const int windowActionBarOverlay = 2130772048;
 			
-			// aapt resource value: 0x7f01004b
-			public const int windowFixedWidthMajor = 2130772043;
+			// aapt resource value: 0x7f010051
+			public const int windowActionModeOverlay = 2130772049;
 			
-			// aapt resource value: 0x7f01004d
-			public const int windowFixedWidthMinor = 2130772045;
+			// aapt resource value: 0x7f010055
+			public const int windowFixedHeightMajor = 2130772053;
+			
+			// aapt resource value: 0x7f010053
+			public const int windowFixedHeightMinor = 2130772051;
+			
+			// aapt resource value: 0x7f010052
+			public const int windowFixedWidthMajor = 2130772050;
+			
+			// aapt resource value: 0x7f010054
+			public const int windowFixedWidthMinor = 2130772052;
+			
+			// aapt resource value: 0x7f010056
+			public const int windowMinWidthMajor = 2130772054;
+			
+			// aapt resource value: 0x7f010057
+			public const int windowMinWidthMinor = 2130772055;
+			
+			// aapt resource value: 0x7f01004f
+			public const int windowNoTitle = 2130772047;
 			
 			static Attribute()
 			{
@@ -633,7 +735,10 @@ namespace ReactiveUI.Tests
 			public const int abc_config_allowActionMenuItemTextWithIcon = 2131099652;
 			
 			// aapt resource value: 0x7f060005
-			public const int abc_config_showMenuShortcutsWhenKeyboardPresent = 2131099653;
+			public const int abc_config_closeDialogWhenTouchOutside = 2131099653;
+			
+			// aapt resource value: 0x7f060006
+			public const int abc_config_showMenuShortcutsWhenKeyboardPresent = 2131099654;
 			
 			static Boolean()
 			{
@@ -648,29 +753,29 @@ namespace ReactiveUI.Tests
 		public partial class Color
 		{
 			
-			// aapt resource value: 0x7f070031
-			public const int abc_background_cache_hint_selector_material_dark = 2131165233;
+			// aapt resource value: 0x7f070033
+			public const int abc_background_cache_hint_selector_material_dark = 2131165235;
 			
-			// aapt resource value: 0x7f070032
-			public const int abc_background_cache_hint_selector_material_light = 2131165234;
+			// aapt resource value: 0x7f070034
+			public const int abc_background_cache_hint_selector_material_light = 2131165236;
 			
 			// aapt resource value: 0x7f070000
 			public const int abc_input_method_navigation_guard = 2131165184;
 			
-			// aapt resource value: 0x7f070033
-			public const int abc_primary_text_disable_only_material_dark = 2131165235;
-			
-			// aapt resource value: 0x7f070034
-			public const int abc_primary_text_disable_only_material_light = 2131165236;
-			
 			// aapt resource value: 0x7f070035
-			public const int abc_primary_text_material_dark = 2131165237;
+			public const int abc_primary_text_disable_only_material_dark = 2131165237;
 			
 			// aapt resource value: 0x7f070036
-			public const int abc_primary_text_material_light = 2131165238;
+			public const int abc_primary_text_disable_only_material_light = 2131165238;
 			
 			// aapt resource value: 0x7f070037
-			public const int abc_search_url_text = 2131165239;
+			public const int abc_primary_text_material_dark = 2131165239;
+			
+			// aapt resource value: 0x7f070038
+			public const int abc_primary_text_material_light = 2131165240;
+			
+			// aapt resource value: 0x7f070039
+			public const int abc_search_url_text = 2131165241;
 			
 			// aapt resource value: 0x7f070001
 			public const int abc_search_url_text_normal = 2131165185;
@@ -681,11 +786,11 @@ namespace ReactiveUI.Tests
 			// aapt resource value: 0x7f070003
 			public const int abc_search_url_text_selected = 2131165187;
 			
-			// aapt resource value: 0x7f070038
-			public const int abc_secondary_text_material_dark = 2131165240;
+			// aapt resource value: 0x7f07003a
+			public const int abc_secondary_text_material_dark = 2131165242;
 			
-			// aapt resource value: 0x7f070039
-			public const int abc_secondary_text_material_light = 2131165241;
+			// aapt resource value: 0x7f07003b
+			public const int abc_secondary_text_material_light = 2131165243;
 			
 			// aapt resource value: 0x7f070004
 			public const int accent_material_dark = 2131165188;
@@ -817,10 +922,22 @@ namespace ReactiveUI.Tests
 			public const int secondary_text_disabled_material_light = 2131165230;
 			
 			// aapt resource value: 0x7f07002f
-			public const int switch_thumb_normal_material_dark = 2131165231;
+			public const int switch_thumb_disabled_material_dark = 2131165231;
 			
 			// aapt resource value: 0x7f070030
-			public const int switch_thumb_normal_material_light = 2131165232;
+			public const int switch_thumb_disabled_material_light = 2131165232;
+			
+			// aapt resource value: 0x7f07003c
+			public const int switch_thumb_material_dark = 2131165244;
+			
+			// aapt resource value: 0x7f07003d
+			public const int switch_thumb_material_light = 2131165245;
+			
+			// aapt resource value: 0x7f070031
+			public const int switch_thumb_normal_material_dark = 2131165233;
+			
+			// aapt resource value: 0x7f070032
+			public const int switch_thumb_normal_material_light = 2131165234;
 			
 			static Color()
 			{
@@ -836,133 +953,202 @@ namespace ReactiveUI.Tests
 		{
 			
 			// aapt resource value: 0x7f080000
-			public const int abc_action_bar_default_height_material = 2131230720;
+			public const int abc_action_bar_content_inset_material = 2131230720;
 			
 			// aapt resource value: 0x7f080001
-			public const int abc_action_bar_default_padding_material = 2131230721;
+			public const int abc_action_bar_default_height_material = 2131230721;
 			
 			// aapt resource value: 0x7f080002
-			public const int abc_action_bar_icon_vertical_padding_material = 2131230722;
+			public const int abc_action_bar_default_padding_material = 2131230722;
 			
 			// aapt resource value: 0x7f080003
-			public const int abc_action_bar_progress_bar_size = 2131230723;
+			public const int abc_action_bar_icon_vertical_padding_material = 2131230723;
 			
 			// aapt resource value: 0x7f080004
-			public const int abc_action_bar_stacked_max_height = 2131230724;
+			public const int abc_action_bar_navigation_padding_start_material = 2131230724;
 			
 			// aapt resource value: 0x7f080005
-			public const int abc_action_bar_stacked_tab_max_width = 2131230725;
+			public const int abc_action_bar_overflow_padding_end_material = 2131230725;
 			
 			// aapt resource value: 0x7f080006
-			public const int abc_action_bar_subtitle_bottom_margin_material = 2131230726;
+			public const int abc_action_bar_overflow_padding_start_material = 2131230726;
 			
 			// aapt resource value: 0x7f080007
-			public const int abc_action_bar_subtitle_top_margin_material = 2131230727;
+			public const int abc_action_bar_progress_bar_size = 2131230727;
 			
 			// aapt resource value: 0x7f080008
-			public const int abc_action_button_min_height_material = 2131230728;
+			public const int abc_action_bar_stacked_max_height = 2131230728;
 			
 			// aapt resource value: 0x7f080009
-			public const int abc_action_button_min_width_material = 2131230729;
+			public const int abc_action_bar_stacked_tab_max_width = 2131230729;
 			
 			// aapt resource value: 0x7f08000a
-			public const int abc_action_button_min_width_overflow_material = 2131230730;
+			public const int abc_action_bar_subtitle_bottom_margin_material = 2131230730;
 			
 			// aapt resource value: 0x7f08000b
-			public const int abc_config_prefDialogWidth = 2131230731;
+			public const int abc_action_bar_subtitle_top_margin_material = 2131230731;
 			
 			// aapt resource value: 0x7f08000c
-			public const int abc_control_inset_material = 2131230732;
+			public const int abc_action_button_min_height_material = 2131230732;
 			
 			// aapt resource value: 0x7f08000d
-			public const int abc_control_padding_material = 2131230733;
+			public const int abc_action_button_min_width_material = 2131230733;
 			
 			// aapt resource value: 0x7f08000e
-			public const int abc_dropdownitem_icon_width = 2131230734;
+			public const int abc_action_button_min_width_overflow_material = 2131230734;
 			
 			// aapt resource value: 0x7f08000f
-			public const int abc_dropdownitem_text_padding_left = 2131230735;
+			public const int abc_alert_dialog_button_bar_height = 2131230735;
 			
 			// aapt resource value: 0x7f080010
-			public const int abc_dropdownitem_text_padding_right = 2131230736;
+			public const int abc_button_inset_horizontal_material = 2131230736;
 			
 			// aapt resource value: 0x7f080011
-			public const int abc_panel_menu_list_width = 2131230737;
+			public const int abc_button_inset_vertical_material = 2131230737;
 			
 			// aapt resource value: 0x7f080012
-			public const int abc_search_view_preferred_width = 2131230738;
+			public const int abc_button_padding_horizontal_material = 2131230738;
 			
 			// aapt resource value: 0x7f080013
-			public const int abc_search_view_text_min_width = 2131230739;
+			public const int abc_button_padding_vertical_material = 2131230739;
 			
 			// aapt resource value: 0x7f080014
-			public const int abc_text_size_body_1_material = 2131230740;
+			public const int abc_config_prefDialogWidth = 2131230740;
 			
 			// aapt resource value: 0x7f080015
-			public const int abc_text_size_body_2_material = 2131230741;
+			public const int abc_control_corner_material = 2131230741;
 			
 			// aapt resource value: 0x7f080016
-			public const int abc_text_size_button_material = 2131230742;
+			public const int abc_control_inset_material = 2131230742;
 			
 			// aapt resource value: 0x7f080017
-			public const int abc_text_size_caption_material = 2131230743;
+			public const int abc_control_padding_material = 2131230743;
 			
 			// aapt resource value: 0x7f080018
-			public const int abc_text_size_display_1_material = 2131230744;
+			public const int abc_dialog_list_padding_vertical_material = 2131230744;
 			
 			// aapt resource value: 0x7f080019
-			public const int abc_text_size_display_2_material = 2131230745;
+			public const int abc_dialog_min_width_major = 2131230745;
 			
 			// aapt resource value: 0x7f08001a
-			public const int abc_text_size_display_3_material = 2131230746;
+			public const int abc_dialog_min_width_minor = 2131230746;
 			
 			// aapt resource value: 0x7f08001b
-			public const int abc_text_size_display_4_material = 2131230747;
+			public const int abc_dialog_padding_material = 2131230747;
 			
 			// aapt resource value: 0x7f08001c
-			public const int abc_text_size_headline_material = 2131230748;
+			public const int abc_dialog_padding_top_material = 2131230748;
 			
 			// aapt resource value: 0x7f08001d
-			public const int abc_text_size_large_material = 2131230749;
+			public const int abc_disabled_alpha_material_dark = 2131230749;
 			
 			// aapt resource value: 0x7f08001e
-			public const int abc_text_size_medium_material = 2131230750;
+			public const int abc_disabled_alpha_material_light = 2131230750;
 			
 			// aapt resource value: 0x7f08001f
-			public const int abc_text_size_menu_material = 2131230751;
+			public const int abc_dropdownitem_icon_width = 2131230751;
 			
 			// aapt resource value: 0x7f080020
-			public const int abc_text_size_small_material = 2131230752;
+			public const int abc_dropdownitem_text_padding_left = 2131230752;
 			
 			// aapt resource value: 0x7f080021
-			public const int abc_text_size_subhead_material = 2131230753;
+			public const int abc_dropdownitem_text_padding_right = 2131230753;
 			
 			// aapt resource value: 0x7f080022
-			public const int abc_text_size_subtitle_material_toolbar = 2131230754;
+			public const int abc_edit_text_inset_bottom_material = 2131230754;
 			
 			// aapt resource value: 0x7f080023
-			public const int abc_text_size_title_material = 2131230755;
+			public const int abc_edit_text_inset_horizontal_material = 2131230755;
 			
 			// aapt resource value: 0x7f080024
-			public const int abc_text_size_title_material_toolbar = 2131230756;
+			public const int abc_edit_text_inset_top_material = 2131230756;
 			
 			// aapt resource value: 0x7f080025
-			public const int dialog_fixed_height_major = 2131230757;
+			public const int abc_floating_window_z = 2131230757;
 			
 			// aapt resource value: 0x7f080026
-			public const int dialog_fixed_height_minor = 2131230758;
+			public const int abc_list_item_padding_horizontal_material = 2131230758;
 			
 			// aapt resource value: 0x7f080027
-			public const int dialog_fixed_width_major = 2131230759;
+			public const int abc_panel_menu_list_width = 2131230759;
 			
 			// aapt resource value: 0x7f080028
-			public const int dialog_fixed_width_minor = 2131230760;
+			public const int abc_search_view_preferred_width = 2131230760;
 			
 			// aapt resource value: 0x7f080029
-			public const int disabled_alpha_material_dark = 2131230761;
+			public const int abc_search_view_text_min_width = 2131230761;
 			
 			// aapt resource value: 0x7f08002a
-			public const int disabled_alpha_material_light = 2131230762;
+			public const int abc_switch_padding = 2131230762;
+			
+			// aapt resource value: 0x7f08002b
+			public const int abc_text_size_body_1_material = 2131230763;
+			
+			// aapt resource value: 0x7f08002c
+			public const int abc_text_size_body_2_material = 2131230764;
+			
+			// aapt resource value: 0x7f08002d
+			public const int abc_text_size_button_material = 2131230765;
+			
+			// aapt resource value: 0x7f08002e
+			public const int abc_text_size_caption_material = 2131230766;
+			
+			// aapt resource value: 0x7f08002f
+			public const int abc_text_size_display_1_material = 2131230767;
+			
+			// aapt resource value: 0x7f080030
+			public const int abc_text_size_display_2_material = 2131230768;
+			
+			// aapt resource value: 0x7f080031
+			public const int abc_text_size_display_3_material = 2131230769;
+			
+			// aapt resource value: 0x7f080032
+			public const int abc_text_size_display_4_material = 2131230770;
+			
+			// aapt resource value: 0x7f080033
+			public const int abc_text_size_headline_material = 2131230771;
+			
+			// aapt resource value: 0x7f080034
+			public const int abc_text_size_large_material = 2131230772;
+			
+			// aapt resource value: 0x7f080035
+			public const int abc_text_size_medium_material = 2131230773;
+			
+			// aapt resource value: 0x7f080036
+			public const int abc_text_size_menu_material = 2131230774;
+			
+			// aapt resource value: 0x7f080037
+			public const int abc_text_size_small_material = 2131230775;
+			
+			// aapt resource value: 0x7f080038
+			public const int abc_text_size_subhead_material = 2131230776;
+			
+			// aapt resource value: 0x7f080039
+			public const int abc_text_size_subtitle_material_toolbar = 2131230777;
+			
+			// aapt resource value: 0x7f08003a
+			public const int abc_text_size_title_material = 2131230778;
+			
+			// aapt resource value: 0x7f08003b
+			public const int abc_text_size_title_material_toolbar = 2131230779;
+			
+			// aapt resource value: 0x7f08003c
+			public const int dialog_fixed_height_major = 2131230780;
+			
+			// aapt resource value: 0x7f08003d
+			public const int dialog_fixed_height_minor = 2131230781;
+			
+			// aapt resource value: 0x7f08003e
+			public const int dialog_fixed_width_major = 2131230782;
+			
+			// aapt resource value: 0x7f08003f
+			public const int dialog_fixed_width_minor = 2131230783;
+			
+			// aapt resource value: 0x7f080040
+			public const int disabled_alpha_material_dark = 2131230784;
+			
+			// aapt resource value: 0x7f080041
+			public const int disabled_alpha_material_light = 2131230785;
 			
 			static Dimension()
 			{
@@ -978,10 +1164,10 @@ namespace ReactiveUI.Tests
 		{
 			
 			// aapt resource value: 0x7f020000
-			public const int abc_ab_share_pack_holo_dark = 2130837504;
+			public const int abc_ab_share_pack_mtrl_alpha = 2130837504;
 			
 			// aapt resource value: 0x7f020001
-			public const int abc_ab_share_pack_holo_light = 2130837505;
+			public const int abc_btn_borderless_material = 2130837505;
 			
 			// aapt resource value: 0x7f020002
 			public const int abc_btn_check_material = 2130837506;
@@ -993,151 +1179,175 @@ namespace ReactiveUI.Tests
 			public const int abc_btn_check_to_on_mtrl_015 = 2130837508;
 			
 			// aapt resource value: 0x7f020005
-			public const int abc_btn_radio_material = 2130837509;
+			public const int abc_btn_default_mtrl_shape = 2130837509;
 			
 			// aapt resource value: 0x7f020006
-			public const int abc_btn_radio_to_on_mtrl_000 = 2130837510;
+			public const int abc_btn_radio_material = 2130837510;
 			
 			// aapt resource value: 0x7f020007
-			public const int abc_btn_radio_to_on_mtrl_015 = 2130837511;
+			public const int abc_btn_radio_to_on_mtrl_000 = 2130837511;
 			
 			// aapt resource value: 0x7f020008
-			public const int abc_btn_switch_to_on_mtrl_00001 = 2130837512;
+			public const int abc_btn_radio_to_on_mtrl_015 = 2130837512;
 			
 			// aapt resource value: 0x7f020009
-			public const int abc_btn_switch_to_on_mtrl_00012 = 2130837513;
+			public const int abc_btn_rating_star_off_mtrl_alpha = 2130837513;
 			
 			// aapt resource value: 0x7f02000a
-			public const int abc_cab_background_internal_bg = 2130837514;
+			public const int abc_btn_rating_star_on_mtrl_alpha = 2130837514;
 			
 			// aapt resource value: 0x7f02000b
-			public const int abc_cab_background_top_material = 2130837515;
+			public const int abc_btn_switch_to_on_mtrl_00001 = 2130837515;
 			
 			// aapt resource value: 0x7f02000c
-			public const int abc_cab_background_top_mtrl_alpha = 2130837516;
+			public const int abc_btn_switch_to_on_mtrl_00012 = 2130837516;
 			
 			// aapt resource value: 0x7f02000d
-			public const int abc_edit_text_material = 2130837517;
+			public const int abc_cab_background_internal_bg = 2130837517;
 			
 			// aapt resource value: 0x7f02000e
-			public const int abc_ic_ab_back_mtrl_am_alpha = 2130837518;
+			public const int abc_cab_background_top_material = 2130837518;
 			
 			// aapt resource value: 0x7f02000f
-			public const int abc_ic_clear_mtrl_alpha = 2130837519;
+			public const int abc_cab_background_top_mtrl_alpha = 2130837519;
 			
 			// aapt resource value: 0x7f020010
-			public const int abc_ic_commit_search_api_mtrl_alpha = 2130837520;
+			public const int abc_dialog_material_background_dark = 2130837520;
 			
 			// aapt resource value: 0x7f020011
-			public const int abc_ic_go_search_api_mtrl_alpha = 2130837521;
+			public const int abc_dialog_material_background_light = 2130837521;
 			
 			// aapt resource value: 0x7f020012
-			public const int abc_ic_menu_copy_mtrl_am_alpha = 2130837522;
+			public const int abc_edit_text_material = 2130837522;
 			
 			// aapt resource value: 0x7f020013
-			public const int abc_ic_menu_cut_mtrl_alpha = 2130837523;
+			public const int abc_ic_ab_back_mtrl_am_alpha = 2130837523;
 			
 			// aapt resource value: 0x7f020014
-			public const int abc_ic_menu_moreoverflow_mtrl_alpha = 2130837524;
+			public const int abc_ic_clear_mtrl_alpha = 2130837524;
 			
 			// aapt resource value: 0x7f020015
-			public const int abc_ic_menu_paste_mtrl_am_alpha = 2130837525;
+			public const int abc_ic_commit_search_api_mtrl_alpha = 2130837525;
 			
 			// aapt resource value: 0x7f020016
-			public const int abc_ic_menu_selectall_mtrl_alpha = 2130837526;
+			public const int abc_ic_go_search_api_mtrl_alpha = 2130837526;
 			
 			// aapt resource value: 0x7f020017
-			public const int abc_ic_menu_share_mtrl_alpha = 2130837527;
+			public const int abc_ic_menu_copy_mtrl_am_alpha = 2130837527;
 			
 			// aapt resource value: 0x7f020018
-			public const int abc_ic_search_api_mtrl_alpha = 2130837528;
+			public const int abc_ic_menu_cut_mtrl_alpha = 2130837528;
 			
 			// aapt resource value: 0x7f020019
-			public const int abc_ic_voice_search_api_mtrl_alpha = 2130837529;
+			public const int abc_ic_menu_moreoverflow_mtrl_alpha = 2130837529;
 			
 			// aapt resource value: 0x7f02001a
-			public const int abc_item_background_holo_dark = 2130837530;
+			public const int abc_ic_menu_paste_mtrl_am_alpha = 2130837530;
 			
 			// aapt resource value: 0x7f02001b
-			public const int abc_item_background_holo_light = 2130837531;
+			public const int abc_ic_menu_selectall_mtrl_alpha = 2130837531;
 			
 			// aapt resource value: 0x7f02001c
-			public const int abc_list_divider_mtrl_alpha = 2130837532;
+			public const int abc_ic_menu_share_mtrl_alpha = 2130837532;
 			
 			// aapt resource value: 0x7f02001d
-			public const int abc_list_focused_holo = 2130837533;
+			public const int abc_ic_search_api_mtrl_alpha = 2130837533;
 			
 			// aapt resource value: 0x7f02001e
-			public const int abc_list_longpressed_holo = 2130837534;
+			public const int abc_ic_voice_search_api_mtrl_alpha = 2130837534;
 			
 			// aapt resource value: 0x7f02001f
-			public const int abc_list_pressed_holo_dark = 2130837535;
+			public const int abc_item_background_holo_dark = 2130837535;
 			
 			// aapt resource value: 0x7f020020
-			public const int abc_list_pressed_holo_light = 2130837536;
+			public const int abc_item_background_holo_light = 2130837536;
 			
 			// aapt resource value: 0x7f020021
-			public const int abc_list_selector_background_transition_holo_dark = 2130837537;
+			public const int abc_list_divider_mtrl_alpha = 2130837537;
 			
 			// aapt resource value: 0x7f020022
-			public const int abc_list_selector_background_transition_holo_light = 2130837538;
+			public const int abc_list_focused_holo = 2130837538;
 			
 			// aapt resource value: 0x7f020023
-			public const int abc_list_selector_disabled_holo_dark = 2130837539;
+			public const int abc_list_longpressed_holo = 2130837539;
 			
 			// aapt resource value: 0x7f020024
-			public const int abc_list_selector_disabled_holo_light = 2130837540;
+			public const int abc_list_pressed_holo_dark = 2130837540;
 			
 			// aapt resource value: 0x7f020025
-			public const int abc_list_selector_holo_dark = 2130837541;
+			public const int abc_list_pressed_holo_light = 2130837541;
 			
 			// aapt resource value: 0x7f020026
-			public const int abc_list_selector_holo_light = 2130837542;
+			public const int abc_list_selector_background_transition_holo_dark = 2130837542;
 			
 			// aapt resource value: 0x7f020027
-			public const int abc_menu_hardkey_panel_mtrl_mult = 2130837543;
+			public const int abc_list_selector_background_transition_holo_light = 2130837543;
 			
 			// aapt resource value: 0x7f020028
-			public const int abc_popup_background_mtrl_mult = 2130837544;
+			public const int abc_list_selector_disabled_holo_dark = 2130837544;
 			
 			// aapt resource value: 0x7f020029
-			public const int abc_spinner_mtrl_am_alpha = 2130837545;
+			public const int abc_list_selector_disabled_holo_light = 2130837545;
 			
 			// aapt resource value: 0x7f02002a
-			public const int abc_switch_thumb_material = 2130837546;
+			public const int abc_list_selector_holo_dark = 2130837546;
 			
 			// aapt resource value: 0x7f02002b
-			public const int abc_switch_track_mtrl_alpha = 2130837547;
+			public const int abc_list_selector_holo_light = 2130837547;
 			
 			// aapt resource value: 0x7f02002c
-			public const int abc_tab_indicator_material = 2130837548;
+			public const int abc_menu_hardkey_panel_mtrl_mult = 2130837548;
 			
 			// aapt resource value: 0x7f02002d
-			public const int abc_tab_indicator_mtrl_alpha = 2130837549;
+			public const int abc_popup_background_mtrl_mult = 2130837549;
 			
 			// aapt resource value: 0x7f02002e
-			public const int abc_textfield_activated_mtrl_alpha = 2130837550;
+			public const int abc_ratingbar_full_material = 2130837550;
 			
 			// aapt resource value: 0x7f02002f
-			public const int abc_textfield_default_mtrl_alpha = 2130837551;
+			public const int abc_spinner_mtrl_am_alpha = 2130837551;
 			
 			// aapt resource value: 0x7f020030
-			public const int abc_textfield_search_activated_mtrl_alpha = 2130837552;
+			public const int abc_spinner_textfield_background_material = 2130837552;
 			
 			// aapt resource value: 0x7f020031
-			public const int abc_textfield_search_default_mtrl_alpha = 2130837553;
+			public const int abc_switch_thumb_material = 2130837553;
 			
 			// aapt resource value: 0x7f020032
-			public const int abc_textfield_search_material = 2130837554;
+			public const int abc_switch_track_mtrl_alpha = 2130837554;
 			
 			// aapt resource value: 0x7f020033
-			public const int dialog_disclosure = 2130837555;
+			public const int abc_tab_indicator_material = 2130837555;
 			
 			// aapt resource value: 0x7f020034
-			public const int dialog_expander_ic_minimized = 2130837556;
+			public const int abc_tab_indicator_mtrl_alpha = 2130837556;
 			
 			// aapt resource value: 0x7f020035
-			public const int Icon = 2130837557;
+			public const int abc_text_cursor_mtrl_alpha = 2130837557;
+			
+			// aapt resource value: 0x7f020036
+			public const int abc_textfield_activated_mtrl_alpha = 2130837558;
+			
+			// aapt resource value: 0x7f020037
+			public const int abc_textfield_default_mtrl_alpha = 2130837559;
+			
+			// aapt resource value: 0x7f020038
+			public const int abc_textfield_search_activated_mtrl_alpha = 2130837560;
+			
+			// aapt resource value: 0x7f020039
+			public const int abc_textfield_search_default_mtrl_alpha = 2130837561;
+			
+			// aapt resource value: 0x7f02003a
+			public const int abc_textfield_search_material = 2130837562;
+			
+			// aapt resource value: 0x7f02003b
+			public const int dialog_disclosure = 2130837563;
+			
+			// aapt resource value: 0x7f02003c
+			public const int dialog_expander_ic_minimized = 2130837564;
+			
+			// aapt resource value: 0x7f02003d
+			public const int Icon = 2130837565;
 			
 			static Drawable()
 			{
@@ -1152,29 +1362,29 @@ namespace ReactiveUI.Tests
 		public partial class Id
 		{
 			
-			// aapt resource value: 0x7f090031
-			public const int action_bar = 2131296305;
+			// aapt resource value: 0x7f090040
+			public const int action_bar = 2131296320;
 			
 			// aapt resource value: 0x7f090000
 			public const int action_bar_activity_content = 2131296256;
 			
-			// aapt resource value: 0x7f090030
-			public const int action_bar_container = 2131296304;
+			// aapt resource value: 0x7f09003f
+			public const int action_bar_container = 2131296319;
 			
-			// aapt resource value: 0x7f09002c
-			public const int action_bar_root = 2131296300;
+			// aapt resource value: 0x7f09003b
+			public const int action_bar_root = 2131296315;
 			
 			// aapt resource value: 0x7f090001
 			public const int action_bar_spinner = 2131296257;
 			
-			// aapt resource value: 0x7f09001f
-			public const int action_bar_subtitle = 2131296287;
+			// aapt resource value: 0x7f090024
+			public const int action_bar_subtitle = 2131296292;
 			
-			// aapt resource value: 0x7f09001e
-			public const int action_bar_title = 2131296286;
+			// aapt resource value: 0x7f090023
+			public const int action_bar_title = 2131296291;
 			
-			// aapt resource value: 0x7f090032
-			public const int action_context_bar = 2131296306;
+			// aapt resource value: 0x7f090041
+			public const int action_context_bar = 2131296321;
 			
 			// aapt resource value: 0x7f090002
 			public const int action_menu_divider = 2131296258;
@@ -1182,17 +1392,20 @@ namespace ReactiveUI.Tests
 			// aapt resource value: 0x7f090003
 			public const int action_menu_presenter = 2131296259;
 			
-			// aapt resource value: 0x7f09002e
-			public const int action_mode_bar = 2131296302;
+			// aapt resource value: 0x7f09003d
+			public const int action_mode_bar = 2131296317;
 			
-			// aapt resource value: 0x7f09002d
-			public const int action_mode_bar_stub = 2131296301;
+			// aapt resource value: 0x7f09003c
+			public const int action_mode_bar_stub = 2131296316;
 			
-			// aapt resource value: 0x7f090020
-			public const int action_mode_close_button = 2131296288;
+			// aapt resource value: 0x7f090025
+			public const int action_mode_close_button = 2131296293;
 			
-			// aapt resource value: 0x7f090021
-			public const int activity_chooser_view_content = 2131296289;
+			// aapt resource value: 0x7f090026
+			public const int activity_chooser_view_content = 2131296294;
+			
+			// aapt resource value: 0x7f090030
+			public const int alertTitle = 2131296304;
 			
 			// aapt resource value: 0x7f090016
 			public const int always = 2131296278;
@@ -1200,56 +1413,68 @@ namespace ReactiveUI.Tests
 			// aapt resource value: 0x7f090013
 			public const int beginning = 2131296275;
 			
-			// aapt resource value: 0x7f090029
-			public const int checkbox = 2131296297;
+			// aapt resource value: 0x7f090036
+			public const int buttonPanel = 2131296310;
+			
+			// aapt resource value: 0x7f090038
+			public const int checkbox = 2131296312;
 			
 			// aapt resource value: 0x7f090017
 			public const int collapseActionView = 2131296279;
 			
-			// aapt resource value: 0x7f09002f
-			public const int decor_content_parent = 2131296303;
+			// aapt resource value: 0x7f090031
+			public const int contentPanel = 2131296305;
 			
-			// aapt resource value: 0x7f090024
-			public const int default_activity_button = 2131296292;
+			// aapt resource value: 0x7f090035
+			public const int custom = 2131296309;
+			
+			// aapt resource value: 0x7f090034
+			public const int customPanel = 2131296308;
+			
+			// aapt resource value: 0x7f09003e
+			public const int decor_content_parent = 2131296318;
+			
+			// aapt resource value: 0x7f090029
+			public const int default_activity_button = 2131296297;
 			
 			// aapt resource value: 0x7f09001b
 			public const int dialog = 2131296283;
 			
-			// aapt resource value: 0x7f090041
-			public const int dialog_BoolField = 2131296321;
+			// aapt resource value: 0x7f090051
+			public const int dialog_BoolField = 2131296337;
 			
-			// aapt resource value: 0x7f090042
-			public const int dialog_Button = 2131296322;
+			// aapt resource value: 0x7f090052
+			public const int dialog_Button = 2131296338;
 			
-			// aapt resource value: 0x7f090048
-			public const int dialog_DisclosureField = 2131296328;
+			// aapt resource value: 0x7f090058
+			public const int dialog_DisclosureField = 2131296344;
 			
-			// aapt resource value: 0x7f090044
-			public const int dialog_ImageLeft = 2131296324;
+			// aapt resource value: 0x7f090054
+			public const int dialog_ImageLeft = 2131296340;
 			
-			// aapt resource value: 0x7f090046
-			public const int dialog_ImageRight = 2131296326;
+			// aapt resource value: 0x7f090056
+			public const int dialog_ImageRight = 2131296342;
 			
-			// aapt resource value: 0x7f09003f
-			public const int dialog_LabelField = 2131296319;
+			// aapt resource value: 0x7f09004f
+			public const int dialog_LabelField = 2131296335;
 			
-			// aapt resource value: 0x7f090040
-			public const int dialog_LabelSubtextField = 2131296320;
+			// aapt resource value: 0x7f090050
+			public const int dialog_LabelSubtextField = 2131296336;
 			
-			// aapt resource value: 0x7f090047
-			public const int dialog_Panel = 2131296327;
+			// aapt resource value: 0x7f090057
+			public const int dialog_Panel = 2131296343;
 			
-			// aapt resource value: 0x7f090049
-			public const int dialog_RadioButtonList = 2131296329;
+			// aapt resource value: 0x7f090059
+			public const int dialog_RadioButtonList = 2131296345;
 			
-			// aapt resource value: 0x7f090045
-			public const int dialog_SliderField = 2131296325;
+			// aapt resource value: 0x7f090055
+			public const int dialog_SliderField = 2131296341;
 			
-			// aapt resource value: 0x7f09004a
-			public const int dialog_Spinner = 2131296330;
+			// aapt resource value: 0x7f09005a
+			public const int dialog_Spinner = 2131296346;
 			
-			// aapt resource value: 0x7f090043
-			public const int dialog_ValueField = 2131296323;
+			// aapt resource value: 0x7f090053
+			public const int dialog_ValueField = 2131296339;
 			
 			// aapt resource value: 0x7f09000c
 			public const int disableHome = 2131296268;
@@ -1257,17 +1482,17 @@ namespace ReactiveUI.Tests
 			// aapt resource value: 0x7f09001c
 			public const int dropdown = 2131296284;
 			
-			// aapt resource value: 0x7f090033
-			public const int edit_query = 2131296307;
+			// aapt resource value: 0x7f090042
+			public const int edit_query = 2131296322;
 			
 			// aapt resource value: 0x7f090014
 			public const int end = 2131296276;
 			
-			// aapt resource value: 0x7f090022
-			public const int expand_activities_button = 2131296290;
+			// aapt resource value: 0x7f090027
+			public const int expand_activities_button = 2131296295;
 			
-			// aapt resource value: 0x7f090028
-			public const int expanded_menu = 2131296296;
+			// aapt resource value: 0x7f090037
+			public const int expanded_menu = 2131296311;
 			
 			// aapt resource value: 0x7f090004
 			public const int home = 2131296260;
@@ -1275,29 +1500,32 @@ namespace ReactiveUI.Tests
 			// aapt resource value: 0x7f09000d
 			public const int homeAsUp = 2131296269;
 			
-			// aapt resource value: 0x7f09004b
-			public const int iFormFieldValue = 2131296331;
+			// aapt resource value: 0x7f09005b
+			public const int iFormFieldValue = 2131296347;
 			
-			// aapt resource value: 0x7f090026
-			public const int icon = 2131296294;
+			// aapt resource value: 0x7f09002b
+			public const int icon = 2131296299;
 			
 			// aapt resource value: 0x7f090018
 			public const int ifRoom = 2131296280;
 			
-			// aapt resource value: 0x7f090023
-			public const int image = 2131296291;
+			// aapt resource value: 0x7f090028
+			public const int image = 2131296296;
 			
 			// aapt resource value: 0x7f090009
 			public const int listMode = 2131296265;
 			
-			// aapt resource value: 0x7f090025
-			public const int list_item = 2131296293;
+			// aapt resource value: 0x7f09002a
+			public const int list_item = 2131296298;
 			
 			// aapt resource value: 0x7f090015
 			public const int middle = 2131296277;
 			
-			// aapt resource value: 0x7f09004c
-			public const int myButton = 2131296332;
+			// aapt resource value: 0x7f09001e
+			public const int multiply = 2131296286;
+			
+			// aapt resource value: 0x7f09005c
+			public const int myButton = 2131296348;
 			
 			// aapt resource value: 0x7f090019
 			public const int never = 2131296281;
@@ -1308,47 +1536,59 @@ namespace ReactiveUI.Tests
 			// aapt resource value: 0x7f09000a
 			public const int normal = 2131296266;
 			
+			// aapt resource value: 0x7f09002d
+			public const int parentPanel = 2131296301;
+			
 			// aapt resource value: 0x7f090005
 			public const int progress_circular = 2131296261;
 			
 			// aapt resource value: 0x7f090006
 			public const int progress_horizontal = 2131296262;
 			
-			// aapt resource value: 0x7f09002b
-			public const int radio = 2131296299;
+			// aapt resource value: 0x7f09003a
+			public const int radio = 2131296314;
 			
-			// aapt resource value: 0x7f090035
-			public const int search_badge = 2131296309;
+			// aapt resource value: 0x7f09001f
+			public const int screen = 2131296287;
 			
-			// aapt resource value: 0x7f090034
-			public const int search_bar = 2131296308;
+			// aapt resource value: 0x7f090032
+			public const int scrollView = 2131296306;
 			
-			// aapt resource value: 0x7f090036
-			public const int search_button = 2131296310;
+			// aapt resource value: 0x7f090044
+			public const int search_badge = 2131296324;
 			
-			// aapt resource value: 0x7f09003b
-			public const int search_close_btn = 2131296315;
+			// aapt resource value: 0x7f090043
+			public const int search_bar = 2131296323;
 			
-			// aapt resource value: 0x7f090037
-			public const int search_edit_frame = 2131296311;
+			// aapt resource value: 0x7f090045
+			public const int search_button = 2131296325;
 			
-			// aapt resource value: 0x7f09003d
-			public const int search_go_btn = 2131296317;
+			// aapt resource value: 0x7f09004a
+			public const int search_close_btn = 2131296330;
 			
-			// aapt resource value: 0x7f090038
-			public const int search_mag_icon = 2131296312;
+			// aapt resource value: 0x7f090046
+			public const int search_edit_frame = 2131296326;
+			
+			// aapt resource value: 0x7f09004c
+			public const int search_go_btn = 2131296332;
+			
+			// aapt resource value: 0x7f090047
+			public const int search_mag_icon = 2131296327;
+			
+			// aapt resource value: 0x7f090048
+			public const int search_plate = 2131296328;
+			
+			// aapt resource value: 0x7f090049
+			public const int search_src_text = 2131296329;
+			
+			// aapt resource value: 0x7f09004d
+			public const int search_voice_btn = 2131296333;
+			
+			// aapt resource value: 0x7f09004e
+			public const int select_dialog_listview = 2131296334;
 			
 			// aapt resource value: 0x7f090039
-			public const int search_plate = 2131296313;
-			
-			// aapt resource value: 0x7f09003a
-			public const int search_src_text = 2131296314;
-			
-			// aapt resource value: 0x7f09003e
-			public const int search_voice_btn = 2131296318;
-			
-			// aapt resource value: 0x7f09002a
-			public const int shortcut = 2131296298;
+			public const int shortcut = 2131296313;
 			
 			// aapt resource value: 0x7f09000f
 			public const int showCustom = 2131296271;
@@ -1362,14 +1602,32 @@ namespace ReactiveUI.Tests
 			// aapt resource value: 0x7f090007
 			public const int split_action_bar = 2131296263;
 			
-			// aapt resource value: 0x7f09003c
-			public const int submit_area = 2131296316;
+			// aapt resource value: 0x7f090020
+			public const int src_atop = 2131296288;
+			
+			// aapt resource value: 0x7f090021
+			public const int src_in = 2131296289;
+			
+			// aapt resource value: 0x7f090022
+			public const int src_over = 2131296290;
+			
+			// aapt resource value: 0x7f09004b
+			public const int submit_area = 2131296331;
 			
 			// aapt resource value: 0x7f09000b
 			public const int tabMode = 2131296267;
 			
-			// aapt resource value: 0x7f090027
-			public const int title = 2131296295;
+			// aapt resource value: 0x7f090033
+			public const int textSpacerNoButtons = 2131296307;
+			
+			// aapt resource value: 0x7f09002c
+			public const int title = 2131296300;
+			
+			// aapt resource value: 0x7f09002f
+			public const int title_template = 2131296303;
+			
+			// aapt resource value: 0x7f09002e
+			public const int topPanel = 2131296302;
 			
 			// aapt resource value: 0x7f090008
 			public const int up = 2131296264;
@@ -1397,7 +1655,13 @@ namespace ReactiveUI.Tests
 		{
 			
 			// aapt resource value: 0x7f0a0000
-			public const int abc_max_action_buttons = 2131361792;
+			public const int abc_config_activityDefaultDur = 2131361792;
+			
+			// aapt resource value: 0x7f0a0001
+			public const int abc_config_activityShortDur = 2131361793;
+			
+			// aapt resource value: 0x7f0a0002
+			public const int abc_max_action_buttons = 2131361794;
 			
 			static Integer()
 			{
@@ -1437,112 +1701,127 @@ namespace ReactiveUI.Tests
 			public const int abc_activity_chooser_view = 2130903047;
 			
 			// aapt resource value: 0x7f030008
-			public const int abc_activity_chooser_view_include = 2130903048;
+			public const int abc_activity_chooser_view_list_item = 2130903048;
 			
 			// aapt resource value: 0x7f030009
-			public const int abc_activity_chooser_view_list_item = 2130903049;
+			public const int abc_alert_dialog_material = 2130903049;
 			
 			// aapt resource value: 0x7f03000a
-			public const int abc_expanded_menu_layout = 2130903050;
+			public const int abc_dialog_title_material = 2130903050;
 			
 			// aapt resource value: 0x7f03000b
-			public const int abc_list_menu_item_checkbox = 2130903051;
+			public const int abc_expanded_menu_layout = 2130903051;
 			
 			// aapt resource value: 0x7f03000c
-			public const int abc_list_menu_item_icon = 2130903052;
+			public const int abc_list_menu_item_checkbox = 2130903052;
 			
 			// aapt resource value: 0x7f03000d
-			public const int abc_list_menu_item_layout = 2130903053;
+			public const int abc_list_menu_item_icon = 2130903053;
 			
 			// aapt resource value: 0x7f03000e
-			public const int abc_list_menu_item_radio = 2130903054;
+			public const int abc_list_menu_item_layout = 2130903054;
 			
 			// aapt resource value: 0x7f03000f
-			public const int abc_popup_menu_item_layout = 2130903055;
+			public const int abc_list_menu_item_radio = 2130903055;
 			
 			// aapt resource value: 0x7f030010
-			public const int abc_screen_content_include = 2130903056;
+			public const int abc_popup_menu_item_layout = 2130903056;
 			
 			// aapt resource value: 0x7f030011
-			public const int abc_screen_simple = 2130903057;
+			public const int abc_screen_content_include = 2130903057;
 			
 			// aapt resource value: 0x7f030012
-			public const int abc_screen_simple_overlay_action_mode = 2130903058;
+			public const int abc_screen_simple = 2130903058;
 			
 			// aapt resource value: 0x7f030013
-			public const int abc_screen_toolbar = 2130903059;
+			public const int abc_screen_simple_overlay_action_mode = 2130903059;
 			
 			// aapt resource value: 0x7f030014
-			public const int abc_search_dropdown_item_icons_2line = 2130903060;
+			public const int abc_screen_toolbar = 2130903060;
 			
 			// aapt resource value: 0x7f030015
-			public const int abc_search_view = 2130903061;
+			public const int abc_search_dropdown_item_icons_2line = 2130903061;
 			
 			// aapt resource value: 0x7f030016
-			public const int abc_simple_dropdown_hint = 2130903062;
+			public const int abc_search_view = 2130903062;
 			
 			// aapt resource value: 0x7f030017
-			public const int dialog_achievements = 2130903063;
+			public const int abc_select_dialog_material = 2130903063;
 			
 			// aapt resource value: 0x7f030018
-			public const int dialog_boolfieldleft = 2130903064;
+			public const int abc_simple_dropdown_hint = 2130903064;
 			
 			// aapt resource value: 0x7f030019
-			public const int dialog_boolfieldright = 2130903065;
+			public const int dialog_achievements = 2130903065;
 			
 			// aapt resource value: 0x7f03001a
-			public const int dialog_boolfieldsubleft = 2130903066;
+			public const int dialog_boolfieldleft = 2130903066;
 			
 			// aapt resource value: 0x7f03001b
-			public const int dialog_boolfieldsubright = 2130903067;
+			public const int dialog_boolfieldright = 2130903067;
 			
 			// aapt resource value: 0x7f03001c
-			public const int dialog_button = 2130903068;
+			public const int dialog_boolfieldsubleft = 2130903068;
 			
 			// aapt resource value: 0x7f03001d
-			public const int dialog_datefield = 2130903069;
+			public const int dialog_boolfieldsubright = 2130903069;
 			
 			// aapt resource value: 0x7f03001e
-			public const int dialog_fieldsetlabel = 2130903070;
+			public const int dialog_button = 2130903070;
 			
 			// aapt resource value: 0x7f03001f
-			public const int dialog_floatimage = 2130903071;
+			public const int dialog_datefield = 2130903071;
 			
 			// aapt resource value: 0x7f030020
-			public const int dialog_labelfieldbelow = 2130903072;
+			public const int dialog_fieldsetlabel = 2130903072;
 			
 			// aapt resource value: 0x7f030021
-			public const int dialog_labelfieldright = 2130903073;
+			public const int dialog_floatimage = 2130903073;
 			
 			// aapt resource value: 0x7f030022
-			public const int dialog_onofffieldright = 2130903074;
+			public const int dialog_labelfieldbelow = 2130903074;
 			
 			// aapt resource value: 0x7f030023
-			public const int dialog_panel = 2130903075;
+			public const int dialog_labelfieldright = 2130903075;
 			
 			// aapt resource value: 0x7f030024
-			public const int dialog_root = 2130903076;
+			public const int dialog_onofffieldright = 2130903076;
 			
 			// aapt resource value: 0x7f030025
-			public const int dialog_selectlist = 2130903077;
+			public const int dialog_panel = 2130903077;
 			
 			// aapt resource value: 0x7f030026
-			public const int dialog_selectlistfield = 2130903078;
+			public const int dialog_root = 2130903078;
 			
 			// aapt resource value: 0x7f030027
-			public const int dialog_textarea = 2130903079;
+			public const int dialog_selectlist = 2130903079;
 			
 			// aapt resource value: 0x7f030028
-			public const int dialog_textfieldbelow = 2130903080;
+			public const int dialog_selectlistfield = 2130903080;
 			
 			// aapt resource value: 0x7f030029
-			public const int dialog_textfieldright = 2130903081;
+			public const int dialog_textarea = 2130903081;
 			
 			// aapt resource value: 0x7f03002a
-			public const int Main = 2130903082;
+			public const int dialog_textfieldbelow = 2130903082;
 			
 			// aapt resource value: 0x7f03002b
-			public const int support_simple_spinner_dropdown_item = 2130903083;
+			public const int dialog_textfieldright = 2130903083;
+			
+			// aapt resource value: 0x7f03002c
+			public const int Main = 2130903084;
+			
+			// aapt resource value: 0x7f03002d
+			public const int select_dialog_item_material = 2130903085;
+			
+			// aapt resource value: 0x7f03002e
+			public const int select_dialog_multichoice_material = 2130903086;
+			
+			// aapt resource value: 0x7f03002f
+			public const int select_dialog_singlechoice_material = 2130903087;
+			
+			// aapt resource value: 0x7f030030
+			public const int support_simple_spinner_dropdown_item = 2130903088;
 			
 			static Layout()
 			{
@@ -1582,28 +1861,31 @@ namespace ReactiveUI.Tests
 			public const int abc_activitychooserview_choose_application = 2131034121;
 			
 			// aapt resource value: 0x7f05000a
-			public const int abc_searchview_description_clear = 2131034122;
+			public const int abc_search_hint = 2131034122;
 			
 			// aapt resource value: 0x7f05000b
-			public const int abc_searchview_description_query = 2131034123;
+			public const int abc_searchview_description_clear = 2131034123;
 			
 			// aapt resource value: 0x7f05000c
-			public const int abc_searchview_description_search = 2131034124;
+			public const int abc_searchview_description_query = 2131034124;
 			
 			// aapt resource value: 0x7f05000d
-			public const int abc_searchview_description_submit = 2131034125;
+			public const int abc_searchview_description_search = 2131034125;
 			
 			// aapt resource value: 0x7f05000e
-			public const int abc_searchview_description_voice = 2131034126;
+			public const int abc_searchview_description_submit = 2131034126;
 			
 			// aapt resource value: 0x7f05000f
-			public const int abc_shareactionprovider_share_with = 2131034127;
+			public const int abc_searchview_description_voice = 2131034127;
 			
 			// aapt resource value: 0x7f050010
-			public const int abc_shareactionprovider_share_with_application = 2131034128;
+			public const int abc_shareactionprovider_share_with = 2131034128;
 			
 			// aapt resource value: 0x7f050011
-			public const int abc_toolbar_collapse_description = 2131034129;
+			public const int abc_shareactionprovider_share_with_application = 2131034129;
+			
+			// aapt resource value: 0x7f050012
+			public const int abc_toolbar_collapse_description = 2131034130;
 			
 			// aapt resource value: 0x7f050001
 			public const int app_name = 2131034113;
@@ -1611,8 +1893,8 @@ namespace ReactiveUI.Tests
 			// aapt resource value: 0x7f050000
 			public const int hello = 2131034112;
 			
-			// aapt resource value: 0x7f050012
-			public const int library_name = 2131034130;
+			// aapt resource value: 0x7f050013
+			public const int library_name = 2131034131;
 			
 			static String()
 			{
@@ -1628,709 +1910,853 @@ namespace ReactiveUI.Tests
 		{
 			
 			// aapt resource value: 0x7f0b0000
-			public const int Base_TextAppearance_AppCompat = 2131427328;
+			public const int AlertDialog_AppCompat = 2131427328;
 			
 			// aapt resource value: 0x7f0b0001
-			public const int Base_TextAppearance_AppCompat_Body1 = 2131427329;
+			public const int AlertDialog_AppCompat_Light = 2131427329;
 			
 			// aapt resource value: 0x7f0b0002
-			public const int Base_TextAppearance_AppCompat_Body2 = 2131427330;
+			public const int Animation_AppCompat_Dialog = 2131427330;
 			
 			// aapt resource value: 0x7f0b0003
-			public const int Base_TextAppearance_AppCompat_Button = 2131427331;
+			public const int Animation_AppCompat_DropDownUp = 2131427331;
 			
 			// aapt resource value: 0x7f0b0004
-			public const int Base_TextAppearance_AppCompat_Caption = 2131427332;
+			public const int Base_AlertDialog_AppCompat = 2131427332;
 			
 			// aapt resource value: 0x7f0b0005
-			public const int Base_TextAppearance_AppCompat_Display1 = 2131427333;
+			public const int Base_AlertDialog_AppCompat_Light = 2131427333;
 			
 			// aapt resource value: 0x7f0b0006
-			public const int Base_TextAppearance_AppCompat_Display2 = 2131427334;
+			public const int Base_Animation_AppCompat_Dialog = 2131427334;
 			
 			// aapt resource value: 0x7f0b0007
-			public const int Base_TextAppearance_AppCompat_Display3 = 2131427335;
+			public const int Base_Animation_AppCompat_DropDownUp = 2131427335;
 			
 			// aapt resource value: 0x7f0b0008
-			public const int Base_TextAppearance_AppCompat_Display4 = 2131427336;
+			public const int Base_DialogWindowTitle_AppCompat = 2131427336;
 			
 			// aapt resource value: 0x7f0b0009
-			public const int Base_TextAppearance_AppCompat_Headline = 2131427337;
+			public const int Base_DialogWindowTitleBackground_AppCompat = 2131427337;
 			
 			// aapt resource value: 0x7f0b000a
-			public const int Base_TextAppearance_AppCompat_Inverse = 2131427338;
+			public const int Base_TextAppearance_AppCompat = 2131427338;
 			
 			// aapt resource value: 0x7f0b000b
-			public const int Base_TextAppearance_AppCompat_Large = 2131427339;
+			public const int Base_TextAppearance_AppCompat_Body1 = 2131427339;
 			
 			// aapt resource value: 0x7f0b000c
-			public const int Base_TextAppearance_AppCompat_Large_Inverse = 2131427340;
+			public const int Base_TextAppearance_AppCompat_Body2 = 2131427340;
 			
 			// aapt resource value: 0x7f0b000d
-			public const int Base_TextAppearance_AppCompat_Light_Widget_PopupMenu_Large = 2131427341;
+			public const int Base_TextAppearance_AppCompat_Button = 2131427341;
 			
 			// aapt resource value: 0x7f0b000e
-			public const int Base_TextAppearance_AppCompat_Light_Widget_PopupMenu_Small = 2131427342;
+			public const int Base_TextAppearance_AppCompat_Caption = 2131427342;
 			
 			// aapt resource value: 0x7f0b000f
-			public const int Base_TextAppearance_AppCompat_Medium = 2131427343;
+			public const int Base_TextAppearance_AppCompat_Display1 = 2131427343;
 			
 			// aapt resource value: 0x7f0b0010
-			public const int Base_TextAppearance_AppCompat_Medium_Inverse = 2131427344;
+			public const int Base_TextAppearance_AppCompat_Display2 = 2131427344;
 			
 			// aapt resource value: 0x7f0b0011
-			public const int Base_TextAppearance_AppCompat_Menu = 2131427345;
+			public const int Base_TextAppearance_AppCompat_Display3 = 2131427345;
 			
 			// aapt resource value: 0x7f0b0012
-			public const int Base_TextAppearance_AppCompat_SearchResult = 2131427346;
+			public const int Base_TextAppearance_AppCompat_Display4 = 2131427346;
 			
 			// aapt resource value: 0x7f0b0013
-			public const int Base_TextAppearance_AppCompat_SearchResult_Subtitle = 2131427347;
+			public const int Base_TextAppearance_AppCompat_Headline = 2131427347;
 			
 			// aapt resource value: 0x7f0b0014
-			public const int Base_TextAppearance_AppCompat_SearchResult_Title = 2131427348;
+			public const int Base_TextAppearance_AppCompat_Inverse = 2131427348;
 			
 			// aapt resource value: 0x7f0b0015
-			public const int Base_TextAppearance_AppCompat_Small = 2131427349;
+			public const int Base_TextAppearance_AppCompat_Large = 2131427349;
 			
 			// aapt resource value: 0x7f0b0016
-			public const int Base_TextAppearance_AppCompat_Small_Inverse = 2131427350;
+			public const int Base_TextAppearance_AppCompat_Large_Inverse = 2131427350;
 			
 			// aapt resource value: 0x7f0b0017
-			public const int Base_TextAppearance_AppCompat_Subhead = 2131427351;
+			public const int Base_TextAppearance_AppCompat_Light_Widget_PopupMenu_Large = 2131427351;
 			
 			// aapt resource value: 0x7f0b0018
-			public const int Base_TextAppearance_AppCompat_Subhead_Inverse = 2131427352;
+			public const int Base_TextAppearance_AppCompat_Light_Widget_PopupMenu_Small = 2131427352;
 			
 			// aapt resource value: 0x7f0b0019
-			public const int Base_TextAppearance_AppCompat_Title = 2131427353;
+			public const int Base_TextAppearance_AppCompat_Medium = 2131427353;
 			
 			// aapt resource value: 0x7f0b001a
-			public const int Base_TextAppearance_AppCompat_Title_Inverse = 2131427354;
+			public const int Base_TextAppearance_AppCompat_Medium_Inverse = 2131427354;
 			
 			// aapt resource value: 0x7f0b001b
-			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Menu = 2131427355;
+			public const int Base_TextAppearance_AppCompat_Menu = 2131427355;
 			
 			// aapt resource value: 0x7f0b001c
-			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Subtitle = 2131427356;
+			public const int Base_TextAppearance_AppCompat_SearchResult = 2131427356;
 			
 			// aapt resource value: 0x7f0b001d
-			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Subtitle_Inverse = 2131427357;
+			public const int Base_TextAppearance_AppCompat_SearchResult_Subtitle = 2131427357;
 			
 			// aapt resource value: 0x7f0b001e
-			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Title = 2131427358;
+			public const int Base_TextAppearance_AppCompat_SearchResult_Title = 2131427358;
 			
 			// aapt resource value: 0x7f0b001f
-			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Title_Inverse = 2131427359;
+			public const int Base_TextAppearance_AppCompat_Small = 2131427359;
 			
 			// aapt resource value: 0x7f0b0020
-			public const int Base_TextAppearance_AppCompat_Widget_ActionMode_Subtitle = 2131427360;
+			public const int Base_TextAppearance_AppCompat_Small_Inverse = 2131427360;
 			
 			// aapt resource value: 0x7f0b0021
-			public const int Base_TextAppearance_AppCompat_Widget_ActionMode_Title = 2131427361;
+			public const int Base_TextAppearance_AppCompat_Subhead = 2131427361;
 			
 			// aapt resource value: 0x7f0b0022
-			public const int Base_TextAppearance_AppCompat_Widget_DropDownItem = 2131427362;
+			public const int Base_TextAppearance_AppCompat_Subhead_Inverse = 2131427362;
 			
 			// aapt resource value: 0x7f0b0023
-			public const int Base_TextAppearance_AppCompat_Widget_PopupMenu_Large = 2131427363;
+			public const int Base_TextAppearance_AppCompat_Title = 2131427363;
 			
 			// aapt resource value: 0x7f0b0024
-			public const int Base_TextAppearance_AppCompat_Widget_PopupMenu_Small = 2131427364;
+			public const int Base_TextAppearance_AppCompat_Title_Inverse = 2131427364;
 			
 			// aapt resource value: 0x7f0b0025
-			public const int Base_TextAppearance_AppCompat_Widget_Switch = 2131427365;
+			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Menu = 2131427365;
 			
 			// aapt resource value: 0x7f0b0026
-			public const int Base_TextAppearance_Widget_AppCompat_ExpandedMenu_Item = 2131427366;
+			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Subtitle = 2131427366;
 			
 			// aapt resource value: 0x7f0b0027
-			public const int Base_TextAppearance_Widget_AppCompat_Toolbar_Subtitle = 2131427367;
+			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Subtitle_Inverse = 2131427367;
 			
 			// aapt resource value: 0x7f0b0028
-			public const int Base_TextAppearance_Widget_AppCompat_Toolbar_Title = 2131427368;
+			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Title = 2131427368;
 			
 			// aapt resource value: 0x7f0b0029
-			public const int Base_Theme_AppCompat = 2131427369;
+			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Title_Inverse = 2131427369;
 			
 			// aapt resource value: 0x7f0b002a
-			public const int Base_Theme_AppCompat_CompactMenu = 2131427370;
+			public const int Base_TextAppearance_AppCompat_Widget_ActionMode_Subtitle = 2131427370;
 			
 			// aapt resource value: 0x7f0b002b
-			public const int Base_Theme_AppCompat_Dialog = 2131427371;
+			public const int Base_TextAppearance_AppCompat_Widget_ActionMode_Title = 2131427371;
 			
 			// aapt resource value: 0x7f0b002c
-			public const int Base_Theme_AppCompat_Dialog_FixedSize = 2131427372;
+			public const int Base_TextAppearance_AppCompat_Widget_DropDownItem = 2131427372;
 			
 			// aapt resource value: 0x7f0b002d
-			public const int Base_Theme_AppCompat_DialogWhenLarge = 2131427373;
+			public const int Base_TextAppearance_AppCompat_Widget_PopupMenu_Large = 2131427373;
 			
 			// aapt resource value: 0x7f0b002e
-			public const int Base_Theme_AppCompat_Light = 2131427374;
+			public const int Base_TextAppearance_AppCompat_Widget_PopupMenu_Small = 2131427374;
 			
 			// aapt resource value: 0x7f0b002f
-			public const int Base_Theme_AppCompat_Light_DarkActionBar = 2131427375;
+			public const int Base_TextAppearance_AppCompat_Widget_Switch = 2131427375;
 			
 			// aapt resource value: 0x7f0b0030
-			public const int Base_Theme_AppCompat_Light_Dialog = 2131427376;
+			public const int Base_TextAppearance_AppCompat_Widget_TextView_SpinnerItem = 2131427376;
 			
 			// aapt resource value: 0x7f0b0031
-			public const int Base_Theme_AppCompat_Light_Dialog_FixedSize = 2131427377;
+			public const int Base_TextAppearance_Widget_AppCompat_ExpandedMenu_Item = 2131427377;
 			
 			// aapt resource value: 0x7f0b0032
-			public const int Base_Theme_AppCompat_Light_DialogWhenLarge = 2131427378;
+			public const int Base_TextAppearance_Widget_AppCompat_Toolbar_Subtitle = 2131427378;
 			
 			// aapt resource value: 0x7f0b0033
-			public const int Base_ThemeOverlay_AppCompat = 2131427379;
+			public const int Base_TextAppearance_Widget_AppCompat_Toolbar_Title = 2131427379;
 			
 			// aapt resource value: 0x7f0b0034
-			public const int Base_ThemeOverlay_AppCompat_ActionBar = 2131427380;
+			public const int Base_Theme_AppCompat = 2131427380;
 			
 			// aapt resource value: 0x7f0b0035
-			public const int Base_ThemeOverlay_AppCompat_Dark = 2131427381;
+			public const int Base_Theme_AppCompat_CompactMenu = 2131427381;
 			
 			// aapt resource value: 0x7f0b0036
-			public const int Base_ThemeOverlay_AppCompat_Dark_ActionBar = 2131427382;
+			public const int Base_Theme_AppCompat_Dialog = 2131427382;
 			
 			// aapt resource value: 0x7f0b0037
-			public const int Base_ThemeOverlay_AppCompat_Light = 2131427383;
-			
-			// aapt resource value: 0x7f0b00df
-			public const int Base_V11_Theme_AppCompat = 2131427551;
-			
-			// aapt resource value: 0x7f0b00e0
-			public const int Base_V11_Theme_AppCompat_Dialog = 2131427552;
-			
-			// aapt resource value: 0x7f0b00e1
-			public const int Base_V11_Theme_AppCompat_Light = 2131427553;
-			
-			// aapt resource value: 0x7f0b00e2
-			public const int Base_V11_Theme_AppCompat_Light_Dialog = 2131427554;
-			
-			// aapt resource value: 0x7f0b00e3
-			public const int Base_V14_Theme_AppCompat = 2131427555;
-			
-			// aapt resource value: 0x7f0b00e4
-			public const int Base_V14_Theme_AppCompat_Dialog = 2131427556;
-			
-			// aapt resource value: 0x7f0b00e5
-			public const int Base_V14_Theme_AppCompat_Light = 2131427557;
-			
-			// aapt resource value: 0x7f0b00e6
-			public const int Base_V14_Theme_AppCompat_Light_Dialog = 2131427558;
-			
-			// aapt resource value: 0x7f0b00e7
-			public const int Base_V21_Theme_AppCompat = 2131427559;
-			
-			// aapt resource value: 0x7f0b00e8
-			public const int Base_V21_Theme_AppCompat_Dialog = 2131427560;
-			
-			// aapt resource value: 0x7f0b00e9
-			public const int Base_V21_Theme_AppCompat_Light = 2131427561;
-			
-			// aapt resource value: 0x7f0b00ea
-			public const int Base_V21_Theme_AppCompat_Light_Dialog = 2131427562;
+			public const int Base_Theme_AppCompat_Dialog_Alert = 2131427383;
 			
 			// aapt resource value: 0x7f0b0038
-			public const int Base_V7_Theme_AppCompat = 2131427384;
+			public const int Base_Theme_AppCompat_Dialog_FixedSize = 2131427384;
 			
 			// aapt resource value: 0x7f0b0039
-			public const int Base_V7_Theme_AppCompat_Dialog = 2131427385;
+			public const int Base_Theme_AppCompat_Dialog_MinWidth = 2131427385;
 			
 			// aapt resource value: 0x7f0b003a
-			public const int Base_V7_Theme_AppCompat_Light = 2131427386;
+			public const int Base_Theme_AppCompat_DialogWhenLarge = 2131427386;
 			
 			// aapt resource value: 0x7f0b003b
-			public const int Base_Widget_AppCompat_ActionBar = 2131427387;
+			public const int Base_Theme_AppCompat_Light = 2131427387;
 			
 			// aapt resource value: 0x7f0b003c
-			public const int Base_Widget_AppCompat_ActionBar_Solid = 2131427388;
+			public const int Base_Theme_AppCompat_Light_DarkActionBar = 2131427388;
 			
 			// aapt resource value: 0x7f0b003d
-			public const int Base_Widget_AppCompat_ActionBar_TabBar = 2131427389;
+			public const int Base_Theme_AppCompat_Light_Dialog = 2131427389;
 			
 			// aapt resource value: 0x7f0b003e
-			public const int Base_Widget_AppCompat_ActionBar_TabText = 2131427390;
+			public const int Base_Theme_AppCompat_Light_Dialog_Alert = 2131427390;
 			
 			// aapt resource value: 0x7f0b003f
-			public const int Base_Widget_AppCompat_ActionBar_TabView = 2131427391;
+			public const int Base_Theme_AppCompat_Light_Dialog_FixedSize = 2131427391;
 			
 			// aapt resource value: 0x7f0b0040
-			public const int Base_Widget_AppCompat_ActionButton = 2131427392;
+			public const int Base_Theme_AppCompat_Light_Dialog_MinWidth = 2131427392;
 			
 			// aapt resource value: 0x7f0b0041
-			public const int Base_Widget_AppCompat_ActionButton_CloseMode = 2131427393;
+			public const int Base_Theme_AppCompat_Light_DialogWhenLarge = 2131427393;
 			
 			// aapt resource value: 0x7f0b0042
-			public const int Base_Widget_AppCompat_ActionButton_Overflow = 2131427394;
+			public const int Base_ThemeOverlay_AppCompat = 2131427394;
 			
 			// aapt resource value: 0x7f0b0043
-			public const int Base_Widget_AppCompat_ActionMode = 2131427395;
+			public const int Base_ThemeOverlay_AppCompat_ActionBar = 2131427395;
 			
 			// aapt resource value: 0x7f0b0044
-			public const int Base_Widget_AppCompat_ActivityChooserView = 2131427396;
+			public const int Base_ThemeOverlay_AppCompat_Dark = 2131427396;
 			
 			// aapt resource value: 0x7f0b0045
-			public const int Base_Widget_AppCompat_AutoCompleteTextView = 2131427397;
+			public const int Base_ThemeOverlay_AppCompat_Dark_ActionBar = 2131427397;
 			
 			// aapt resource value: 0x7f0b0046
-			public const int Base_Widget_AppCompat_CompoundButton_Switch = 2131427398;
+			public const int Base_ThemeOverlay_AppCompat_Light = 2131427398;
+			
+			// aapt resource value: 0x7f0b010f
+			public const int Base_V11_Theme_AppCompat_Dialog = 2131427599;
+			
+			// aapt resource value: 0x7f0b0110
+			public const int Base_V11_Theme_AppCompat_Light_Dialog = 2131427600;
+			
+			// aapt resource value: 0x7f0b0117
+			public const int Base_V21_Theme_AppCompat = 2131427607;
+			
+			// aapt resource value: 0x7f0b0118
+			public const int Base_V21_Theme_AppCompat_Dialog = 2131427608;
+			
+			// aapt resource value: 0x7f0b0119
+			public const int Base_V21_Theme_AppCompat_Light = 2131427609;
+			
+			// aapt resource value: 0x7f0b011a
+			public const int Base_V21_Theme_AppCompat_Light_Dialog = 2131427610;
 			
 			// aapt resource value: 0x7f0b0047
-			public const int Base_Widget_AppCompat_DrawerArrowToggle = 2131427399;
+			public const int Base_V7_Theme_AppCompat = 2131427399;
 			
 			// aapt resource value: 0x7f0b0048
-			public const int Base_Widget_AppCompat_DropDownItem_Spinner = 2131427400;
+			public const int Base_V7_Theme_AppCompat_Dialog = 2131427400;
 			
 			// aapt resource value: 0x7f0b0049
-			public const int Base_Widget_AppCompat_EditText = 2131427401;
+			public const int Base_V7_Theme_AppCompat_Light = 2131427401;
 			
 			// aapt resource value: 0x7f0b004a
-			public const int Base_Widget_AppCompat_Light_ActionBar = 2131427402;
+			public const int Base_V7_Theme_AppCompat_Light_Dialog = 2131427402;
 			
 			// aapt resource value: 0x7f0b004b
-			public const int Base_Widget_AppCompat_Light_ActionBar_Solid = 2131427403;
+			public const int Base_Widget_AppCompat_ActionBar = 2131427403;
 			
 			// aapt resource value: 0x7f0b004c
-			public const int Base_Widget_AppCompat_Light_ActionBar_TabBar = 2131427404;
+			public const int Base_Widget_AppCompat_ActionBar_Solid = 2131427404;
 			
 			// aapt resource value: 0x7f0b004d
-			public const int Base_Widget_AppCompat_Light_ActionBar_TabText = 2131427405;
+			public const int Base_Widget_AppCompat_ActionBar_TabBar = 2131427405;
 			
 			// aapt resource value: 0x7f0b004e
-			public const int Base_Widget_AppCompat_Light_ActionBar_TabText_Inverse = 2131427406;
+			public const int Base_Widget_AppCompat_ActionBar_TabText = 2131427406;
 			
 			// aapt resource value: 0x7f0b004f
-			public const int Base_Widget_AppCompat_Light_ActionBar_TabView = 2131427407;
+			public const int Base_Widget_AppCompat_ActionBar_TabView = 2131427407;
 			
 			// aapt resource value: 0x7f0b0050
-			public const int Base_Widget_AppCompat_Light_ActivityChooserView = 2131427408;
+			public const int Base_Widget_AppCompat_ActionButton = 2131427408;
 			
 			// aapt resource value: 0x7f0b0051
-			public const int Base_Widget_AppCompat_Light_AutoCompleteTextView = 2131427409;
+			public const int Base_Widget_AppCompat_ActionButton_CloseMode = 2131427409;
 			
 			// aapt resource value: 0x7f0b0052
-			public const int Base_Widget_AppCompat_Light_PopupMenu = 2131427410;
+			public const int Base_Widget_AppCompat_ActionButton_Overflow = 2131427410;
 			
 			// aapt resource value: 0x7f0b0053
-			public const int Base_Widget_AppCompat_Light_PopupMenu_Overflow = 2131427411;
+			public const int Base_Widget_AppCompat_ActionMode = 2131427411;
 			
 			// aapt resource value: 0x7f0b0054
-			public const int Base_Widget_AppCompat_ListPopupWindow = 2131427412;
+			public const int Base_Widget_AppCompat_ActivityChooserView = 2131427412;
 			
 			// aapt resource value: 0x7f0b0055
-			public const int Base_Widget_AppCompat_ListView_DropDown = 2131427413;
+			public const int Base_Widget_AppCompat_AutoCompleteTextView = 2131427413;
 			
 			// aapt resource value: 0x7f0b0056
-			public const int Base_Widget_AppCompat_ListView_Menu = 2131427414;
+			public const int Base_Widget_AppCompat_Button = 2131427414;
 			
 			// aapt resource value: 0x7f0b0057
-			public const int Base_Widget_AppCompat_PopupMenu = 2131427415;
+			public const int Base_Widget_AppCompat_Button_Borderless = 2131427415;
 			
 			// aapt resource value: 0x7f0b0058
-			public const int Base_Widget_AppCompat_PopupMenu_Overflow = 2131427416;
+			public const int Base_Widget_AppCompat_Button_Borderless_Colored = 2131427416;
 			
 			// aapt resource value: 0x7f0b0059
-			public const int Base_Widget_AppCompat_PopupWindow = 2131427417;
+			public const int Base_Widget_AppCompat_Button_ButtonBar_AlertDialog = 2131427417;
 			
 			// aapt resource value: 0x7f0b005a
-			public const int Base_Widget_AppCompat_ProgressBar = 2131427418;
+			public const int Base_Widget_AppCompat_Button_Small = 2131427418;
 			
 			// aapt resource value: 0x7f0b005b
-			public const int Base_Widget_AppCompat_ProgressBar_Horizontal = 2131427419;
+			public const int Base_Widget_AppCompat_ButtonBar = 2131427419;
 			
 			// aapt resource value: 0x7f0b005c
-			public const int Base_Widget_AppCompat_SearchView = 2131427420;
+			public const int Base_Widget_AppCompat_ButtonBar_AlertDialog = 2131427420;
 			
 			// aapt resource value: 0x7f0b005d
-			public const int Base_Widget_AppCompat_Spinner = 2131427421;
+			public const int Base_Widget_AppCompat_CompoundButton_CheckBox = 2131427421;
 			
 			// aapt resource value: 0x7f0b005e
-			public const int Base_Widget_AppCompat_Spinner_DropDown_ActionBar = 2131427422;
+			public const int Base_Widget_AppCompat_CompoundButton_RadioButton = 2131427422;
 			
 			// aapt resource value: 0x7f0b005f
-			public const int Base_Widget_AppCompat_Toolbar = 2131427423;
+			public const int Base_Widget_AppCompat_CompoundButton_Switch = 2131427423;
 			
 			// aapt resource value: 0x7f0b0060
-			public const int Base_Widget_AppCompat_Toolbar_Button_Navigation = 2131427424;
+			public const int Base_Widget_AppCompat_DrawerArrowToggle = 2131427424;
 			
 			// aapt resource value: 0x7f0b0061
-			public const int Platform_AppCompat = 2131427425;
+			public const int Base_Widget_AppCompat_DrawerArrowToggle_Common = 2131427425;
 			
 			// aapt resource value: 0x7f0b0062
-			public const int Platform_AppCompat_Dialog = 2131427426;
+			public const int Base_Widget_AppCompat_DropDownItem_Spinner = 2131427426;
 			
 			// aapt resource value: 0x7f0b0063
-			public const int Platform_AppCompat_Light = 2131427427;
+			public const int Base_Widget_AppCompat_EditText = 2131427427;
 			
 			// aapt resource value: 0x7f0b0064
-			public const int Platform_AppCompat_Light_Dialog = 2131427428;
+			public const int Base_Widget_AppCompat_Light_ActionBar = 2131427428;
 			
 			// aapt resource value: 0x7f0b0065
-			public const int RtlOverlay_Widget_AppCompat_ActionBar_TitleItem = 2131427429;
+			public const int Base_Widget_AppCompat_Light_ActionBar_Solid = 2131427429;
 			
 			// aapt resource value: 0x7f0b0066
-			public const int RtlOverlay_Widget_AppCompat_ActionButton_CloseMode = 2131427430;
+			public const int Base_Widget_AppCompat_Light_ActionBar_TabBar = 2131427430;
 			
 			// aapt resource value: 0x7f0b0067
-			public const int RtlOverlay_Widget_AppCompat_ActionButton_Overflow = 2131427431;
+			public const int Base_Widget_AppCompat_Light_ActionBar_TabText = 2131427431;
 			
 			// aapt resource value: 0x7f0b0068
-			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem = 2131427432;
+			public const int Base_Widget_AppCompat_Light_ActionBar_TabText_Inverse = 2131427432;
 			
 			// aapt resource value: 0x7f0b0069
-			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem_InternalGroup = 2131427433;
+			public const int Base_Widget_AppCompat_Light_ActionBar_TabView = 2131427433;
 			
 			// aapt resource value: 0x7f0b006a
-			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem_Text = 2131427434;
+			public const int Base_Widget_AppCompat_Light_PopupMenu = 2131427434;
 			
 			// aapt resource value: 0x7f0b006b
-			public const int RtlOverlay_Widget_AppCompat_Search_DropDown = 2131427435;
+			public const int Base_Widget_AppCompat_Light_PopupMenu_Overflow = 2131427435;
 			
 			// aapt resource value: 0x7f0b006c
-			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Icon1 = 2131427436;
+			public const int Base_Widget_AppCompat_ListPopupWindow = 2131427436;
 			
 			// aapt resource value: 0x7f0b006d
-			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Icon2 = 2131427437;
+			public const int Base_Widget_AppCompat_ListView = 2131427437;
 			
 			// aapt resource value: 0x7f0b006e
-			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Query = 2131427438;
+			public const int Base_Widget_AppCompat_ListView_DropDown = 2131427438;
 			
 			// aapt resource value: 0x7f0b006f
-			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Text = 2131427439;
+			public const int Base_Widget_AppCompat_ListView_Menu = 2131427439;
 			
 			// aapt resource value: 0x7f0b0070
-			public const int RtlOverlay_Widget_AppCompat_SearchView_MagIcon = 2131427440;
+			public const int Base_Widget_AppCompat_PopupMenu = 2131427440;
 			
 			// aapt resource value: 0x7f0b0071
-			public const int TextAppearance_AppCompat = 2131427441;
+			public const int Base_Widget_AppCompat_PopupMenu_Overflow = 2131427441;
 			
 			// aapt resource value: 0x7f0b0072
-			public const int TextAppearance_AppCompat_Body1 = 2131427442;
+			public const int Base_Widget_AppCompat_PopupWindow = 2131427442;
 			
 			// aapt resource value: 0x7f0b0073
-			public const int TextAppearance_AppCompat_Body2 = 2131427443;
+			public const int Base_Widget_AppCompat_ProgressBar = 2131427443;
 			
 			// aapt resource value: 0x7f0b0074
-			public const int TextAppearance_AppCompat_Button = 2131427444;
+			public const int Base_Widget_AppCompat_ProgressBar_Horizontal = 2131427444;
 			
 			// aapt resource value: 0x7f0b0075
-			public const int TextAppearance_AppCompat_Caption = 2131427445;
+			public const int Base_Widget_AppCompat_RatingBar = 2131427445;
 			
 			// aapt resource value: 0x7f0b0076
-			public const int TextAppearance_AppCompat_Display1 = 2131427446;
+			public const int Base_Widget_AppCompat_SearchView = 2131427446;
 			
 			// aapt resource value: 0x7f0b0077
-			public const int TextAppearance_AppCompat_Display2 = 2131427447;
+			public const int Base_Widget_AppCompat_SearchView_ActionBar = 2131427447;
 			
 			// aapt resource value: 0x7f0b0078
-			public const int TextAppearance_AppCompat_Display3 = 2131427448;
+			public const int Base_Widget_AppCompat_Spinner = 2131427448;
 			
 			// aapt resource value: 0x7f0b0079
-			public const int TextAppearance_AppCompat_Display4 = 2131427449;
+			public const int Base_Widget_AppCompat_Spinner_DropDown_ActionBar = 2131427449;
 			
 			// aapt resource value: 0x7f0b007a
-			public const int TextAppearance_AppCompat_Headline = 2131427450;
+			public const int Base_Widget_AppCompat_Spinner_Underlined = 2131427450;
 			
 			// aapt resource value: 0x7f0b007b
-			public const int TextAppearance_AppCompat_Inverse = 2131427451;
+			public const int Base_Widget_AppCompat_TextView_SpinnerItem = 2131427451;
 			
 			// aapt resource value: 0x7f0b007c
-			public const int TextAppearance_AppCompat_Large = 2131427452;
+			public const int Base_Widget_AppCompat_Toolbar = 2131427452;
 			
 			// aapt resource value: 0x7f0b007d
-			public const int TextAppearance_AppCompat_Large_Inverse = 2131427453;
+			public const int Base_Widget_AppCompat_Toolbar_Button_Navigation = 2131427453;
 			
 			// aapt resource value: 0x7f0b007e
-			public const int TextAppearance_AppCompat_Light_SearchResult_Subtitle = 2131427454;
+			public const int Platform_AppCompat = 2131427454;
 			
 			// aapt resource value: 0x7f0b007f
-			public const int TextAppearance_AppCompat_Light_SearchResult_Title = 2131427455;
+			public const int Platform_AppCompat_Light = 2131427455;
 			
 			// aapt resource value: 0x7f0b0080
-			public const int TextAppearance_AppCompat_Light_Widget_PopupMenu_Large = 2131427456;
+			public const int Platform_ThemeOverlay_AppCompat_Dark = 2131427456;
 			
 			// aapt resource value: 0x7f0b0081
-			public const int TextAppearance_AppCompat_Light_Widget_PopupMenu_Small = 2131427457;
+			public const int Platform_ThemeOverlay_AppCompat_Light = 2131427457;
+			
+			// aapt resource value: 0x7f0b0111
+			public const int Platform_V11_AppCompat = 2131427601;
+			
+			// aapt resource value: 0x7f0b0112
+			public const int Platform_V11_AppCompat_Light = 2131427602;
+			
+			// aapt resource value: 0x7f0b0113
+			public const int Platform_V12_AppCompat = 2131427603;
+			
+			// aapt resource value: 0x7f0b0114
+			public const int Platform_V12_AppCompat_Light = 2131427604;
+			
+			// aapt resource value: 0x7f0b0115
+			public const int Platform_V14_AppCompat = 2131427605;
+			
+			// aapt resource value: 0x7f0b0116
+			public const int Platform_V14_AppCompat_Light = 2131427606;
 			
 			// aapt resource value: 0x7f0b0082
-			public const int TextAppearance_AppCompat_Medium = 2131427458;
+			public const int RtlOverlay_Widget_AppCompat_ActionBar_TitleItem = 2131427458;
 			
 			// aapt resource value: 0x7f0b0083
-			public const int TextAppearance_AppCompat_Medium_Inverse = 2131427459;
+			public const int RtlOverlay_Widget_AppCompat_ActionButton_Overflow = 2131427459;
 			
 			// aapt resource value: 0x7f0b0084
-			public const int TextAppearance_AppCompat_Menu = 2131427460;
+			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem = 2131427460;
 			
 			// aapt resource value: 0x7f0b0085
-			public const int TextAppearance_AppCompat_SearchResult_Subtitle = 2131427461;
+			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem_InternalGroup = 2131427461;
 			
 			// aapt resource value: 0x7f0b0086
-			public const int TextAppearance_AppCompat_SearchResult_Title = 2131427462;
+			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem_Text = 2131427462;
 			
 			// aapt resource value: 0x7f0b0087
-			public const int TextAppearance_AppCompat_Small = 2131427463;
+			public const int RtlOverlay_Widget_AppCompat_Search_DropDown = 2131427463;
 			
 			// aapt resource value: 0x7f0b0088
-			public const int TextAppearance_AppCompat_Small_Inverse = 2131427464;
+			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Icon1 = 2131427464;
 			
 			// aapt resource value: 0x7f0b0089
-			public const int TextAppearance_AppCompat_Subhead = 2131427465;
+			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Icon2 = 2131427465;
 			
 			// aapt resource value: 0x7f0b008a
-			public const int TextAppearance_AppCompat_Subhead_Inverse = 2131427466;
+			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Query = 2131427466;
 			
 			// aapt resource value: 0x7f0b008b
-			public const int TextAppearance_AppCompat_Title = 2131427467;
+			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Text = 2131427467;
 			
 			// aapt resource value: 0x7f0b008c
-			public const int TextAppearance_AppCompat_Title_Inverse = 2131427468;
+			public const int RtlOverlay_Widget_AppCompat_SearchView_MagIcon = 2131427468;
 			
 			// aapt resource value: 0x7f0b008d
-			public const int TextAppearance_AppCompat_Widget_ActionBar_Menu = 2131427469;
+			public const int RtlOverlay_Widget_AppCompat_Toolbar_Button_Navigation = 2131427469;
 			
 			// aapt resource value: 0x7f0b008e
-			public const int TextAppearance_AppCompat_Widget_ActionBar_Subtitle = 2131427470;
+			public const int TextAppearance_AppCompat = 2131427470;
 			
 			// aapt resource value: 0x7f0b008f
-			public const int TextAppearance_AppCompat_Widget_ActionBar_Subtitle_Inverse = 2131427471;
+			public const int TextAppearance_AppCompat_Body1 = 2131427471;
 			
 			// aapt resource value: 0x7f0b0090
-			public const int TextAppearance_AppCompat_Widget_ActionBar_Title = 2131427472;
+			public const int TextAppearance_AppCompat_Body2 = 2131427472;
 			
 			// aapt resource value: 0x7f0b0091
-			public const int TextAppearance_AppCompat_Widget_ActionBar_Title_Inverse = 2131427473;
+			public const int TextAppearance_AppCompat_Button = 2131427473;
 			
 			// aapt resource value: 0x7f0b0092
-			public const int TextAppearance_AppCompat_Widget_ActionMode_Subtitle = 2131427474;
+			public const int TextAppearance_AppCompat_Caption = 2131427474;
 			
 			// aapt resource value: 0x7f0b0093
-			public const int TextAppearance_AppCompat_Widget_ActionMode_Subtitle_Inverse = 2131427475;
+			public const int TextAppearance_AppCompat_Display1 = 2131427475;
 			
 			// aapt resource value: 0x7f0b0094
-			public const int TextAppearance_AppCompat_Widget_ActionMode_Title = 2131427476;
+			public const int TextAppearance_AppCompat_Display2 = 2131427476;
 			
 			// aapt resource value: 0x7f0b0095
-			public const int TextAppearance_AppCompat_Widget_ActionMode_Title_Inverse = 2131427477;
+			public const int TextAppearance_AppCompat_Display3 = 2131427477;
 			
 			// aapt resource value: 0x7f0b0096
-			public const int TextAppearance_AppCompat_Widget_DropDownItem = 2131427478;
+			public const int TextAppearance_AppCompat_Display4 = 2131427478;
 			
 			// aapt resource value: 0x7f0b0097
-			public const int TextAppearance_AppCompat_Widget_PopupMenu_Large = 2131427479;
+			public const int TextAppearance_AppCompat_Headline = 2131427479;
 			
 			// aapt resource value: 0x7f0b0098
-			public const int TextAppearance_AppCompat_Widget_PopupMenu_Small = 2131427480;
+			public const int TextAppearance_AppCompat_Inverse = 2131427480;
 			
 			// aapt resource value: 0x7f0b0099
-			public const int TextAppearance_AppCompat_Widget_Switch = 2131427481;
+			public const int TextAppearance_AppCompat_Large = 2131427481;
 			
 			// aapt resource value: 0x7f0b009a
-			public const int TextAppearance_Widget_AppCompat_ExpandedMenu_Item = 2131427482;
+			public const int TextAppearance_AppCompat_Large_Inverse = 2131427482;
 			
 			// aapt resource value: 0x7f0b009b
-			public const int TextAppearance_Widget_AppCompat_Toolbar_Subtitle = 2131427483;
+			public const int TextAppearance_AppCompat_Light_SearchResult_Subtitle = 2131427483;
 			
 			// aapt resource value: 0x7f0b009c
-			public const int TextAppearance_Widget_AppCompat_Toolbar_Title = 2131427484;
+			public const int TextAppearance_AppCompat_Light_SearchResult_Title = 2131427484;
 			
 			// aapt resource value: 0x7f0b009d
-			public const int Theme_AppCompat = 2131427485;
+			public const int TextAppearance_AppCompat_Light_Widget_PopupMenu_Large = 2131427485;
 			
 			// aapt resource value: 0x7f0b009e
-			public const int Theme_AppCompat_CompactMenu = 2131427486;
+			public const int TextAppearance_AppCompat_Light_Widget_PopupMenu_Small = 2131427486;
 			
 			// aapt resource value: 0x7f0b009f
-			public const int Theme_AppCompat_Dialog = 2131427487;
+			public const int TextAppearance_AppCompat_Medium = 2131427487;
 			
 			// aapt resource value: 0x7f0b00a0
-			public const int Theme_AppCompat_DialogWhenLarge = 2131427488;
+			public const int TextAppearance_AppCompat_Medium_Inverse = 2131427488;
 			
 			// aapt resource value: 0x7f0b00a1
-			public const int Theme_AppCompat_Light = 2131427489;
+			public const int TextAppearance_AppCompat_Menu = 2131427489;
 			
 			// aapt resource value: 0x7f0b00a2
-			public const int Theme_AppCompat_Light_DarkActionBar = 2131427490;
+			public const int TextAppearance_AppCompat_SearchResult_Subtitle = 2131427490;
 			
 			// aapt resource value: 0x7f0b00a3
-			public const int Theme_AppCompat_Light_Dialog = 2131427491;
+			public const int TextAppearance_AppCompat_SearchResult_Title = 2131427491;
 			
 			// aapt resource value: 0x7f0b00a4
-			public const int Theme_AppCompat_Light_DialogWhenLarge = 2131427492;
+			public const int TextAppearance_AppCompat_Small = 2131427492;
 			
 			// aapt resource value: 0x7f0b00a5
-			public const int Theme_AppCompat_Light_NoActionBar = 2131427493;
+			public const int TextAppearance_AppCompat_Small_Inverse = 2131427493;
 			
 			// aapt resource value: 0x7f0b00a6
-			public const int Theme_AppCompat_NoActionBar = 2131427494;
+			public const int TextAppearance_AppCompat_Subhead = 2131427494;
 			
 			// aapt resource value: 0x7f0b00a7
-			public const int ThemeOverlay_AppCompat = 2131427495;
+			public const int TextAppearance_AppCompat_Subhead_Inverse = 2131427495;
 			
 			// aapt resource value: 0x7f0b00a8
-			public const int ThemeOverlay_AppCompat_ActionBar = 2131427496;
+			public const int TextAppearance_AppCompat_Title = 2131427496;
 			
 			// aapt resource value: 0x7f0b00a9
-			public const int ThemeOverlay_AppCompat_Dark = 2131427497;
+			public const int TextAppearance_AppCompat_Title_Inverse = 2131427497;
 			
 			// aapt resource value: 0x7f0b00aa
-			public const int ThemeOverlay_AppCompat_Dark_ActionBar = 2131427498;
+			public const int TextAppearance_AppCompat_Widget_ActionBar_Menu = 2131427498;
 			
 			// aapt resource value: 0x7f0b00ab
-			public const int ThemeOverlay_AppCompat_Light = 2131427499;
+			public const int TextAppearance_AppCompat_Widget_ActionBar_Subtitle = 2131427499;
 			
 			// aapt resource value: 0x7f0b00ac
-			public const int Widget_AppCompat_ActionBar = 2131427500;
+			public const int TextAppearance_AppCompat_Widget_ActionBar_Subtitle_Inverse = 2131427500;
 			
 			// aapt resource value: 0x7f0b00ad
-			public const int Widget_AppCompat_ActionBar_Solid = 2131427501;
+			public const int TextAppearance_AppCompat_Widget_ActionBar_Title = 2131427501;
 			
 			// aapt resource value: 0x7f0b00ae
-			public const int Widget_AppCompat_ActionBar_TabBar = 2131427502;
+			public const int TextAppearance_AppCompat_Widget_ActionBar_Title_Inverse = 2131427502;
 			
 			// aapt resource value: 0x7f0b00af
-			public const int Widget_AppCompat_ActionBar_TabText = 2131427503;
+			public const int TextAppearance_AppCompat_Widget_ActionMode_Subtitle = 2131427503;
 			
 			// aapt resource value: 0x7f0b00b0
-			public const int Widget_AppCompat_ActionBar_TabView = 2131427504;
+			public const int TextAppearance_AppCompat_Widget_ActionMode_Subtitle_Inverse = 2131427504;
 			
 			// aapt resource value: 0x7f0b00b1
-			public const int Widget_AppCompat_ActionButton = 2131427505;
+			public const int TextAppearance_AppCompat_Widget_ActionMode_Title = 2131427505;
 			
 			// aapt resource value: 0x7f0b00b2
-			public const int Widget_AppCompat_ActionButton_CloseMode = 2131427506;
+			public const int TextAppearance_AppCompat_Widget_ActionMode_Title_Inverse = 2131427506;
 			
 			// aapt resource value: 0x7f0b00b3
-			public const int Widget_AppCompat_ActionButton_Overflow = 2131427507;
+			public const int TextAppearance_AppCompat_Widget_DropDownItem = 2131427507;
 			
 			// aapt resource value: 0x7f0b00b4
-			public const int Widget_AppCompat_ActionMode = 2131427508;
+			public const int TextAppearance_AppCompat_Widget_PopupMenu_Large = 2131427508;
 			
 			// aapt resource value: 0x7f0b00b5
-			public const int Widget_AppCompat_ActivityChooserView = 2131427509;
+			public const int TextAppearance_AppCompat_Widget_PopupMenu_Small = 2131427509;
 			
 			// aapt resource value: 0x7f0b00b6
-			public const int Widget_AppCompat_AutoCompleteTextView = 2131427510;
+			public const int TextAppearance_AppCompat_Widget_Switch = 2131427510;
 			
 			// aapt resource value: 0x7f0b00b7
-			public const int Widget_AppCompat_CompoundButton_Switch = 2131427511;
+			public const int TextAppearance_AppCompat_Widget_TextView_SpinnerItem = 2131427511;
 			
 			// aapt resource value: 0x7f0b00b8
-			public const int Widget_AppCompat_DrawerArrowToggle = 2131427512;
+			public const int TextAppearance_Widget_AppCompat_ExpandedMenu_Item = 2131427512;
 			
 			// aapt resource value: 0x7f0b00b9
-			public const int Widget_AppCompat_DropDownItem_Spinner = 2131427513;
+			public const int TextAppearance_Widget_AppCompat_Toolbar_Subtitle = 2131427513;
 			
 			// aapt resource value: 0x7f0b00ba
-			public const int Widget_AppCompat_EditText = 2131427514;
+			public const int TextAppearance_Widget_AppCompat_Toolbar_Title = 2131427514;
 			
 			// aapt resource value: 0x7f0b00bb
-			public const int Widget_AppCompat_Light_ActionBar = 2131427515;
+			public const int Theme_AppCompat = 2131427515;
 			
 			// aapt resource value: 0x7f0b00bc
-			public const int Widget_AppCompat_Light_ActionBar_Solid = 2131427516;
+			public const int Theme_AppCompat_CompactMenu = 2131427516;
 			
 			// aapt resource value: 0x7f0b00bd
-			public const int Widget_AppCompat_Light_ActionBar_Solid_Inverse = 2131427517;
+			public const int Theme_AppCompat_Dialog = 2131427517;
 			
 			// aapt resource value: 0x7f0b00be
-			public const int Widget_AppCompat_Light_ActionBar_TabBar = 2131427518;
+			public const int Theme_AppCompat_Dialog_Alert = 2131427518;
 			
 			// aapt resource value: 0x7f0b00bf
-			public const int Widget_AppCompat_Light_ActionBar_TabBar_Inverse = 2131427519;
+			public const int Theme_AppCompat_Dialog_MinWidth = 2131427519;
 			
 			// aapt resource value: 0x7f0b00c0
-			public const int Widget_AppCompat_Light_ActionBar_TabText = 2131427520;
+			public const int Theme_AppCompat_DialogWhenLarge = 2131427520;
 			
 			// aapt resource value: 0x7f0b00c1
-			public const int Widget_AppCompat_Light_ActionBar_TabText_Inverse = 2131427521;
+			public const int Theme_AppCompat_Light = 2131427521;
 			
 			// aapt resource value: 0x7f0b00c2
-			public const int Widget_AppCompat_Light_ActionBar_TabView = 2131427522;
+			public const int Theme_AppCompat_Light_DarkActionBar = 2131427522;
 			
 			// aapt resource value: 0x7f0b00c3
-			public const int Widget_AppCompat_Light_ActionBar_TabView_Inverse = 2131427523;
+			public const int Theme_AppCompat_Light_Dialog = 2131427523;
 			
 			// aapt resource value: 0x7f0b00c4
-			public const int Widget_AppCompat_Light_ActionButton = 2131427524;
+			public const int Theme_AppCompat_Light_Dialog_Alert = 2131427524;
 			
 			// aapt resource value: 0x7f0b00c5
-			public const int Widget_AppCompat_Light_ActionButton_CloseMode = 2131427525;
+			public const int Theme_AppCompat_Light_Dialog_MinWidth = 2131427525;
 			
 			// aapt resource value: 0x7f0b00c6
-			public const int Widget_AppCompat_Light_ActionButton_Overflow = 2131427526;
+			public const int Theme_AppCompat_Light_DialogWhenLarge = 2131427526;
 			
 			// aapt resource value: 0x7f0b00c7
-			public const int Widget_AppCompat_Light_ActionMode_Inverse = 2131427527;
+			public const int Theme_AppCompat_Light_NoActionBar = 2131427527;
 			
 			// aapt resource value: 0x7f0b00c8
-			public const int Widget_AppCompat_Light_ActivityChooserView = 2131427528;
+			public const int Theme_AppCompat_NoActionBar = 2131427528;
 			
 			// aapt resource value: 0x7f0b00c9
-			public const int Widget_AppCompat_Light_AutoCompleteTextView = 2131427529;
+			public const int ThemeOverlay_AppCompat = 2131427529;
 			
 			// aapt resource value: 0x7f0b00ca
-			public const int Widget_AppCompat_Light_DropDownItem_Spinner = 2131427530;
+			public const int ThemeOverlay_AppCompat_ActionBar = 2131427530;
 			
 			// aapt resource value: 0x7f0b00cb
-			public const int Widget_AppCompat_Light_ListPopupWindow = 2131427531;
+			public const int ThemeOverlay_AppCompat_Dark = 2131427531;
 			
 			// aapt resource value: 0x7f0b00cc
-			public const int Widget_AppCompat_Light_ListView_DropDown = 2131427532;
+			public const int ThemeOverlay_AppCompat_Dark_ActionBar = 2131427532;
 			
 			// aapt resource value: 0x7f0b00cd
-			public const int Widget_AppCompat_Light_PopupMenu = 2131427533;
+			public const int ThemeOverlay_AppCompat_Light = 2131427533;
 			
 			// aapt resource value: 0x7f0b00ce
-			public const int Widget_AppCompat_Light_PopupMenu_Overflow = 2131427534;
+			public const int Widget_AppCompat_ActionBar = 2131427534;
 			
 			// aapt resource value: 0x7f0b00cf
-			public const int Widget_AppCompat_Light_SearchView = 2131427535;
+			public const int Widget_AppCompat_ActionBar_Solid = 2131427535;
 			
 			// aapt resource value: 0x7f0b00d0
-			public const int Widget_AppCompat_Light_Spinner_DropDown_ActionBar = 2131427536;
+			public const int Widget_AppCompat_ActionBar_TabBar = 2131427536;
 			
 			// aapt resource value: 0x7f0b00d1
-			public const int Widget_AppCompat_ListPopupWindow = 2131427537;
+			public const int Widget_AppCompat_ActionBar_TabText = 2131427537;
 			
 			// aapt resource value: 0x7f0b00d2
-			public const int Widget_AppCompat_ListView_DropDown = 2131427538;
+			public const int Widget_AppCompat_ActionBar_TabView = 2131427538;
 			
 			// aapt resource value: 0x7f0b00d3
-			public const int Widget_AppCompat_ListView_Menu = 2131427539;
+			public const int Widget_AppCompat_ActionButton = 2131427539;
 			
 			// aapt resource value: 0x7f0b00d4
-			public const int Widget_AppCompat_PopupMenu = 2131427540;
+			public const int Widget_AppCompat_ActionButton_CloseMode = 2131427540;
 			
 			// aapt resource value: 0x7f0b00d5
-			public const int Widget_AppCompat_PopupMenu_Overflow = 2131427541;
+			public const int Widget_AppCompat_ActionButton_Overflow = 2131427541;
 			
 			// aapt resource value: 0x7f0b00d6
-			public const int Widget_AppCompat_PopupWindow = 2131427542;
+			public const int Widget_AppCompat_ActionMode = 2131427542;
 			
 			// aapt resource value: 0x7f0b00d7
-			public const int Widget_AppCompat_ProgressBar = 2131427543;
+			public const int Widget_AppCompat_ActivityChooserView = 2131427543;
 			
 			// aapt resource value: 0x7f0b00d8
-			public const int Widget_AppCompat_ProgressBar_Horizontal = 2131427544;
+			public const int Widget_AppCompat_AutoCompleteTextView = 2131427544;
 			
 			// aapt resource value: 0x7f0b00d9
-			public const int Widget_AppCompat_SearchView = 2131427545;
+			public const int Widget_AppCompat_Button = 2131427545;
 			
 			// aapt resource value: 0x7f0b00da
-			public const int Widget_AppCompat_Spinner = 2131427546;
+			public const int Widget_AppCompat_Button_Borderless = 2131427546;
 			
 			// aapt resource value: 0x7f0b00db
-			public const int Widget_AppCompat_Spinner_DropDown = 2131427547;
+			public const int Widget_AppCompat_Button_Borderless_Colored = 2131427547;
 			
 			// aapt resource value: 0x7f0b00dc
-			public const int Widget_AppCompat_Spinner_DropDown_ActionBar = 2131427548;
+			public const int Widget_AppCompat_Button_ButtonBar_AlertDialog = 2131427548;
 			
 			// aapt resource value: 0x7f0b00dd
-			public const int Widget_AppCompat_Toolbar = 2131427549;
+			public const int Widget_AppCompat_Button_Small = 2131427549;
 			
 			// aapt resource value: 0x7f0b00de
-			public const int Widget_AppCompat_Toolbar_Button_Navigation = 2131427550;
+			public const int Widget_AppCompat_ButtonBar = 2131427550;
+			
+			// aapt resource value: 0x7f0b00df
+			public const int Widget_AppCompat_ButtonBar_AlertDialog = 2131427551;
+			
+			// aapt resource value: 0x7f0b00e0
+			public const int Widget_AppCompat_CompoundButton_CheckBox = 2131427552;
+			
+			// aapt resource value: 0x7f0b00e1
+			public const int Widget_AppCompat_CompoundButton_RadioButton = 2131427553;
+			
+			// aapt resource value: 0x7f0b00e2
+			public const int Widget_AppCompat_CompoundButton_Switch = 2131427554;
+			
+			// aapt resource value: 0x7f0b00e3
+			public const int Widget_AppCompat_DrawerArrowToggle = 2131427555;
+			
+			// aapt resource value: 0x7f0b00e4
+			public const int Widget_AppCompat_DropDownItem_Spinner = 2131427556;
+			
+			// aapt resource value: 0x7f0b00e5
+			public const int Widget_AppCompat_EditText = 2131427557;
+			
+			// aapt resource value: 0x7f0b00e6
+			public const int Widget_AppCompat_Light_ActionBar = 2131427558;
+			
+			// aapt resource value: 0x7f0b00e7
+			public const int Widget_AppCompat_Light_ActionBar_Solid = 2131427559;
+			
+			// aapt resource value: 0x7f0b00e8
+			public const int Widget_AppCompat_Light_ActionBar_Solid_Inverse = 2131427560;
+			
+			// aapt resource value: 0x7f0b00e9
+			public const int Widget_AppCompat_Light_ActionBar_TabBar = 2131427561;
+			
+			// aapt resource value: 0x7f0b00ea
+			public const int Widget_AppCompat_Light_ActionBar_TabBar_Inverse = 2131427562;
+			
+			// aapt resource value: 0x7f0b00eb
+			public const int Widget_AppCompat_Light_ActionBar_TabText = 2131427563;
+			
+			// aapt resource value: 0x7f0b00ec
+			public const int Widget_AppCompat_Light_ActionBar_TabText_Inverse = 2131427564;
+			
+			// aapt resource value: 0x7f0b00ed
+			public const int Widget_AppCompat_Light_ActionBar_TabView = 2131427565;
+			
+			// aapt resource value: 0x7f0b00ee
+			public const int Widget_AppCompat_Light_ActionBar_TabView_Inverse = 2131427566;
+			
+			// aapt resource value: 0x7f0b00ef
+			public const int Widget_AppCompat_Light_ActionButton = 2131427567;
+			
+			// aapt resource value: 0x7f0b00f0
+			public const int Widget_AppCompat_Light_ActionButton_CloseMode = 2131427568;
+			
+			// aapt resource value: 0x7f0b00f1
+			public const int Widget_AppCompat_Light_ActionButton_Overflow = 2131427569;
+			
+			// aapt resource value: 0x7f0b00f2
+			public const int Widget_AppCompat_Light_ActionMode_Inverse = 2131427570;
+			
+			// aapt resource value: 0x7f0b00f3
+			public const int Widget_AppCompat_Light_ActivityChooserView = 2131427571;
+			
+			// aapt resource value: 0x7f0b00f4
+			public const int Widget_AppCompat_Light_AutoCompleteTextView = 2131427572;
+			
+			// aapt resource value: 0x7f0b00f5
+			public const int Widget_AppCompat_Light_DropDownItem_Spinner = 2131427573;
+			
+			// aapt resource value: 0x7f0b00f6
+			public const int Widget_AppCompat_Light_ListPopupWindow = 2131427574;
+			
+			// aapt resource value: 0x7f0b00f7
+			public const int Widget_AppCompat_Light_ListView_DropDown = 2131427575;
+			
+			// aapt resource value: 0x7f0b00f8
+			public const int Widget_AppCompat_Light_PopupMenu = 2131427576;
+			
+			// aapt resource value: 0x7f0b00f9
+			public const int Widget_AppCompat_Light_PopupMenu_Overflow = 2131427577;
+			
+			// aapt resource value: 0x7f0b00fa
+			public const int Widget_AppCompat_Light_SearchView = 2131427578;
+			
+			// aapt resource value: 0x7f0b00fb
+			public const int Widget_AppCompat_Light_Spinner_DropDown_ActionBar = 2131427579;
+			
+			// aapt resource value: 0x7f0b00fc
+			public const int Widget_AppCompat_ListPopupWindow = 2131427580;
+			
+			// aapt resource value: 0x7f0b00fd
+			public const int Widget_AppCompat_ListView = 2131427581;
+			
+			// aapt resource value: 0x7f0b00fe
+			public const int Widget_AppCompat_ListView_DropDown = 2131427582;
+			
+			// aapt resource value: 0x7f0b00ff
+			public const int Widget_AppCompat_ListView_Menu = 2131427583;
+			
+			// aapt resource value: 0x7f0b0100
+			public const int Widget_AppCompat_PopupMenu = 2131427584;
+			
+			// aapt resource value: 0x7f0b0101
+			public const int Widget_AppCompat_PopupMenu_Overflow = 2131427585;
+			
+			// aapt resource value: 0x7f0b0102
+			public const int Widget_AppCompat_PopupWindow = 2131427586;
+			
+			// aapt resource value: 0x7f0b0103
+			public const int Widget_AppCompat_ProgressBar = 2131427587;
+			
+			// aapt resource value: 0x7f0b0104
+			public const int Widget_AppCompat_ProgressBar_Horizontal = 2131427588;
+			
+			// aapt resource value: 0x7f0b0105
+			public const int Widget_AppCompat_RatingBar = 2131427589;
+			
+			// aapt resource value: 0x7f0b0106
+			public const int Widget_AppCompat_SearchView = 2131427590;
+			
+			// aapt resource value: 0x7f0b0107
+			public const int Widget_AppCompat_SearchView_ActionBar = 2131427591;
+			
+			// aapt resource value: 0x7f0b0108
+			public const int Widget_AppCompat_Spinner = 2131427592;
+			
+			// aapt resource value: 0x7f0b0109
+			public const int Widget_AppCompat_Spinner_DropDown = 2131427593;
+			
+			// aapt resource value: 0x7f0b010a
+			public const int Widget_AppCompat_Spinner_DropDown_ActionBar = 2131427594;
+			
+			// aapt resource value: 0x7f0b010b
+			public const int Widget_AppCompat_Spinner_Underlined = 2131427595;
+			
+			// aapt resource value: 0x7f0b010c
+			public const int Widget_AppCompat_TextView_SpinnerItem = 2131427596;
+			
+			// aapt resource value: 0x7f0b010d
+			public const int Widget_AppCompat_Toolbar = 2131427597;
+			
+			// aapt resource value: 0x7f0b010e
+			public const int Widget_AppCompat_Toolbar_Button_Navigation = 2131427598;
 			
 			static Style()
 			{
@@ -2373,7 +2799,7 @@ namespace ReactiveUI.Tests
 					2130771993,
 					2130771994,
 					2130771995,
-					2130772081};
+					2130772092};
 			
 			// aapt resource value: 10
 			public const int ActionBar_background = 10;
@@ -2510,23 +2936,54 @@ namespace ReactiveUI.Tests
 			// aapt resource value: 0
 			public const int ActivityChooserView_initialActivityCount = 0;
 			
-			public static int[] CompatTextView = new int[]
+			public static int[] AlertDialog = new int[]
 			{
-					2130771999};
-			
-			// aapt resource value: 0
-			public const int CompatTextView_textAllCaps = 0;
-			
-			public static int[] DrawerArrowToggle = new int[]
-			{
+					16842994,
+					2130771999,
 					2130772000,
 					2130772001,
 					2130772002,
-					2130772003,
-					2130772004,
+					2130772003};
+			
+			// aapt resource value: 0
+			public const int AlertDialog_android_layout = 0;
+			
+			// aapt resource value: 1
+			public const int AlertDialog_buttonPanelSideLayout = 1;
+			
+			// aapt resource value: 5
+			public const int AlertDialog_listItemLayout = 5;
+			
+			// aapt resource value: 2
+			public const int AlertDialog_listLayout = 2;
+			
+			// aapt resource value: 3
+			public const int AlertDialog_multiChoiceItemLayout = 3;
+			
+			// aapt resource value: 4
+			public const int AlertDialog_singleChoiceItemLayout = 4;
+			
+			public static int[] AppCompatTextView = new int[]
+			{
+					16842804,
+					2130772004};
+			
+			// aapt resource value: 0
+			public const int AppCompatTextView_android_textAppearance = 0;
+			
+			// aapt resource value: 1
+			public const int AppCompatTextView_textAllCaps = 1;
+			
+			public static int[] DrawerArrowToggle = new int[]
+			{
 					2130772005,
 					2130772006,
-					2130772007};
+					2130772007,
+					2130772008,
+					2130772009,
+					2130772010,
+					2130772011,
+					2130772012};
 			
 			// aapt resource value: 6
 			public const int DrawerArrowToggle_barSize = 6;
@@ -2560,9 +3017,9 @@ namespace ReactiveUI.Tests
 					16843047,
 					16843048,
 					2130771979,
-					2130772008,
-					2130772009,
-					2130772010};
+					2130772013,
+					2130772014,
+					2130772015};
 			
 			// aapt resource value: 2
 			public const int LinearLayoutCompat_android_baselineAligned = 2;
@@ -2663,10 +3120,10 @@ namespace ReactiveUI.Tests
 					16843236,
 					16843237,
 					16843375,
-					2130772011,
-					2130772012,
-					2130772013,
-					2130772014};
+					2130772016,
+					2130772017,
+					2130772018,
+					2130772019};
 			
 			// aapt resource value: 14
 			public const int MenuItem_actionLayout = 14;
@@ -2728,7 +3185,7 @@ namespace ReactiveUI.Tests
 					16843055,
 					16843056,
 					16843057,
-					2130772015};
+					2130772020};
 			
 			// aapt resource value: 4
 			public const int MenuView_android_headerBackground = 4;
@@ -2757,7 +3214,7 @@ namespace ReactiveUI.Tests
 			public static int[] PopupWindow = new int[]
 			{
 					16843126,
-					2130772016};
+					2130772021};
 			
 			// aapt resource value: 0
 			public const int PopupWindow_android_popupBackground = 0;
@@ -2767,7 +3224,7 @@ namespace ReactiveUI.Tests
 			
 			public static int[] PopupWindowBackgroundState = new int[]
 			{
-					2130772017};
+					2130772022};
 			
 			// aapt resource value: 0
 			public const int PopupWindowBackgroundState_state_above_anchor = 0;
@@ -2778,17 +3235,18 @@ namespace ReactiveUI.Tests
 					16843039,
 					16843296,
 					16843364,
-					2130772018,
-					2130772019,
-					2130772020,
-					2130772021,
-					2130772022,
 					2130772023,
 					2130772024,
 					2130772025,
 					2130772026,
 					2130772027,
-					2130772028};
+					2130772028,
+					2130772029,
+					2130772030,
+					2130772031,
+					2130772032,
+					2130772033,
+					2130772034};
 			
 			// aapt resource value: 0
 			public const int SearchView_android_focusable = 0;
@@ -2805,8 +3263,8 @@ namespace ReactiveUI.Tests
 			// aapt resource value: 7
 			public const int SearchView_closeIcon = 7;
 			
-			// aapt resource value: 11
-			public const int SearchView_commitIcon = 11;
+			// aapt resource value: 12
+			public const int SearchView_commitIcon = 12;
 			
 			// aapt resource value: 8
 			public const int SearchView_goIcon = 8;
@@ -2817,23 +3275,26 @@ namespace ReactiveUI.Tests
 			// aapt resource value: 4
 			public const int SearchView_layout = 4;
 			
-			// aapt resource value: 13
-			public const int SearchView_queryBackground = 13;
+			// aapt resource value: 14
+			public const int SearchView_queryBackground = 14;
 			
 			// aapt resource value: 6
 			public const int SearchView_queryHint = 6;
 			
+			// aapt resource value: 10
+			public const int SearchView_searchHintIcon = 10;
+			
 			// aapt resource value: 9
 			public const int SearchView_searchIcon = 9;
 			
-			// aapt resource value: 14
-			public const int SearchView_submitBackground = 14;
+			// aapt resource value: 15
+			public const int SearchView_submitBackground = 15;
 			
-			// aapt resource value: 12
-			public const int SearchView_suggestionRowLayout = 12;
+			// aapt resource value: 13
+			public const int SearchView_suggestionRowLayout = 13;
 			
-			// aapt resource value: 10
-			public const int SearchView_voiceIcon = 10;
+			// aapt resource value: 11
+			public const int SearchView_voiceIcon = 11;
 			
 			public static int[] Spinner = new int[]
 			{
@@ -2844,10 +3305,10 @@ namespace ReactiveUI.Tests
 					16843362,
 					16843436,
 					16843437,
-					2130772029,
-					2130772030,
-					2130772031,
-					2130772032};
+					2130772035,
+					2130772036,
+					2130772037,
+					2130772038};
 			
 			// aapt resource value: 1
 			public const int Spinner_android_background = 1;
@@ -2887,13 +3348,13 @@ namespace ReactiveUI.Tests
 					16843044,
 					16843045,
 					16843074,
-					2130772033,
-					2130772034,
-					2130772035,
-					2130772036,
-					2130772037,
-					2130772038,
-					2130772039};
+					2130772039,
+					2130772040,
+					2130772041,
+					2130772042,
+					2130772043,
+					2130772044,
+					2130772045};
 			
 			// aapt resource value: 1
 			public const int SwitchCompat_android_textOff = 1;
@@ -2925,15 +3386,33 @@ namespace ReactiveUI.Tests
 			// aapt resource value: 3
 			public const int SwitchCompat_track = 3;
 			
+			public static int[] TextAppearance = new int[]
+			{
+					16842901,
+					16842902,
+					16842903,
+					16842904,
+					2130772004};
+			
+			// aapt resource value: 3
+			public const int TextAppearance_android_textColor = 3;
+			
+			// aapt resource value: 0
+			public const int TextAppearance_android_textSize = 0;
+			
+			// aapt resource value: 2
+			public const int TextAppearance_android_textStyle = 2;
+			
+			// aapt resource value: 1
+			public const int TextAppearance_android_typeface = 1;
+			
+			// aapt resource value: 4
+			public const int TextAppearance_textAllCaps = 4;
+			
 			public static int[] Theme = new int[]
 			{
 					16842839,
-					2130772040,
-					2130772041,
-					2130772042,
-					2130772043,
-					2130772044,
-					2130772045,
+					16842926,
 					2130772046,
 					2130772047,
 					2130772048,
@@ -3009,268 +3488,7 @@ namespace ReactiveUI.Tests
 					2130772118,
 					2130772119,
 					2130772120,
-					2130772121};
-			
-			// aapt resource value: 19
-			public const int Theme_actionBarDivider = 19;
-			
-			// aapt resource value: 20
-			public const int Theme_actionBarItemBackground = 20;
-			
-			// aapt resource value: 13
-			public const int Theme_actionBarPopupTheme = 13;
-			
-			// aapt resource value: 18
-			public const int Theme_actionBarSize = 18;
-			
-			// aapt resource value: 15
-			public const int Theme_actionBarSplitStyle = 15;
-			
-			// aapt resource value: 14
-			public const int Theme_actionBarStyle = 14;
-			
-			// aapt resource value: 9
-			public const int Theme_actionBarTabBarStyle = 9;
-			
-			// aapt resource value: 8
-			public const int Theme_actionBarTabStyle = 8;
-			
-			// aapt resource value: 10
-			public const int Theme_actionBarTabTextStyle = 10;
-			
-			// aapt resource value: 16
-			public const int Theme_actionBarTheme = 16;
-			
-			// aapt resource value: 17
-			public const int Theme_actionBarWidgetTheme = 17;
-			
-			// aapt resource value: 43
-			public const int Theme_actionButtonStyle = 43;
-			
-			// aapt resource value: 38
-			public const int Theme_actionDropDownStyle = 38;
-			
-			// aapt resource value: 21
-			public const int Theme_actionMenuTextAppearance = 21;
-			
-			// aapt resource value: 22
-			public const int Theme_actionMenuTextColor = 22;
-			
-			// aapt resource value: 25
-			public const int Theme_actionModeBackground = 25;
-			
-			// aapt resource value: 24
-			public const int Theme_actionModeCloseButtonStyle = 24;
-			
-			// aapt resource value: 27
-			public const int Theme_actionModeCloseDrawable = 27;
-			
-			// aapt resource value: 29
-			public const int Theme_actionModeCopyDrawable = 29;
-			
-			// aapt resource value: 28
-			public const int Theme_actionModeCutDrawable = 28;
-			
-			// aapt resource value: 33
-			public const int Theme_actionModeFindDrawable = 33;
-			
-			// aapt resource value: 30
-			public const int Theme_actionModePasteDrawable = 30;
-			
-			// aapt resource value: 35
-			public const int Theme_actionModePopupWindowStyle = 35;
-			
-			// aapt resource value: 31
-			public const int Theme_actionModeSelectAllDrawable = 31;
-			
-			// aapt resource value: 32
-			public const int Theme_actionModeShareDrawable = 32;
-			
-			// aapt resource value: 26
-			public const int Theme_actionModeSplitBackground = 26;
-			
-			// aapt resource value: 23
-			public const int Theme_actionModeStyle = 23;
-			
-			// aapt resource value: 34
-			public const int Theme_actionModeWebSearchDrawable = 34;
-			
-			// aapt resource value: 11
-			public const int Theme_actionOverflowButtonStyle = 11;
-			
-			// aapt resource value: 12
-			public const int Theme_actionOverflowMenuStyle = 12;
-			
-			// aapt resource value: 50
-			public const int Theme_activityChooserViewStyle = 50;
-			
-			// aapt resource value: 0
-			public const int Theme_android_windowIsFloating = 0;
-			
-			// aapt resource value: 45
-			public const int Theme_buttonBarButtonStyle = 45;
-			
-			// aapt resource value: 44
-			public const int Theme_buttonBarStyle = 44;
-			
-			// aapt resource value: 77
-			public const int Theme_colorAccent = 77;
-			
-			// aapt resource value: 81
-			public const int Theme_colorButtonNormal = 81;
-			
-			// aapt resource value: 79
-			public const int Theme_colorControlActivated = 79;
-			
-			// aapt resource value: 80
-			public const int Theme_colorControlHighlight = 80;
-			
-			// aapt resource value: 78
-			public const int Theme_colorControlNormal = 78;
-			
-			// aapt resource value: 75
-			public const int Theme_colorPrimary = 75;
-			
-			// aapt resource value: 76
-			public const int Theme_colorPrimaryDark = 76;
-			
-			// aapt resource value: 82
-			public const int Theme_colorSwitchThumbNormal = 82;
-			
-			// aapt resource value: 49
-			public const int Theme_dividerHorizontal = 49;
-			
-			// aapt resource value: 48
-			public const int Theme_dividerVertical = 48;
-			
-			// aapt resource value: 67
-			public const int Theme_dropDownListViewStyle = 67;
-			
-			// aapt resource value: 39
-			public const int Theme_dropdownListPreferredItemHeight = 39;
-			
-			// aapt resource value: 56
-			public const int Theme_editTextBackground = 56;
-			
-			// aapt resource value: 55
-			public const int Theme_editTextColor = 55;
-			
-			// aapt resource value: 42
-			public const int Theme_homeAsUpIndicator = 42;
-			
-			// aapt resource value: 74
-			public const int Theme_listChoiceBackgroundIndicator = 74;
-			
-			// aapt resource value: 68
-			public const int Theme_listPopupWindowStyle = 68;
-			
-			// aapt resource value: 62
-			public const int Theme_listPreferredItemHeight = 62;
-			
-			// aapt resource value: 64
-			public const int Theme_listPreferredItemHeightLarge = 64;
-			
-			// aapt resource value: 63
-			public const int Theme_listPreferredItemHeightSmall = 63;
-			
-			// aapt resource value: 65
-			public const int Theme_listPreferredItemPaddingLeft = 65;
-			
-			// aapt resource value: 66
-			public const int Theme_listPreferredItemPaddingRight = 66;
-			
-			// aapt resource value: 71
-			public const int Theme_panelBackground = 71;
-			
-			// aapt resource value: 73
-			public const int Theme_panelMenuListTheme = 73;
-			
-			// aapt resource value: 72
-			public const int Theme_panelMenuListWidth = 72;
-			
-			// aapt resource value: 53
-			public const int Theme_popupMenuStyle = 53;
-			
-			// aapt resource value: 54
-			public const int Theme_popupWindowStyle = 54;
-			
-			// aapt resource value: 61
-			public const int Theme_searchViewStyle = 61;
-			
-			// aapt resource value: 46
-			public const int Theme_selectableItemBackground = 46;
-			
-			// aapt resource value: 47
-			public const int Theme_selectableItemBackgroundBorderless = 47;
-			
-			// aapt resource value: 41
-			public const int Theme_spinnerDropDownItemStyle = 41;
-			
-			// aapt resource value: 40
-			public const int Theme_spinnerStyle = 40;
-			
-			// aapt resource value: 57
-			public const int Theme_switchStyle = 57;
-			
-			// aapt resource value: 36
-			public const int Theme_textAppearanceLargePopupMenu = 36;
-			
-			// aapt resource value: 69
-			public const int Theme_textAppearanceListItem = 69;
-			
-			// aapt resource value: 70
-			public const int Theme_textAppearanceListItemSmall = 70;
-			
-			// aapt resource value: 59
-			public const int Theme_textAppearanceSearchResultSubtitle = 59;
-			
-			// aapt resource value: 58
-			public const int Theme_textAppearanceSearchResultTitle = 58;
-			
-			// aapt resource value: 37
-			public const int Theme_textAppearanceSmallPopupMenu = 37;
-			
-			// aapt resource value: 60
-			public const int Theme_textColorSearchUrl = 60;
-			
-			// aapt resource value: 52
-			public const int Theme_toolbarNavigationButtonStyle = 52;
-			
-			// aapt resource value: 51
-			public const int Theme_toolbarStyle = 51;
-			
-			// aapt resource value: 1
-			public const int Theme_windowActionBar = 1;
-			
-			// aapt resource value: 2
-			public const int Theme_windowActionBarOverlay = 2;
-			
-			// aapt resource value: 3
-			public const int Theme_windowActionModeOverlay = 3;
-			
-			// aapt resource value: 7
-			public const int Theme_windowFixedHeightMajor = 7;
-			
-			// aapt resource value: 5
-			public const int Theme_windowFixedHeightMinor = 5;
-			
-			// aapt resource value: 4
-			public const int Theme_windowFixedWidthMajor = 4;
-			
-			// aapt resource value: 6
-			public const int Theme_windowFixedWidthMinor = 6;
-			
-			public static int[] Toolbar = new int[]
-			{
-					16842927,
-					16843072,
-					2130771971,
-					2130771974,
-					2130771990,
-					2130771991,
-					2130771992,
-					2130771993,
-					2130771995,
+					2130772121,
 					2130772122,
 					2130772123,
 					2130772124,
@@ -3283,7 +3501,364 @@ namespace ReactiveUI.Tests
 					2130772131,
 					2130772132,
 					2130772133,
-					2130772134};
+					2130772134,
+					2130772135,
+					2130772136,
+					2130772137,
+					2130772138,
+					2130772139,
+					2130772140,
+					2130772141,
+					2130772142,
+					2130772143,
+					2130772144,
+					2130772145,
+					2130772146,
+					2130772147,
+					2130772148,
+					2130772149};
+			
+			// aapt resource value: 23
+			public const int Theme_actionBarDivider = 23;
+			
+			// aapt resource value: 24
+			public const int Theme_actionBarItemBackground = 24;
+			
+			// aapt resource value: 17
+			public const int Theme_actionBarPopupTheme = 17;
+			
+			// aapt resource value: 22
+			public const int Theme_actionBarSize = 22;
+			
+			// aapt resource value: 19
+			public const int Theme_actionBarSplitStyle = 19;
+			
+			// aapt resource value: 18
+			public const int Theme_actionBarStyle = 18;
+			
+			// aapt resource value: 13
+			public const int Theme_actionBarTabBarStyle = 13;
+			
+			// aapt resource value: 12
+			public const int Theme_actionBarTabStyle = 12;
+			
+			// aapt resource value: 14
+			public const int Theme_actionBarTabTextStyle = 14;
+			
+			// aapt resource value: 20
+			public const int Theme_actionBarTheme = 20;
+			
+			// aapt resource value: 21
+			public const int Theme_actionBarWidgetTheme = 21;
+			
+			// aapt resource value: 49
+			public const int Theme_actionButtonStyle = 49;
+			
+			// aapt resource value: 45
+			public const int Theme_actionDropDownStyle = 45;
+			
+			// aapt resource value: 25
+			public const int Theme_actionMenuTextAppearance = 25;
+			
+			// aapt resource value: 26
+			public const int Theme_actionMenuTextColor = 26;
+			
+			// aapt resource value: 29
+			public const int Theme_actionModeBackground = 29;
+			
+			// aapt resource value: 28
+			public const int Theme_actionModeCloseButtonStyle = 28;
+			
+			// aapt resource value: 31
+			public const int Theme_actionModeCloseDrawable = 31;
+			
+			// aapt resource value: 33
+			public const int Theme_actionModeCopyDrawable = 33;
+			
+			// aapt resource value: 32
+			public const int Theme_actionModeCutDrawable = 32;
+			
+			// aapt resource value: 37
+			public const int Theme_actionModeFindDrawable = 37;
+			
+			// aapt resource value: 34
+			public const int Theme_actionModePasteDrawable = 34;
+			
+			// aapt resource value: 39
+			public const int Theme_actionModePopupWindowStyle = 39;
+			
+			// aapt resource value: 35
+			public const int Theme_actionModeSelectAllDrawable = 35;
+			
+			// aapt resource value: 36
+			public const int Theme_actionModeShareDrawable = 36;
+			
+			// aapt resource value: 30
+			public const int Theme_actionModeSplitBackground = 30;
+			
+			// aapt resource value: 27
+			public const int Theme_actionModeStyle = 27;
+			
+			// aapt resource value: 38
+			public const int Theme_actionModeWebSearchDrawable = 38;
+			
+			// aapt resource value: 15
+			public const int Theme_actionOverflowButtonStyle = 15;
+			
+			// aapt resource value: 16
+			public const int Theme_actionOverflowMenuStyle = 16;
+			
+			// aapt resource value: 56
+			public const int Theme_activityChooserViewStyle = 56;
+			
+			// aapt resource value: 89
+			public const int Theme_alertDialogButtonGroupStyle = 89;
+			
+			// aapt resource value: 90
+			public const int Theme_alertDialogCenterButtons = 90;
+			
+			// aapt resource value: 88
+			public const int Theme_alertDialogStyle = 88;
+			
+			// aapt resource value: 91
+			public const int Theme_alertDialogTheme = 91;
+			
+			// aapt resource value: 1
+			public const int Theme_android_windowAnimationStyle = 1;
+			
+			// aapt resource value: 0
+			public const int Theme_android_windowIsFloating = 0;
+			
+			// aapt resource value: 96
+			public const int Theme_autoCompleteTextViewStyle = 96;
+			
+			// aapt resource value: 51
+			public const int Theme_buttonBarButtonStyle = 51;
+			
+			// aapt resource value: 94
+			public const int Theme_buttonBarNegativeButtonStyle = 94;
+			
+			// aapt resource value: 95
+			public const int Theme_buttonBarNeutralButtonStyle = 95;
+			
+			// aapt resource value: 93
+			public const int Theme_buttonBarPositiveButtonStyle = 93;
+			
+			// aapt resource value: 50
+			public const int Theme_buttonBarStyle = 50;
+			
+			// aapt resource value: 97
+			public const int Theme_buttonStyle = 97;
+			
+			// aapt resource value: 98
+			public const int Theme_buttonStyleSmall = 98;
+			
+			// aapt resource value: 99
+			public const int Theme_checkboxStyle = 99;
+			
+			// aapt resource value: 100
+			public const int Theme_checkedTextViewStyle = 100;
+			
+			// aapt resource value: 82
+			public const int Theme_colorAccent = 82;
+			
+			// aapt resource value: 86
+			public const int Theme_colorButtonNormal = 86;
+			
+			// aapt resource value: 84
+			public const int Theme_colorControlActivated = 84;
+			
+			// aapt resource value: 85
+			public const int Theme_colorControlHighlight = 85;
+			
+			// aapt resource value: 83
+			public const int Theme_colorControlNormal = 83;
+			
+			// aapt resource value: 80
+			public const int Theme_colorPrimary = 80;
+			
+			// aapt resource value: 81
+			public const int Theme_colorPrimaryDark = 81;
+			
+			// aapt resource value: 87
+			public const int Theme_colorSwitchThumbNormal = 87;
+			
+			// aapt resource value: 43
+			public const int Theme_dialogPreferredPadding = 43;
+			
+			// aapt resource value: 42
+			public const int Theme_dialogTheme = 42;
+			
+			// aapt resource value: 55
+			public const int Theme_dividerHorizontal = 55;
+			
+			// aapt resource value: 54
+			public const int Theme_dividerVertical = 54;
+			
+			// aapt resource value: 72
+			public const int Theme_dropDownListViewStyle = 72;
+			
+			// aapt resource value: 46
+			public const int Theme_dropdownListPreferredItemHeight = 46;
+			
+			// aapt resource value: 62
+			public const int Theme_editTextBackground = 62;
+			
+			// aapt resource value: 61
+			public const int Theme_editTextColor = 61;
+			
+			// aapt resource value: 101
+			public const int Theme_editTextStyle = 101;
+			
+			// aapt resource value: 48
+			public const int Theme_homeAsUpIndicator = 48;
+			
+			// aapt resource value: 79
+			public const int Theme_listChoiceBackgroundIndicator = 79;
+			
+			// aapt resource value: 44
+			public const int Theme_listDividerAlertDialog = 44;
+			
+			// aapt resource value: 73
+			public const int Theme_listPopupWindowStyle = 73;
+			
+			// aapt resource value: 67
+			public const int Theme_listPreferredItemHeight = 67;
+			
+			// aapt resource value: 69
+			public const int Theme_listPreferredItemHeightLarge = 69;
+			
+			// aapt resource value: 68
+			public const int Theme_listPreferredItemHeightSmall = 68;
+			
+			// aapt resource value: 70
+			public const int Theme_listPreferredItemPaddingLeft = 70;
+			
+			// aapt resource value: 71
+			public const int Theme_listPreferredItemPaddingRight = 71;
+			
+			// aapt resource value: 76
+			public const int Theme_panelBackground = 76;
+			
+			// aapt resource value: 78
+			public const int Theme_panelMenuListTheme = 78;
+			
+			// aapt resource value: 77
+			public const int Theme_panelMenuListWidth = 77;
+			
+			// aapt resource value: 59
+			public const int Theme_popupMenuStyle = 59;
+			
+			// aapt resource value: 60
+			public const int Theme_popupWindowStyle = 60;
+			
+			// aapt resource value: 102
+			public const int Theme_radioButtonStyle = 102;
+			
+			// aapt resource value: 103
+			public const int Theme_ratingBarStyle = 103;
+			
+			// aapt resource value: 66
+			public const int Theme_searchViewStyle = 66;
+			
+			// aapt resource value: 52
+			public const int Theme_selectableItemBackground = 52;
+			
+			// aapt resource value: 53
+			public const int Theme_selectableItemBackgroundBorderless = 53;
+			
+			// aapt resource value: 47
+			public const int Theme_spinnerDropDownItemStyle = 47;
+			
+			// aapt resource value: 104
+			public const int Theme_spinnerStyle = 104;
+			
+			// aapt resource value: 105
+			public const int Theme_switchStyle = 105;
+			
+			// aapt resource value: 40
+			public const int Theme_textAppearanceLargePopupMenu = 40;
+			
+			// aapt resource value: 74
+			public const int Theme_textAppearanceListItem = 74;
+			
+			// aapt resource value: 75
+			public const int Theme_textAppearanceListItemSmall = 75;
+			
+			// aapt resource value: 64
+			public const int Theme_textAppearanceSearchResultSubtitle = 64;
+			
+			// aapt resource value: 63
+			public const int Theme_textAppearanceSearchResultTitle = 63;
+			
+			// aapt resource value: 41
+			public const int Theme_textAppearanceSmallPopupMenu = 41;
+			
+			// aapt resource value: 92
+			public const int Theme_textColorAlertDialogListItem = 92;
+			
+			// aapt resource value: 65
+			public const int Theme_textColorSearchUrl = 65;
+			
+			// aapt resource value: 58
+			public const int Theme_toolbarNavigationButtonStyle = 58;
+			
+			// aapt resource value: 57
+			public const int Theme_toolbarStyle = 57;
+			
+			// aapt resource value: 2
+			public const int Theme_windowActionBar = 2;
+			
+			// aapt resource value: 4
+			public const int Theme_windowActionBarOverlay = 4;
+			
+			// aapt resource value: 5
+			public const int Theme_windowActionModeOverlay = 5;
+			
+			// aapt resource value: 9
+			public const int Theme_windowFixedHeightMajor = 9;
+			
+			// aapt resource value: 7
+			public const int Theme_windowFixedHeightMinor = 7;
+			
+			// aapt resource value: 6
+			public const int Theme_windowFixedWidthMajor = 6;
+			
+			// aapt resource value: 8
+			public const int Theme_windowFixedWidthMinor = 8;
+			
+			// aapt resource value: 10
+			public const int Theme_windowMinWidthMajor = 10;
+			
+			// aapt resource value: 11
+			public const int Theme_windowMinWidthMinor = 11;
+			
+			// aapt resource value: 3
+			public const int Theme_windowNoTitle = 3;
+			
+			public static int[] Toolbar = new int[]
+			{
+					16842927,
+					16843072,
+					2130771971,
+					2130771974,
+					2130771990,
+					2130771991,
+					2130771992,
+					2130771993,
+					2130771995,
+					2130772150,
+					2130772151,
+					2130772152,
+					2130772153,
+					2130772154,
+					2130772155,
+					2130772156,
+					2130772157,
+					2130772158,
+					2130772159,
+					2130772160,
+					2130772161};
 			
 			// aapt resource value: 0
 			public const int Toolbar_android_gravity = 0;
@@ -3291,11 +3866,11 @@ namespace ReactiveUI.Tests
 			// aapt resource value: 1
 			public const int Toolbar_android_minHeight = 1;
 			
-			// aapt resource value: 19
-			public const int Toolbar_collapseContentDescription = 19;
-			
 			// aapt resource value: 18
-			public const int Toolbar_collapseIcon = 18;
+			public const int Toolbar_collapseContentDescription = 18;
+			
+			// aapt resource value: 17
+			public const int Toolbar_collapseIcon = 17;
 			
 			// aapt resource value: 5
 			public const int Toolbar_contentInsetEnd = 5;
@@ -3312,11 +3887,11 @@ namespace ReactiveUI.Tests
 			// aapt resource value: 16
 			public const int Toolbar_maxButtonHeight = 16;
 			
-			// aapt resource value: 21
-			public const int Toolbar_navigationContentDescription = 21;
-			
 			// aapt resource value: 20
-			public const int Toolbar_navigationIcon = 20;
+			public const int Toolbar_navigationContentDescription = 20;
+			
+			// aapt resource value: 19
+			public const int Toolbar_navigationIcon = 19;
 			
 			// aapt resource value: 8
 			public const int Toolbar_popupTheme = 8;
@@ -3326,9 +3901,6 @@ namespace ReactiveUI.Tests
 			
 			// aapt resource value: 10
 			public const int Toolbar_subtitleTextAppearance = 10;
-			
-			// aapt resource value: 17
-			public const int Toolbar_theme = 17;
 			
 			// aapt resource value: 2
 			public const int Toolbar_title = 2;
@@ -3353,18 +3925,34 @@ namespace ReactiveUI.Tests
 			
 			public static int[] View = new int[]
 			{
+					16842752,
 					16842970,
-					2130772135,
-					2130772136};
-			
-			// aapt resource value: 0
-			public const int View_android_focusable = 0;
-			
-			// aapt resource value: 2
-			public const int View_paddingEnd = 2;
+					2130772162,
+					2130772163,
+					2130772164,
+					2130772165,
+					2130772166};
 			
 			// aapt resource value: 1
-			public const int View_paddingStart = 1;
+			public const int View_android_focusable = 1;
+			
+			// aapt resource value: 0
+			public const int View_android_theme = 0;
+			
+			// aapt resource value: 5
+			public const int View_backgroundTint = 5;
+			
+			// aapt resource value: 6
+			public const int View_backgroundTintMode = 6;
+			
+			// aapt resource value: 3
+			public const int View_paddingEnd = 3;
+			
+			// aapt resource value: 2
+			public const int View_paddingStart = 2;
+			
+			// aapt resource value: 4
+			public const int View_theme = 4;
 			
 			public static int[] ViewStubCompat = new int[]
 			{

--- a/ReactiveUI.Tests/packages.ReactiveUI.Tests_Android.config
+++ b/ReactiveUI.Tests/packages.ReactiveUI.Tests_Android.config
@@ -5,7 +5,7 @@
   <package id="Rx-Linq" version="2.2.5" targetFramework="MonoAndroid44" />
   <package id="Rx-Main" version="2.2.5" targetFramework="MonoAndroid44" />
   <package id="Rx-PlatformServices" version="2.2.5" targetFramework="MonoAndroid44" />
-  <package id="Splat" version="1.6.0" targetFramework="MonoAndroid44" />
+  <package id="Splat" version="1.6.2" targetFramework="MonoAndroid44" />
   <package id="Xamarin.Android.Support.v4" version="20.0.0.2" targetFramework="MonoAndroid44" />
   <package id="xunit" version="2.0.0-beta-build2700" targetFramework="MonoAndroid44" />
   <package id="xunit.abstractions" version="2.0.0-beta-build2700" targetFramework="MonoAndroid44" />

--- a/ReactiveUI.Tests/packages.ReactiveUI.Tests_Net45.config
+++ b/ReactiveUI.Tests/packages.ReactiveUI.Tests_Net45.config
@@ -7,7 +7,7 @@
   <package id="Rx-PlatformServices" version="2.2.5" targetFramework="net45" />
   <package id="Rx-Testing" version="2.2.5" targetFramework="net45" />
   <package id="Rx-Xaml" version="2.2.5" targetFramework="net45" />
-  <package id="Splat" version="1.6.0" targetFramework="net45" />
+  <package id="Splat" version="1.6.2" targetFramework="net45" />
   <package id="xunit" version="[1,2)" targetFramework="net45" />
   <package id="xunit.runner.visualstudio" version="2.1.0-beta2-build1055" targetFramework="net45" />
 </packages>

--- a/ReactiveUI.Tests/packages.ReactiveUI.Tests_Net45.config
+++ b/ReactiveUI.Tests/packages.ReactiveUI.Tests_Net45.config
@@ -8,6 +8,6 @@
   <package id="Rx-Testing" version="2.2.5" targetFramework="net45" />
   <package id="Rx-Xaml" version="2.2.5" targetFramework="net45" />
   <package id="Splat" version="1.6.2" targetFramework="net45" />
-  <package id="xunit" version="[1,2)" targetFramework="net45" />
+  <package id="xunit" version="1.9.2" allowedVersions="[1,2)" targetFramework="net45" />
   <package id="xunit.runner.visualstudio" version="2.1.0-beta2-build1055" targetFramework="net45" />
 </packages>

--- a/ReactiveUI.Tests/packages.ReactiveUI.Tests_iOS.config
+++ b/ReactiveUI.Tests/packages.ReactiveUI.Tests_iOS.config
@@ -5,7 +5,7 @@
   <package id="Rx-Linq" version="2.2.5" targetFramework="MonoTouch10" />
   <package id="Rx-Main" version="2.2.5" targetFramework="MonoTouch10" />
   <package id="Rx-PlatformServices" version="2.2.5" targetFramework="MonoTouch10" />
-  <package id="Splat" version="1.6.0" targetFramework="MonoTouch10" />
+  <package id="Splat" version="1.6.2" targetFramework="MonoTouch10" />
   <package id="xunit" version="2.0.0-beta-build2700" targetFramework="MonoTouch10" />
   <package id="xunit.abstractions" version="2.0.0-beta-build2700" targetFramework="MonoTouch10" />
   <package id="xunit.assert" version="2.0.0-beta-build2700" targetFramework="MonoTouch10" />

--- a/ReactiveUI.Winforms/ReactiveUI.Winforms_Net45.csproj
+++ b/ReactiveUI.Winforms/ReactiveUI.Winforms_Net45.csproj
@@ -49,9 +49,9 @@
     <NoWarn>1591, 1573, 1711, 1587, 1570, 1572</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Splat, Version=1.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="Splat, Version=1.6.2.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Splat.1.6.0\lib\Net45\Splat.dll</HintPath>
+      <HintPath>..\packages\Splat.1.6.2\lib\Net45\Splat.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/ReactiveUI.Winforms/packages.config
+++ b/ReactiveUI.Winforms/packages.config
@@ -5,5 +5,5 @@
   <package id="Rx-Linq" version="2.2.5" targetFramework="net45" />
   <package id="Rx-Main" version="2.2.5" targetFramework="net45" />
   <package id="Rx-PlatformServices" version="2.2.5" targetFramework="net45" />
-  <package id="Splat" version="1.6.0" targetFramework="net45" />
+  <package id="Splat" version="1.6.2" targetFramework="net45" />
 </packages>

--- a/ReactiveUI.XamForms/ReactiveUI.XamForms.csproj
+++ b/ReactiveUI.XamForms/ReactiveUI.XamForms.csproj
@@ -64,10 +64,10 @@
       <HintPath>..\packages\Rx-PlatformServices.2.2.5\lib\portable-windows8+net45+wp8\System.Reactive.PlatformServices.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Core">
-      <HintPath>..\packages\Xamarin.Forms.1.4.0.6341\lib\portable-win+net45+wp80+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.Core.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.1.4.2.6359\lib\portable-win+net45+wp80+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.Core.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Xaml">
-      <HintPath>..\packages\Xamarin.Forms.1.4.0.6341\lib\portable-win+net45+wp80+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.Xaml.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.1.4.2.6359\lib\portable-win+net45+wp80+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.Xaml.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -83,7 +83,7 @@
     <Compile Include="XamForms\RoutedViewHost.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
-  <Import Project="..\packages\Xamarin.Forms.1.4.0.6341\build\portable-win+net45+wp80+MonoAndroid10+MonoTouch10\Xamarin.Forms.targets" Condition="Exists('..\packages\Xamarin.Forms.1.4.0.6341\build\portable-win+net45+wp80+MonoAndroid10+MonoTouch10\Xamarin.Forms.targets')" />
+  <Import Project="..\packages\Xamarin.Forms.1.4.2.6359\build\portable-win+net45+wp80+MonoAndroid10+MonoTouch10\Xamarin.Forms.targets" Condition="Exists('..\packages\Xamarin.Forms.1.4.2.6359\build\portable-win+net45+wp80+MonoAndroid10+MonoTouch10\Xamarin.Forms.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/ReactiveUI.XamForms/ReactiveUI.XamForms.csproj
+++ b/ReactiveUI.XamForms/ReactiveUI.XamForms.csproj
@@ -49,7 +49,7 @@
     <Reference Include="System.Xml.Linq" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Splat">
-      <HintPath>..\packages\Splat.1.6.0\lib\Net45\Splat.dll</HintPath>
+      <HintPath>..\packages\Splat.1.6.2\lib\Net45\Splat.dll</HintPath>
     </Reference>
     <Reference Include="System.Reactive.Core">
       <HintPath>..\packages\Rx-Core.2.2.5\lib\net45\System.Reactive.Core.dll</HintPath>

--- a/ReactiveUI.XamForms/ReactiveUI.XamForms.csproj
+++ b/ReactiveUI.XamForms/ReactiveUI.XamForms.csproj
@@ -64,10 +64,13 @@
       <HintPath>..\packages\Rx-PlatformServices.2.2.5\lib\portable-windows8+net45+wp8\System.Reactive.PlatformServices.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Core">
-      <HintPath>..\packages\Xamarin.Forms.1.4.2.6359\lib\portable-win+net45+wp80+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.Core.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.1.4.2.6359\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Forms.Platform">
+      <HintPath>..\packages\Xamarin.Forms.1.4.2.6359\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.Platform.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Xaml">
-      <HintPath>..\packages\Xamarin.Forms.1.4.2.6359\lib\portable-win+net45+wp80+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.Xaml.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.1.4.2.6359\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.Xaml.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/ReactiveUI.XamForms/packages.config
+++ b/ReactiveUI.XamForms/packages.config
@@ -5,6 +5,6 @@
   <package id="Rx-Linq" version="2.2.5" targetFramework="net45" />
   <package id="Rx-Main" version="2.2.5" targetFramework="net45" />
   <package id="Rx-PlatformServices" version="2.2.5" targetFramework="net45" />
-  <package id="Splat" version="1.6.0" targetFramework="net45" />
+  <package id="Splat" version="1.6.2" targetFramework="net45" />
   <package id="Xamarin.Forms" version="1.4.0.6341" targetFramework="portable-net45+win+wp80+MonoAndroid10+MonoTouch10" />
 </packages>

--- a/ReactiveUI.XamForms/packages.config
+++ b/ReactiveUI.XamForms/packages.config
@@ -6,5 +6,5 @@
   <package id="Rx-Main" version="2.2.5" targetFramework="net45" />
   <package id="Rx-PlatformServices" version="2.2.5" targetFramework="net45" />
   <package id="Splat" version="1.6.2" targetFramework="net45" />
-  <package id="Xamarin.Forms" version="1.4.0.6341" targetFramework="portable-net45+win+wp80+MonoAndroid10+MonoTouch10" />
+  <package id="Xamarin.Forms" version="1.4.2.6359" targetFramework="portable-net45+win+wp80+MonoAndroid10+MonoTouch10" />
 </packages>

--- a/ReactiveUI.sln
+++ b/ReactiveUI.sln
@@ -60,6 +60,11 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{AA2BDF98-2D28-4212-BFA6-8C5270065C06}"
 EndProject
 Global
+	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		Playground-Wpa81\Playground-Wpa81.Shared\Playground-Wpa81.Shared.projitems*{faf376b9-b829-4bf9-9da9-eaae2f491e65}*SharedItemsImports = 13
+		Playground-Wpa81\Playground-Wpa81.Shared\Playground-Wpa81.Shared.projitems*{87310a2d-d731-4daa-b930-7bce328a7b49}*SharedItemsImports = 4
+		Playground-Wpa81\Playground-Wpa81.Shared\Playground-Wpa81.Shared.projitems*{f27311c9-2ca2-45bf-b61c-e93445bd3261}*SharedItemsImports = 4
+	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Ad-Hoc|Any CPU = Ad-Hoc|Any CPU
 		Ad-Hoc|ARM = Ad-Hoc|ARM

--- a/ReactiveUI/ReactiveUI.csproj
+++ b/ReactiveUI/ReactiveUI.csproj
@@ -48,7 +48,7 @@
       <LastGenOutput>VariadicTemplates.cs</LastGenOutput>
     </None>
     <Reference Include="Splat">
-      <HintPath>..\packages\Splat.1.6.0\lib\Portable-net45+win+wpa81+wp80\Splat.dll</HintPath>
+      <HintPath>..\packages\Splat.1.6.2\lib\Portable-net45+win+wpa81+wp80\Splat.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/ReactiveUI/ReactiveUI_Android.csproj
+++ b/ReactiveUI/ReactiveUI_Android.csproj
@@ -52,7 +52,7 @@
     <Reference Include="Mono.Android" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="Splat">
-      <HintPath>..\packages\Splat.1.6.0\lib\monoandroid\Splat.dll</HintPath>
+      <HintPath>..\packages\Splat.1.6.2\lib\monoandroid\Splat.dll</HintPath>
     </Reference>
     <Reference Include="System.Reactive.Core">
       <HintPath>..\packages\Rx-Core.2.2.5\lib\portable-windows8+net45+wp8\System.Reactive.Core.dll</HintPath>

--- a/ReactiveUI/ReactiveUI_Mac.csproj
+++ b/ReactiveUI/ReactiveUI_Mac.csproj
@@ -59,7 +59,7 @@
     <Reference Include="XamMac" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="Splat">
-      <HintPath>..\packages\Splat.1.6.0\lib\MonoMac\Splat.dll</HintPath>
+      <HintPath>..\packages\Splat.1.6.2\lib\MonoMac\Splat.dll</HintPath>
     </Reference>
     <Reference Include="System.Reactive.Core">
       <HintPath>..\packages\Rx-Core.2.2.5\lib\net45\System.Reactive.Core.dll</HintPath>

--- a/ReactiveUI/ReactiveUI_Mac64.csproj
+++ b/ReactiveUI/ReactiveUI_Mac64.csproj
@@ -58,7 +58,7 @@
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="Splat">
-      <HintPath>..\packages\Splat.1.6.0\lib\Xamarin.Mac10\Splat.dll</HintPath>
+      <HintPath>..\packages\Splat.1.6.2\lib\Xamarin.Mac10\Splat.dll</HintPath>
     </Reference>
     <Reference Include="System.Reactive.Core">
       <HintPath>..\packages\Rx-Core.2.2.5\lib\net45\System.Reactive.Core.dll</HintPath>

--- a/ReactiveUI/ReactiveUI_Net45.csproj
+++ b/ReactiveUI/ReactiveUI_Net45.csproj
@@ -44,9 +44,9 @@
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="PresentationFramework.Aero" />
-    <Reference Include="Splat, Version=1.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="Splat, Version=1.6.2.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Splat.1.6.0\lib\Net45\Splat.dll</HintPath>
+      <HintPath>..\packages\Splat.1.6.2\lib\Net45\Splat.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/ReactiveUI/ReactiveUI_WP8.csproj
+++ b/ReactiveUI/ReactiveUI_WP8.csproj
@@ -45,9 +45,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="mscorlib.Extensions" />
-    <Reference Include="Splat, Version=1.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="Splat, Version=1.6.2.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Splat.1.6.0\lib\wp8\Splat.dll</HintPath>
+      <HintPath>..\packages\Splat.1.6.2\lib\wp8\Splat.dll</HintPath>
     </Reference>
     <Reference Include="System.Observable" />
     <Reference Include="System.Reactive.Core, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/ReactiveUI/ReactiveUI_WinRT.csproj
+++ b/ReactiveUI/ReactiveUI_WinRT.csproj
@@ -114,7 +114,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Splat">
-      <HintPath>..\packages\Splat.1.6.0\lib\Portable-Win81+Wpa81\Splat.dll</HintPath>
+      <HintPath>..\packages\Splat.1.6.2\lib\Portable-Win81+Wpa81\Splat.dll</HintPath>
     </Reference>
     <Reference Include="System.Reactive.Core">
       <HintPath>..\packages\Rx-Core.2.2.5\lib\portable-win81+wpa81\System.Reactive.Core.dll</HintPath>

--- a/ReactiveUI/ReactiveUI_WinRT80.csproj
+++ b/ReactiveUI/ReactiveUI_WinRT80.csproj
@@ -113,9 +113,9 @@
     <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Splat, Version=1.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="Splat, Version=1.6.2.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Splat.1.6.0\lib\NetCore45\Splat.dll</HintPath>
+      <HintPath>..\packages\Splat.1.6.2\lib\NetCore45\Splat.dll</HintPath>
     </Reference>
     <Reference Include="System.Reactive.Core, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/ReactiveUI/ReactiveUI_iOS.csproj
+++ b/ReactiveUI/ReactiveUI_iOS.csproj
@@ -48,7 +48,7 @@
     <Reference Include="monotouch" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="Splat">
-      <HintPath>..\packages\Splat.1.6.0\lib\monotouch\Splat.dll</HintPath>
+      <HintPath>..\packages\Splat.1.6.2\lib\monotouch\Splat.dll</HintPath>
     </Reference>
     <Reference Include="System.Reactive.Core">
       <HintPath>..\packages\Rx-Core.2.2.5\lib\portable-windows8+net45+wp8\System.Reactive.Core.dll</HintPath>

--- a/ReactiveUI/ReactiveUI_iOS64.csproj
+++ b/ReactiveUI/ReactiveUI_iOS64.csproj
@@ -48,7 +48,7 @@
     <Reference Include="Xamarin.iOS" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="Splat">
-      <HintPath>..\packages\Splat.1.6.0\lib\Xamarin.iOS10\Splat.dll</HintPath>
+      <HintPath>..\packages\Splat.1.6.2\lib\Xamarin.iOS10\Splat.dll</HintPath>
     </Reference>
     <Reference Include="System.Reactive.Core">
       <HintPath>..\packages\Rx-Core.2.2.5\lib\portable-windows8+net45+wp8\System.Reactive.Core.dll</HintPath>

--- a/ReactiveUI/RxApp.cs
+++ b/ReactiveUI/RxApp.cs
@@ -93,7 +93,6 @@ namespace ReactiveUI
         /// </summary>
         public static IScheduler MainThreadScheduler {
             get {
-                var scheduler = _UnitTestMainThreadScheduler ?? _MainThreadScheduler;
                 return _UnitTestMainThreadScheduler ?? _MainThreadScheduler;
             }
             set {
@@ -121,7 +120,6 @@ namespace ReactiveUI
         /// </summary>
         public static IScheduler TaskpoolScheduler {
             get {
-                var scheduler = _UnitTestTaskpoolScheduler ?? _TaskpoolScheduler;
                 return _UnitTestTaskpoolScheduler ?? _TaskpoolScheduler;
             }
             set {
@@ -143,12 +141,8 @@ namespace ReactiveUI
         /// the application with an error message.
         /// </summary>
         public static IObserver<Exception> DefaultExceptionHandler {
-            get {
-                return _DefaultExceptionHandler;
-            }
-            set {
-                _DefaultExceptionHandler = value;
-            }
+            get { return _DefaultExceptionHandler; }
+            set { _DefaultExceptionHandler = value; }
         }
 
         [ThreadStatic] static ISuspensionHost _UnitTestSuspensionHost;

--- a/ReactiveUI/packages.ReactiveUI.config
+++ b/ReactiveUI/packages.ReactiveUI.config
@@ -5,5 +5,5 @@
   <package id="Rx-Linq" version="2.2.5" targetFramework="portable-net45+win+wpa81+wp80+MonoAndroid10+MonoTouch10" />
   <package id="Rx-Main" version="2.2.5" targetFramework="portable-net45+win+wpa81+wp80+MonoAndroid10+MonoTouch10" />
   <package id="Rx-PlatformServices" version="2.2.5" targetFramework="portable-net45+win+wpa81+wp80+MonoAndroid10+MonoTouch10" />
-  <package id="Splat" version="1.6.0" targetFramework="portable-net45+win+wpa81+wp80+MonoAndroid10+MonoTouch10" />
+  <package id="Splat" version="1.6.2" targetFramework="portable-net45+win+wpa81+wp80+MonoAndroid10+MonoTouch10" />
 </packages>

--- a/ReactiveUI/packages.ReactiveUI_Android.config
+++ b/ReactiveUI/packages.ReactiveUI_Android.config
@@ -5,5 +5,5 @@
   <package id="Rx-Linq" version="2.2.5" targetFramework="MonoAndroid403" />
   <package id="Rx-Main" version="2.2.5" targetFramework="MonoAndroid403" />
   <package id="Rx-PlatformServices" version="2.2.5" targetFramework="MonoAndroid403" />
-  <package id="Splat" version="1.6.0" targetFramework="MonoAndroid403" />
+  <package id="Splat" version="1.6.2" targetFramework="MonoAndroid403" />
 </packages>

--- a/ReactiveUI/packages.ReactiveUI_Net45.config
+++ b/ReactiveUI/packages.ReactiveUI_Net45.config
@@ -6,5 +6,5 @@
   <package id="Rx-Main" version="2.2.5" targetFramework="net45" />
   <package id="Rx-PlatformServices" version="2.2.5" targetFramework="net45" />
   <package id="Rx-Xaml" version="2.2.5" targetFramework="net45" />
-  <package id="Splat" version="1.6.0" targetFramework="net45" />
+  <package id="Splat" version="1.6.2" targetFramework="net45" />
 </packages>

--- a/ReactiveUI/packages.ReactiveUI_WP8.config
+++ b/ReactiveUI/packages.ReactiveUI_WP8.config
@@ -7,5 +7,5 @@
   <package id="Rx-PlatformServices" version="2.2.5" targetFramework="wp80" />
   <package id="Rx-WinRT" version="2.2.5" targetFramework="wp80" />
   <package id="Rx-XAML" version="2.2.5" targetFramework="wp80" />
-  <package id="Splat" version="1.6.0" targetFramework="wp80" />
+  <package id="Splat" version="1.6.2" targetFramework="wp80" />
 </packages>

--- a/ReactiveUI/packages.ReactiveUI_WinRT.config
+++ b/ReactiveUI/packages.ReactiveUI_WinRT.config
@@ -7,5 +7,5 @@
   <package id="Rx-PlatformServices" version="2.2.5" targetFramework="portable-win81+wpa81" />
   <package id="Rx-WinRT" version="2.2.5" targetFramework="portable-win81+wpa81" />
   <package id="Rx-Xaml" version="2.2.5" targetFramework="portable-win81+wpa81" />
-  <package id="Splat" version="1.6.0" targetFramework="portable-win81+wpa81" />
+  <package id="Splat" version="1.6.2" targetFramework="portable-win81+wpa81" />
 </packages>

--- a/ReactiveUI/packages.ReactiveUI_WinRT80.config
+++ b/ReactiveUI/packages.ReactiveUI_WinRT80.config
@@ -7,5 +7,5 @@
   <package id="Rx-PlatformServices" version="2.2.5" targetFramework="win" />
   <package id="Rx-WinRT" version="2.2.5" targetFramework="win" />
   <package id="Rx-Xaml" version="2.2.5" targetFramework="win" />
-  <package id="Splat" version="1.6.0" targetFramework="win" />
+  <package id="Splat" version="1.6.2" targetFramework="win" />
 </packages>

--- a/ReactiveUI/packages.ReactiveUI_iOS.config
+++ b/ReactiveUI/packages.ReactiveUI_iOS.config
@@ -5,5 +5,5 @@
   <package id="Rx-Linq" version="2.2.5" targetFramework="MonoTouch10" />
   <package id="Rx-Main" version="2.2.5" targetFramework="MonoTouch10" />
   <package id="Rx-PlatformServices" version="2.2.5" targetFramework="MonoTouch10" />
-  <package id="Splat" version="1.6.0" targetFramework="MonoTouch10" />
+  <package id="Splat" version="1.6.2" targetFramework="MonoTouch10" />
 </packages>

--- a/ReactiveUI/packages.ReactiveUI_iOS64.config
+++ b/ReactiveUI/packages.ReactiveUI_iOS64.config
@@ -5,5 +5,5 @@
   <package id="Rx-Linq" version="2.2.5" targetFramework="MonoTouch10" />
   <package id="Rx-Main" version="2.2.5" targetFramework="MonoTouch10" />
   <package id="Rx-PlatformServices" version="2.2.5" targetFramework="MonoTouch10" />
-  <package id="Splat" version="1.6.0" targetFramework="MonoTouch10" />
+  <package id="Splat" version="1.6.2" targetFramework="MonoTouch10" />
 </packages>

--- a/packages/repositories.config
+++ b/packages/repositories.config
@@ -27,6 +27,8 @@
   <repository path="../ReactiveUI/packages.ReactiveUI_iOS64.config" />
   <repository path="../ReactiveUI/packages.ReactiveUI_Mac.config" />
   <repository path="..\PerfConsoleRunner\packages.config" />
+  <repository path="..\Playground-Wpa81\Playground-Wpa81.Windows\packages.config" />
+  <repository path="..\Playground-Wpa81\Playground-Wpa81.WindowsPhone\packages.config" />
   <repository path="..\ReactiveUI.Blend\packages.ReactiveUI.Blend_Net45.config" />
   <repository path="..\ReactiveUI.Blend\packages.ReactiveUI.Blend_WinRT.config" />
   <repository path="..\ReactiveUI.Blend\packages.ReactiveUI.Blend_WP8.config" />


### PR DESCRIPTION
This PR updates our dependencies and gets us set up for ReactiveUI 7.x by making sure nobody will end up picking up the version of Splat that removes old platforms.