### PR TITLE
Fix bug executing via ICommand with nullable parameter types.

### DIFF
--- a/ReactiveUI.Tests/ReactiveCommandTest.cs
+++ b/ReactiveUI.Tests/ReactiveCommandTest.cs
@@ -315,6 +315,21 @@ namespace ReactiveUI.Tests
         }
 
         [Fact]
+        public void ExecuteViaICommandWorksWithNullableTypes()
+        {
+            int? value = null;
+            ICommand fixture = ReactiveCommand.Create<int?>(param => {
+                value = param;
+            });
+
+            fixture.Execute(42);
+            Assert.Equal(42, value);
+
+            fixture.Execute(null);
+            Assert.Null(value);
+        }
+
+        [Fact]
         public void ExecuteViaICommandThrowsIfParameterTypeIsIncorrect()
         {
             ICommand fixture = ReactiveCommand.Create<int>(_ => { });

--- a/ReactiveUI/ReactiveCommand.cs
+++ b/ReactiveUI/ReactiveCommand.cs
@@ -564,7 +564,7 @@ namespace ReactiveUI
                 parameter = default(TParam);
             }
 
-            if (!(parameter is TParam)) {
+            if (parameter != null && !(parameter is TParam)) {
                 throw new InvalidOperationException(
                     String.Format(
                         "Command requires parameters of type {0}, but received parameter of type {1}.",


### PR DESCRIPTION
Fixes a bug with RxCommands that take a nullable parameter type. Executing via `ICommand` and passing `null` as the parameter would throw:

```cs
ICommand command = ReactiveCommand.Create<int?>(p => {});

// this throws
command.Execute(null);
```