### PR TITLE
Have a lot of Views? Hate registering each one? This PR is for you!

### DIFF
--- a/.hgeol
+++ b/.hgeol
@@ -1,0 +1,2 @@
+[repository]
+native = LF

--- a/ReactiveUI.Tests/DependencyResolverTests.cs
+++ b/ReactiveUI.Tests/DependencyResolverTests.cs
@@ -13,6 +13,8 @@
         public class NeverUsedViewModel : ReactiveObject { }
 
         public class SingleInstanceExampleViewModel : ReactiveObject { }
+
+        public class ViewModelWithWeirdName : ReactiveObject { }
     }
 
     namespace TestViews
@@ -58,6 +60,8 @@
                 Instances++;
             }
         }
+
+        public class ViewWithoutMatchingName : ReactiveUserControl<ViewModelWithWeirdName> { }
     }
 
     public class DependencyResolverTests
@@ -78,7 +82,7 @@
             using (resolver.WithResolver()) {
                 Assert.Single(resolver.GetServices<IViewFor<ExampleViewModel>>());
                 Assert.Single(resolver.GetServices<IViewFor<AnotherViewModel>>());
-                Assert.Single(resolver.GetServices<IViewFor<NeverUsedViewModel>>());
+                Assert.Single(resolver.GetServices<IViewFor<ViewModelWithWeirdName>>());
             }
         }
 

--- a/ReactiveUI.Tests/DependencyResolverTests.cs
+++ b/ReactiveUI.Tests/DependencyResolverTests.cs
@@ -1,0 +1,149 @@
+﻿namespace ReactiveUI.Tests
+{
+    using Splat;
+    using TestViewModels;
+    using TestViews;
+    using Xunit;
+
+    namespace TestViewModels
+    {
+        public class ExampleViewModel : ReactiveObject { }
+        public class AnotherViewModel : ReactiveObject { }
+
+        public class NeverUsedViewModel : ReactiveObject { }
+
+        public class SingleInstanceExampleViewModel : ReactiveObject { }
+    }
+
+    namespace TestViews
+    {
+        using TestViewModels;
+
+        public class ExampleView : ReactiveUserControl<ExampleViewModel> { }
+        public class AnotherView : ReactiveUserControl<AnotherViewModel> { }
+
+        [ViewContract("contract")]
+        public class ContractExampleView : ReactiveUserControl<ExampleViewModel> { }
+
+        [SingleInstanceView]
+        public class NeverUsedView : ReactiveUserControl<NeverUsedViewModel>
+        {
+            public static int Instances = 0;
+
+            public NeverUsedView()
+            {
+                Instances++;
+            }
+        }
+
+        [SingleInstanceView]
+        public class SingleInstanceExampleView : ReactiveUserControl<SingleInstanceExampleViewModel>
+        {
+            public static int Instances = 0;
+
+            public SingleInstanceExampleView()
+            {
+                Instances++;
+            }
+        }
+
+        [ViewContract("contract")]
+        [SingleInstanceView]
+        public class SingleInstanceWithContractExampleView : ReactiveUserControl<SingleInstanceExampleViewModel>
+        {
+            public static int Instances = 0;
+
+            public SingleInstanceWithContractExampleView()
+            {
+                Instances++;
+            }
+        }
+    }
+
+    public class DependencyResolverTests
+    {
+        readonly IMutableDependencyResolver resolver;
+
+        public DependencyResolverTests()
+        {
+            resolver = new ModernDependencyResolver();
+            resolver.InitializeSplat();
+            resolver.InitializeReactiveUI();
+            resolver.RegisterViewsForViewModels(GetType().Assembly);
+        }
+
+        [Fact]
+        public void RegisterViewsForViewModelShouldRegisterAllViews()
+        {
+            using (resolver.WithResolver()) {
+                Assert.Single(resolver.GetServices<IViewFor<ExampleViewModel>>());
+                Assert.Single(resolver.GetServices<IViewFor<AnotherViewModel>>());
+                Assert.Single(resolver.GetServices<IViewFor<NeverUsedViewModel>>());
+            }
+        }
+
+        [Fact]
+        public void RegisterViewsForViewModelShouldIncludeContracts()
+        {
+            using (resolver.WithResolver()) {
+                Assert.Single(resolver.GetServices(typeof(IViewFor<ExampleViewModel>), "contract"));
+            }
+        }
+
+        [Fact]
+        public void NonContractRegistrationsShouldResolveCorrectly()
+        {
+            using (resolver.WithResolver()) {
+                Assert.IsType<AnotherView>(resolver.GetService<IViewFor<AnotherViewModel>>());
+            }
+        }
+
+        [Fact]
+        public void ContractRegistrationsShouldResolveCorrectly()
+        {
+            using (resolver.WithResolver()) {
+                Assert.IsType<ContractExampleView>(resolver.GetService(typeof(IViewFor<ExampleViewModel>), "contract"));
+            }
+        }
+
+        [Fact]
+        public void SingleInstanceViewsShouldOnlyBeInstantiatedWhenRequested()
+        {
+            using (resolver.WithResolver()) {
+                Assert.Equal(0, NeverUsedView.Instances);
+            }
+        }
+
+        [Fact]
+        public void SingleInstanceViewsShouldOnlyBeInstantiatedOnce()
+        {
+            using (resolver.WithResolver()) {
+                Assert.Equal(0, SingleInstanceExampleView.Instances);
+
+                var instance = resolver.GetService(typeof(IViewFor<SingleInstanceExampleViewModel>));
+                Assert.Equal(1, SingleInstanceExampleView.Instances);
+
+                var instance2 = resolver.GetService(typeof(IViewFor<SingleInstanceExampleViewModel>));
+                Assert.Equal(1, SingleInstanceExampleView.Instances);
+
+                Assert.Same(instance, instance2);
+            }
+        }
+
+        [Fact]
+        public void SingleInstanceViewsWithContractShouldResolveCorrectly()
+        {
+            using (resolver.WithResolver()) {
+                Assert.Equal(0, SingleInstanceWithContractExampleView.Instances);
+
+                var instance = resolver.GetService(typeof(IViewFor<SingleInstanceExampleViewModel>), "contract");
+                Assert.Equal(1, SingleInstanceWithContractExampleView.Instances);
+
+                var instance2 = resolver.GetService(typeof(IViewFor<SingleInstanceExampleViewModel>), "contract");
+                Assert.Equal(1, SingleInstanceWithContractExampleView.Instances);
+
+                Assert.Same(instance, instance2);
+            }
+        }
+    }
+}

--- a/ReactiveUI.Tests/ReactiveUI.Tests_Net45.csproj
+++ b/ReactiveUI.Tests/ReactiveUI.Tests_Net45.csproj
@@ -101,6 +101,7 @@
     <Compile Include="AwaiterTest.cs" />
     <Compile Include="BindingTypeConvertersTest.cs" />
     <Compile Include="CommandBindingTests.cs" />
+    <Compile Include="DependencyResolverTests.cs" />
     <Compile Include="INPCObservableForPropertyTests.cs" />
     <Compile Include="InteractionsTest.cs" />
     <Compile Include="TestUtilsTest.cs" />

--- a/ReactiveUI/IDependencyResolver.cs
+++ b/ReactiveUI/IDependencyResolver.cs
@@ -1,10 +1,7 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Reactive.Disposables;
+using System.Linq.Expressions;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 using Splat;
 
 namespace ReactiveUI
@@ -36,18 +33,70 @@ namespace ReactiveUI
             extraNs.ForEach(ns => processRegistrationForNamespace(ns, assmName, resolver));
         }
 
-        static bool processRegistrationForNamespace(string ns, AssemblyName assmName, IMutableDependencyResolver resolver)
+        public static void RegisterViewsForViewModels(this IMutableDependencyResolver resolver, Assembly assembly)
+        {
+            // for each type that implements IViewFor
+            foreach (var ti in assembly.DefinedTypes
+                .Where(ti => ti.ImplementedInterfaces.Contains(typeof(IViewFor)))
+                .Where(ti => !ti.IsAbstract))
+            {
+                // grab the first _implemented_ interface that also implements IViewFor, this should be the expected IViewFor<>
+                var ivf = ti.ImplementedInterfaces.FirstOrDefault(t => t.GetTypeInfo().ImplementedInterfaces.Contains(typeof(IViewFor)));
+
+                // need to check for null because some classes may implement IViewFor but not IViewFor<T> - we don't care about those
+                if (ivf != null) {
+                    // my kingdom for c# 6!
+                    var contractSource = ti.GetCustomAttribute<ViewContractAttribute>();
+                    var contract = contractSource != null ? contractSource.Contract : string.Empty;
+
+                    registerType(resolver, ti, ivf, contract);
+                }
+            }
+        }
+
+        public static void Register<TService>(this IMutableDependencyResolver resolver, Func<object> factory, string contract = null)
+        {
+            resolver.Register(factory, typeof(TService), contract);
+        }
+
+        public static void RegisterConstant<TService>(this IMutableDependencyResolver resolver, TService value, string contract = null)
+        {
+            resolver.RegisterConstant(value, typeof(TService), contract);
+        }
+
+        static void registerType(IMutableDependencyResolver resolver, TypeInfo ti, Type serviceType, string contract)
+        {
+            var factory = typeFactory(ti);
+            if (ti.GetCustomAttribute<SingleInstanceViewAttribute>() != null)
+            {
+                resolver.RegisterLazySingleton(factory, serviceType, contract);
+            }
+            else
+            {
+                resolver.Register(factory, serviceType, contract);
+            }
+        }
+
+        static Func<object> typeFactory(TypeInfo typeInfo)
+        {
+#if PORTABLE
+            throw new Exception("You are referencing the Portable version of ReactiveUI in an App. Reference the platform-specific version.");
+#else
+            return Expression.Lambda<Func<object>>(Expression.New(
+                typeInfo.DeclaredConstructors.First(ci => ci.IsPublic && !ci.GetParameters().Any()))).Compile();
+#endif
+        }
+
+        static void processRegistrationForNamespace(string ns, AssemblyName assmName, IMutableDependencyResolver resolver)
         {
             var targetType = ns + ".Registrations";
-            string fullName = targetType + ", " + assmName.FullName.Replace(assmName.Name, ns);
+            var fullName = targetType + ", " + assmName.FullName.Replace(assmName.Name, ns);
 
             var registerTypeClass = Reflection.ReallyFindType(fullName, false);
-            if (registerTypeClass == null) return false;
-
+            if (registerTypeClass != null) {
             var registerer = (IWantsToRegisterStuff)Activator.CreateInstance(registerTypeClass);
             registerer.Register((f, t) => resolver.RegisterConstant(f(), t));
-
-            return true;
         }
     }
+}
 }

--- a/ReactiveUI/Interfaces.cs
+++ b/ReactiveUI/Interfaces.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
@@ -452,7 +451,7 @@ namespace ReactiveUI
         IObservable<Unit> Deactivated { get; }
     }
 
-    internal interface ICanForceManualActivation 
+    interface ICanForceManualActivation 
     {
         void Activate(bool activate);
     }

--- a/ReactiveUI/ReactiveUI.csproj
+++ b/ReactiveUI/ReactiveUI.csproj
@@ -111,6 +111,7 @@
     <Compile Include="RoutableViewModelMixin.cs" />
     <Compile Include="RoutingState.cs" />
     <Compile Include="RxApp.cs" />
+    <Compile Include="ViewAttributes.cs" />
     <Compile Include="ViewLocator.cs" />
     <Compile Include="ScheduledSubject.cs" />
     <Compile Include="VariadicTemplates.cs">

--- a/ReactiveUI/ReactiveUI_Net45.csproj
+++ b/ReactiveUI/ReactiveUI_Net45.csproj
@@ -83,6 +83,7 @@
     <Compile Include="ExpressionRewriter.cs" />
     <Compile Include="Interactions.cs" />
     <Compile Include="Platform\ComponentModelTypeConverter.cs" />
+    <Compile Include="ViewAttributes.cs" />
     <Compile Include="Xaml\ReactiveUserControl.cs" />
     <Compile Include="Xaml\Attributes.cs" />
     <Compile Include="Xaml\WpfAutoSuspendHelper.cs" />

--- a/ReactiveUI/ReactiveUI_WP8.csproj
+++ b/ReactiveUI/ReactiveUI_WP8.csproj
@@ -83,6 +83,7 @@
     <Compile Include="ExpressionMixins.cs" />
     <Compile Include="ExpressionRewriter.cs" />
     <Compile Include="Platform\Registrations.cs" />
+    <Compile Include="ViewAttributes.cs" />
     <Compile Include="Xaml\ActivationForViewFetcher.cs" />
     <Compile Include="Xaml\Attributes.cs" />
     <Compile Include="Xaml\AutoDataTemplateBindingHook.cs" />

--- a/ReactiveUI/ReactiveUI_WinRT.csproj
+++ b/ReactiveUI/ReactiveUI_WinRT.csproj
@@ -44,6 +44,7 @@
     <Compile Include="ExpressionMixins.cs" />
     <Compile Include="ExpressionRewriter.cs" />
     <Compile Include="Platform\Registrations.cs" />
+    <Compile Include="ViewAttributes.cs" />
     <Compile Include="Xaml\ActivationForViewFetcher.cs" />
     <Compile Include="Xaml\AutoDataTemplateBindingHook.cs" />
     <Compile Include="Xaml\BindingTypeConverters.cs" />

--- a/ReactiveUI/ViewAttributes.cs
+++ b/ReactiveUI/ViewAttributes.cs
@@ -1,0 +1,35 @@
+﻿namespace ReactiveUI
+{
+    using System;
+
+    /// <summary>
+    /// Allows an additional string to make view resolution more specific than
+    /// just a type. When applied to your <see cref="IViewFor{T}"/> -derived
+    /// View, you can select between different Views for a single ViewModel
+    /// instance.
+    /// </summary>
+    public class ViewContractAttribute : Attribute
+    {
+        /// <summary>
+        /// Constructs the ViewContractAttribute with a specific contract value.
+        /// </summary>
+        /// <param name="contract">The value of the contract for view
+        /// resolution.</param>
+        public ViewContractAttribute(string contract)
+        {
+            Contract = contract;
+        }
+
+        internal string Contract { get; }
+    }
+
+    /// <summary>
+    /// Indicates that this View should be constructed _once_ and then used
+    /// every time its ViewModel View is resolved.
+    /// Obviously, this is not supported on Views that may be reused multiple
+    /// times in the Visual Tree.
+    /// </summary>
+    public class SingleInstanceViewAttribute : Attribute
+    {
+    }
+}


### PR DESCRIPTION
The many lines of:

```csharp
resolver.Register(() => new FooView(), IViewFor<FooViewModel>);
resolver.Register(() => new BarView(), IViewFor<BarViewModel>);
... <etc> ...
```

Can be reduced to: `resolver.RegisterViewsForViewModels(typeof(FooView).Assembly)`
