### PR TITLE
eventbuilder.exe is now xplat (tm) and always uses the latest SDK's.

### DIFF
--- a/EventBuilder.sln
+++ b/EventBuilder.sln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.24720.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EventBuilder", "EventBuilder\EventBuilder.csproj", "{A6B86E12-057F-4591-98A3-FD50E9CEAE69}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A6B86E12-057F-4591-98A3-FD50E9CEAE69}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A6B86E12-057F-4591-98A3-FD50E9CEAE69}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A6B86E12-057F-4591-98A3-FD50E9CEAE69}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A6B86E12-057F-4591-98A3-FD50E9CEAE69}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/EventBuilder/App.config
+++ b/EventBuilder/App.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+  </startup>
+  <appSettings>
+    <add key="serilog:minimum-level" value="Verbose" />
+    <add key="serilog:write-to:ColoredConsole.restrictedToMinimumLevel" value="Fatal" />
+    <add key="serilog:write-to:File.path" value="EventBuilder.log" />
+  </appSettings>
+</configuration>

--- a/EventBuilder/Cecil/DelegateTemplateInformation.cs
+++ b/EventBuilder/Cecil/DelegateTemplateInformation.cs
@@ -1,0 +1,86 @@
+﻿using EventBuilder.Entities;
+using Mono.Cecil;
+using System;
+using System.Linq;
+
+namespace EventBuilder.Cecil
+{
+    public static class DelegateTemplateInformation
+    {
+        public static NamespaceInfo[] Create(AssemblyDefinition[] targetAssemblies)
+        {
+            var garbageTypeList = new[]
+            {
+                "AVPlayerItemLegibleOutputPushDelegate"
+                // NB: Aparrently this used to break "build on device because of reasons". We don't know what these reasons are and this may not be needed anymore.
+            };
+
+            var publicDelegateTypes = targetAssemblies
+                .SelectMany(x => SafeTypes.GetSafeTypes(x))
+                .Where(x => x.IsPublic && !x.IsInterface && !x.HasGenericParameters && IsCocoaDelegateName(x.Name))
+                .Where(x => x.BaseType == null || !x.BaseType.FullName.Contains("MulticastDelegate"))
+                .Where(x => !garbageTypeList.Any(y => x.FullName.Contains(y)))
+                .Select(x => new {Type = x, Delegates = GetPublicDelegateMethods(x)})
+                .Where(x => x.Delegates.Length > 0)
+                .ToArray();
+
+            var namespaceData = publicDelegateTypes
+                .GroupBy(x => x.Type.Namespace)
+                //.Where(x => !garbageNamespaceList.Contains(x.Key))    // NB: We don't know why this is disabled.
+                .Select(x => new NamespaceInfo
+                {
+                    Name = x.Key,
+                    Types = x.Select(y => new PublicTypeInfo
+                    {
+                        Name = y.Type.Name,
+                        Type = y.Type,
+                        Abstract = y.Type.IsAbstract ? "abstract" : "",
+                        ZeroParameterMethods =
+                            y.Delegates.Where(z => z.Parameters.Count == 0).Select(z => new ParentInfo
+                            {
+                                Name = z.Name
+                            }).ToArray(),
+                        SingleParameterMethods =
+                            y.Delegates.Where(z => z.Parameters.Count == 1).Select(z => new SingleParameterMethod
+                            {
+                                Name = z.Name,
+                                ParameterType = z.Parameters[0].ParameterType.FullName,
+                                ParameterName = z.Parameters[0].Name
+                            }).ToArray(),
+                        MultiParameterMethods =
+                            y.Delegates.Where(z => z.Parameters.Count > 1).Select(z => new MultiParameterMethod
+                            {
+                                Name = z.Name,
+                                ParameterList =
+                                    string.Join(", ",
+                                        z.Parameters.Select(
+                                            a => string.Format("{0} {1}", a.ParameterType.FullName, a.Name))),
+                                ParameterTypeList =
+                                    string.Join(", ", z.Parameters.Select(a => a.ParameterType.FullName)),
+                                ParameterNameList = string.Join(", ", z.Parameters.Select(a => a.Name))
+                            }).ToArray()
+                    }).ToArray()
+                }).ToArray();
+
+            return namespaceData;
+        }
+
+        private static bool IsCocoaDelegateName(string name)
+        {
+            if (name.EndsWith("Delegate", StringComparison.OrdinalIgnoreCase)) return true;
+            if (name.EndsWith("UITableViewSource", StringComparison.OrdinalIgnoreCase)) return true;
+            return false;
+        }
+
+        private static MethodDefinition[] GetPublicDelegateMethods(TypeDefinition t)
+        {
+            var bannedMethods = new[] {"Dispose", "Finalize"};
+            return t.Methods
+                .Where(x => x.IsVirtual && !x.IsConstructor && !x.IsSetter && x.ReturnType.FullName == "System.Void")
+                .Where(x => x.Parameters.All(y => y.ParameterType.FullName.Contains("&") == false))
+                .Where(x => !bannedMethods.Contains(x.Name))
+                .GroupBy(x => x.Name).Select(x => x.OrderByDescending(y => y.Parameters.Count).First())
+                .ToArray();
+        }
+    }
+}

--- a/EventBuilder/Cecil/EventTemplateInformation.cs
+++ b/EventBuilder/Cecil/EventTemplateInformation.cs
@@ -1,0 +1,152 @@
+﻿using EventBuilder.Entities;
+using Mono.Cecil;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace EventBuilder.Cecil
+{
+    public static class EventTemplateInformation
+    {
+        private static readonly Dictionary<string, string> SubstitutionList = new Dictionary<string, string>
+        {
+            {"Windows.UI.Xaml.Data.PropertyChangedEventArgs", "global::System.ComponentModel.PropertyChangedEventArgs"},
+            {
+                "Windows.UI.Xaml.Data.PropertyChangedEventHandler",
+                "global::System.ComponentModel.PropertyChangedEventHandler"
+            },
+            {"Windows.Foundation.EventHandler", "EventHandler"},
+            {"Windows.Foundation.EventHandler`1", "EventHandler"},
+            {"Windows.Foundation.EventHandler`2", "EventHandler"}
+        };
+
+        private static string RenameBogusWinRTTypes(string typeName)
+        {
+            if (SubstitutionList.ContainsKey(typeName)) return SubstitutionList[typeName];
+            return typeName;
+        }
+
+        private static string GetEventArgsTypeForEvent(EventDefinition ei)
+        {
+            // Find the EventArgs type parameter of the event via digging around via reflection
+            var type = ei.EventType.Resolve();
+            var invoke = type.Methods.First(x => x.Name == "Invoke");
+            if (invoke.Parameters.Count < 2) return null;
+
+            var param = invoke.Parameters[1];
+            var ret = RenameBogusWinRTTypes(param.ParameterType.FullName);
+
+            var generic = ei.EventType as GenericInstanceType;
+            if (generic != null)
+            {
+                foreach (
+                    var kvp in
+                        type.GenericParameters.Zip(generic.GenericArguments, (name, actual) => new {name, actual}))
+                {
+                    var realType = GetRealTypeName(kvp.actual);
+
+                    ret = ret.Replace(kvp.name.FullName, realType);
+                }
+            }
+
+            // NB: Inner types in Mono.Cecil get reported as 'Foo/Bar'
+            return ret.Replace('/', '.');
+        }
+
+        private static string GetRealTypeName(TypeDefinition t)
+        {
+            if (t.GenericParameters.Count == 0) return RenameBogusWinRTTypes(t.FullName);
+
+            var ret = string.Format("{0}<{1}>",
+                RenameBogusWinRTTypes(t.Namespace + "." + t.Name),
+                string.Join(",", t.GenericParameters.Select(x => GetRealTypeName(x.Resolve()))));
+
+            // NB: Inner types in Mono.Cecil get reported as 'Foo/Bar'
+            return ret.Replace('/', '.');
+        }
+
+        private static string GetRealTypeName(TypeReference t)
+        {
+            var generic = t as GenericInstanceType;
+            if (generic == null) return RenameBogusWinRTTypes(t.FullName);
+
+            var ret = string.Format("{0}<{1}>",
+                RenameBogusWinRTTypes(generic.Namespace + "." + generic.Name),
+                string.Join(",", generic.GenericArguments.Select(x => GetRealTypeName(x))));
+
+            // NB: Inner types in Mono.Cecil get reported as 'Foo/Bar'
+            return ret.Replace('/', '.');
+        }
+
+        private static EventDefinition[] GetPublicEvents(TypeDefinition t)
+        {
+            return
+                t.Events.Where(x => x.AddMethod.IsPublic && !x.AddMethod.IsStatic && GetEventArgsTypeForEvent(x) != null)
+                    .ToArray();
+        }
+
+        public static NamespaceInfo[] Create(AssemblyDefinition[] targetAssemblies)
+        {
+            var publicTypesWithEvents = targetAssemblies
+                .SelectMany(x => SafeTypes.GetSafeTypes(x))
+                .Where(x => x.IsPublic && !x.HasGenericParameters)
+                .Select(x => new {Type = x, Events = GetPublicEvents(x)})
+                .Where(x => x.Events.Length > 0)
+                .ToArray();
+
+            var garbageNamespaceList = new[]
+            {
+                "Windows.UI.Xaml.Data",
+                "Windows.UI.Xaml.Interop",
+                "Windows.UI.Xaml.Input",
+                "MonoTouch.AudioToolbox",
+                "MonoMac.AudioToolbox",
+                "ReactiveUI.Events"
+            };
+
+            var namespaceData = publicTypesWithEvents
+                .GroupBy(x => x.Type.Namespace)
+                .Where(x => !garbageNamespaceList.Contains(x.Key))
+                .Select(x => new NamespaceInfo
+                {
+                    Name = x.Key,
+                    Types = x.Select(y => new PublicTypeInfo
+                    {
+                        Name = y.Type.Name,
+                        Type = y.Type,
+                        Events = y.Events.Select(z => new PublicEventInfo
+                        {
+                            Name = z.Name,
+                            EventHandlerType = GetRealTypeName(z.EventType),
+                            EventArgsType = GetEventArgsTypeForEvent(z)
+                        }).ToArray()
+                    }).ToArray()
+                }).ToArray();
+
+            foreach (var type in namespaceData.SelectMany(x => x.Types))
+            {
+                var parentWithEvents = GetParents(type.Type).FirstOrDefault(x => GetPublicEvents(x).Any());
+                if (parentWithEvents == null) continue;
+
+                type.Parent = new ParentInfo {Name = parentWithEvents.FullName};
+            }
+
+            return namespaceData;
+        }
+
+        private static IEnumerable<TypeDefinition> GetParents(TypeDefinition type)
+        {
+            var current = type.BaseType != null
+                ? type.BaseType.Resolve()
+                : null;
+
+            while (current != null)
+            {
+                yield return current.Resolve();
+
+                current = current.BaseType != null
+                    ? current.BaseType.Resolve()
+                    : null;
+            }
+        }
+    }
+}

--- a/EventBuilder/Cecil/PathSearchAssemblyResolver.cs
+++ b/EventBuilder/Cecil/PathSearchAssemblyResolver.cs
@@ -1,0 +1,87 @@
+using Mono.Cecil;
+using Serilog;
+using System;
+using System.IO;
+using System.Linq;
+
+namespace EventBuilder.Cecil
+{
+    public class PathSearchAssemblyResolver : IAssemblyResolver
+    {
+        private readonly string[] _targetAssemblyDirs;
+
+        public PathSearchAssemblyResolver(string[] targetAssemblyDirs)
+        {
+            _targetAssemblyDirs = targetAssemblyDirs;
+        }
+
+        public AssemblyDefinition Resolve(string fullName, ReaderParameters parameters)
+        {
+            var dllName = fullName.Split(',')[0] + ".dll";
+
+            var fullPath = _targetAssemblyDirs.Select(x => Path.Combine(x, dllName)).FirstOrDefault(x => File.Exists(x));
+            if (fullPath == null)
+            {
+                dllName = fullName.Split(',')[0] + ".winmd";
+                fullPath = _targetAssemblyDirs.Select(x => Path.Combine(x, dllName)).FirstOrDefault(x => File.Exists(x));
+            }
+
+            // NB: This hacks WinRT's weird mscorlib to just use the regular one
+            // We forget why this was needed, maybe it's not needed anymore?
+            if (fullName.Contains("mscorlib") && fullName.Contains("255"))
+            {
+                fullPath =
+                    Environment.ExpandEnvironmentVariables(
+                        @"%SystemRoot%\Microsoft.NET\Framework\v4.0.30319\mscorlib.dll");
+            }
+
+            if (fullPath == null)
+            {
+                var errorMessage = $"Failed to resolve!!! {fullName}";
+                Log.Error(errorMessage);
+                throw new Exception(errorMessage);
+            }
+
+            return AssemblyDefinition.ReadAssembly(fullPath, parameters);
+        }
+
+        public AssemblyDefinition Resolve(string fullName)
+        {
+            var dllName = fullName.Split(',')[0] + ".dll";
+
+            var fullPath = _targetAssemblyDirs.Select(x => Path.Combine(x, dllName)).FirstOrDefault(x => File.Exists(x));
+            if (fullPath == null)
+            {
+                dllName = fullName.Split(',')[0] + ".winmd";
+                fullPath = _targetAssemblyDirs.Select(x => Path.Combine(x, dllName)).FirstOrDefault(x => File.Exists(x));
+            }
+
+            // NB: This hacks WinRT's weird mscorlib to just use the regular one
+            if (fullName.Contains("mscorlib") && fullName.Contains("255"))
+            {
+                fullPath =
+                    Environment.ExpandEnvironmentVariables(
+                        @"%SystemRoot%\Microsoft.NET\Framework\v4.0.30319\mscorlib.dll");
+            }
+
+            if (fullPath == null)
+            {
+                var errorMessage = $"Failed to resolve!!! {fullName}";
+                Log.Error(errorMessage);
+                throw new Exception(errorMessage);
+            }
+
+            return AssemblyDefinition.ReadAssembly(fullPath);
+        }
+
+        public AssemblyDefinition Resolve(AssemblyNameReference name, ReaderParameters parameters)
+        {
+            return Resolve(name.FullName, parameters);
+        }
+
+        public AssemblyDefinition Resolve(AssemblyNameReference name)
+        {
+            return Resolve(name.FullName);
+        }
+    }
+}

--- a/EventBuilder/Cecil/README.md
+++ b/EventBuilder/Cecil/README.md
@@ -1,0 +1,39 @@
+﻿# Here be dragons (tm)
+This section of EventBuilder is a hairball of complexity, it has served us well but it was written in a fit of rage and there now exist better ways which that at the time did not exist. If you have the skills and time, we would _really_ appreciate a pull request that contains a refactor of this away from `Mono.Cecil` towards the `System.Reflection.Metadata` nuget package.
+
+Deliverables:
+
+* Unit tests.
+* Proper OO modeling instead of static everywhere.
+* Refactored to use System.Reflection.Metadata.
+* Inline comments explaining what it is doing, how it works and why it's doing what it does.
+
+Here's an example of how to use `System.Reflection.Metadata` we hope it sets you on the right path forward.
+
+```csharp
+//string path = @"C:\windows\Microsoft.NET\Framework\v4.0.30319\mscorlib.dll";
+string path = @"C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\Xamarin.iOS\v1.0\Xamarin.iOS.dll";
+//string path = @"C:\PROGRA~2\Windows Phone Kits\8.1\References\CommonConfiguration\Neutral\Windows.winmd";
+using (
+    var peReader = new PEReader(new FileStream(path, FileMode.Open, FileAccess.Read),
+        PEStreamOptions.PrefetchMetadata))
+{
+    var contractReader = peReader.GetMetadataReader();
+
+    MetadataReader metadataReader = peReader.GetMetadataReader();
+    foreach (var type in metadataReader.TypeDefinitions)
+    {
+        TypeDefinition typeDefinition = metadataReader.GetTypeDefinition(type);
+
+        foreach (var eventDefinitionHandle in typeDefinition.GetEvents())
+        {
+            var event = metadataReader.GetEvent(eventDefinitionHandle);
+            var eventName = metadataReader.GetString(test.Name);
+
+            Console.WriteLine(eventName);
+        }
+
+    }
+}
+```
+

--- a/EventBuilder/Cecil/SafeTypes.cs
+++ b/EventBuilder/Cecil/SafeTypes.cs
@@ -1,0 +1,13 @@
+﻿using Mono.Cecil;
+using System.Linq;
+
+namespace EventBuilder.Cecil
+{
+    public static class SafeTypes
+    {
+        public static TypeDefinition[] GetSafeTypes(AssemblyDefinition a)
+        {
+            return a.Modules.SelectMany(x => x.GetTypes()).ToArray();
+        }
+    }
+}

--- a/EventBuilder/CommandLineOptions.cs
+++ b/EventBuilder/CommandLineOptions.cs
@@ -1,0 +1,45 @@
+using CommandLine;
+using CommandLine.Text;
+using System.Collections.Generic;
+
+namespace EventBuilder
+{
+    public enum AutoPlatform
+    {
+        None,
+        Android,
+        iOS,
+        Mac,
+        XamForms,
+        UWP,
+        WP8,
+        WPA81
+    }
+
+    public class CommandLineOptions
+    {
+        [ParserState]
+        public IParserState LastParserState { get; set; }
+
+        [Option('p', "platform", Required = true,
+            HelpText =
+                "Platform to automatically generate. Possible options include: NONE, ANDROID, IOS, MAC, UWP, WP8, WPA81, XAMFORMS"
+            )]
+        public AutoPlatform Platform { get; set; }
+
+        [Option('t', "template", Required = false,
+            HelpText = "Specify another mustache template other than the default.")]
+        public string Template { get; set; }
+
+        // Manual generation using the specified assemblies. Use with --platform=NONE.
+        [ValueList(typeof (List<string>))]
+        public List<string> Assemblies { get; set; }
+
+        [HelpOption]
+        public string GetUsage()
+        {
+            return HelpText.AutoBuild(this,
+                current => HelpText.DefaultParsingErrorsHandler(this, current));
+        }
+    }
+}

--- a/EventBuilder/DefaultTemplate.mustache
+++ b/EventBuilder/DefaultTemplate.mustache
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using ReactiveUI.Events;
+
+{{#Namespaces}}
+using {{Name}};
+{{/Namespaces}}
+{{#DelegateNamespaces}}
+using {{Name}};
+{{/DelegateNamespaces}}
+
+{{#Namespaces}}
+namespace {{Name}}
+{
+    public static class EventsMixin
+    {
+{{#Types}}
+        public static {{Name}}Events Events(this {{Name}} This)
+        {
+            return new {{Name}}Events(This);
+        }
+{{/Types}}
+    }
+
+{{#Types}}
+    public class {{Name}}Events
+{{#Parent}}
+        : {{Name}}Events
+{{/Parent}}
+    {
+        {{Name}} This;
+
+        public {{Name}}Events({{Name}} This)
+{{#Parent}}
+            : base(This)
+{{/Parent}}
+        {
+            this.This = This;
+        }
+
+{{#Events}}
+        public IObservable<{{EventArgsType}}> {{Name}} {
+            get { return Observable.FromEventPattern<{{EventHandlerType}}, {{EventArgsType}}>(x => This.{{Name}} += x, x => This.{{Name}} -= x).Select(x => x.EventArgs); }
+        }
+
+{{/Events}}
+    }
+{{/Types}}
+}
+{{/Namespaces}}
+
+{{#DelegateNamespaces}}
+namespace {{Name}}.Rx
+{
+{{#Types}}
+    public {{Abstract}} partial class {{Name}}Rx : {{Name}}
+    {
+{{#ZeroParameterMethods}}
+        readonly SingleAwaitSubject<Unit> _{{Name}} = new SingleAwaitSubject<Unit>();
+        public IObservable<Unit> {{Name}}Obs { get { return _{{Name}}; } }
+        public override void {{Name}}()
+        {
+            _{{Name}}.OnNext(Unit.Default);
+        }
+
+{{/ZeroParameterMethods}}
+{{#SingleParameterMethods}}
+        readonly SingleAwaitSubject<{{ParameterType}}> _{{Name}} = new SingleAwaitSubject<{{ParameterType}}>();
+        public IObservable<{{ParameterType}}> {{Name}}Obs { get { return _{{Name}}; } }
+        public override void {{Name}}({{ParameterType}} {{ParameterName}})
+        {
+            _{{Name}}.OnNext({{ParameterName}});
+        }
+
+{{/SingleParameterMethods}}
+{{#MultiParameterMethods}}
+        readonly SingleAwaitSubject<Tuple<{{ParameterTypeList}}>> _{{Name}} = new SingleAwaitSubject<Tuple<{{ParameterTypeList}}>>();
+        public IObservable<Tuple<{{ParameterTypeList}}>> {{Name}}Obs { get { return _{{Name}}; } }
+        public override void {{Name}}({{ParameterList}})
+        {
+            _{{Name}}.OnNext(Tuple.Create({{ParameterNameList}}));
+        }
+
+{{/MultiParameterMethods}}
+    }
+{{/Types}}
+}
+{{/DelegateNamespaces}}

--- a/EventBuilder/Entities/MultiParameterMethod.cs
+++ b/EventBuilder/Entities/MultiParameterMethod.cs
@@ -1,0 +1,10 @@
+namespace EventBuilder.Entities
+{
+    public class MultiParameterMethod
+    {
+        public string Name { get; set; }
+        public string ParameterList { get; set; } // "FooType foo, BarType bar, BazType baz"
+        public string ParameterTypeList { get; set; } // "FooType, BarType, BazType"
+        public string ParameterNameList { get; set; } // "foo, bar, baz"
+    }
+}

--- a/EventBuilder/Entities/NamespaceInfo.cs
+++ b/EventBuilder/Entities/NamespaceInfo.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace EventBuilder.Entities
+{
+    public class NamespaceInfo
+    {
+        public string Name { get; set; }
+        public IEnumerable<PublicTypeInfo> Types { get; set; }
+    }
+}

--- a/EventBuilder/Entities/ParentInfo.cs
+++ b/EventBuilder/Entities/ParentInfo.cs
@@ -1,0 +1,7 @@
+namespace EventBuilder.Entities
+{
+    public class ParentInfo
+    {
+        public string Name { get; set; }
+    }
+}

--- a/EventBuilder/Entities/PublicEventInfo.cs
+++ b/EventBuilder/Entities/PublicEventInfo.cs
@@ -1,0 +1,9 @@
+namespace EventBuilder.Entities
+{
+    public class PublicEventInfo
+    {
+        public string Name { get; set; }
+        public string EventHandlerType { get; set; }
+        public string EventArgsType { get; set; }
+    }
+}

--- a/EventBuilder/Entities/PublicTypeInfo.cs
+++ b/EventBuilder/Entities/PublicTypeInfo.cs
@@ -1,0 +1,17 @@
+using Mono.Cecil;
+using System.Collections.Generic;
+
+namespace EventBuilder.Entities
+{
+    public class PublicTypeInfo
+    {
+        public string Name { get; set; }
+        public string Abstract { get; set; }
+        public TypeDefinition Type { get; set; }
+        public ParentInfo Parent { get; set; }
+        public IEnumerable<PublicEventInfo> Events { get; set; }
+        public IEnumerable<ParentInfo> ZeroParameterMethods { get; set; }
+        public IEnumerable<SingleParameterMethod> SingleParameterMethods { get; set; }
+        public MultiParameterMethod[] MultiParameterMethods { get; set; }
+    }
+}

--- a/EventBuilder/Entities/SingleParameterMethod.cs
+++ b/EventBuilder/Entities/SingleParameterMethod.cs
@@ -1,0 +1,9 @@
+namespace EventBuilder.Entities
+{
+    public class SingleParameterMethod
+    {
+        public string Name { get; set; }
+        public string ParameterType { get; set; }
+        public string ParameterName { get; set; }
+    }
+}

--- a/EventBuilder/EventBuilder.csproj
+++ b/EventBuilder/EventBuilder.csproj
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{A6B86E12-057F-4591-98A3-FD50E9CEAE69}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>EventBuilder</RootNamespace>
+    <AssemblyName>EventBuilder</AssemblyName>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+    <Reference Include="CommandLine, Version=1.9.71.2, Culture=neutral, PublicKeyToken=de6f01bd326f8c32">
+      <HintPath>..\packages\CommandLineParser.1.9.71\lib\net45\CommandLine.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Web.XmlTransform, Version=2.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\packages\Microsoft.Web.Xdt.2.1.1\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
+    </Reference>
+    <Reference Include="NuGet.Core, Version=2.10.1.766, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
+      <HintPath>..\packages\NuGet.Core.2.10.1\lib\net40-Client\NuGet.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Nustache.Core, Version=1.15.3.7, Culture=neutral, PublicKeyToken=efd6f3d8f76ecd9f">
+      <HintPath>..\packages\Nustache.1.15.3.7\lib\net20\Nustache.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Polly, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\Polly.3.0.0\lib\net45\Polly.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10">
+      <HintPath>..\packages\Serilog.1.5.14\lib\net45\Serilog.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog.FullNetFx, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10">
+      <HintPath>..\packages\Serilog.1.5.14\lib\net45\Serilog.FullNetFx.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil">
+      <HintPath>..\packages\Mono.Cecil.0.9.6.1\lib\net45\Mono.Cecil.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil.Mdb">
+      <HintPath>..\packages\Mono.Cecil.0.9.6.1\lib\net45\Mono.Cecil.Mdb.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil.Pdb">
+      <HintPath>..\packages\Mono.Cecil.0.9.6.1\lib\net45\Mono.Cecil.Pdb.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil.Rocks">
+      <HintPath>..\packages\Mono.Cecil.0.9.6.1\lib\net45\Mono.Cecil.Rocks.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Cecil\DelegateTemplateInformation.cs" />
+    <Compile Include="Cecil\PathSearchAssemblyResolver.cs" />
+    <Compile Include="Cecil\EventTemplateInformation.cs" />
+    <Compile Include="Cecil\SafeTypes.cs" />
+    <Compile Include="CommandLineOptions.cs" />
+    <Compile Include="Entities\MultiParameterMethod.cs" />
+    <Compile Include="Entities\NamespaceInfo.cs" />
+    <Compile Include="Entities\ParentInfo.cs" />
+    <Compile Include="Entities\PublicEventInfo.cs" />
+    <Compile Include="Entities\PublicTypeInfo.cs" />
+    <Compile Include="Entities\SingleParameterMethod.cs" />
+    <Compile Include="PlatformHelper.cs" />
+    <Compile Include="Platforms\Android.cs" />
+    <Compile Include="Platforms\iOS.cs" />
+    <Compile Include="Platforms\IPlatform.cs" />
+    <Compile Include="Platforms\Mac.cs" />
+    <Compile Include="Platforms\UWP.cs" />
+    <Compile Include="Platforms\WP8.cs" />
+    <Compile Include="Platforms\WPA81.cs" />
+    <Compile Include="Platforms\XamForms.cs" />
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Platforms\BasePlatform.cs" />
+    <Compile Include="Platforms\Bespoke.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="Cecil\README.md" />
+    <None Include="DefaultTemplate.mustache">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/EventBuilder/PlatformHelper.cs
+++ b/EventBuilder/PlatformHelper.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace EventBuilder
+{
+    public static class PlatformHelper
+    {
+        private static readonly Lazy<bool> _IsRunningOnMono = new Lazy<bool>(() => Type.GetType("Mono.Runtime") != null);
+
+        public static bool IsRunningOnMono()
+        {
+            return _IsRunningOnMono.Value;
+        }
+    }
+}

--- a/EventBuilder/Platforms/Android.cs
+++ b/EventBuilder/Platforms/Android.cs
@@ -1,0 +1,39 @@
+﻿using System.IO;
+using System.Linq;
+
+namespace EventBuilder.Platforms
+{
+    public class Android : BasePlatform
+    {
+        public Android()
+        {
+            if (PlatformHelper.IsRunningOnMono())
+            {
+                var sdks =
+                    Directory.GetFiles(
+                        @"/Library/Frameworks/Xamarin.Android.framework/Libraries/xbuild-frameworks/MonoAndroid",
+                        "Mono.Android.dll", SearchOption.AllDirectories);
+
+                var latestVersion = sdks.Last();
+                Assemblies.Add(latestVersion);
+
+                CecilSearchDirectories.Add(Path.GetDirectoryName(latestVersion));
+                CecilSearchDirectories.Add(
+                    "/Library/Frameworks/Xamarin.Android.framework/Libraries/xbuild-frameworks/MonoAndroid/v1.0");
+            }
+            else
+            {
+                var assemblies =
+                    Directory.GetFiles(@"C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\MonoAndroid",
+                        "Mono.Android.dll", SearchOption.AllDirectories);
+
+                var latestVersion = assemblies.Last();
+                Assemblies.Add(latestVersion);
+
+                CecilSearchDirectories.Add(Path.GetDirectoryName(latestVersion));
+                CecilSearchDirectories.Add(@"C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\MonoAndroid\v1.0");
+
+            }
+        }
+    }
+}

--- a/EventBuilder/Platforms/BasePlatform.cs
+++ b/EventBuilder/Platforms/BasePlatform.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.Generic;
+
+namespace EventBuilder.Platforms
+{
+    public class BasePlatform : IPlatform
+    {
+        public BasePlatform()
+        {
+            Assemblies = new List<string>();
+            CecilSearchDirectories = new List<string>();
+        }
+
+        public List<string> Assemblies { get; set; }
+        public List<string> CecilSearchDirectories { get; set; }
+    }
+}

--- a/EventBuilder/Platforms/Bespoke.cs
+++ b/EventBuilder/Platforms/Bespoke.cs
@@ -1,0 +1,6 @@
+﻿namespace EventBuilder.Platforms
+{
+    public class Bespoke : BasePlatform
+    {
+    }
+}

--- a/EventBuilder/Platforms/IPlatform.cs
+++ b/EventBuilder/Platforms/IPlatform.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+
+namespace EventBuilder.Platforms
+{
+    public interface IPlatform
+    {
+        List<string> Assemblies { get; set; }
+
+        // Cecil when run on Mono needs some direction as to the location of the platform specific MSCORLIB.
+        List<string> CecilSearchDirectories { get; set; }
+    }
+}

--- a/EventBuilder/Platforms/Mac.cs
+++ b/EventBuilder/Platforms/Mac.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.IO;
+
+namespace EventBuilder.Platforms
+{
+    public class Mac : BasePlatform
+    {
+        public Mac()
+        {
+            if (PlatformHelper.IsRunningOnMono())
+            {
+                var assembly = @"/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/lib/mono/XamMac.dll";
+                Assemblies.Add(assembly);
+
+                CecilSearchDirectories.Add(Path.GetDirectoryName(assembly));
+                CecilSearchDirectories.Add("/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/4.5");
+            }
+            else
+            {
+                throw new NotSupportedException("Building events for Xamarin.Mac on Windows is not implemented yet.");
+            }
+        }
+    }
+}

--- a/EventBuilder/Platforms/UWP.cs
+++ b/EventBuilder/Platforms/UWP.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace EventBuilder.Platforms
+{
+    public class UWP : BasePlatform
+    {
+        public UWP()
+        {
+            if (PlatformHelper.IsRunningOnMono())
+            {
+                throw new NotSupportedException("Building events for UWP on Mac is not implemented for obvious reasons.");
+            }
+            Assemblies.Add(@"C:\Program Files (x86)\Windows Kits\10\UnionMetadata\Windows.winmd");
+        }
+    }
+}

--- a/EventBuilder/Platforms/WP8.cs
+++ b/EventBuilder/Platforms/WP8.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace EventBuilder.Platforms
+{
+    public class WP8 : BasePlatform
+    {
+        public WP8()
+        {
+            if (PlatformHelper.IsRunningOnMono())
+            {
+                throw new NotSupportedException("Building events for WP8 on Mac is not implemented for obvious reasons.");
+            }
+            Assemblies.Add(
+                @"C:\Program Files (x86)\Windows Phone Silverlight Kits\8.1\Windows MetaData\Windows.winmd");
+        }
+    }
+}

--- a/EventBuilder/Platforms/WPA81.cs
+++ b/EventBuilder/Platforms/WPA81.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace EventBuilder.Platforms
+{
+    public class WPA81 : BasePlatform
+    {
+        public WPA81()
+        {
+            Assemblies = new List<string>();
+            CecilSearchDirectories = new List<string>();
+
+            if (PlatformHelper.IsRunningOnMono())
+            {
+                throw new NotSupportedException(
+                    "Building events for WPA81 on Mac is not implemented for obvious reasons.");
+            }
+            Assemblies.Add(
+                @"C:\Program Files (x86)\Windows Phone Kits\8.1\References\CommonConfiguration\Neutral\Windows.winmd");
+        }
+    }
+}

--- a/EventBuilder/Platforms/XamForms.cs
+++ b/EventBuilder/Platforms/XamForms.cs
@@ -1,0 +1,62 @@
+﻿using NuGet;
+using Polly;
+using Serilog;
+using System;
+using System.IO;
+using System.Linq;
+
+namespace EventBuilder.Platforms
+{
+    public class XamForms : BasePlatform
+    {
+        private const string _packageName = "Xamarin.Forms";
+
+        public XamForms()
+        {
+            var packageUnzipPath = Environment.CurrentDirectory;
+
+            var retryPolicy = Policy
+                .Handle<Exception>()
+                .WaitAndRetry(
+                    5,
+                    retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)),
+                    (exception, timeSpan, context) =>
+                    {
+                        Log.Warning(
+                            "An exception was thrown whilst retrieving or installing {packageName}: {exception}",
+                            _packageName, exception);
+                    });
+
+            retryPolicy.Execute(() =>
+            {
+                var repo = PackageRepositoryFactory.Default.CreateRepository("https://packages.nuget.org/api/v2");
+
+                var packageManager = new PackageManager(repo, packageUnzipPath);
+
+                var package = repo.FindPackagesById(_packageName).Single(x => x.IsLatestVersion);
+
+                packageManager.InstallPackage(package.Id);
+
+                Log.Debug("Using Xamarin Forms {Version} released on {Published}", package.Version, package.Published);
+                Log.Debug("{ReleaseNotes}", package.ReleaseNotes);
+            });
+
+            var xamarinForms =
+                Directory.GetFiles(packageUnzipPath,
+                    "Xamarin.Forms.Core.dll", SearchOption.AllDirectories);
+
+            var latestVersion = xamarinForms.Last();
+            Assemblies.Add(latestVersion);
+
+            if (PlatformHelper.IsRunningOnMono())
+            {
+                CecilSearchDirectories.Add(
+                    @"/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/xbuild-frameworks/.NETPortable/v4.5/Profile/Profile111");
+            }
+            else
+            {
+                CecilSearchDirectories.Add(@"C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETPortable\v4.5\Profile\Profile111");
+            }
+        }
+    }
+}

--- a/EventBuilder/Platforms/iOS.cs
+++ b/EventBuilder/Platforms/iOS.cs
@@ -1,0 +1,32 @@
+﻿using System.IO;
+using System.Linq;
+
+namespace EventBuilder.Platforms
+{
+    // ReSharper disable once InconsistentNaming
+    public class iOS : BasePlatform
+    {
+        public iOS()
+        {
+            if (PlatformHelper.IsRunningOnMono())
+            {
+                var assembly =
+                    @"/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/mono/Xamarin.iOS/Xamarin.iOS.dll";
+                Assemblies.Add(assembly);
+
+                CecilSearchDirectories.Add(Path.GetDirectoryName(assembly));
+            }
+            else
+            {
+                var assemblies =
+                    Directory.GetFiles(@"C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\Xamarin.iOS",
+                        "Xamarin.iOS.dll", SearchOption.AllDirectories);
+
+                var latestVersion = assemblies.Last();
+                Assemblies.Add(latestVersion);
+
+                CecilSearchDirectories.Add(Path.GetDirectoryName(latestVersion));
+            }
+        }
+    }
+}

--- a/EventBuilder/Program.cs
+++ b/EventBuilder/Program.cs
@@ -1,0 +1,158 @@
+﻿using EventBuilder.Cecil;
+using EventBuilder.Platforms;
+using Mono.Cecil;
+using Nustache.Core;
+using Serilog;
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Parser = CommandLine.Parser;
+
+namespace EventBuilder
+{
+    internal class Program
+    {
+        /// <summary>
+        ///     The exit/return code (aka %ERRORLEVEL%) on application exit.
+        /// </summary>
+        public enum ExitCode
+        {
+            Success = 0,
+            Error = 1
+        }
+
+        private static string _mustacheTemplate = "DefaultTemplate.mustache";
+
+        private static void Main(string[] args)
+        {
+            Log.Logger = new LoggerConfiguration()
+                .ReadFrom.AppSettings()
+                .CreateLogger();
+
+            var options = new CommandLineOptions();
+
+            // allow app to be debugged in visual studio.
+            if (Debugger.IsAttached)
+            {
+                //args = "--help ".Split(' ');
+                args = "--platform=ios".Split(' ');
+                //args = new[]
+                //{
+                //    "--platform=none",
+                //    @"C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\Xamarin.iOS\v1.0\Xamarin.iOS.dll"
+                //};
+            }
+
+            // Parse in 'strict mode'; i.e. success or quit
+            if (Parser.Default.ParseArgumentsStrict(args, options))
+            {
+                try
+                {
+                    if (!string.IsNullOrWhiteSpace(options.Template))
+                    {
+                        _mustacheTemplate = options.Template;
+
+                        Log.Debug("Using {template} instead of the default template.", _mustacheTemplate);
+                    }
+
+                    IPlatform platform = null;
+                    switch (options.Platform)
+                    {
+                        case AutoPlatform.None:
+                            if (!options.Assemblies.Any())
+                            {
+                                throw new Exception("Assemblies to be used for manual generation were not specified.");
+                            }
+
+                            platform = new Bespoke();
+                            platform.Assemblies = options.Assemblies;
+
+                            if (PlatformHelper.IsRunningOnMono())
+                            {
+                                platform.CecilSearchDirectories =
+                                    platform.Assemblies.Select(x => Path.GetDirectoryName(x)).Distinct().ToList();
+                            }
+
+                            break;
+
+                        case AutoPlatform.Android:
+                            platform = new Android();
+                            break;
+
+                        case AutoPlatform.iOS:
+                            platform = new iOS();
+                            break;
+
+                        case AutoPlatform.Mac:
+                            platform = new Mac();
+                            break;
+
+                        case AutoPlatform.XamForms:
+                            platform = new XamForms();
+                            break;
+
+                        case AutoPlatform.UWP:
+                            platform = new UWP();
+                            break;
+
+                        case AutoPlatform.WP8:
+                            platform = new WP8();
+                            break;
+
+                        case AutoPlatform.WPA81:
+                            platform = new WPA81();
+                            break;
+
+                        default:
+                            throw new ArgumentOutOfRangeException();
+                    }
+
+                    ExtractEventsFromAssemblies(platform);
+
+                    Environment.Exit((int) ExitCode.Success);
+                }
+                catch (Exception ex)
+                {
+                    Log.Fatal(ex.ToString());
+                }
+            }
+
+            Environment.Exit((int) ExitCode.Error);
+        }
+
+        public static void ExtractEventsFromAssemblies(IPlatform platform)
+        {
+            Log.Debug("Extracting events from the following assemblies: {assemblies}", platform.Assemblies);
+
+            Log.Debug("Using the following search directories: {assemblies}", platform.CecilSearchDirectories);
+            var targetAssemblyDirs = platform.CecilSearchDirectories;
+
+            var rp = new ReaderParameters
+            {
+                AssemblyResolver = new PathSearchAssemblyResolver(targetAssemblyDirs.ToArray())
+            };
+
+            var targetAssemblies = platform.Assemblies.Select(x => AssemblyDefinition.ReadAssembly(x, rp)).ToArray();
+
+            Log.Debug("Using {template} as the mustache template", _mustacheTemplate);
+            var template = File.ReadAllText(_mustacheTemplate, Encoding.UTF8);
+
+            var namespaceData = EventTemplateInformation.Create(targetAssemblies);
+
+            var delegateData = DelegateTemplateInformation.Create(targetAssemblies);
+
+            var result = Render.StringToString(template,
+                new {Namespaces = namespaceData, DelegateNamespaces = delegateData})
+                .Replace("System.String", "string")
+                .Replace("System.Object", "object")
+                .Replace("&lt;", "<")
+                .Replace("&gt;", ">")
+                .Replace("`1", "")
+                .Replace("`2", "");
+
+            Console.WriteLine(result);
+        }
+    }
+}

--- a/EventBuilder/Properties/AssemblyInfo.cs
+++ b/EventBuilder/Properties/AssemblyInfo.cs
@@ -1,0 +1,39 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+
+[assembly: AssemblyTitle("EventBuilder")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("ReactiveUI")]
+[assembly: AssemblyProduct("EventBuilder")]
+[assembly: AssemblyCopyright("http://reactiveui.net/")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+
+[assembly: Guid("a6b86e12-057f-4591-98a3-fd50e9ceae69")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/EventBuilder/packages.config
+++ b/EventBuilder/packages.config
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="CommandLineParser" version="1.9.71" targetFramework="net452" />
+  <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net452" />
+  <package id="Mono.Cecil" version="0.9.6.1" targetFramework="net451" />
+  <package id="NuGet.Core" version="2.10.1" targetFramework="net452" />
+  <package id="Nustache" version="1.15.3.7" targetFramework="net452" />
+  <package id="Polly" version="3.0.0" targetFramework="net452" />
+  <package id="Serilog" version="1.5.14" targetFramework="net452" />
+</packages>

--- a/packages/repositories.config
+++ b/packages/repositories.config
@@ -1,5 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <repositories>
+  <repository path="../EventBuilder/packages.config" />
   <repository path="../Microsoft.Reactive.Testing/packages.Microsoft.Reactive.Testing_Android.config" />
   <repository path="../Microsoft.Reactive.Testing/packages.Microsoft.Reactive.Testing_iOS.config" />
   <repository path="../Microsoft.Reactive.Testing/packages.Microsoft.Reactive.Testing_iOS64.config" />


### PR DESCRIPTION
# Don't merge yet. 

Progresses issue #1043 

Next steps is
* :fire: all `$platform_XS.csproj` conventions
* :fire: all prebuild mdtool/msbuild conventions
* Configure EventBuilder (this) into CI
* Create ReactiveUI-Events packages
* Progress iOS CI story.