### PR TITLE
Forward exceptions on creating execute observable to ThrownExceptions

### DIFF
--- a/ReactiveUI/ReactiveCommand.cs
+++ b/ReactiveUI/ReactiveCommand.cs
@@ -375,7 +375,7 @@ namespace ReactiveUI
                     })
                 };
 
-                var disp = executeAsync(parameter)
+                var disp = executeAsyncSafe(parameter)
                     .ObserveOn(scheduler)
                     .Do(
                         _ => { },
@@ -390,6 +390,19 @@ namespace ReactiveUI
             return ret.Publish().RefCount();
         }
 
+        private IObservable<T> executeAsyncSafe(object parameter)
+        {
+            IObservable<T> ret;
+
+            try {
+                ret = executeAsync(parameter);
+            }
+            catch (Exception ex) {
+                ret = Observable.Throw<T>(ex);
+            }
+
+            return ret;
+        }
 
         /// <summary>
         /// Executes a Command and returns the result as a Task. This method


### PR DESCRIPTION
If the `executeAsync` func throws an exception while creating the observable (i.e. synchronously), then this exception is lost by frameworks relying on `ICommand.Execute` - this swallows any exceptions returned from `ReactiveCommand.ExecuteAsync`.

This change ensures these exceptions are forwarded to `ThrownExceptions`, which would seem to be the expected behaviour.

Fixes #973 