### PR TITLE
Make ToProperty work properly on Indexers

### DIFF
--- a/ReactiveUI.Tests/ObservableAsPropertyHelperTest.cs
+++ b/ReactiveUI.Tests/ObservableAsPropertyHelperTest.cs
@@ -13,6 +13,29 @@ namespace ReactiveUI.Tests
 {
     public class ObservableAsPropertyHelperTest
     {
+        internal class OAPHTestFixture : ReactiveObject
+        {
+            private string _text;
+
+            public string Text
+            {
+                get { return _text; }
+                set { this.RaiseAndSetIfChanged(ref _text, value); }
+            }
+
+            public string this[string propertyName]
+            {
+                get { return string.Empty; }
+            }
+
+            public OAPHTestFixture()
+            {
+                var temp = this.WhenAnyValue(f => f.Text)
+                       .ToProperty(this, f => f["Whatever"])
+                       .Value;
+            }
+        }
+
         [Fact]
         public void OAPHShouldFireChangeNotifications()
         {
@@ -100,6 +123,22 @@ namespace ReactiveUI.Tests
     
                 Assert.False(failed);
                 Assert.Equal(4, fixture.Value);
+            });
+        }
+
+        [Fact]
+        public void ToProperty_GivenIndexer_NotifiesOnExpectedPropertyName()
+        {
+            (new TestScheduler()).With(sched => {
+                var fixture = new OAPHTestFixture();
+                var propertiesChanged = new List<string>();
+                fixture.PropertyChanged += (sender, args) => {
+                    propertiesChanged.Add(args.PropertyName);
+                };
+
+                fixture.Text = "awesome";
+
+                Assert.Equal(new[] { "Text", "Item[]" }, propertiesChanged);
             });
         }
     }

--- a/ReactiveUI/ObservableAsPropertyHelper.cs
+++ b/ReactiveUI/ObservableAsPropertyHelper.cs
@@ -1,13 +1,12 @@
-﻿using System;
+﻿using Splat;
+using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Diagnostics.Contracts;
 using System.Linq.Expressions;
 using System.Reactive.Concurrency;
+using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
-using Splat;
-using System.Reactive.Disposables;
 
 namespace ReactiveUI
 {
@@ -126,8 +125,12 @@ namespace ReactiveUI
                 throw new ArgumentException("Property expression must be of the form 'x => x.SomeProperty'");
             }
 
-            var ret = new ObservableAsPropertyHelper<TRet>(observable, 
-                _ => This.raisePropertyChanged(expression.GetMemberInfo().Name), 
+            var name = expression.GetMemberInfo().Name;
+            if (expression is IndexExpression)
+                name += "[]";
+
+            var ret = new ObservableAsPropertyHelper<TRet>(observable,
+                _ => This.raisePropertyChanged(name),
                 initialValue, scheduler);
 
             return ret;


### PR DESCRIPTION
In order for Data Bindings to work properly, we need to signal the right property name, in the case of indexers.