### PR TITLE
Add XmlnsDefinitionAttribute for those XAML platforms that support it.

### DIFF
--- a/ReactiveUI/ReactiveUI_Net45.csproj
+++ b/ReactiveUI/ReactiveUI_Net45.csproj
@@ -82,6 +82,7 @@
     <Compile Include="ExpressionMixins.cs" />
     <Compile Include="ExpressionRewriter.cs" />
     <Compile Include="Platform\ComponentModelTypeConverter.cs" />
+    <Compile Include="Xaml\Attributes.cs" />
     <Compile Include="Xaml\WpfAutoSuspendHelper.cs" />
     <Compile Include="Xaml\WpfDependencyObjectObservableForProperty.cs" />
     <Compile Include="Xaml\ActivationForViewFetcher.cs" />

--- a/ReactiveUI/ReactiveUI_WP8.csproj
+++ b/ReactiveUI/ReactiveUI_WP8.csproj
@@ -84,6 +84,7 @@
     <Compile Include="ExpressionRewriter.cs" />
     <Compile Include="Platform\Registrations.cs" />
     <Compile Include="Xaml\ActivationForViewFetcher.cs" />
+    <Compile Include="Xaml\Attributes.cs" />
     <Compile Include="Xaml\AutoDataTemplateBindingHook.cs" />
     <Compile Include="Xaml\BindingTypeConverters.cs" />
     <Compile Include="Xaml\DependencyObjectObservableForProperty.cs" />

--- a/ReactiveUI/ReactiveUI_WinRT.csproj
+++ b/ReactiveUI/ReactiveUI_WinRT.csproj
@@ -45,6 +45,7 @@
     <Compile Include="ExpressionRewriter.cs" />
     <Compile Include="Platform\Registrations.cs" />
     <Compile Include="Xaml\ActivationForViewFetcher.cs" />
+    <Compile Include="Xaml\Attributes.cs" />
     <Compile Include="Xaml\AutoDataTemplateBindingHook.cs" />
     <Compile Include="Xaml\BindingTypeConverters.cs" />
     <Compile Include="Xaml\DependencyObjectObservableForProperty.cs" />

--- a/ReactiveUI/ReactiveUI_WinRT80.csproj
+++ b/ReactiveUI/ReactiveUI_WinRT80.csproj
@@ -45,6 +45,7 @@
     <Compile Include="ExpressionRewriter.cs" />
     <Compile Include="Platform\Registrations.cs" />
     <Compile Include="Xaml\ActivationForViewFetcher.cs" />
+    <Compile Include="Xaml\Attributes.cs" />
     <Compile Include="Xaml\AutoDataTemplateBindingHook.cs" />
     <Compile Include="Xaml\BindingTypeConverters.cs" />
     <Compile Include="Xaml\DependencyObjectObservableForProperty.cs" />

--- a/ReactiveUI/Xaml/Attributes.cs
+++ b/ReactiveUI/Xaml/Attributes.cs
@@ -1,0 +1,3 @@
+﻿using System.Windows.Markup;
+
+[assembly:XmlnsDefinition("http://reactiveui.net", "ReactiveUI")]


### PR DESCRIPTION
This PR fixes #863 by adding the `XmlnsDefinition` attribute for supported XAML platforms. Consequently, XAML code can do this:

```XML
<Whatever x:rxui="http://reactiveui.net">
```

Unfortunately, the Xam Forms XAML layer does not support XmlnsDefinition nor (to my knowledge) anything equivalent to it, so for now you're stuck writing out crazy long namespace mappings on that platform.