### PR TITLE
Don't automatically create a DataTemplate, if the DisplayMemberPath of the ItemsControl is set

### DIFF
--- a/ReactiveUI.Tests/PropertyBindingTest.cs
+++ b/ReactiveUI.Tests/PropertyBindingTest.cs
@@ -319,6 +319,19 @@ namespace ReactiveUI.Tests
         }
 
         [Fact]
+        public void ItemsControlWithDisplayMemberPathSetShouldNotGetADataTemplate()
+        {
+            var vm = new PropertyBindViewModel();
+            var view = new PropertyBindView() { ViewModel = vm };
+            view.FakeItemsControl.DisplayMemberPath = "Bla";
+
+            Assert.Null(view.FakeItemsControl.ItemTemplate);
+            view.OneWayBind(vm, x => x.SomeCollectionOfStrings, x => x.FakeItemsControl.ItemsSource);
+
+            Assert.Null(view.FakeItemsControl.ItemTemplate);
+        }
+
+        [Fact]
         public void ItemsControlShouldGetADataTemplateInBindTo()
         {
             var vm = new PropertyBindViewModel();

--- a/ReactiveUI/Xaml/AutoDataTemplateBindingHook.cs
+++ b/ReactiveUI/Xaml/AutoDataTemplateBindingHook.cs
@@ -56,6 +56,8 @@ namespace ReactiveUI
             var itemsControl = lastViewProperty.Sender as ItemsControl;
             if (itemsControl == null) return true;
 
+            if (!String.IsNullOrEmpty(itemsControl.DisplayMemberPath)) return true;
+
             if (viewProperties.Last().GetPropertyName() != "ItemsSource") return true;
 
             if (itemsControl.ItemTemplate != null) return true;


### PR DESCRIPTION
This prevents ReactiveUI from setting a DataTemplate for simple cases
like a ComboBox that displays just a list of strings where there is no
need for a dedicated datatemplate