### PR TITLE
Ensure exceptions are delivered on output scheduler.

### DIFF
--- a/ReactiveUI/ReactiveCommand.cs
+++ b/ReactiveUI/ReactiveCommand.cs
@@ -647,7 +647,7 @@ namespace ReactiveUI
                 .Where(x => x.Demarcation == ExecutionDemarcation.EndWithResult)
                 .Select(x => x.Result);
 
-            this.exceptions = new ScheduledSubject<Exception>(CurrentThreadScheduler.Instance, RxApp.DefaultExceptionHandler);
+            this.exceptions = new ScheduledSubject<Exception>(outputScheduler, RxApp.DefaultExceptionHandler);
 
             this
                 .canExecute
@@ -842,7 +842,7 @@ namespace ReactiveUI
                 .ThrownExceptions
                 .Subscribe();
 
-            this.exceptions = new ScheduledSubject<Exception>(CurrentThreadScheduler.Instance, RxApp.DefaultExceptionHandler);
+            this.exceptions = new ScheduledSubject<Exception>(outputScheduler, RxApp.DefaultExceptionHandler);
 
             this
                 .CanExecute


### PR DESCRIPTION
As per discussion on Slack, RxCommand should deliver exceptions via the provided output scheduler.