### PR TITLE
Cancellation support in RxCommand, plus better naming

### DIFF
--- a/ReactiveUI.Tests/ObservedChangedMixinTest.cs
+++ b/ReactiveUI.Tests/ObservedChangedMixinTest.cs
@@ -21,7 +21,7 @@ namespace ReactiveUI.Tests
 
             (new TestScheduler()).With(sched => {
                 var fixture = new TestFixture();
-                
+
                 // ...whereas ObservableForProperty *is* guaranteed to.
                 fixture.ObservableForProperty(x => x.IsOnlyOneWord).Subscribe(x => {
                     output.Add(x.GetValue());
@@ -135,7 +135,7 @@ namespace ReactiveUI.Tests
         public void BindToStackOverFlowTest()
         {
             // Before the code changes packed in the same commit
-            // as this test the test would go into an infinite 
+            // as this test the test would go into an infinite
             // event storm. The critical issue is that the
             // property StackOverflowTrigger will clone the
             // value before setting it.
@@ -150,7 +150,7 @@ namespace ReactiveUI.Tests
 
                 source.BindTo(fixturea, x => x.StackOverflowTrigger);
             });
-            
+
         }
     }
 
@@ -168,7 +168,7 @@ namespace ReactiveUI.Tests
         {
             foreach (var i in Enumerable.Range(1, 7)) {
                 viewmodel.NewPlayerName = "Player" + i;
-                viewmodel.AddPlayer.ExecuteAsync();
+                viewmodel.AddPlayer.Execute();
                 Assert.Equal(i, viewmodel.Players.Count);
             }
         }

--- a/ReactiveUI.Tests/ReactiveCommandTest.cs
+++ b/ReactiveUI.Tests/ReactiveCommandTest.cs
@@ -87,7 +87,7 @@ namespace ReactiveUI.Tests
                     .CanExecute
                     .CreateCollection();
 
-                fixture.ExecuteAsync().Subscribe();
+                fixture.Execute().Subscribe();
                 sched.AdvanceByMs(100);
 
                 Assert.Equal(2, canExecute.Count);
@@ -168,7 +168,7 @@ namespace ReactiveUI.Tests
                     .IsExecuting
                     .CreateCollection();
 
-                fixture.ExecuteAsync().Subscribe();
+                fixture.Execute().Subscribe();
                 sched.AdvanceByMs(100);
 
                 Assert.Equal(2, isExecuting.Count);
@@ -183,7 +183,7 @@ namespace ReactiveUI.Tests
         }
 
         [Fact]
-        public void ExecuteAsyncPassesThroughParameter()
+        public void ExecutePassesThroughParameter()
         {
             var parameters = new List<int>();
             var fixture = ReactiveCommand.CreateFromObservable<int, Unit>(param => {
@@ -191,9 +191,9 @@ namespace ReactiveUI.Tests
                     return Observable.Return(Unit.Default);
                 });
 
-            fixture.ExecuteAsync(1).Subscribe();
-            fixture.ExecuteAsync(42).Subscribe();
-            fixture.ExecuteAsync(348).Subscribe();
+            fixture.Execute(1).Subscribe();
+            fixture.Execute(42).Subscribe();
+            fixture.Execute(348).Subscribe();
 
             Assert.Equal(3, parameters.Count);
             Assert.Equal(1, parameters[0]);
@@ -202,7 +202,7 @@ namespace ReactiveUI.Tests
         }
 
         [Fact]
-        public void ExecuteAsyncExecutesOnTheSpecifiedScheduler()
+        public void ExecuteExecutesOnTheSpecifiedScheduler()
         {
             (new TestScheduler()).With(sched => {
                 var execute = Observable.Return(Unit.Default).Delay(TimeSpan.FromSeconds(1), sched);
@@ -211,7 +211,7 @@ namespace ReactiveUI.Tests
                     .IsExecuting
                     .CreateCollection();
 
-                fixture.ExecuteAsync().Subscribe();
+                fixture.Execute().Subscribe();
                 sched.AdvanceByMs(999);
 
                 Assert.Equal(2, isExecuting.Count);
@@ -226,7 +226,7 @@ namespace ReactiveUI.Tests
         }
 
         [Fact]
-        public void ExecuteAsyncTicksThroughTheResult()
+        public void ExecuteTicksThroughTheResult()
         {
             var num = 0;
             var fixture = ReactiveCommand.CreateFromObservable(() => Observable.Return(num));
@@ -234,11 +234,11 @@ namespace ReactiveUI.Tests
                 .CreateCollection();
 
             num = 1;
-            fixture.ExecuteAsync().Subscribe();
+            fixture.Execute().Subscribe();
             num = 10;
-            fixture.ExecuteAsync().Subscribe();
+            fixture.Execute().Subscribe();
             num = 30;
-            fixture.ExecuteAsync().Subscribe();
+            fixture.Execute().Subscribe();
 
             Assert.Equal(3, results.Count);
             Assert.Equal(1, results[0]);
@@ -247,7 +247,7 @@ namespace ReactiveUI.Tests
         }
 
         [Fact]
-        public void ExecuteAsyncTicksAnyException()
+        public void ExecuteTicksAnyException()
         {
             var fixture = ReactiveCommand.CreateFromObservable(() => Observable.Throw<Unit>(new InvalidOperationException()));
             fixture
@@ -255,7 +255,7 @@ namespace ReactiveUI.Tests
                 .Subscribe();
             Exception exception = null;
             fixture
-                .ExecuteAsync()
+                .Execute()
                 .Subscribe(
                     _ => { },
                     ex => exception = ex,
@@ -265,7 +265,7 @@ namespace ReactiveUI.Tests
         }
 
         [Fact]
-        public void ExecuteAsyncTicksAnyLambdaException()
+        public void ExecuteTicksAnyLambdaException()
         {
             var fixture = ReactiveCommand.CreateFromObservable<Unit>(() => { throw new InvalidOperationException(); });
             fixture
@@ -273,7 +273,7 @@ namespace ReactiveUI.Tests
                 .Subscribe();
             Exception exception = null;
             fixture
-                .ExecuteAsync()
+                .Execute()
                 .Subscribe(
                     _ => { },
                     ex => exception = ex,
@@ -283,7 +283,7 @@ namespace ReactiveUI.Tests
         }
 
         [Fact]
-        public void ExecuteAsyncCanBeCancelled()
+        public void ExecuteCanBeCancelled()
         {
             (new TestScheduler()).With(sched => {
                 var execute = Observable.Return(Unit.Default).Delay(TimeSpan.FromSeconds(1), sched);
@@ -291,8 +291,8 @@ namespace ReactiveUI.Tests
                 var executed = fixture
                     .CreateCollection();
 
-                var sub1 = fixture.ExecuteAsync().Subscribe();
-                var sub2 = fixture.ExecuteAsync().Subscribe();
+                var sub1 = fixture.Execute().Subscribe();
+                var sub2 = fixture.Execute().Subscribe();
                 sched.AdvanceByMs(999);
 
                 Assert.True(fixture.IsExecuting.FirstAsync().Wait());
@@ -315,10 +315,10 @@ namespace ReactiveUI.Tests
                     .ThrownExceptions
                     .Subscribe(ex => exception = ex);
                 fixture
-                    .ExecuteAsync()
+                    .Execute()
                     .Subscribe(
                         _ => { },
-                        ex => { });
+                        _ => { });
 
                 Assert.Null(exception);
                 sched.Start();
@@ -374,7 +374,7 @@ namespace ReactiveUI.Tests
                 var results = fixture
                     .CreateCollection();
 
-                fixture.ExecuteAsync().Subscribe();
+                fixture.Execute().Subscribe();
                 Assert.Empty(results);
 
                 sched.AdvanceByMs(1);
@@ -383,7 +383,7 @@ namespace ReactiveUI.Tests
         }
 
         [Fact]
-        public void ExecuteAsyncTicksErrorsThroughThrownExceptions()
+        public void ExecuteTicksErrorsThroughThrownExceptions()
         {
             var fixture = ReactiveCommand.CreateFromObservable(() => Observable.Throw<Unit>(new InvalidOperationException("oops")));
             var thrownExceptions = fixture
@@ -391,17 +391,17 @@ namespace ReactiveUI.Tests
                 .CreateCollection();
 
             fixture
-                .ExecuteAsync()
+                .Execute()
                 .Subscribe(
                     _ => { },
-                    ex => { });
+                    _ => { });
 
             Assert.Equal(1, thrownExceptions.Count);
             Assert.Equal("oops", thrownExceptions[0].Message);
         }
 
         [Fact]
-        public void ExecuteAsyncTicksLambdaErrorsThroughThrownExceptions()
+        public void ExecuteTicksLambdaErrorsThroughThrownExceptions()
         {
             var fixture = ReactiveCommand.CreateFromObservable<Unit>(() => { throw new InvalidOperationException("oops"); });
             var thrownExceptions = fixture
@@ -409,17 +409,17 @@ namespace ReactiveUI.Tests
                 .CreateCollection();
 
             fixture
-                .ExecuteAsync()
+                .Execute()
                 .Subscribe(
                     _ => { },
-                    ex => { });
+                    _ => { });
 
             Assert.Equal(1, thrownExceptions.Count);
             Assert.Equal("oops", thrownExceptions[0].Message);
         }
 
         [Fact]
-        public void ExecuteAsyncReenablesExecutionEvenAfterFailure()
+        public void ExecuteReenablesExecutionEvenAfterFailure()
         {
             var fixture = ReactiveCommand.CreateFromObservable(() => Observable.Throw<Unit>(new InvalidOperationException("oops")));
             var canExecute = fixture
@@ -430,10 +430,10 @@ namespace ReactiveUI.Tests
                 .CreateCollection();
 
             fixture
-                .ExecuteAsync()
+                .Execute()
                 .Subscribe(
                     _ => { },
-                    ex => { });
+                    _ => { });
 
             Assert.Equal(1, thrownExceptions.Count);
             Assert.Equal("oops", thrownExceptions[0].Message);
@@ -451,7 +451,7 @@ namespace ReactiveUI.Tests
             var results = fixture
                 .CreateCollection();
 
-            fixture.ExecuteAsync().Subscribe();
+            fixture.Execute().Subscribe();
 
             Assert.Equal(1, results.Count);
             Assert.Equal(13, results[0]);
@@ -464,8 +464,8 @@ namespace ReactiveUI.Tests
             var results = fixture
                 .CreateCollection();
 
-            fixture.ExecuteAsync(3).Subscribe();
-            fixture.ExecuteAsync(41).Subscribe();
+            fixture.Execute(3).Subscribe();
+            fixture.Execute(41).Subscribe();
 
             Assert.Equal(2, results.Count);
             Assert.Equal(4, results[0]);
@@ -574,7 +574,7 @@ namespace ReactiveUI.Tests
         }
 
         [Fact]
-        public void ExecuteAsyncExecutesAllChildCommands()
+        public void ExecuteExecutesAllChildCommands()
         {
             var child1 = ReactiveCommand.Create(() => Observable.Return(Unit.Default));
             var child2 = ReactiveCommand.Create(() => Observable.Return(Unit.Default));
@@ -595,7 +595,7 @@ namespace ReactiveUI.Tests
                 .IsExecuting
                 .CreateCollection();
 
-            fixture.ExecuteAsync().Subscribe();
+            fixture.Execute().Subscribe();
 
             Assert.Equal(3, isExecuting.Count);
             Assert.False(isExecuting[0]);
@@ -619,7 +619,7 @@ namespace ReactiveUI.Tests
         }
 
         [Fact]
-        public void ExecuteAsyncTicksThroughTheResults()
+        public void ExecuteTicksThroughTheResults()
         {
             var child1 = ReactiveCommand.CreateFromObservable(() => Observable.Return(1));
             var child2 = ReactiveCommand.CreateFromObservable(() => Observable.Return(2));
@@ -629,7 +629,7 @@ namespace ReactiveUI.Tests
             var results = fixture
                 .CreateCollection();
 
-            fixture.ExecuteAsync().Subscribe();
+            fixture.Execute().Subscribe();
 
             Assert.Equal(1, results.Count);
             Assert.Equal(2, results[0].Count);
@@ -648,7 +648,7 @@ namespace ReactiveUI.Tests
                 var results = fixture
                     .CreateCollection();
 
-                fixture.ExecuteAsync().Subscribe();
+                fixture.Execute().Subscribe();
                 Assert.Empty(results);
 
                 sched.AdvanceByMs(1);
@@ -657,7 +657,7 @@ namespace ReactiveUI.Tests
         }
 
         [Fact]
-        public void ExecuteAsyncTicksErrorsInAnyChildCommandThroughThrownExceptions()
+        public void ExecuteTicksErrorsInAnyChildCommandThroughThrownExceptions()
         {
             var child1 = ReactiveCommand.CreateFromObservable(() => Observable.Return(Unit.Default));
             var child2 = ReactiveCommand.CreateFromObservable(() => Observable.Throw<Unit>(new InvalidOperationException("oops")));
@@ -668,10 +668,10 @@ namespace ReactiveUI.Tests
                 .CreateCollection();
 
             fixture
-                .ExecuteAsync()
+                .Execute()
                 .Subscribe(
                     _ => { },
-                    ex => { });
+                    _ => { });
 
             Assert.Equal(1, thrownExceptions.Count);
             Assert.Equal("oops", thrownExceptions[0].Message);
@@ -689,10 +689,10 @@ namespace ReactiveUI.Tests
                     .ThrownExceptions
                     .Subscribe(ex => exception = ex);
                 fixture
-                    .ExecuteAsync()
-                    .Subscribe(
-                        _ => { },
-                        ex => { });
+                   .Execute()
+                   .Subscribe(
+                       _ => { },
+                       _ => { });
 
                 Assert.Null(exception);
                 sched.Start();

--- a/ReactiveUI.Tests/ReactiveCommandTest.cs
+++ b/ReactiveUI.Tests/ReactiveCommandTest.cs
@@ -87,7 +87,7 @@ namespace ReactiveUI.Tests
                     .CanExecute
                     .CreateCollection();
 
-                fixture.ExecuteAsync();
+                fixture.ExecuteAsync().Subscribe();
                 sched.AdvanceByMs(100);
 
                 Assert.Equal(2, canExecute.Count);
@@ -168,7 +168,7 @@ namespace ReactiveUI.Tests
                     .IsExecuting
                     .CreateCollection();
 
-                fixture.ExecuteAsync();
+                fixture.ExecuteAsync().Subscribe();
                 sched.AdvanceByMs(100);
 
                 Assert.Equal(2, isExecuting.Count);
@@ -191,9 +191,9 @@ namespace ReactiveUI.Tests
                     return Observable.Return(Unit.Default);
                 });
 
-            fixture.ExecuteAsync(1);
-            fixture.ExecuteAsync(42);
-            fixture.ExecuteAsync(348);
+            fixture.ExecuteAsync(1).Subscribe();
+            fixture.ExecuteAsync(42).Subscribe();
+            fixture.ExecuteAsync(348).Subscribe();
 
             Assert.Equal(3, parameters.Count);
             Assert.Equal(1, parameters[0]);
@@ -211,7 +211,7 @@ namespace ReactiveUI.Tests
                     .IsExecuting
                     .CreateCollection();
 
-                fixture.ExecuteAsync();
+                fixture.ExecuteAsync().Subscribe();
                 sched.AdvanceByMs(999);
 
                 Assert.Equal(2, isExecuting.Count);
@@ -226,25 +226,6 @@ namespace ReactiveUI.Tests
         }
 
         [Fact]
-        public void ExecuteAsyncExecutesEvenWithoutASubscription()
-        {
-            (new TestScheduler()).With(sched => {
-                var execute = Observable.Return(Unit.Default).Delay(TimeSpan.FromSeconds(1), sched);
-                var fixture = ReactiveCommand.CreateFromObservable(() => execute, outputScheduler: sched);
-                var isExecuting = fixture
-                    .IsExecuting
-                    .CreateCollection();
-
-                fixture.ExecuteAsync();
-                sched.AdvanceByMs(1);
-
-                Assert.Equal(2, isExecuting.Count);
-                Assert.False(isExecuting[0]);
-                Assert.True(isExecuting[1]);
-            });
-        }
-
-        [Fact]
         public void ExecuteAsyncTicksThroughTheResult()
         {
             var num = 0;
@@ -253,11 +234,11 @@ namespace ReactiveUI.Tests
                 .CreateCollection();
 
             num = 1;
-            fixture.ExecuteAsync();
+            fixture.ExecuteAsync().Subscribe();
             num = 10;
-            fixture.ExecuteAsync();
+            fixture.ExecuteAsync().Subscribe();
             num = 30;
-            fixture.ExecuteAsync();
+            fixture.ExecuteAsync().Subscribe();
 
             Assert.Equal(3, results.Count);
             Assert.Equal(1, results[0]);
@@ -370,7 +351,7 @@ namespace ReactiveUI.Tests
                 var results = fixture
                     .CreateCollection();
 
-                fixture.ExecuteAsync();
+                fixture.ExecuteAsync().Subscribe();
                 Assert.Empty(results);
 
                 sched.AdvanceByMs(1);
@@ -386,7 +367,11 @@ namespace ReactiveUI.Tests
                 .ThrownExceptions
                 .CreateCollection();
 
-            fixture.ExecuteAsync();
+            fixture
+                .ExecuteAsync()
+                .Subscribe(
+                    _ => { },
+                    ex => { });
 
             Assert.Equal(1, thrownExceptions.Count);
             Assert.Equal("oops", thrownExceptions[0].Message);
@@ -400,7 +385,11 @@ namespace ReactiveUI.Tests
                 .ThrownExceptions
                 .CreateCollection();
 
-            fixture.ExecuteAsync();
+            fixture
+                .ExecuteAsync()
+                .Subscribe(
+                    _ => { },
+                    ex => { });
 
             Assert.Equal(1, thrownExceptions.Count);
             Assert.Equal("oops", thrownExceptions[0].Message);
@@ -417,7 +406,11 @@ namespace ReactiveUI.Tests
                 .ThrownExceptions
                 .CreateCollection();
 
-            fixture.ExecuteAsync();
+            fixture
+                .ExecuteAsync()
+                .Subscribe(
+                    _ => { },
+                    ex => { });
 
             Assert.Equal(1, thrownExceptions.Count);
             Assert.Equal("oops", thrownExceptions[0].Message);
@@ -435,7 +428,7 @@ namespace ReactiveUI.Tests
             var results = fixture
                 .CreateCollection();
 
-            fixture.ExecuteAsync();
+            fixture.ExecuteAsync().Subscribe();
 
             Assert.Equal(1, results.Count);
             Assert.Equal(13, results[0]);
@@ -448,8 +441,8 @@ namespace ReactiveUI.Tests
             var results = fixture
                 .CreateCollection();
 
-            fixture.ExecuteAsync(3);
-            fixture.ExecuteAsync(41);
+            fixture.ExecuteAsync(3).Subscribe();
+            fixture.ExecuteAsync(41).Subscribe();
 
             Assert.Equal(2, results.Count);
             Assert.Equal(4, results[0]);
@@ -579,7 +572,7 @@ namespace ReactiveUI.Tests
                 .IsExecuting
                 .CreateCollection();
 
-            fixture.ExecuteAsync();
+            fixture.ExecuteAsync().Subscribe();
 
             Assert.Equal(3, isExecuting.Count);
             Assert.False(isExecuting[0]);
@@ -613,7 +606,7 @@ namespace ReactiveUI.Tests
             var results = fixture
                 .CreateCollection();
 
-            fixture.ExecuteAsync();
+            fixture.ExecuteAsync().Subscribe();
 
             Assert.Equal(1, results.Count);
             Assert.Equal(2, results[0].Count);
@@ -632,7 +625,7 @@ namespace ReactiveUI.Tests
                 var results = fixture
                     .CreateCollection();
 
-                fixture.ExecuteAsync();
+                fixture.ExecuteAsync().Subscribe();
                 Assert.Empty(results);
 
                 sched.AdvanceByMs(1);
@@ -651,7 +644,11 @@ namespace ReactiveUI.Tests
                 .ThrownExceptions
                 .CreateCollection();
 
-            fixture.ExecuteAsync();
+            fixture
+                .ExecuteAsync()
+                .Subscribe(
+                    _ => { },
+                    ex => { });
 
             Assert.Equal(1, thrownExceptions.Count);
             Assert.Equal("oops", thrownExceptions[0].Message);

--- a/ReactiveUI.Tests/ReactiveCommandTest.cs
+++ b/ReactiveUI.Tests/ReactiveCommandTest.cs
@@ -183,6 +183,21 @@ namespace ReactiveUI.Tests
         }
 
         [Fact]
+        public void ExecuteOnlyExecutesOnceRegardlessOfNumberOfSubscribers()
+        {
+            var executionCount = 0;
+            var fixture = ReactiveCommand.Create(() => { ++executionCount; });
+            var execute = fixture.Execute();
+
+            execute.Subscribe();
+            execute.Subscribe();
+            execute.Subscribe();
+            execute.Subscribe();
+
+            Assert.Equal(1, executionCount);
+        }
+
+        [Fact]
         public void ExecutePassesThroughParameter()
         {
             var parameters = new List<int>();

--- a/ReactiveUI.Tests/ReactiveNotifyPropertyChangedMixinTest.cs
+++ b/ReactiveUI.Tests/ReactiveNotifyPropertyChangedMixinTest.cs
@@ -183,7 +183,7 @@ namespace ReactiveUI.Tests
                 sched.Start();
                 Assert.Equal(2, changes.Count);
 
-                // Tricky! This is a change too, because from the perspective 
+                // Tricky! This is a change too, because from the perspective
                 // of the binding, we've went from "Bar" to null
                 fixture.Child = new TestFixture();
                 sched.Start();
@@ -205,7 +205,7 @@ namespace ReactiveUI.Tests
                 Assert.True(changes.All(x => x.Sender == fixture));
                 Assert.True(changes.All(x => x.GetPropertyName() == "Child.IsOnlyOneWord"));
                 changes.Select(x => x.Value).AssertAreEqual(new[] {"Foo", "Bar", null, "Baz"});
-            });           
+            });
         }
 
 
@@ -229,7 +229,7 @@ namespace ReactiveUI.Tests
                 sched.Start();
                 Assert.Equal(2, changes.Count);
 
-                // Tricky! This is a change too, because from the perspective 
+                // Tricky! This is a change too, because from the perspective
                 // of the binding, we've went from "Bar" to null
                 fixture.Child = new TestFixture();
                 sched.Start();
@@ -270,7 +270,7 @@ namespace ReactiveUI.Tests
 
                 var changes = fixture.ObservableForProperty(x => x.InpcProperty.IsOnlyOneWord).CreateCollection();
 
-                fixture.InpcProperty = new TestFixture(); 
+                fixture.InpcProperty = new TestFixture();
                 sched.Start();
                 Assert.Equal(1, changes.Count);
 
@@ -285,25 +285,25 @@ namespace ReactiveUI.Tests
         }
 
         [Fact]
-        public void AnyChangeInExpressionListTriggersUpdate() 
+        public void AnyChangeInExpressionListTriggersUpdate()
         {
             var obj = new ObjChain1();
             bool obsUpdated;
 
             obj.ObservableForProperty(x => x.Model.Model.Model.SomeOtherParam).Subscribe(_ => obsUpdated = true);
-           
+
             obsUpdated = false;
             obj.Model.Model.Model.SomeOtherParam = 42;
             Assert.True(obsUpdated);
- 
+
             obsUpdated = false;
             obj.Model.Model.Model = new HostTestFixture();
             Assert.True(obsUpdated);
- 
+
             obsUpdated = false;
             obj.Model.Model = new ObjChain3() {Model = new HostTestFixture() {SomeOtherParam = 10 } } ;
             Assert.True(obsUpdated);
- 
+
             obsUpdated = false;
             obj.Model = new ObjChain2();
             Assert.True(obsUpdated);
@@ -318,7 +318,7 @@ namespace ReactiveUI.Tests
                .Subscribe(x => observedValue = x);
 
             obj.SomeOtherParam = 42;
-            
+
             Assert.True(observedValue == obj.SomeOtherParam);
         }
 
@@ -406,7 +406,7 @@ namespace ReactiveUI.Tests
 
             var output4 = new List<int?>();
             fixture.WhenAnyValue(x => x.NullableInt).Subscribe(output4.Add);
-           
+
             Assert.Equal(1, output.Count);
             Assert.Equal(fixture, output[0].Sender);
             Assert.Equal("PocoProperty", output[0].GetPropertyName());
@@ -613,13 +613,13 @@ namespace ReactiveUI.Tests
 
             Assert.Equal(0, list.Count);
 
-            await fixture.Command1.ExecuteAsync(1);
+            await fixture.Command1.Execute(1);
             Assert.Equal(1, list.Count);
 
-            await fixture.Command2.ExecuteAsync(2);
+            await fixture.Command2.Execute(2);
             Assert.Equal(2, list.Count);
 
-            await fixture.Command1.ExecuteAsync(1);
+            await fixture.Command1.Execute(1);
             Assert.Equal(3, list.Count);
 
             Assert.True(

--- a/ReactiveUI.Tests/RoutableViewModelMixinTests.cs
+++ b/ReactiveUI.Tests/RoutableViewModelMixinTests.cs
@@ -40,7 +40,7 @@ namespace ReactiveUI.Tests
                 return Disposable.Empty;
             });
 
-            screen.Router.Navigate.ExecuteAsync(vm);
+            screen.Router.Navigate.Execute(vm);
 
             Assert.Equal(1, count);
         }
@@ -60,9 +60,9 @@ namespace ReactiveUI.Tests
                 return Disposable.Empty;
             });
 
-            screen.Router.Navigate.ExecuteAsync(vm);
-            screen.Router.Navigate.ExecuteAsync(vm2);
-            screen.Router.Navigate.ExecuteAsync(vm);
+            screen.Router.Navigate.Execute(vm);
+            screen.Router.Navigate.Execute(vm2);
+            screen.Router.Navigate.Execute(vm);
 
             Assert.Equal(2, count);
         }
@@ -80,11 +80,11 @@ namespace ReactiveUI.Tests
                 return Disposable.Create(() => count++);
             });
 
-            screen.Router.Navigate.ExecuteAsync(vm);
+            screen.Router.Navigate.Execute(vm);
 
             Assert.Equal(0, count);
 
-            screen.Router.Navigate.ExecuteAsync(vm2);
+            screen.Router.Navigate.Execute(vm2);
 
             Assert.Equal(1, count);
         }
@@ -101,7 +101,7 @@ namespace ReactiveUI.Tests
                 count++;
             });
 
-            screen.Router.Navigate.ExecuteAsync(vm);
+            screen.Router.Navigate.Execute(vm);
 
             Assert.Equal(1, count);
         }
@@ -119,9 +119,9 @@ namespace ReactiveUI.Tests
                 count++;
             });
 
-            screen.Router.Navigate.ExecuteAsync(vm);
-            screen.Router.Navigate.ExecuteAsync(vm2);
-            screen.Router.Navigate.ExecuteAsync(vm);
+            screen.Router.Navigate.Execute(vm);
+            screen.Router.Navigate.Execute(vm2);
+            screen.Router.Navigate.Execute(vm);
 
             Assert.Equal(2, count);
         }
@@ -138,8 +138,8 @@ namespace ReactiveUI.Tests
                 _ => {},
                 () => { count++; });
 
-            screen.Router.Navigate.ExecuteAsync(vm);
-            screen.Router.NavigateBack.ExecuteAsync();
+            screen.Router.Navigate.Execute(vm);
+            screen.Router.NavigateBack.Execute();
 
             Assert.Equal(1, count);
         }
@@ -156,8 +156,8 @@ namespace ReactiveUI.Tests
                 count++;
             });
 
-            screen.Router.Navigate.ExecuteAsync(vm);
-            screen.Router.Navigate.ExecuteAsync(vm2);
+            screen.Router.Navigate.Execute(vm);
+            screen.Router.Navigate.Execute(vm2);
 
             Assert.Equal(1, count);
         }
@@ -174,8 +174,8 @@ namespace ReactiveUI.Tests
                 _ => {},
                 () => { count++; });
 
-            screen.Router.Navigate.ExecuteAsync(vm);
-            screen.Router.NavigateBack.ExecuteAsync();
+            screen.Router.Navigate.Execute(vm);
+            screen.Router.NavigateBack.Execute();
 
             Assert.Equal(1, count);
         }

--- a/ReactiveUI.Tests/RoutingState.cs
+++ b/ReactiveUI.Tests/RoutingState.cs
@@ -43,17 +43,17 @@ namespace ReactiveUI.Routing.Tests
             var fixture = new RoutingState();
 
             Assert.False(await fixture.NavigateBack.CanExecute.FirstAsync());
-            await fixture.Navigate.ExecuteAsync(new TestViewModel());
+            await fixture.Navigate.Execute(new TestViewModel());
 
             Assert.Equal(1, fixture.NavigationStack.Count);
             Assert.False(await fixture.NavigateBack.CanExecute.FirstAsync());
 
-            await fixture.Navigate.ExecuteAsync(new TestViewModel());
+            await fixture.Navigate.Execute(new TestViewModel());
 
             Assert.Equal(2, fixture.NavigationStack.Count);
             Assert.True(await fixture.NavigateBack.CanExecute.FirstAsync());
 
-            await fixture.NavigateBack.ExecuteAsync();
+            await fixture.NavigateBack.Execute();
 
             Assert.Equal(1, fixture.NavigationStack.Count);
         }
@@ -66,14 +66,14 @@ namespace ReactiveUI.Routing.Tests
 
             Assert.Equal(1, output.Count);
 
-            fixture.Navigate.ExecuteAsync(new TestViewModel() { SomeProp = "A" });
+            fixture.Navigate.Execute(new TestViewModel() { SomeProp = "A" });
             Assert.Equal(2, output.Count);
 
-            fixture.Navigate.ExecuteAsync(new TestViewModel() { SomeProp = "B" });
+            fixture.Navigate.Execute(new TestViewModel() { SomeProp = "B" });
             Assert.Equal(3, output.Count);
             Assert.Equal("B", ((TestViewModel)output.Last()).SomeProp);
 
-            fixture.NavigateBack.ExecuteAsync();
+            fixture.NavigateBack.Execute();
             Assert.Equal(4, output.Count);
             Assert.Equal("A", ((TestViewModel)output.Last()).SomeProp);
         }
@@ -87,14 +87,14 @@ namespace ReactiveUI.Routing.Tests
 
             Assert.Equal(1, output.Count);
 
-            fixture.Router.Navigate.ExecuteAsync(new TestViewModel() { SomeProp = "A" });
+            fixture.Router.Navigate.Execute(new TestViewModel() { SomeProp = "A" });
             Assert.Equal(2, output.Count);
 
-            fixture.Router.Navigate.ExecuteAsync(new TestViewModel() { SomeProp = "B" });
+            fixture.Router.Navigate.Execute(new TestViewModel() { SomeProp = "B" });
             Assert.Equal(3, output.Count);
             Assert.Equal("B", ((TestViewModel)output.Last()).SomeProp);
 
-            fixture.Router.NavigateBack.ExecuteAsync();
+            fixture.Router.NavigateBack.Execute();
             Assert.Equal(4, output.Count);
             Assert.Equal("A", ((TestViewModel)output.Last()).SomeProp);
         }
@@ -108,7 +108,7 @@ namespace ReactiveUI.Routing.Tests
 
             Assert.False(fixture.Router.NavigationStack.Any());
 
-            fixture.Router.NavigateAndReset.ExecuteAsync(viewModel);
+            fixture.Router.NavigateAndReset.Execute(viewModel);
 
             Assert.True(fixture.Router.NavigationStack.Count == 1);
             Assert.True(object.ReferenceEquals(fixture.Router.NavigationStack.First(), viewModel));
@@ -132,17 +132,17 @@ namespace ReactiveUI.Routing.Tests
                 .NavigateAndReset
                 .CreateCollection();
 
-            fixture.Navigate.ExecuteAsync(new TestViewModel()).Subscribe();
+            fixture.Navigate.Execute(new TestViewModel()).Subscribe();
             Assert.Empty(navigate);
             scheduler.Start();
             Assert.NotEmpty(navigate);
 
-            fixture.NavigateBack.ExecuteAsync().Subscribe();
+            fixture.NavigateBack.Execute().Subscribe();
             Assert.Empty(navigateBack);
             scheduler.Start();
             Assert.NotEmpty(navigateBack);
 
-            fixture.NavigateAndReset.ExecuteAsync(new TestViewModel()).Subscribe();
+            fixture.NavigateAndReset.Execute(new TestViewModel()).Subscribe();
             Assert.Empty(navigateAndReset);
             scheduler.Start();
             Assert.NotEmpty(navigateAndReset);

--- a/ReactiveUI.Tests/RoutingState.cs
+++ b/ReactiveUI.Tests/RoutingState.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Reactive.Linq;
 using Xunit;
 
@@ -97,7 +98,7 @@ namespace ReactiveUI.Routing.Tests
             Assert.Equal(4, output.Count);
             Assert.Equal("A", ((TestViewModel)output.Last()).SomeProp);
         }
-        
+
         [Fact]
         public void NavigateAndResetCheckNavigationStack()
         {
@@ -131,17 +132,17 @@ namespace ReactiveUI.Routing.Tests
                 .NavigateAndReset
                 .CreateCollection();
 
-            fixture.Navigate.ExecuteAsync(new TestViewModel());
+            fixture.Navigate.ExecuteAsync(new TestViewModel()).Subscribe();
             Assert.Empty(navigate);
             scheduler.Start();
             Assert.NotEmpty(navigate);
 
-            fixture.NavigateBack.ExecuteAsync();
+            fixture.NavigateBack.ExecuteAsync().Subscribe();
             Assert.Empty(navigateBack);
             scheduler.Start();
             Assert.NotEmpty(navigateBack);
 
-            fixture.NavigateAndReset.ExecuteAsync(new TestViewModel());
+            fixture.NavigateAndReset.ExecuteAsync(new TestViewModel()).Subscribe();
             Assert.Empty(navigateAndReset);
             scheduler.Start();
             Assert.NotEmpty(navigateAndReset);

--- a/ReactiveUI.Tests/Winforms/RoutedViewHostTests.cs
+++ b/ReactiveUI.Tests/Winforms/RoutedViewHostTests.cs
@@ -16,14 +16,14 @@ namespace ReactiveUI.Tests.Winforms
             var viewLocator = new FakeViewLocator { LocatorFunc = t => new FakeWinformsView() };
             var router = new RoutingState();
             var target = new WinFormsRoutedViewHost { Router = router, ViewLocator = viewLocator };
-            router.Navigate.ExecuteAsync(new FakeWinformViewModel());
+            router.Navigate.Execute(new FakeWinformViewModel());
 
             FakeWinformsView currentView = target.Controls.OfType<FakeWinformsView>().Single();
             bool isDisposed = false;
             currentView.Disposed += (o, e) => isDisposed = true;
 
             // switch the viewmodel
-            router.Navigate.ExecuteAsync(new FakeWinformViewModel());
+            router.Navigate.Execute(new FakeWinformViewModel());
 
             Assert.True(isDisposed);
         }
@@ -50,7 +50,7 @@ namespace ReactiveUI.Tests.Winforms
             var viewLocator = new FakeViewLocator { LocatorFunc = t => new FakeWinformsView() };
             var router = new RoutingState();
             var target = new WinFormsRoutedViewHost { Router = router, ViewLocator = viewLocator };
-            router.Navigate.ExecuteAsync(new FakeWinformViewModel());
+            router.Navigate.Execute(new FakeWinformViewModel());
 
             Assert.Equal(1, target.Controls.OfType<FakeWinformsView>().Count());
         }

--- a/ReactiveUI/ReactiveCommand.cs
+++ b/ReactiveUI/ReactiveCommand.cs
@@ -572,7 +572,10 @@ namespace ReactiveUI
                         parameter.GetType().FullName));
             }
 
-            this.ExecuteAsync((TParam)parameter);
+            this
+                .ExecuteAsync((TParam)parameter)
+                .Catch(Observable.Empty<TResult>())
+                .Subscribe();
         }
     }
 
@@ -693,8 +696,7 @@ namespace ReactiveUI
                         this.synchronizedExecutionInfo.OnNext(ExecutionInfo.CreateFail());
                         exceptions.OnNext(ex);
                         return Observable.Throw<TResult>(ex);
-                    })
-                    .RunAsync(CancellationToken.None);
+                    });
             } catch (Exception ex) {
                 this.exceptions.OnNext(ex);
                 return Observable.Throw<TResult>(ex);

--- a/ReactiveUI/ReactiveCommand.cs
+++ b/ReactiveUI/ReactiveCommand.cs
@@ -367,9 +367,9 @@ namespace ReactiveUI
         /// The type of the command's result.
         /// </typeparam>
         public static ReactiveCommand<TParam, TResult> CreateFromObservable<TParam, TResult>(
-                Func<TParam, IObservable<TResult>> executeAsync,
-                IObservable<bool> canExecute = null,
-                IScheduler outputScheduler = null)
+            Func<TParam, IObservable<TResult>> executeAsync,
+            IObservable<bool> canExecute = null,
+            IScheduler outputScheduler = null)
         {
             return new ReactiveCommand<TParam, TResult>(
                 executeAsync,
@@ -399,9 +399,9 @@ namespace ReactiveUI
         /// The type of the command's result.
         /// </typeparam>
         public static ReactiveCommand<TParam, TResult> CreateFromTask<TParam, TResult>(
-                Func<TParam, Task<TResult>> executeAsync,
-                IObservable<bool> canExecute = null,
-                IScheduler outputScheduler = null)
+            Func<TParam, Task<TResult>> executeAsync,
+            IObservable<bool> canExecute = null,
+            IScheduler outputScheduler = null)
         {
             return CreateFromObservable<TParam, TResult>(
                 param => executeAsync(param).ToObservable(),
@@ -431,9 +431,9 @@ namespace ReactiveUI
         /// The type of the command's result.
         /// </typeparam>
         public static ReactiveCommand<TParam, TResult> CreateFromTask<TParam, TResult>(
-                Func<TParam, CancellationToken, Task<TResult>> executeAsync,
-                IObservable<bool> canExecute = null,
-                IScheduler outputScheduler = null)
+            Func<TParam, CancellationToken, Task<TResult>> executeAsync,
+            IObservable<bool> canExecute = null,
+            IScheduler outputScheduler = null)
         {
             return CreateFromObservable<TParam, TResult>(
                 param => Observable.StartAsync(ct => executeAsync(param, ct)),
@@ -460,9 +460,9 @@ namespace ReactiveUI
         /// The type of the parameter passed through to command execution.
         /// </typeparam>
         public static ReactiveCommand<TParam, Unit> CreateFromTask<TParam>(
-                Func<TParam, Task> executeAsync,
-                IObservable<bool> canExecute = null,
-                IScheduler outputScheduler = null)
+            Func<TParam, Task> executeAsync,
+            IObservable<bool> canExecute = null,
+            IScheduler outputScheduler = null)
         {
             return CreateFromObservable<TParam, Unit>(
                 param => executeAsync(param).ToObservable(),
@@ -489,9 +489,9 @@ namespace ReactiveUI
         /// The type of the parameter passed through to command execution.
         /// </typeparam>
         public static ReactiveCommand<TParam, Unit> CreateFromTask<TParam>(
-                Func<TParam, CancellationToken, Task> executeAsync,
-                IObservable<bool> canExecute = null,
-                IScheduler outputScheduler = null)
+            Func<TParam, CancellationToken, Task> executeAsync,
+            IObservable<bool> canExecute = null,
+            IScheduler outputScheduler = null)
         {
             return CreateFromObservable<TParam, Unit>(
                 param => Observable.StartAsync(ct => executeAsync(param, ct)),
@@ -522,9 +522,9 @@ namespace ReactiveUI
         /// The type of the command's result.
         /// </typeparam>
         public static CombinedReactiveCommand<TParam, TResult> CreateCombined<TParam, TResult>(
-                IEnumerable<ReactiveCommandBase<TParam, TResult>> childCommands,
-                IObservable<bool> canExecute = null,
-                IScheduler outputScheduler = null)
+            IEnumerable<ReactiveCommandBase<TParam, TResult>> childCommands,
+            IObservable<bool> canExecute = null,
+            IScheduler outputScheduler = null)
         {
             return new CombinedReactiveCommand<TParam, TResult>(childCommands, canExecute ?? Observable.Return(true), outputScheduler ?? RxApp.MainThreadScheduler);
         }

--- a/ReactiveUI/ReactiveCommand.cs
+++ b/ReactiveUI/ReactiveCommand.cs
@@ -646,17 +646,24 @@ namespace ReactiveUI
         public abstract IDisposable Subscribe(IObserver<TResult> observer);
 
         /// <summary>
-        /// Asynchronously executes this command.
+        /// Gets an observable that, when subscribed, executes this command.
         /// </summary>
         /// <remarks>
         /// <para>
-        /// Invoking this method will execute the logic encapsulated by the command. If no parameter value is provided,
-        /// a default value of type <typeparamref name="TParam"/> will be passed into the execution logic.
+        /// Invoking this method will return a cold (lazy) observable that, when subscribed, will execute the logic
+        /// encapsulated by the command. It is worth restating that the returned observable is lazy. Nothing will
+        /// happen if you call <c>Execute</c> and neglect to subscribe (directly or indirectly) to the returned observable.
         /// </para>
         /// <para>
-        /// There is no requirement to subscribe to the returned observable in order to kick start the execution. And
-        /// late subscribers are guaranteed to still receive the execution result value if there is one. In those cases
-        /// where execution fails, there will be no result value. Instead, the failure will tick through the
+        /// If no parameter value is provided, a default value of type <typeparamref name="TParam"/> will be passed into
+        /// the execution logic.
+        /// </para>
+        /// <para>
+        /// Any number of subscribers can subscribe to a given execution observable and the execution logic will only
+        /// run once. That is, the result is broadcast to those subscribers.
+        /// </para>
+        /// <para>
+        /// In those cases where execution fails, there will be no result value. Instead, the failure will tick through the
         /// <see cref="ThrownExceptions"/> observable.
         /// </para>
         /// </remarks>

--- a/ReactiveUI/ReactiveCommand.cs
+++ b/ReactiveUI/ReactiveCommand.cs
@@ -205,7 +205,7 @@ namespace ReactiveUI
         /// <summary>
         /// Creates a parameterless <see cref="ReactiveCommand{TParam, TResult}"/> with asynchronous execution logic.
         /// </summary>
-        /// <param name="executeAsync">
+        /// <param name="execute">
         /// Provides an observable representing the command's asynchronous execution logic.
         /// </param>
         /// <param name="canExecute">
@@ -221,16 +221,16 @@ namespace ReactiveUI
         /// The type of the command's result.
         /// </typeparam>
         public static ReactiveCommand<Unit, TResult> CreateFromObservable<TResult>(
-            Func<IObservable<TResult>> executeAsync,
+            Func<IObservable<TResult>> execute,
             IObservable<bool> canExecute = null,
             IScheduler outputScheduler = null)
         {
-            if (executeAsync == null) {
-                throw new ArgumentNullException("executeAsync");
+            if (execute == null) {
+                throw new ArgumentNullException("execute");
             }
 
             return new ReactiveCommand<Unit, TResult>(
-                _ => executeAsync(),
+                _ => execute(),
                 canExecute ?? Observable.Return(true),
                 outputScheduler ?? RxApp.MainThreadScheduler);
         }
@@ -238,7 +238,7 @@ namespace ReactiveUI
         /// <summary>
         /// Creates a parameterless <see cref="ReactiveCommand{TParam, TResult}"/> with asynchronous execution logic.
         /// </summary>
-        /// <param name="executeAsync">
+        /// <param name="execute">
         /// Provides a <see cref="Task"/> representing the command's asynchronous execution logic.
         /// </param>
         /// <param name="canExecute">
@@ -254,12 +254,12 @@ namespace ReactiveUI
         /// The type of the command's result.
         /// </typeparam>
         public static ReactiveCommand<Unit, TResult> CreateFromTask<TResult>(
-            Func<Task<TResult>> executeAsync,
+            Func<Task<TResult>> execute,
             IObservable<bool> canExecute = null,
             IScheduler outputScheduler = null)
         {
             return CreateFromObservable(
-                () => executeAsync().ToObservable(),
+                () => execute().ToObservable(),
                 canExecute,
                 outputScheduler);
         }
@@ -267,7 +267,7 @@ namespace ReactiveUI
         /// <summary>
         /// Creates a parameterless, cancellable <see cref="ReactiveCommand{TParam, TResult}"/> with asynchronous execution logic.
         /// </summary>
-        /// <param name="executeAsync">
+        /// <param name="execute">
         /// Provides a <see cref="Task"/> representing the command's asynchronous execution logic.
         /// </param>
         /// <param name="canExecute">
@@ -283,12 +283,12 @@ namespace ReactiveUI
         /// The type of the command's result.
         /// </typeparam>
         public static ReactiveCommand<Unit, TResult> CreateFromTask<TResult>(
-            Func<CancellationToken, Task<TResult>> executeAsync,
+            Func<CancellationToken, Task<TResult>> execute,
             IObservable<bool> canExecute = null,
             IScheduler outputScheduler = null)
         {
             return CreateFromObservable(
-                () => Observable.StartAsync(ct => executeAsync(ct)),
+                () => Observable.StartAsync(ct => execute(ct)),
                 canExecute,
                 outputScheduler);
         }
@@ -296,7 +296,7 @@ namespace ReactiveUI
         /// <summary>
         /// Creates a parameterless <see cref="ReactiveCommand{TParam, TResult}"/> with asynchronous execution logic.
         /// </summary>
-        /// <param name="executeAsync">
+        /// <param name="execute">
         /// Provides a <see cref="Task"/> representing the command's asynchronous execution logic.
         /// </param>
         /// <param name="canExecute">
@@ -309,12 +309,12 @@ namespace ReactiveUI
         /// The <c>ReactiveCommand</c> instance.
         /// </returns>
         public static ReactiveCommand<Unit, Unit> CreateFromTask(
-            Func<Task> executeAsync,
+            Func<Task> execute,
             IObservable<bool> canExecute = null,
             IScheduler outputScheduler = null)
         {
             return CreateFromObservable(
-                () => executeAsync().ToObservable(),
+                () => execute().ToObservable(),
                 canExecute,
                 outputScheduler);
         }
@@ -322,7 +322,7 @@ namespace ReactiveUI
         /// <summary>
         /// Creates a parameterless, cancellable <see cref="ReactiveCommand{TParam, TResult}"/> with asynchronous execution logic.
         /// </summary>
-        /// <param name="executeAsync">
+        /// <param name="execute">
         /// Provides a <see cref="Task"/> representing the command's asynchronous execution logic.
         /// </param>
         /// <param name="canExecute">
@@ -335,12 +335,12 @@ namespace ReactiveUI
         /// The <c>ReactiveCommand</c> instance.
         /// </returns>
         public static ReactiveCommand<Unit, Unit> CreateFromTask(
-            Func<CancellationToken, Task> executeAsync,
+            Func<CancellationToken, Task> execute,
             IObservable<bool> canExecute = null,
             IScheduler outputScheduler = null)
         {
             return CreateFromObservable(
-                () => Observable.StartAsync(ct => executeAsync(ct)),
+                () => Observable.StartAsync(ct => execute(ct)),
                 canExecute,
                 outputScheduler);
         }
@@ -348,7 +348,7 @@ namespace ReactiveUI
         /// <summary>
         /// Creates a <see cref="ReactiveCommand{TParam, TResult}"/> with asynchronous execution logic that takes a parameter of type <typeparamref name="TParam"/>.
         /// </summary>
-        /// <param name="executeAsync">
+        /// <param name="execute">
         /// Provides an observable representing the command's asynchronous execution logic.
         /// </param>
         /// <param name="canExecute">
@@ -367,12 +367,12 @@ namespace ReactiveUI
         /// The type of the command's result.
         /// </typeparam>
         public static ReactiveCommand<TParam, TResult> CreateFromObservable<TParam, TResult>(
-            Func<TParam, IObservable<TResult>> executeAsync,
+            Func<TParam, IObservable<TResult>> execute,
             IObservable<bool> canExecute = null,
             IScheduler outputScheduler = null)
         {
             return new ReactiveCommand<TParam, TResult>(
-                executeAsync,
+                execute,
                 canExecute ?? Observable.Return(true),
                 outputScheduler ?? RxApp.MainThreadScheduler);
         }
@@ -380,7 +380,7 @@ namespace ReactiveUI
         /// <summary>
         /// Creates a <see cref="ReactiveCommand{TParam, TResult}"/> with asynchronous execution logic that takes a parameter of type <typeparamref name="TParam"/>.
         /// </summary>
-        /// <param name="executeAsync">
+        /// <param name="execute">
         /// Provides a <see cref="Task"/> representing the command's asynchronous execution logic.
         /// </param>
         /// <param name="canExecute">
@@ -399,12 +399,12 @@ namespace ReactiveUI
         /// The type of the command's result.
         /// </typeparam>
         public static ReactiveCommand<TParam, TResult> CreateFromTask<TParam, TResult>(
-            Func<TParam, Task<TResult>> executeAsync,
+            Func<TParam, Task<TResult>> execute,
             IObservable<bool> canExecute = null,
             IScheduler outputScheduler = null)
         {
             return CreateFromObservable<TParam, TResult>(
-                param => executeAsync(param).ToObservable(),
+                param => execute(param).ToObservable(),
                 canExecute,
                 outputScheduler);
         }
@@ -412,7 +412,7 @@ namespace ReactiveUI
         /// <summary>
         /// Creates a <see cref="ReactiveCommand{TParam, TResult}"/> with asynchronous, cancellable execution logic that takes a parameter of type <typeparamref name="TParam"/>.
         /// </summary>
-        /// <param name="executeAsync">
+        /// <param name="execute">
         /// Provides a <see cref="Task"/> representing the command's asynchronous execution logic.
         /// </param>
         /// <param name="canExecute">
@@ -431,12 +431,12 @@ namespace ReactiveUI
         /// The type of the command's result.
         /// </typeparam>
         public static ReactiveCommand<TParam, TResult> CreateFromTask<TParam, TResult>(
-            Func<TParam, CancellationToken, Task<TResult>> executeAsync,
+            Func<TParam, CancellationToken, Task<TResult>> execute,
             IObservable<bool> canExecute = null,
             IScheduler outputScheduler = null)
         {
             return CreateFromObservable<TParam, TResult>(
-                param => Observable.StartAsync(ct => executeAsync(param, ct)),
+                param => Observable.StartAsync(ct => execute(param, ct)),
                 canExecute,
                 outputScheduler);
         }
@@ -444,7 +444,7 @@ namespace ReactiveUI
         /// <summary>
         /// Creates a <see cref="ReactiveCommand{TParam, TResult}"/> with asynchronous execution logic that takes a parameter of type <typeparamref name="TParam"/>.
         /// </summary>
-        /// <param name="executeAsync">
+        /// <param name="execute">
         /// Provides a <see cref="Task"/> representing the command's asynchronous execution logic.
         /// </param>
         /// <param name="canExecute">
@@ -460,12 +460,12 @@ namespace ReactiveUI
         /// The type of the parameter passed through to command execution.
         /// </typeparam>
         public static ReactiveCommand<TParam, Unit> CreateFromTask<TParam>(
-            Func<TParam, Task> executeAsync,
+            Func<TParam, Task> execute,
             IObservable<bool> canExecute = null,
             IScheduler outputScheduler = null)
         {
             return CreateFromObservable<TParam, Unit>(
-                param => executeAsync(param).ToObservable(),
+                param => execute(param).ToObservable(),
                 canExecute,
                 outputScheduler);
         }
@@ -473,7 +473,7 @@ namespace ReactiveUI
         /// <summary>
         /// Creates a <see cref="ReactiveCommand{TParam, TResult}"/> with asynchronous, cancellable execution logic that takes a parameter of type <typeparamref name="TParam"/>.
         /// </summary>
-        /// <param name="executeAsync">
+        /// <param name="execute">
         /// Provides a <see cref="Task"/> representing the command's asynchronous execution logic.
         /// </param>
         /// <param name="canExecute">
@@ -489,12 +489,12 @@ namespace ReactiveUI
         /// The type of the parameter passed through to command execution.
         /// </typeparam>
         public static ReactiveCommand<TParam, Unit> CreateFromTask<TParam>(
-            Func<TParam, CancellationToken, Task> executeAsync,
+            Func<TParam, CancellationToken, Task> execute,
             IObservable<bool> canExecute = null,
             IScheduler outputScheduler = null)
         {
             return CreateFromObservable<TParam, Unit>(
-                param => Observable.StartAsync(ct => executeAsync(param, ct)),
+                param => Observable.StartAsync(ct => execute(param, ct)),
                 canExecute,
                 outputScheduler);
         }
@@ -666,7 +666,7 @@ namespace ReactiveUI
         /// <returns>
         /// An observable that will tick the single result value if and when it becomes available.
         /// </returns>
-        public abstract IObservable<TResult> ExecuteAsync(TParam parameter = default(TParam));
+        public abstract IObservable<TResult> Execute(TParam parameter = default(TParam));
 
         protected override bool ICommandCanExecute(object parameter)
         {
@@ -689,7 +689,7 @@ namespace ReactiveUI
             }
 
             this
-                .ExecuteAsync((TParam)parameter)
+                .Execute((TParam)parameter)
                 .Catch(Observable.Empty<TResult>())
                 .Subscribe();
         }
@@ -713,7 +713,7 @@ namespace ReactiveUI
     /// </typeparam>
     public class ReactiveCommand<TParam, TResult> : ReactiveCommandBase<TParam, TResult>
     {
-        private readonly Func<TParam, IObservable<TResult>> executeAsync;
+        private readonly Func<TParam, IObservable<TResult>> execute;
         private readonly IScheduler outputScheduler;
         private readonly Subject<ExecutionInfo> executionInfo;
         private readonly ISubject<ExecutionInfo, ExecutionInfo> synchronizedExecutionInfo;
@@ -724,12 +724,12 @@ namespace ReactiveUI
         private readonly IDisposable canExecuteSubscription;
 
         internal protected ReactiveCommand(
-            Func<TParam, IObservable<TResult>> executeAsync,
+            Func<TParam, IObservable<TResult>> execute,
             IObservable<bool> canExecute,
             IScheduler outputScheduler)
         {
-            if (executeAsync == null) {
-                throw new ArgumentNullException("executeAsync");
+            if (execute == null) {
+                throw new ArgumentNullException("execute");
             }
 
             if (canExecute == null) {
@@ -740,7 +740,7 @@ namespace ReactiveUI
                 throw new ArgumentNullException("outputScheduler");
             }
 
-            this.executeAsync = executeAsync;
+            this.execute = execute;
             this.outputScheduler = outputScheduler;
             this.executionInfo = new Subject<ExecutionInfo>();
             this.synchronizedExecutionInfo = Subject.Synchronize(this.executionInfo, outputScheduler);
@@ -800,13 +800,13 @@ namespace ReactiveUI
         }
 
         /// <inheritdoc/>
-        public override IObservable<TResult> ExecuteAsync(TParam parameter = default(TParam))
+        public override IObservable<TResult> Execute(TParam parameter = default(TParam))
         {
             this.synchronizedExecutionInfo.OnNext(ExecutionInfo.CreateBegin());
 
             try {
                 return this
-                    .executeAsync(parameter)
+                    .execute(parameter)
                     .Do(
                         result => this.synchronizedExecutionInfo.OnNext(ExecutionInfo.CreateResult(result)),
                         () => this.synchronizedExecutionInfo.OnNext(ExecutionInfo.CreateEnded()))
@@ -957,7 +957,7 @@ namespace ReactiveUI
                     Observable
                         .CombineLatest(
                             childCommandsArray
-                                .Select(x => x.ExecuteAsync(param))),
+                                .Select(x => x.Execute(param))),
                 combinedCanExecute,
                 outputScheduler);
 
@@ -1000,9 +1000,9 @@ namespace ReactiveUI
         }
 
         /// <inheritdoc/>
-        public override IObservable<IList<TResult>> ExecuteAsync(TParam parameter = default(TParam))
+        public override IObservable<IList<TResult>> Execute(TParam parameter = default(TParam))
         {
-            return this.innerCommand.ExecuteAsync(parameter);
+            return this.innerCommand.Execute(parameter);
         }
 
         protected override void Dispose(bool disposing)
@@ -1047,7 +1047,7 @@ namespace ReactiveUI
         public static IDisposable InvokeCommand<T, TResult>(this IObservable<T> This, ReactiveCommand<T, TResult> command)
         {
             return This.Throttle(x => command.CanExecute.Where(b => b))
-                .Select(x => command.ExecuteAsync(x).Catch(Observable.Empty<TResult>()))
+                .Select(x => command.Execute(x).Catch(Observable.Empty<TResult>()))
                 .Switch()
                 .Subscribe();
         }
@@ -1086,7 +1086,7 @@ namespace ReactiveUI
         {
             return This.CombineLatest(target.WhenAnyValue(commandProperty), (val, cmd) => new { val, cmd })
                 .Throttle(x => x.cmd.CanExecute.Where(b => b))
-                .Select(x => x.cmd.ExecuteAsync(x.val).Catch(Observable.Empty<TResult>()))
+                .Select(x => x.cmd.Execute(x.val).Catch(Observable.Empty<TResult>()))
                 .Switch()
                 .Subscribe();
         }

--- a/ReactiveUI/RoutingState.cs
+++ b/ReactiveUI/RoutingState.cs
@@ -111,7 +111,7 @@ namespace ReactiveUI
 
             NavigateAndReset = ReactiveCommand.CreateFromObservable<IRoutableViewModel, IRoutableViewModel>(x => {
                 NavigationStack.Clear();
-                return Navigate.ExecuteAsync(x);
+                return Navigate.Execute(x);
             },
             outputScheduler: scheduler);
             


### PR DESCRIPTION
Fixes #1062 by:

* ensuring executing a reactive command returns a cold/lazy observable
* adding overloads of `ReactiveCommand.CreateFromTask` that work with `CancellationToken`
* renaming `ReactiveCommand.ExecuteAsync` to `ReactiveCommand.Execute`