### PR TITLE
Don't double-count when navigating back from external trigger.

### DIFF
--- a/ReactiveUI.XamForms/XamForms/RoutedViewHost.cs
+++ b/ReactiveUI.XamForms/XamForms/RoutedViewHost.cs
@@ -41,7 +41,7 @@ namespace ReactiveUI.XamForms
                 var currentCount = previousCount.Skip(1);
 
                 d (Observable.Zip(previousCount, currentCount, (previous, current) => new { Delta = previous - current, Current = current })
-				    .Where(_ => !userInstigated)
+                    .Where(_ => !userInstigated)
                     .Where(x => x.Delta > 0)
                     .SelectMany(
                         async x =>


### PR DESCRIPTION
When the user navigates back externally (e.g. by pressing back in the action bar), make sure we don't double count. That is, make sure we don't _also_ call `PopAsync` because obviously the user will navigate back two pages instead of one and the nav stack will be out of sync with the visible screen.