### PR TITLE
unship RELEASENOTES.MD as part of package due to XS + NuGet issue

### DIFF
--- a/src/ReactiveUI.nuspec
+++ b/src/ReactiveUI.nuspec
@@ -9,7 +9,4 @@
       <dependency id="reactiveui-core" version="7.0.0" />
     </dependencies>
   </metadata>
-  <files>
-    <file src="RELEASENOTES.md" target="./" />
-  </files>
 </package>


### PR DESCRIPTION
appears that when targeting destination of "./" XS does not like it.

Successfully installed 'reactiveui-core 7.0.0.1460439208'.
Installing 'reactiveui 7.0.0.1467085873'.
Could not find a part of the path
"/var/folders/q3/954zjj750dx3rds3rvlpy8pwwd4mly/T/nuget/udgmfebb.wkc/RELEASENOTES.md".