### PR TITLE
Support ancestral parent changes in View activation.

### DIFF
--- a/ReactiveUI.XamForms/XamForms/ActivationForViewFetcher.cs
+++ b/ReactiveUI.XamForms/XamForms/ActivationForViewFetcher.cs
@@ -46,19 +46,35 @@ namespace ReactiveUI.XamForms
             if (view == null) {
                 return null;
             }
+            
+            var propertyChanged = Observable.FromEventPattern<PropertyChangedEventHandler, PropertyChangedEventArgs>(
+                x => view.PropertyChanged += x,
+                x => view.PropertyChanged -= x);
+            return propertyChanged
+                .Where(x => x.EventArgs.PropertyName == "IsVisible")
+                .Select(_ => view.IsVisible)
+                .StartWith(view.IsVisible);
 
-            return GetAnyParentChangedFor(view)
-                .StartWith(Unit.Default)
-                .Select(_ => GetPageFor(view))
-                .Select(x =>
-                    x == null ?
-                    Observable.Return(false) :
-                    Observable
-                    .Merge(
-                        Observable.FromEventPattern<EventHandler, EventArgs>(y => x.Appearing += y, y => x.Appearing -= y).Select(_ => true),
-                        Observable.FromEventPattern<EventHandler, EventArgs>(y => x.Disappearing += y, y => x.Disappearing -= y).Select(_ => false))
-                    .StartWith(true))
-                .Switch();
+            //return GetAnyParentChangedFor(view)
+            //    .StartWith(Unit.Default)
+            //    .Select(_ => GetPageFor(view))
+            //    .Select(x =>
+            //        x == null ?
+            //        Observable.Return(false) :
+            //        Observable
+            //        .Merge(
+            //            Observable
+            //                .FromEventPattern<EventHandler, EventArgs>(y => x.Appearing += y, y => x.Appearing -= y)
+            //                .Do(_ => System.Diagnostics.Debug.WriteLine("{0} APPEARING", view))
+            //                .Select(_ => true),
+            //            Observable
+            //                .FromEventPattern<EventHandler, EventArgs>(y => x.Disappearing += y, y => x.Disappearing -= y)
+            //                .Do(_ => System.Diagnostics.Debug.WriteLine("{0} DISAPPEARING", view))
+            //                .Select(_ => false))
+            //        .Do(_ => System.Diagnostics.Debug.WriteLine("PAGE FOUND FOR {0}, IS VISIBLE: {1}", view, x.IsVisible))
+            //        .StartWith(x.IsVisible))
+            //    .Switch()
+            //    .Do(x => System.Diagnostics.Debug.WriteLine("{0} ACTIVATED: {1}", view, x));
         }
 
         private static IObservable<Element> GetParentChangedFor(Element element)

--- a/ReactiveUI.XamForms/XamForms/ActivationForViewFetcher.cs
+++ b/ReactiveUI.XamForms/XamForms/ActivationForViewFetcher.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Reactive;
 using System.Reactive.Linq;
 using System.Reflection;
 using Xamarin.Forms;
@@ -54,57 +52,6 @@ namespace ReactiveUI.XamForms
                 .Where(x => x.EventArgs.PropertyName == "IsVisible")
                 .Select(_ => view.IsVisible)
                 .StartWith(view.IsVisible);
-
-            //return GetAnyParentChangedFor(view)
-            //    .StartWith(Unit.Default)
-            //    .Select(_ => GetPageFor(view))
-            //    .Select(x =>
-            //        x == null ?
-            //        Observable.Return(false) :
-            //        Observable
-            //        .Merge(
-            //            Observable
-            //                .FromEventPattern<EventHandler, EventArgs>(y => x.Appearing += y, y => x.Appearing -= y)
-            //                .Do(_ => System.Diagnostics.Debug.WriteLine("{0} APPEARING", view))
-            //                .Select(_ => true),
-            //            Observable
-            //                .FromEventPattern<EventHandler, EventArgs>(y => x.Disappearing += y, y => x.Disappearing -= y)
-            //                .Do(_ => System.Diagnostics.Debug.WriteLine("{0} DISAPPEARING", view))
-            //                .Select(_ => false))
-            //        .Do(_ => System.Diagnostics.Debug.WriteLine("PAGE FOUND FOR {0}, IS VISIBLE: {1}", view, x.IsVisible))
-            //        .StartWith(x.IsVisible))
-            //    .Switch()
-            //    .Do(x => System.Diagnostics.Debug.WriteLine("{0} ACTIVATED: {1}", view, x));
-        }
-
-        private static IObservable<Element> GetParentChangedFor(Element element)
-        {
-            var propertyChanged = Observable.FromEventPattern<PropertyChangedEventHandler, PropertyChangedEventArgs>(
-                x => element.PropertyChanged += x,
-                x => element.PropertyChanged -= x);
-            return propertyChanged
-                .Where(x => x.EventArgs.PropertyName == "Parent")
-                .Select(_ => element.Parent);
-        }
-
-        private static IObservable<Unit> GetParentChangedForRecursive(Element element)
-        {
-            var observables = new List<IObservable<Unit>>();
-
-            while (element != null)
-            {
-                observables.Add(GetParentChangedFor(element).Select(_ => Unit.Default));
-                element = element.Parent;
-            }
-
-            return Observable.Merge(observables);
-        }
-
-        private static IObservable<Unit> GetAnyParentChangedFor(Element element)
-        {
-            return GetParentChangedForRecursive(element)
-                .Select(_ => GetParentChangedForRecursive(element).StartWith(Unit.Default))
-                .Switch();
         }
 
         private static IObservable<bool> GetActivationFor(Cell cell)


### PR DESCRIPTION
The code I wrote previously to detect parent changes for a `View` so that activation can be hooked is insufficient. We need to monitor all ancestors.