### PR TITLE
WhenActivated and CompositeDisposable enhancements

### DIFF
--- a/ReactiveUI/Activation.cs
+++ b/ReactiveUI/Activation.cs
@@ -138,6 +138,25 @@ namespace ReactiveUI
 
         /// <summary>
         /// WhenActivated allows you to register a Func to be called when a
+        /// ViewModel's View is Activated.
+        /// </summary>
+        /// <param name="This">Object that supports activation.</param>
+        /// <param name="block">The method to be called when the corresponding
+        /// View is activated. The Action parameter (usually called 'disposables') allows
+        /// you to collate all the disposables to be cleaned up during deactivation.</param>
+        public static void WhenActivated(this ISupportsActivation This, Action<CompositeDisposable> block)
+        {
+            This
+                .WhenActivated(
+                    () => {
+                        var d = new CompositeDisposable();
+                        block(d);
+                        return new[] { d };
+                    });
+        }
+
+        /// <summary>
+        /// WhenActivated allows you to register a Func to be called when a
         /// View is Activated.
         /// </summary>
         /// <param name="This">Object that supports activation.</param>
@@ -219,6 +238,30 @@ namespace ReactiveUI
             }, view);
         }
 
+        /// <summary>
+        /// WhenActivated allows you to register a Func to be called when a
+        /// View is Activated.
+        /// </summary>
+        /// <param name="This">Object that supports activation.</param>
+        /// <param name="block">The method to be called when the corresponding
+        /// View is activated. The Action parameter (usually called 'disposables') allows
+        /// you to collate all disposables that should be cleaned up during deactivation.</param>
+        /// <param name="view">The IActivatable will ordinarily also host the View
+        /// Model, but in the event it is not, a class implementing <see cref="IViewFor" />
+        /// can be supplied here.
+        /// <returns>A Disposable that deactivates this registration.</returns>
+        public static IDisposable WhenActivated(this IActivatable This, Action<CompositeDisposable> block, IViewFor view = null)
+        {
+            return This
+                .WhenActivated(
+                    () => {
+                        var d = new CompositeDisposable();
+                        block(d);
+                        return new[] { d };
+                    },
+                    view);
+        }
+
         static IDisposable handleViewActivation(Func<IEnumerable<IDisposable>> block, IObservable<bool> activation)
         {
             var viewDisposable = new SerialDisposable();
@@ -243,7 +286,7 @@ namespace ReactiveUI
 
             return new CompositeDisposable(
                 // Activation
-                activation.Subscribe(activated => {                    
+                activation.Subscribe(activated => {
                     if (activated) {
                         viewVmDisposable.Disposable = view.WhenAnyValue(x => x.ViewModel)
                             .Select(x => x as ISupportsActivation)

--- a/ReactiveUI/Activation.cs
+++ b/ReactiveUI/Activation.cs
@@ -146,13 +146,11 @@ namespace ReactiveUI
         /// you to collate all the disposables to be cleaned up during deactivation.</param>
         public static void WhenActivated(this ISupportsActivation This, Action<CompositeDisposable> block)
         {
-            This
-                .WhenActivated(
-                    () => {
-                        var d = new CompositeDisposable();
-                        block(d);
-                        return new[] { d };
-                    });
+            This.Activator.addActivationBlock(() => {
+                var d = new CompositeDisposable();
+                block(d);
+                return new[] { d };
+            });
         }
 
         /// <summary>
@@ -252,14 +250,11 @@ namespace ReactiveUI
         /// <returns>A Disposable that deactivates this registration.</returns>
         public static IDisposable WhenActivated(this IActivatable This, Action<CompositeDisposable> block, IViewFor view = null)
         {
-            return This
-                .WhenActivated(
-                    () => {
-                        var d = new CompositeDisposable();
-                        block(d);
-                        return new[] { d };
-                    },
-                    view);
+            return This.WhenActivated(() => {
+                var d = new CompositeDisposable();
+                block(d);
+                return new[] { d };
+            }, view);
         }
 
         static IDisposable handleViewActivation(Func<IEnumerable<IDisposable>> block, IObservable<bool> activation)

--- a/ReactiveUI/AddTo.cs
+++ b/ReactiveUI/AddTo.cs
@@ -1,0 +1,27 @@
+﻿namespace System.Reactive.Disposables
+{
+    public static class CompositeDisposableExtensions
+    {
+        /// <summary>
+        /// Adds a disposable to the specified <see cref="CompositeDisposable"/>.
+        /// </summary>
+        /// <typeparam name="T">
+        /// The type of the disposable.
+        /// </typeparam>
+        /// <param name="this">
+        /// The disposable.
+        /// </param>
+        /// <param name="compositeDisposable">
+        /// The <see cref="CompositeDisposable"/> to which <paramref name="this"/> will be added.
+        /// </param>
+        /// <returns>
+        /// The disposable.
+        /// </returns>
+        public static T AddTo<T>(this T @this, CompositeDisposable compositeDisposable)
+            where T : IDisposable
+        {
+            compositeDisposable.Add(@this);
+            return @this;
+        }
+    }
+}

--- a/ReactiveUI/DisposableMixins.cs
+++ b/ReactiveUI/DisposableMixins.cs
@@ -1,9 +1,9 @@
 ﻿namespace System.Reactive.Disposables
 {
-    public static class CompositeDisposableExtensions
+    public static class DisposableMixins
     {
         /// <summary>
-        /// Adds a disposable to the specified <see cref="CompositeDisposable"/>.
+        /// Ensures the provided disposable is disposed with the specified <see cref="CompositeDisposable"/>.
         /// </summary>
         /// <typeparam name="T">
         /// The type of the disposable.
@@ -17,7 +17,7 @@
         /// <returns>
         /// The disposable.
         /// </returns>
-        public static T AddTo<T>(this T @this, CompositeDisposable compositeDisposable)
+        public static T DisposeWith<T>(this T @this, CompositeDisposable compositeDisposable)
             where T : IDisposable
         {
             compositeDisposable.Add(@this);

--- a/ReactiveUI/ReactiveUI.csproj
+++ b/ReactiveUI/ReactiveUI.csproj
@@ -72,7 +72,7 @@
     <Compile Include="..\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
-    <Compile Include="AddTo.cs" />
+    <Compile Include="DisposableMixins.cs" />
     <Compile Include="Activation.cs" />
     <Compile Include="ExpressionMixins.cs" />
     <Compile Include="ExpressionRewriter.cs" />

--- a/ReactiveUI/ReactiveUI.csproj
+++ b/ReactiveUI/ReactiveUI.csproj
@@ -72,6 +72,7 @@
     <Compile Include="..\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="AddTo.cs" />
     <Compile Include="Activation.cs" />
     <Compile Include="ExpressionMixins.cs" />
     <Compile Include="ExpressionRewriter.cs" />

--- a/ReactiveUI/ReactiveUI_Android.csproj
+++ b/ReactiveUI/ReactiveUI_Android.csproj
@@ -71,7 +71,7 @@
     <Compile Include="..\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
-    <Compile Include="AddTo.cs" />
+    <Compile Include="DisposableMixins.cs" />
     <Compile Include="Android\AndroidCommandBinders.cs" />
     <Compile Include="Android\AndroidUIScheduler.cs" />
     <Compile Include="Android\ControlFetcherMixin.cs" />

--- a/ReactiveUI/ReactiveUI_Android.csproj
+++ b/ReactiveUI/ReactiveUI_Android.csproj
@@ -71,6 +71,7 @@
     <Compile Include="..\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="AddTo.cs" />
     <Compile Include="Android\AndroidCommandBinders.cs" />
     <Compile Include="Android\AndroidUIScheduler.cs" />
     <Compile Include="Android\ControlFetcherMixin.cs" />

--- a/ReactiveUI/ReactiveUI_Mac.csproj
+++ b/ReactiveUI/ReactiveUI_Mac.csproj
@@ -94,6 +94,7 @@
     <Compile Include="..\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="AddTo.cs" />
     <Compile Include="Activation.cs" />
     <Compile Include="ReactiveBinding.cs" />
     <Compile Include="AutoPersistHelper.cs" />

--- a/ReactiveUI/ReactiveUI_Mac.csproj
+++ b/ReactiveUI/ReactiveUI_Mac.csproj
@@ -94,7 +94,7 @@
     <Compile Include="..\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
-    <Compile Include="AddTo.cs" />
+    <Compile Include="DisposableMixins.cs" />
     <Compile Include="Activation.cs" />
     <Compile Include="ReactiveBinding.cs" />
     <Compile Include="AutoPersistHelper.cs" />

--- a/ReactiveUI/ReactiveUI_Mac64.csproj
+++ b/ReactiveUI/ReactiveUI_Mac64.csproj
@@ -93,7 +93,7 @@
     <Compile Include="..\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
-    <Compile Include="AddTo.cs" />
+    <Compile Include="DisposableMixins.cs" />
     <Compile Include="Activation.cs" />
     <Compile Include="ReactiveBinding.cs" />
     <Compile Include="AutoPersistHelper.cs" />

--- a/ReactiveUI/ReactiveUI_Mac64.csproj
+++ b/ReactiveUI/ReactiveUI_Mac64.csproj
@@ -93,6 +93,7 @@
     <Compile Include="..\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="AddTo.cs" />
     <Compile Include="Activation.cs" />
     <Compile Include="ReactiveBinding.cs" />
     <Compile Include="AutoPersistHelper.cs" />

--- a/ReactiveUI/ReactiveUI_Net45.csproj
+++ b/ReactiveUI/ReactiveUI_Net45.csproj
@@ -79,7 +79,7 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="AddTo.cs" />
+    <Compile Include="DisposableMixins.cs" />
     <Compile Include="ExpressionMixins.cs" />
     <Compile Include="ExpressionRewriter.cs" />
     <Compile Include="Interactions.cs" />

--- a/ReactiveUI/ReactiveUI_Net45.csproj
+++ b/ReactiveUI/ReactiveUI_Net45.csproj
@@ -79,6 +79,7 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AddTo.cs" />
     <Compile Include="ExpressionMixins.cs" />
     <Compile Include="ExpressionRewriter.cs" />
     <Compile Include="Interactions.cs" />

--- a/ReactiveUI/ReactiveUI_UWP.csproj
+++ b/ReactiveUI/ReactiveUI_UWP.csproj
@@ -50,7 +50,7 @@
     <Compile Include="..\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
-    <Compile Include="AddTo.cs" />
+    <Compile Include="DisposableMixins.cs" />
     <Compile Include="Activation.cs" />
     <Compile Include="AutoPersistHelper.cs" />
     <Compile Include="BindingTypeConverters.cs" />

--- a/ReactiveUI/ReactiveUI_UWP.csproj
+++ b/ReactiveUI/ReactiveUI_UWP.csproj
@@ -50,6 +50,7 @@
     <Compile Include="..\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="AddTo.cs" />
     <Compile Include="Activation.cs" />
     <Compile Include="AutoPersistHelper.cs" />
     <Compile Include="BindingTypeConverters.cs" />

--- a/ReactiveUI/ReactiveUI_WP8.csproj
+++ b/ReactiveUI/ReactiveUI_WP8.csproj
@@ -80,7 +80,7 @@
     <Reference Include="System.Net" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="AddTo.cs" />
+    <Compile Include="DisposableMixins.cs" />
     <Compile Include="ExpressionMixins.cs" />
     <Compile Include="ExpressionRewriter.cs" />
     <Compile Include="Platform\Registrations.cs" />

--- a/ReactiveUI/ReactiveUI_WP8.csproj
+++ b/ReactiveUI/ReactiveUI_WP8.csproj
@@ -80,6 +80,7 @@
     <Reference Include="System.Net" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AddTo.cs" />
     <Compile Include="ExpressionMixins.cs" />
     <Compile Include="ExpressionRewriter.cs" />
     <Compile Include="Platform\Registrations.cs" />

--- a/ReactiveUI/ReactiveUI_WinRT.csproj
+++ b/ReactiveUI/ReactiveUI_WinRT.csproj
@@ -43,6 +43,7 @@
     <GenerateLibraryLayout>true</GenerateLibraryLayout>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="AddTo.cs" />
     <Compile Include="ExpressionMixins.cs" />
     <Compile Include="ExpressionRewriter.cs" />
     <Compile Include="Platform\Registrations.cs" />

--- a/ReactiveUI/ReactiveUI_WinRT.csproj
+++ b/ReactiveUI/ReactiveUI_WinRT.csproj
@@ -43,7 +43,7 @@
     <GenerateLibraryLayout>true</GenerateLibraryLayout>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="AddTo.cs" />
+    <Compile Include="DisposableMixins.cs" />
     <Compile Include="ExpressionMixins.cs" />
     <Compile Include="ExpressionRewriter.cs" />
     <Compile Include="Platform\Registrations.cs" />

--- a/ReactiveUI/ReactiveUI_iOS.csproj
+++ b/ReactiveUI/ReactiveUI_iOS.csproj
@@ -105,6 +105,7 @@
     <Compile Include="Cocoa\ReactivePageViewController.cs" />
     <Compile Include="Cocoa\ReactiveCollectionView.cs" />
     <Compile Include="Cocoa\ReactiveCollectionReusableView.cs" />
+    <Compile Include="AddTo.cs" />
     <Compile Include="Activation.cs" />
     <Compile Include="ReactiveBinding.cs" />
     <Compile Include="AutoPersistHelper.cs" />

--- a/ReactiveUI/ReactiveUI_iOS.csproj
+++ b/ReactiveUI/ReactiveUI_iOS.csproj
@@ -105,7 +105,7 @@
     <Compile Include="Cocoa\ReactivePageViewController.cs" />
     <Compile Include="Cocoa\ReactiveCollectionView.cs" />
     <Compile Include="Cocoa\ReactiveCollectionReusableView.cs" />
-    <Compile Include="AddTo.cs" />
+    <Compile Include="DisposableMixins.cs" />
     <Compile Include="Activation.cs" />
     <Compile Include="ReactiveBinding.cs" />
     <Compile Include="AutoPersistHelper.cs" />

--- a/ReactiveUI/ReactiveUI_iOS64.csproj
+++ b/ReactiveUI/ReactiveUI_iOS64.csproj
@@ -103,6 +103,7 @@
     <Compile Include="Cocoa\ReactivePageViewController.cs" />
     <Compile Include="Cocoa\ReactiveCollectionView.cs" />
     <Compile Include="Cocoa\ReactiveCollectionReusableView.cs" />
+    <Compile Include="AddTo.cs" />
     <Compile Include="Activation.cs" />
     <Compile Include="ReactiveBinding.cs" />
     <Compile Include="AutoPersistHelper.cs" />

--- a/ReactiveUI/ReactiveUI_iOS64.csproj
+++ b/ReactiveUI/ReactiveUI_iOS64.csproj
@@ -103,7 +103,7 @@
     <Compile Include="Cocoa\ReactivePageViewController.cs" />
     <Compile Include="Cocoa\ReactiveCollectionView.cs" />
     <Compile Include="Cocoa\ReactiveCollectionReusableView.cs" />
-    <Compile Include="AddTo.cs" />
+    <Compile Include="DisposableMixins.cs" />
     <Compile Include="Activation.cs" />
     <Compile Include="ReactiveBinding.cs" />
     <Compile Include="AutoPersistHelper.cs" />


### PR DESCRIPTION
Fixes #1063 by adding `WhenActivated` overloads that work with `CompositeDisposable`, as well as a `DisposeWith` extension method to add a disposable to a `CompositeDisposable`.

Facilitates code that looks like this:

```cs
this
     .WhenActivated(
         disposables =>
         {
            this
                .Bind(this.ViewModel, x => x.SomeProperty, x => x.someControl.SomeProperty)
                .DisposeWith(disposables);
            this
                .BindCommand(this.ViewModel, x => x.SomeCommand, x => x.someButton)
                .DisposeWith(disposables);
         });
```