### PR TITLE
Portable PlatformRegistrations should work from unit tests

### DIFF
--- a/ReactiveUI/PortableLibraryStubs.cs
+++ b/ReactiveUI/PortableLibraryStubs.cs
@@ -1,8 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Reflection;
 
 namespace ReactiveUI
 {
@@ -10,7 +8,16 @@ namespace ReactiveUI
     {
         public void Register(Action<Func<object>, Type> registerFunction)
         {
+            if (IsRunningFromNUnit()) return;
             throw new Exception("You are referencing the Portable version of ReactiveUI in an App. Reference the platform-specific version.");
+        }
+
+        private bool IsRunningFromNUnit()
+        {
+            var currentdomain = typeof(string).GetTypeInfo().Assembly.GetType("System.AppDomain").GetRuntimeProperty("CurrentDomain").GetMethod.Invoke(null, new object[] { });
+            var getassemblies = currentdomain.GetType().GetRuntimeMethod("GetAssemblies", new Type[]{ });
+            var assemblies = getassemblies.Invoke(currentdomain, new object[]{ }) as Assembly[];
+            return assemblies.Any(assembly => assembly.FullName.ToLowerInvariant().StartsWith("nunit.framework"));
         }
     }
 }

--- a/ReactiveUI/PortableLibraryStubs.cs
+++ b/ReactiveUI/PortableLibraryStubs.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Linq;
-using System.Reflection;
 
 namespace ReactiveUI
 {
@@ -8,16 +6,8 @@ namespace ReactiveUI
     {
         public void Register(Action<Func<object>, Type> registerFunction)
         {
-            if (IsRunningFromNUnit()) return;
+            if (Splat.ModeDetector.InUnitTestRunner()) return;
             throw new Exception("You are referencing the Portable version of ReactiveUI in an App. Reference the platform-specific version.");
-        }
-
-        private bool IsRunningFromNUnit()
-        {
-            var currentdomain = typeof(string).GetTypeInfo().Assembly.GetType("System.AppDomain").GetRuntimeProperty("CurrentDomain").GetMethod.Invoke(null, new object[] { });
-            var getassemblies = currentdomain.GetType().GetRuntimeMethod("GetAssemblies", new Type[]{ });
-            var assemblies = getassemblies.Invoke(currentdomain, new object[]{ }) as Assembly[];
-            return assemblies.Any(assembly => assembly.FullName.ToLowerInvariant().StartsWith("nunit.framework"));
         }
     }
 }


### PR DESCRIPTION
When use Xamarin Studio on OS X it is not possible to use ReactiveUI in Unit Testing Library projects. I am able to add "reactiveui-testing" nuget package, but during ReactiveUI initialisation it uses PlatformRegistrations from PortableLibraryStubs and crashes. As we do not need any additional registrations during unit tests I propose to allow ReactiveUI work when NUnit in loaded. This assumption smells like a hack, but at least this allows us to use ReactiveUI in our production process. Thanks!
