### PR TITLE
Add ReactiveUserControl for XAML platforms.

### DIFF
--- a/ReactiveUI/ReactiveUI_Net45.csproj
+++ b/ReactiveUI/ReactiveUI_Net45.csproj
@@ -82,6 +82,7 @@
     <Compile Include="ExpressionMixins.cs" />
     <Compile Include="ExpressionRewriter.cs" />
     <Compile Include="Platform\ComponentModelTypeConverter.cs" />
+    <Compile Include="Xaml\ReactiveUserControl.cs" />
     <Compile Include="Xaml\WpfAutoSuspendHelper.cs" />
     <Compile Include="Xaml\WpfDependencyObjectObservableForProperty.cs" />
     <Compile Include="Xaml\ActivationForViewFetcher.cs" />

--- a/ReactiveUI/ReactiveUI_WP8.csproj
+++ b/ReactiveUI/ReactiveUI_WP8.csproj
@@ -89,6 +89,7 @@
     <Compile Include="Xaml\DependencyObjectObservableForProperty.cs" />
     <Compile Include="Xaml\PhoneServiceStateDriver.cs" />
     <Compile Include="Xaml\PlatformOperations.cs" />
+    <Compile Include="Xaml\ReactiveUserControl.cs" />
     <Compile Include="Xaml\RoutedViewHost.cs" />
     <Compile Include="Xaml\TransitioningContentControl.cs" />
     <Compile Include="Xaml\ViewModelViewHost.cs" />

--- a/ReactiveUI/ReactiveUI_WinRT.csproj
+++ b/ReactiveUI/ReactiveUI_WinRT.csproj
@@ -49,6 +49,7 @@
     <Compile Include="Xaml\BindingTypeConverters.cs" />
     <Compile Include="Xaml\DependencyObjectObservableForProperty.cs" />
     <Compile Include="Xaml\PlatformOperations.cs" />
+    <Compile Include="Xaml\ReactiveUserControl.cs" />
     <Compile Include="Xaml\RoutedViewHost.cs" />
     <Compile Include="Xaml\TransitioningContentControl.WinRT.cs" />
     <Compile Include="Xaml\ViewModelViewHost.cs" />

--- a/ReactiveUI/ReactiveUI_WinRT80.csproj
+++ b/ReactiveUI/ReactiveUI_WinRT80.csproj
@@ -49,6 +49,7 @@
     <Compile Include="Xaml\BindingTypeConverters.cs" />
     <Compile Include="Xaml\DependencyObjectObservableForProperty.cs" />
     <Compile Include="Xaml\PlatformOperations.cs" />
+    <Compile Include="Xaml\ReactiveUserControl.cs" />
     <Compile Include="Xaml\RoutedViewHost.cs" />
     <Compile Include="Xaml\TransitioningContentControl.WinRT.cs" />
     <Compile Include="Xaml\ViewModelViewHost.cs" />

--- a/ReactiveUI/Xaml/ReactiveUserControl.cs
+++ b/ReactiveUI/Xaml/ReactiveUserControl.cs
@@ -1,0 +1,62 @@
+﻿namespace ReactiveUI
+{
+#if WINRT
+    using Windows.UI.Xaml;
+    using Windows.UI.Xaml.Controls;
+#else
+    using System.Windows;
+    using System.Windows.Controls;
+#endif
+
+    /// <summary>
+    /// A <see cref="UserControl"/> that is reactive.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This class is a WPF <see cref="UserControl"/> that is also reactive. That is, it implements <see cref="IViewFor{TViewModel}"/>.
+    /// You can extend this class to get an implementation of <see cref="IViewFor{TViewModel}"/> rather than writing one yourself.
+    /// </para>
+    /// <para>
+    /// Note that the XAML for your control must specify the same base class, including the generic argument you provide for your view
+    /// model. To do this, use the <c>TypeArguments</c> attribute as follows:
+    /// <code>
+    /// <![CDATA[
+    /// <rxui:ReactiveUserControl
+    ///         x:Class="views:YourView"
+    ///         x:TypeArguments="vms:YourViewModel"
+    ///         xmlns:rxui="http://reactiveui.net"
+    ///         xmlns:views="clr-namespace:Foo.Bar.Views"
+    ///         xmlns:vms="clr-namespace:Foo.Bar.ViewModels">
+    ///     <!-- view XAML here -->
+    /// </rxui:ReactiveUserControl>
+    /// ]]>
+    /// </code>
+    /// </para>
+    /// </remarks>
+    /// <typeparam name="TViewModel">
+    /// The type of the view model backing the view.
+    /// </typeparam>
+    public abstract class ReactiveUserControl<TViewModel> :
+        UserControl, IViewFor<TViewModel>
+        where TViewModel : class
+    {
+        public static readonly DependencyProperty ViewModelProperty =
+            DependencyProperty.Register(
+                "ViewModel",
+                typeof(TViewModel),
+                typeof(ReactiveUserControl<TViewModel>),
+                new PropertyMetadata(null));
+
+        public TViewModel ViewModel
+        {
+            get { return (TViewModel)this.GetValue(ViewModelProperty); }
+            set { this.SetValue(ViewModelProperty, value); }
+        }
+
+        object IViewFor.ViewModel
+        {
+            get { return this.ViewModel; }
+            set { this.ViewModel = (TViewModel)value; }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a `ReactiveUserControl<TViewModel>` for XAML platforms. It is the simplest possible thing that works and is intended to supersede #349 in the absence of a reason for the complexity of that solution.