### PR TITLE
BindTo helpful error

### DIFF
--- a/ReactiveUI.Tests/PropertyBindingTest.cs
+++ b/ReactiveUI.Tests/PropertyBindingTest.cs
@@ -301,6 +301,16 @@ namespace ReactiveUI.Tests
             Assert.Equal(vm.JustADouble.ToString(), view.FakeControl.NullHatingString);
         }
 
+        [Fact]
+        public void BindToNullShouldThrowHelpfulError() {
+            var view = new PropertyBindView() {ViewModel = null};
+
+            Assert.Throws<ArgumentNullException>(() =>
+                 view.WhenAnyValue(x => x.FakeControl.NullHatingString)
+                     .BindTo(view.ViewModel, x => x.Property1));
+
+        }
+
 #if !MONO
         [Fact]
         public void TwoWayBindToSelectedItemOfItemsControl()

--- a/ReactiveUI/PropertyBinding.cs
+++ b/ReactiveUI/PropertyBinding.cs
@@ -906,6 +906,11 @@ namespace ReactiveUI
             object conversionHint = null,
             IBindingTypeConverter vmToViewConverterOverride = null)
         {
+
+            if (target == null) {
+                throw new ArgumentNullException("target", "Can't bind to a property on null.  To fix this, you probably want BindTo(this, ...) isntead. ");
+            }
+
             var viewExpression = Reflection.Rewrite(property.Body);
 
             var ret = evalBindingHooks(This, target, null, viewExpression, BindingDirection.OneWay);

--- a/ReactiveUI/PropertyBinding.cs
+++ b/ReactiveUI/PropertyBinding.cs
@@ -908,7 +908,7 @@ namespace ReactiveUI
         {
 
             if (target == null) {
-                throw new ArgumentNullException("target", "Can't bind to a property on null.  To fix this, you probably want BindTo(this, ...) isntead. ");
+                throw new ArgumentNullException("target");
             }
 
             var viewExpression = Reflection.Rewrite(property.Body);


### PR DESCRIPTION
If you `observable.BindTo(null, x => x.SomeProperty)`, the binding will fail when it tries to execute with the somewhat cryptic error message "Non-static method requires a target" and a stack trace that doesn't point you to where you Did It Wrong (tm). 

I have `BindTo` throw an `ArgumentNullException` if its `target` paramter is `null` with what I hope is a helpful error message. 

I'm pretty new to the framework myself so please let me know if you'd like me to change anything.