### PR TITLE
WaitForScheduler Exception handling

### DIFF
--- a/ReactiveUI/WaitForDispatcherScheduler.cs
+++ b/ReactiveUI/WaitForDispatcherScheduler.cs
@@ -53,7 +53,7 @@ namespace ReactiveUI
             try {
                 _innerScheduler = _schedulerFactory();
                 return _innerScheduler;
-            } catch (Exception) {
+            } catch (InvalidOperationException) {
                 // NB: Dispatcher's not ready yet. Keep using CurrentThread
                 return CurrentThreadScheduler.Instance;
             }


### PR DESCRIPTION
Replace catching Exception into InvalidOperationException. We want to be explicit because i.e when System.Reactive.Windows.Threading is not attached then FileNotFoundException is thrown and causes using CurrentThreadScheduler instead of DispatcherScheduler. It may cause a lot of silent exceptions being thrown and usage of wrong dispatcher