### PR TITLE
Just use IActivatedEventArgs inside WINRTAutoSuspendApplication inste…

### DIFF
--- a/ReactiveUI/Xaml/WinRTAutoSuspendApplication.cs
+++ b/ReactiveUI/Xaml/WinRTAutoSuspendApplication.cs
@@ -15,23 +15,23 @@ namespace ReactiveUI
 {
     public class AutoSuspendHelper : IEnableLogger
     {
-        readonly ReplaySubject<IActivatedEventArgs> _launched = new ReplaySubject<IActivatedEventArgs>(1);
+        readonly ReplaySubject<IActivatedEventArgs> _activated = new ReplaySubject<IActivatedEventArgs>(1);
 
         public AutoSuspendHelper(Application app)
         {
             Reflection.ThrowIfMethodsNotOverloaded("AutoSuspendHelper", app, "OnLaunched");
 
             var launchNew = new[] { ApplicationExecutionState.ClosedByUser, ApplicationExecutionState.NotRunning, };
-            RxApp.SuspensionHost.IsLaunchingNew = _launched
+            RxApp.SuspensionHost.IsLaunchingNew = _activated
                 .Where(x => launchNew.Contains(x.PreviousExecutionState))
                 .Select(_ => Unit.Default);
 
-            RxApp.SuspensionHost.IsResuming = _launched
+            RxApp.SuspensionHost.IsResuming = _activated
                 .Where(x => x.PreviousExecutionState == ApplicationExecutionState.Terminated)
                 .Select(_ => Unit.Default);
 
             var unpausing = new[] { ApplicationExecutionState.Suspended, ApplicationExecutionState.Running, };
-            RxApp.SuspensionHost.IsUnpausing = _launched
+            RxApp.SuspensionHost.IsUnpausing = _activated
                 .Where(x => unpausing.Contains(x.PreviousExecutionState))
                 .Select(_ => Unit.Default);
 
@@ -50,7 +50,7 @@ namespace ReactiveUI
 
         public void OnLaunched(IActivatedEventArgs args)
         {
-            _launched.OnNext(args);
+            _activated.OnNext(args);
         }
     }
 }

--- a/ReactiveUI/Xaml/WinRTAutoSuspendApplication.cs
+++ b/ReactiveUI/Xaml/WinRTAutoSuspendApplication.cs
@@ -15,7 +15,7 @@ namespace ReactiveUI
 {
     public class AutoSuspendHelper : IEnableLogger
     {
-        readonly ReplaySubject<LaunchActivatedEventArgs> _launched = new ReplaySubject<LaunchActivatedEventArgs>(1);
+        readonly ReplaySubject<IActivatedEventArgs> _launched = new ReplaySubject<IActivatedEventArgs>(1);
 
         public AutoSuspendHelper(Application app)
         {
@@ -48,7 +48,7 @@ namespace ReactiveUI
             RxApp.SuspensionHost.ShouldInvalidateState = shouldInvalidateState;
         }
 
-        public void OnLaunched(LaunchActivatedEventArgs args)
+        public void OnLaunched(IActivatedEventArgs args)
         {
             _launched.OnNext(args);
         }


### PR DESCRIPTION
 Can you use IActivatedEventArgs inside WINRTAutoSuspendApplication instead of LaunchActivatedEventArgs so it can be called from OnActivated. In scenarios like where you open app from a protocol OnLaunched won't be called but OnActivated will be...  Changes are pretty unexciting... Just changing the two places where it's LaunchActivatedEventArgs to IActivatedEventArgs ... The only things accessed in the class are defined at the interface level so no special business.

I realize this issue was closed but it seemed more valid then the issue that was referenced in that issue
https://github.com/reactiveui/ReactiveUI/issues/796