### PR TITLE
Add support for ICanActivate.

### DIFF
--- a/ReactiveUI.XamForms/XamForms/ActivationForViewFetcher.cs
+++ b/ReactiveUI.XamForms/XamForms/ActivationForViewFetcher.cs
@@ -37,7 +37,7 @@ namespace ReactiveUI.XamForms
 
             return Observable.Merge(
                 canActivate.Activated.Select(_ => true),
-                canActivate.Activated.Select(_ => false));
+                canActivate.Deactivated.Select(_ => false));
         }
 
         private static IObservable<bool> GetActivationFor(Page page)

--- a/ReactiveUI.XamForms/XamForms/ActivationForViewFetcher.cs
+++ b/ReactiveUI.XamForms/XamForms/ActivationForViewFetcher.cs
@@ -20,12 +20,24 @@ namespace ReactiveUI.XamForms
         public IObservable<bool> GetActivationForView(IActivatable view)
         {
             var activation =
+                GetActivationFor(view as ICanActivate) ??
                 GetActivationFor(view as Page) ??
                 GetActivationFor(view as View) ??
                 GetActivationFor(view as Cell) ??
                 Observable.Never<bool>();
 
             return activation.DistinctUntilChanged();
+        }
+
+        private static IObservable<bool> GetActivationFor(ICanActivate canActivate)
+        {
+            if (canActivate == null) {
+                return null;
+            }
+
+            return Observable.Merge(
+                canActivate.Activated.Select(_ => true),
+                canActivate.Activated.Select(_ => false));
         }
 
         private static IObservable<bool> GetActivationFor(Page page)


### PR DESCRIPTION
A change in XF behavior triggered this. Basically, views that are hidden by a dialog are no longer considered active, so their `OnDisappearing` triggers. This was causing problems for me because my main view (which extends `RoutedViewHost`) was disappearing and then reappearing.

Rather than attempt to fix the routing infrastructure (which I don't really want to touch ever again) I decided to make the XF activation-for-view-fetcher support `ICanActivate`. This allows me to circumvent the problem by implementing said interface on my main view such that it _never_ deactivates.