### PR TITLE
Add support for View activation.

### DIFF
--- a/ReactiveUI.XamForms/XamForms/ActivationForViewFetcher.cs
+++ b/ReactiveUI.XamForms/XamForms/ActivationForViewFetcher.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.ComponentModel;
-using System.Linq;
 using System.Reactive;
 using System.Reactive.Linq;
 using System.Reflection;
@@ -21,52 +20,62 @@ namespace ReactiveUI.XamForms
 
         public IObservable<bool> GetActivationForView(IActivatable view)
         {
-            var ret = Observable.Never<bool>();
-            
+            var activation =
+                GetActivationFor(view as Page) ??
+                GetActivationFor(view as View) ??
+                GetActivationFor(view as Cell) ??
+                Observable.Never<bool>();
 
-            var page = view as Page;
+            return activation.DistinctUntilChanged();
+        }
 
-            if (page != null) {
-                ret = Observable.Merge(
-                    Observable.FromEventPattern<EventHandler, EventArgs>(x => page.Appearing += x, x => page.Appearing -= x).Select(_ => true),
-                    Observable.FromEventPattern<EventHandler, EventArgs>(x => page.Disappearing += x, x => page.Disappearing -= x).Select(_ => false));
-            } else {
-                var xfView = view as View;
-
-                if (xfView != null) {
-                    var propertyChanged = Observable.FromEventPattern<PropertyChangedEventHandler, PropertyChangedEventArgs>(
-                        x => xfView.PropertyChanged += x,
-                        x => xfView.PropertyChanged -= x);
-                    var parentChanged = propertyChanged
-                        .Where(x => x.EventArgs.PropertyName == "Parent")
-                        .Select(_ => Unit.Default);
-
-                    return parentChanged
-                        .StartWith(Unit.Default)
-                        .Select(_ => GetPageFor(xfView))
-                        .Select(x =>
-                            x == null ?
-                                Observable.Return(false) :
-                                Observable
-                                    .Merge(
-                                        Observable.FromEventPattern<EventHandler, EventArgs>(y => x.Appearing += y, y => x.Appearing -= y).Select(_ => true),
-                                        Observable.FromEventPattern<EventHandler, EventArgs>(y => x.Disappearing += y, y => x.Disappearing -= y).Select(_ => false))
-                                    .StartWith(true))
-                        .Switch();
-                } else {
-                    var cell = view as Cell;
-
-                    if (cell != null)
-                    {
-                        ret = Observable
-                            .Merge(
-                                Observable.FromEventPattern<EventHandler, EventArgs>(x => cell.Appearing += x, x => cell.Appearing -= x).Select(_ => true),
-                                Observable.FromEventPattern<EventHandler, EventArgs>(x => cell.Disappearing += x, x => cell.Disappearing -= x).Select(_ => false));
-                    }
-                }
+        private static IObservable<bool> GetActivationFor(Page page)
+        {
+            if (page == null) {
+                return null;
             }
 
-            return ret.DistinctUntilChanged();
+            return Observable.Merge(
+                Observable.FromEventPattern<EventHandler, EventArgs>(x => page.Appearing += x, x => page.Appearing -= x).Select(_ => true),
+                Observable.FromEventPattern<EventHandler, EventArgs>(x => page.Disappearing += x, x => page.Disappearing -= x).Select(_ => false));
+        }
+
+        private static IObservable<bool> GetActivationFor(View view)
+        {
+            if (view == null) {
+                return null;
+            }
+
+            var propertyChanged = Observable.FromEventPattern<PropertyChangedEventHandler, PropertyChangedEventArgs>(
+                x => view.PropertyChanged += x,
+                x => view.PropertyChanged -= x);
+            var parentChanged = propertyChanged
+                .Where(x => x.EventArgs.PropertyName == "Parent")
+                .Select(_ => Unit.Default);
+
+            return parentChanged
+                .StartWith(Unit.Default)
+                .Select(_ => GetPageFor(view))
+                .Select(x =>
+                    x == null ?
+                    Observable.Return(false) :
+                    Observable
+                    .Merge(
+                        Observable.FromEventPattern<EventHandler, EventArgs>(y => x.Appearing += y, y => x.Appearing -= y).Select(_ => true),
+                        Observable.FromEventPattern<EventHandler, EventArgs>(y => x.Disappearing += y, y => x.Disappearing -= y).Select(_ => false))
+                    .StartWith(true))
+                .Switch();
+        }
+
+        private static IObservable<bool> GetActivationFor(Cell cell)
+        {
+            if (cell == null) {
+                return null;
+            }
+
+            return Observable.Merge(
+                Observable.FromEventPattern<EventHandler, EventArgs>(x => cell.Appearing += x, x => cell.Appearing -= x).Select(_ => true),
+                Observable.FromEventPattern<EventHandler, EventArgs>(x => cell.Disappearing += x, x => cell.Disappearing -= x).Select(_ => false));
         }
 
         private static Page GetPageFor(Element element)

--- a/ReactiveUI.XamForms/XamForms/ActivationForViewFetcher.cs
+++ b/ReactiveUI.XamForms/XamForms/ActivationForViewFetcher.cs
@@ -1,11 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Reactive;
 using System.Reactive.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows;
 using System.Reflection;
 using Xamarin.Forms;
 
@@ -17,6 +14,7 @@ namespace ReactiveUI.XamForms
         {
             return
                 (typeof(Page).GetTypeInfo().IsAssignableFrom(view.GetTypeInfo())) ||
+                (typeof(View).GetTypeInfo().IsAssignableFrom(view.GetTypeInfo())) ||
                 (typeof(Cell).GetTypeInfo().IsAssignableFrom(view.GetTypeInfo()))
                 ? 10 : 0;
         }
@@ -24,6 +22,7 @@ namespace ReactiveUI.XamForms
         public IObservable<bool> GetActivationForView(IActivatable view)
         {
             var ret = Observable.Never<bool>();
+            
 
             var page = view as Page;
 
@@ -32,17 +31,61 @@ namespace ReactiveUI.XamForms
                     Observable.FromEventPattern<EventHandler, EventArgs>(x => page.Appearing += x, x => page.Appearing -= x).Select(_ => true),
                     Observable.FromEventPattern<EventHandler, EventArgs>(x => page.Disappearing += x, x => page.Disappearing -= x).Select(_ => false));
             } else {
-                var cell = view as Cell;
+                var xfView = view as View;
 
-                if (cell != null) {
-                    ret = Observable
-                        .Merge(
-                            Observable.FromEventPattern<EventHandler, EventArgs>(x => cell.Appearing += x, x => cell.Appearing -= x).Select(_ => true),
-                            Observable.FromEventPattern<EventHandler, EventArgs>(x => cell.Disappearing += x, x => cell.Disappearing -= x).Select(_ => false));
+                if (xfView != null) {
+                    var propertyChanged = Observable.FromEventPattern<PropertyChangedEventHandler, PropertyChangedEventArgs>(
+                        x => xfView.PropertyChanged += x,
+                        x => xfView.PropertyChanged -= x);
+                    var parentChanged = propertyChanged
+                        .Where(x => x.EventArgs.PropertyName == "Parent")
+                        .Select(_ => Unit.Default);
+
+                    return parentChanged
+                        .StartWith(Unit.Default)
+                        .Select(_ => GetPageFor(xfView))
+                        .Select(x =>
+                            x == null ?
+                                Observable.Return(false) :
+                                Observable
+                                    .Merge(
+                                        Observable.FromEventPattern<EventHandler, EventArgs>(y => x.Appearing += y, y => x.Appearing -= y).Select(_ => true),
+                                        Observable.FromEventPattern<EventHandler, EventArgs>(y => x.Disappearing += y, y => x.Disappearing -= y).Select(_ => false))
+                                    .StartWith(true))
+                        .Switch();
+                } else {
+                    var cell = view as Cell;
+
+                    if (cell != null)
+                    {
+                        ret = Observable
+                            .Merge(
+                                Observable.FromEventPattern<EventHandler, EventArgs>(x => cell.Appearing += x, x => cell.Appearing -= x).Select(_ => true),
+                                Observable.FromEventPattern<EventHandler, EventArgs>(x => cell.Disappearing += x, x => cell.Disappearing -= x).Select(_ => false));
+                    }
                 }
             }
 
             return ret.DistinctUntilChanged();
+        }
+
+        private static Page GetPageFor(Element element)
+        {
+            Page page = null;
+
+            while (element != null)
+            {
+                page = element as Page;
+
+                if (page != null)
+                {
+                    return page;
+                }
+
+                element = element.Parent;
+            }
+
+            return null;
         }
     }
 }


### PR DESCRIPTION
Fixes #949 by adding support for `View` activation.

The implementation is a little more awkward than we would like, but that's due to Xamarin Forms not exposing any lifecycle events for `View` objects. Instead, we have to hook into the lifecycle events of the view's hosting `Page`.