### PR TITLE
Added test case illustrating problem with task failing "too early".

### DIFF
--- a/ReactiveUI.Tests/ReactiveCommandTest.cs
+++ b/ReactiveUI.Tests/ReactiveCommandTest.cs
@@ -571,6 +571,29 @@ namespace ReactiveUI.Tests
         }
 
         [Fact]
+        public void TaskCreationExceptionsShouldBeMarshaledToThrownExceptions()
+        {
+            (new TestScheduler()).With(sched => {
+                var fixture = ReactiveCommand.CreateAsyncTask(Observable.Return(true), _ => {
+                    //var tcs = new TaskCompletionSource<bool>();
+                    //tcs.SetException(new Exception("Die"));
+                    //return tcs.Task;
+                    throw new Exception("Die");
+                }, sched);
+
+                var error = default(Exception);
+                fixture.ThrownExceptions.Subscribe(ex => error = ex);
+                fixture.Execute(null);
+
+                sched.AdvanceByMs(20);
+
+                bool canExecute = fixture.CanExecute(null);
+                Assert.NotNull(error);
+                Assert.True(canExecute);
+            });
+        }
+
+        [Fact]
         public async Task IsExecutingIsFalseAfterAwaitingCommand()
         {
             var command = ReactiveCommand.CreateAsyncTask(_ => Task.Run(() => Thread.Sleep(10)));


### PR DESCRIPTION
Below is test case illustrating problem described at number 3 in discussion:
https://github.com/reactiveui/ReactiveUI/issues/906

Commented out Task implementation work fine/passes, current implementation causes Task to become in "cannot execute" state without providing error to `ThrownExceptions`

Multiple existing methods/API in the world do parameter validation "before" actually starting asynchronous operations (sometime separate parameter validating wrapper is public, and actual `async` implementation is private for example).

I was going to dive deeper and fix it - but would like to know if you consider it "bug" or I am missing sth :)