### PR TITLE
BindTo helpful error when binding to null.

### DIFF
--- a/ReactiveUI.Tests/PropertyBindingTest.cs
+++ b/ReactiveUI.Tests/PropertyBindingTest.cs
@@ -286,6 +286,16 @@ namespace ReactiveUI.Tests
             Assert.Equal(vm.JustADouble.ToString(), view.FakeControl.NullHatingString);
         }
 
+        [Fact]
+        public void BindToNullShouldThrowHelpfulError() {
+            var view = new PropertyBindView() {ViewModel = null};
+
+            Assert.Throws<ArgumentNullException>(() =>
+                 view.WhenAnyValue(x => x.FakeControl.NullHatingString)
+                     .BindTo(view.ViewModel, x => x.Property1));
+
+        }
+
 #if !MONO
         [Fact]
         public void TwoWayBindToSelectedItemOfItemsControl()

--- a/ReactiveUI/PropertyBinding.cs
+++ b/ReactiveUI/PropertyBinding.cs
@@ -677,6 +677,11 @@ namespace ReactiveUI
             object conversionHint = null,
             IBindingTypeConverter vmToViewConverterOverride = null)
         {
+
+            if (target == null) {
+                throw new ArgumentNullException("target");
+            }
+
             var viewExpression = Reflection.Rewrite(property.Body);
 
             var ret = evalBindingHooks(This, target, null, viewExpression, BindingDirection.OneWay);


### PR DESCRIPTION
If you `observable.BindTo(null, x => x.SomeProperty)`, the binding will fail when it tries to execute with the somewhat cryptic error message "Non-static method requires a target" and a stack trace that doesn't point you to where you Did It Wrong (tm).  Instead, I have `BindTo` throw an `ArgumentNullException` if its `target` paramter is `null`.

See #1017 for previous discussion.