### PR TITLE
Upgrade Xamarin Forms dependency.

### DIFF
--- a/NuGet/ReactiveUI-XamForms/ReactiveUI-XamForms.nuspec
+++ b/NuGet/ReactiveUI-XamForms/ReactiveUI-XamForms.nuspec
@@ -12,7 +12,7 @@
 
     <dependencies>
       <dependency id="reactiveui-core" version="[6.5.0]" />
-      <dependency id="Xamarin.Forms" version="1.4.2.6359" />
+      <dependency id="Xamarin.Forms" version="1.5.0.6446" />
     </dependencies>
   </metadata>
 </package>

--- a/ReactiveUI.XamForms/ReactiveUI.XamForms.csproj
+++ b/ReactiveUI.XamForms/ReactiveUI.XamForms.csproj
@@ -48,15 +48,6 @@
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Xamarin.Forms.Core">
-      <HintPath>..\packages\Xamarin.Forms.1.4.2.6359\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="Xamarin.Forms.Platform">
-      <HintPath>..\packages\Xamarin.Forms.1.4.2.6359\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.Platform.dll</HintPath>
-    </Reference>
-    <Reference Include="Xamarin.Forms.Xaml">
-      <HintPath>..\packages\Xamarin.Forms.1.4.2.6359\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.Xaml.dll</HintPath>
-    </Reference>
     <Reference Include="System.Reactive.Core">
       <HintPath>..\packages\Rx-Core.2.2.5\lib\portable-net45+winrt45+wp8+wpa81\System.Reactive.Core.dll</HintPath>
     </Reference>
@@ -71,6 +62,18 @@
     </Reference>
     <Reference Include="System.Reactive.Linq">
       <HintPath>..\packages\Rx-Linq.2.2.5\lib\portable-net45+winrt45+wp8+wpa81\System.Reactive.Linq.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Forms.Core, Version=1.5.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\driveriq\Src\packages\Xamarin.Forms.1.5.0.6446\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Xamarin.Forms.Platform, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\driveriq\Src\packages\Xamarin.Forms.1.5.0.6446\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.Platform.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Xamarin.Forms.Xaml, Version=1.5.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\driveriq\Src\packages\Xamarin.Forms.1.5.0.6446\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.Xaml.dll</HintPath>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/ReactiveUI.XamForms/packages.config
+++ b/ReactiveUI.XamForms/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Rx-Core" version="2.2.5" targetFramework="portable-net45+win+wpa81+wp80+MonoAndroid10+xamarinios10+MonoTouch10" />
-  <package id="Rx-Interfaces" version="2.2.5" targetFramework="portable-net45+win+wpa81+wp80+MonoAndroid10+xamarinios10+MonoTouch10" />
-  <package id="Rx-Linq" version="2.2.5" targetFramework="portable-net45+win+wpa81+wp80+MonoAndroid10+xamarinios10+MonoTouch10" />
+  <package id="Rx-Core" version="2.2.5" targetFramework="portable-net45+win8+wp8+wpa81" />
+  <package id="Rx-Interfaces" version="2.2.5" targetFramework="portable-net45+win8+wp8+wpa81" />
+  <package id="Rx-Linq" version="2.2.5" targetFramework="portable-net45+win8+wp8+wpa81" />
   <package id="Rx-Main" version="2.2.5" targetFramework="net45" />
-  <package id="Rx-PlatformServices" version="2.2.5" targetFramework="portable-net45+win+wpa81+wp80+MonoAndroid10+xamarinios10+MonoTouch10" />
-  <package id="Splat" version="1.6.2" targetFramework="portable-net45+win+wpa81+wp80+MonoAndroid10+xamarinios10+MonoTouch10" />
-  <package id="Xamarin.Forms" version="1.4.2.6359" targetFramework="portable-net45+win+wp80+MonoAndroid10+MonoTouch10" />
+  <package id="Rx-PlatformServices" version="2.2.5" targetFramework="portable-net45+win8+wp8+wpa81" />
+  <package id="Splat" version="1.6.2" targetFramework="portable-net45+win8+wp8+wpa81" />
+  <package id="Xamarin.Forms" version="1.5.0.6446" targetFramework="portable45-net45+win8+wp8+wpa81" />
 </packages>


### PR DESCRIPTION
Fixes #948 by upgrading the XF dependency to latest.

Technically, RxUI does not have a binary dependency on the latest XF version, but I'm creating this under the assumption we want people to use the latest. Will discuss.