### PR TITLE
Ability to override view model type used in view resolution using a  view model attribute

### DIFF
--- a/ReactiveUI.Tests/RxRouting.cs
+++ b/ReactiveUI.Tests/RxRouting.cs
@@ -34,6 +34,14 @@ namespace Foobar.ViewModels
             HostScreen = hostScreen;
         }
     }
+
+    [ViewResolutionTypeOverride(Type = typeof(BazViewModel))]
+    public class BazViewModel<T> : BazViewModel
+    {
+        public BazViewModel(IScreen hostScreen) : base(hostScreen)
+        {
+        }
+    }
 }
 
 namespace Foobar.Views
@@ -74,6 +82,26 @@ namespace ReactiveUI.Routing.Tests
             using (resolver.WithResolver()) {
                 var fixture = new DefaultViewLocator();
                 var vm = new BazViewModel(null);
+
+                var result = fixture.ResolveView(vm);
+                this.Log().Info(result.GetType().FullName);
+                Assert.True(result is BazView);
+            }
+        }
+
+        [Fact]
+        public void ResolveViewForGenericViewModelType()
+        {
+            var resolver = new ModernDependencyResolver();
+
+            resolver.InitializeSplat();
+            resolver.InitializeReactiveUI();
+            resolver.Register(() => new BazView(), typeof(IViewFor<BazViewModel>));
+
+            using (resolver.WithResolver())
+            {
+                var fixture = new DefaultViewLocator();
+                var vm = new BazViewModel<int>(null);
 
                 var result = fixture.ResolveView(vm);
                 this.Log().Info(result.GetType().FullName);

--- a/ReactiveUI/Interfaces.cs
+++ b/ReactiveUI/Interfaces.cs
@@ -468,6 +468,20 @@ namespace ReactiveUI
         /// </summary>
         public string Contract { get; set; }
     }
+
+    /// <summary>
+    /// Allows overriding the type information used for view resolution of a view 
+    /// model. This is useful if your view model is a generic type and you would 
+    /// prefer to resolve your view using an interface.
+    /// </summary>
+    public class ViewResolutionTypeOverrideAttribute : Attribute
+    {
+        /// <summary>
+        /// The type that will be used in view resolution instead of the owning 
+        /// view model type
+        /// </summary>
+        public Type Type { get; set; }
+    }
 }
 
 // vim: tw=120 ts=4 sw=4 et :

--- a/ReactiveUI/ViewLocator.cs
+++ b/ReactiveUI/ViewLocator.cs
@@ -50,21 +50,23 @@ namespace ReactiveUI
             // * IViewFor<IFooBarViewModel>
             // * IViewFor<FooBarViewModel> (the original behavior in RxUI 3.1)
 
-            var attrs = viewModel.GetType().GetTypeInfo().GetCustomAttributes(typeof (ViewContractAttribute), true);
+            var viewModelType = viewModel.GetType();
+
+            var attrs = viewModelType.GetTypeInfo().GetCustomAttributes(typeof(ViewContractAttribute), true);
 
             if (attrs.Any()) {
                 contract = contract ?? ((ViewContractAttribute) attrs.First()).Contract;
             }
 
             // IFooBarView that implements IViewFor (or custom ViewModelToViewFunc)
-            var typeToFind = ViewModelToViewFunc(viewModel.GetType().AssemblyQualifiedName);
+            var typeToFind = ViewModelToViewFunc(viewModelType.AssemblyQualifiedName);
                 
             var ret = attemptToResolveView(Reflection.ReallyFindType(typeToFind, false), contract);
             if (ret != null) return ret;
 
             // IViewFor<FooBarViewModel> (the original behavior in RxUI 3.1)
             var viewType = typeof (IViewFor<>);
-            return attemptToResolveView(viewType.MakeGenericType(viewModel.GetType()), contract);
+            return attemptToResolveView(viewType.MakeGenericType(viewModelType), contract);
         }
 
         IViewFor attemptToResolveView(Type type, string contract)

--- a/ReactiveUI/ViewLocator.cs
+++ b/ReactiveUI/ViewLocator.cs
@@ -60,8 +60,7 @@ namespace ReactiveUI
 
             attrs = viewModelType.GetTypeInfo().GetCustomAttributes(typeof(ViewResolutionTypeOverrideAttribute), true);
 
-            if (attrs.Any())
-            {
+            if (attrs.Any()) {
                 viewModelType = ((ViewResolutionTypeOverrideAttribute)attrs.First()).Type;
             }
 

--- a/ReactiveUI/ViewLocator.cs
+++ b/ReactiveUI/ViewLocator.cs
@@ -58,6 +58,13 @@ namespace ReactiveUI
                 contract = contract ?? ((ViewContractAttribute) attrs.First()).Contract;
             }
 
+            attrs = viewModelType.GetTypeInfo().GetCustomAttributes(typeof(ViewResolutionTypeOverrideAttribute), true);
+
+            if (attrs.Any())
+            {
+                viewModelType = ((ViewResolutionTypeOverrideAttribute)attrs.First()).Type;
+            }
+
             // IFooBarView that implements IViewFor (or custom ViewModelToViewFunc)
             var typeToFind = ViewModelToViewFunc(viewModelType.AssemblyQualifiedName);
                 


### PR DESCRIPTION
I am creating this PR because I ran into an issue yesterday where I wanted to make a generically typed view model that would all use a common view. The problem with this approach is that you cannot register your IViewFor<> associations because the generic type doesn't allow that (this might work if you use an IoC that supports generic registrations, I'm not entirely sure). The simplest solution I could think of was to allow overriding the type information used in view resolution by using a custom attribute. This attribute then supplies the type override to use in view resolution (and does not even necessarily have to be related to the view model it decorates, but that would probably be a strange setup).

Here are some examples where we could use this new attribute
```csharp
[ViewResolutionTypeOverride(Type = typeof(IMyViewModel))]
public class MyGenericViewModel<T> : ReactiveObject, IMyViewModel
{
    // ...
}

public class MyBaseViewModel : ReactiveObject
{
    // ...
}

[ViewResolutionTypeOverride(Type = typeof(MyBaseViewModel))]
public class MyDerivedGenericViewModel<T> : MyBaseViewModel
{
    // ...
}

// and in the view registrations
public void RegisterViews()
{
    Locator.CurrentMutable.Register(() => MyView(), typeof(IViewFor<IMyViewModel>));
    Locator.CurrentMutable.Register(() => MyOtherView(), typeof(IViewFor<MyBaseViewModel>));
}
```

p.s. if a  test is required for this PR to be accepted let me know and I'll look into writing a new test for it.