### PR TITLE
adding observable version of WhenNavigatedTo, plus tests

### DIFF
--- a/ReactiveUI.Tests/ReactiveUI.Tests_Net45.csproj
+++ b/ReactiveUI.Tests/ReactiveUI.Tests_Net45.csproj
@@ -103,6 +103,7 @@
     <Compile Include="CommandBindingTests.cs" />
     <Compile Include="INPCObservableForPropertyTests.cs" />
     <Compile Include="InteractionsTest.cs" />
+    <Compile Include="RoutableViewModelMixinTests.cs" />
     <Compile Include="TestUtilsTest.cs" />
     <Compile Include="WeakEventManagerTest.cs" />
     <Compile Include="Winforms\ActivationTests.cs" />

--- a/ReactiveUI.Tests/RoutableViewModelMixinTests.cs
+++ b/ReactiveUI.Tests/RoutableViewModelMixinTests.cs
@@ -1,0 +1,185 @@
+﻿using ReactiveUI.Tests.RoutableViewMixinTests;
+using Xunit;
+
+namespace ReactiveUI.Tests
+{
+    using System;
+    using System.Reactive.Disposables;
+    using Assert = Xunit.Assert;
+
+    namespace RoutableViewMixinTests
+    {
+        public class TestScreen : IScreen
+        {
+            public RoutingState Router { get; } = new RoutingState();
+        }
+
+        public class RoutableViewModel : ReactiveObject, IRoutableViewModel
+        {
+            public RoutableViewModel(IScreen screen)
+            {
+                HostScreen = screen;
+            }
+
+            public string UrlPathSegment => "Test";
+            public IScreen HostScreen { get; }
+        }
+    }
+
+    public class RoutableViewModelMixinTests
+    {
+        [Fact]
+        public void WhenNavigatedToCallsOnNavigatedToWhenViewModelIsFirstAdded()
+        {
+            var count = 0;
+
+            var screen = new TestScreen();
+            var vm = new RoutableViewModel(screen);
+
+            vm.WhenNavigatedTo(() => {
+                count++;
+
+                return Disposable.Empty;
+            });
+
+            screen.Router.Navigate.Execute(vm);
+
+            Assert.Equal(1, count);
+        }
+
+        [Fact]
+        public void WhenNavigatedToCallsOnNavigatedToWhenViewModelReturnsToTopOfStack()
+        {
+            var count = 0;
+
+            var screen = new TestScreen();
+            var vm = new RoutableViewModel(screen);
+            var vm2 = new RoutableViewModel(screen);
+
+            vm.WhenNavigatedTo(() => {
+                count++;
+
+                return Disposable.Empty;
+            });
+
+            screen.Router.Navigate.Execute(vm);
+            screen.Router.Navigate.Execute(vm2);
+            screen.Router.Navigate.Execute(vm);
+
+            Assert.Equal(2, count);
+        }
+
+        [Fact]
+        public void WhenNavigatedToCallsDisposeWhenViewModelLosesFocus()
+        {
+            var count = 0;
+
+            var screen = new TestScreen();
+            var vm = new RoutableViewModel(screen);
+            var vm2 = new RoutableViewModel(screen);
+
+            vm.WhenNavigatedTo(() => {
+                return Disposable.Create(() => count++);
+            });
+
+            screen.Router.Navigate.Execute(vm);
+
+            Assert.Equal(0, count);
+
+            screen.Router.Navigate.Execute(vm2);
+
+            Assert.Equal(1, count);
+        }
+
+        [Fact]
+        public void WhenNavigatedToObservableFiresWhenViewModelAddedToNavigationStack()
+        {
+            var count = 0;
+
+            var screen = new TestScreen();
+            var vm = new RoutableViewModel(screen);
+
+            vm.WhenNavigatedToObservable().Subscribe(_ => {
+                count++;
+            });
+
+            screen.Router.Navigate.Execute(vm);
+
+            Assert.Equal(1, count);
+        }
+
+        [Fact]
+        public void WhenNavigatedToObservableFiresWhenViewModelReturnsToNavigationStack()
+        {
+            var count = 0;
+
+            var screen = new TestScreen();
+            var vm = new RoutableViewModel(screen);
+            var vm2 = new RoutableViewModel(screen);
+
+            vm.WhenNavigatedToObservable().Subscribe(_ => {
+                count++;
+            });
+
+            screen.Router.Navigate.Execute(vm);
+            screen.Router.Navigate.Execute(vm2);
+            screen.Router.Navigate.Execute(vm);
+
+            Assert.Equal(2, count);
+        }
+
+        [Fact]
+        public void WhenNavigatedToObservableCompletesWhenViewModelIsRemovedFromNavigationStack()
+        {
+            var count = 0;
+
+            var screen = new TestScreen();
+            var vm = new RoutableViewModel(screen);
+
+            vm.WhenNavigatedToObservable().Subscribe(
+                _ => {},
+                () => { count++; });
+
+            screen.Router.Navigate.Execute(vm);
+            screen.Router.NavigateBack.Execute(null);
+
+            Assert.Equal(1, count);
+        }
+
+        [Fact]
+        public void WhenNavigatingFromObservableFiresWhenViewModelLosesFocus()
+        {
+            var count = 0;
+            var screen = new TestScreen();
+            var vm = new RoutableViewModel(screen);
+            var vm2 = new RoutableViewModel(screen);
+
+            vm.WhenNavigatingFromObservable().Subscribe(_ => {
+                count++;
+            });
+
+            screen.Router.Navigate.Execute(vm);
+            screen.Router.Navigate.Execute(vm2);
+
+            Assert.Equal(1, count);
+        }
+
+        [Fact]
+        public void WhenNavigatingFromObservableCompletesWhenViewModelIsRemovedFromNavigationStack()
+        {
+            var count = 0;
+
+            var screen = new TestScreen();
+            var vm = new RoutableViewModel(screen);
+
+            vm.WhenNavigatingFromObservable().Subscribe(
+                _ => {},
+                () => { count++; });
+
+            screen.Router.Navigate.Execute(vm);
+            screen.Router.NavigateBack.Execute(null);
+
+            Assert.Equal(1, count);
+        }
+    }
+}

--- a/ReactiveUI/RoutableViewModelMixin.cs
+++ b/ReactiveUI/RoutableViewModelMixin.cs
@@ -1,8 +1,6 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Reactive;
+using System.Reactive.Linq;
 
 namespace ReactiveUI
 {
@@ -34,6 +32,55 @@ namespace ReactiveUI
                     }
                 }
             });
+        }
+
+        /// <summary>
+        /// This method will return an observable that fires events every time
+        /// the topmost ViewModel in the navigation stack is this ViewModel.
+        /// This allows you to set up connections that only operate while the
+        /// ViewModel has focus.
+        /// 
+        /// The observable will complete when the ViewModel is removed completely
+        /// from the navigation stack. If your ViewModel can be _removed_ from
+        /// the navigation stack and then reused later, you must call this method
+        /// and resubscribe each time it is reused.
+        /// </summary>
+        /// <returns>An IObservable{Unit} that signals when the ViewModel has
+        /// been added or brought to the top of the navigation stack. The
+        /// observable completes when the ViewModel is no longer a part of the
+        /// navigation stack.</returns>
+        public static IObservable<Unit> WhenNavigatedToObservable(this IRoutableViewModel This)
+        {
+            var router = This.HostScreen.Router;
+            return router.NavigationStack.CountChanged
+                .Where(_ => router.GetCurrentViewModel() == This)
+                .Select(_ => Unit.Default)
+                .TakeUntil(router.NavigationStack.BeforeItemsRemoved
+                    .Where(itemRemoved => itemRemoved == This));
+        }
+
+        /// <summary>
+        /// This method will return an observable that fires events _just before_
+        /// the ViewModel is no longer the topmost ViewModel in the navigation
+        /// stack. This allows you to clean up anything before losing focus.
+        /// 
+        /// The observable will complete when the ViewModel is removed completely
+        /// from the navigation stack. If your ViewModel can be _removed_ from
+        /// the navigation stack and then reused later, you must call this method
+        /// and resubscribe each time it is reused.
+        /// </summary>
+        /// <returns>An IObservable{Unit} that signals when the ViewModel is no
+        /// longer the topmost ViewModel in the navigation stack. The observable
+        /// completes when the ViewModel is no longer a part of the navigation
+        /// stack.</returns>
+        public static IObservable<Unit> WhenNavigatingFromObservable(this IRoutableViewModel This)
+        {
+            var router = This.HostScreen.Router;
+            return router.NavigationStack.CountChanging
+                .Where(_ => router.GetCurrentViewModel() == This)
+                .Select(_ => Unit.Default)
+                .TakeUntil(router.NavigationStack.ItemsRemoved
+                    .Where(itemRemoved => itemRemoved == This));
         }
     }
 }


### PR DESCRIPTION
I found I wanted to compose an existing observable with an observable version of `WhenNavigatedTo`, so that's what we've got here.

`WhenNavigatedToObservable()` returns an observable that fires events in the stream when the navigation stack is modified such that this VM is the topmost VM. To avoid leaking resources, it will fire `OnCompleted` when the VM is removed from the navigation stack. The alternative would be to have the user track this subscription and then dispose of it manually later, but I'm assuming that most of the time the calling VM is going to be thrown away when it no longer exists in the back stack. This removes a potential leak if the user fails to track the subscription.

`WhenNavigatingFromObservable` fires events just before another view model is added to the top of the stack. Otherwise, it functions the same.