### PR TITLE
Small bug fixes to ReactiveRecyclerViewAdapter and ViewHolder

### DIFF
--- a/src/ReactiveUI.AndroidSupport/ReactiveRecyclerViewAdapter.cs
+++ b/src/ReactiveUI.AndroidSupport/ReactiveRecyclerViewAdapter.cs
@@ -35,7 +35,7 @@ namespace ReactiveUI.Android.Support
 
         public override void OnBindViewHolder(RecyclerView.ViewHolder holder, int position)
         {
-            ((ReactiveRecyclerViewViewHolder<TViewModel>)holder).ViewModel = list[position];
+            ((IViewFor)holder).ViewModel = list[position];
         }
 
         public override int ItemCount { get { return list.Count; } }

--- a/src/ReactiveUI.AndroidSupport/ReactiveRecyclerViewAdapter.cs
+++ b/src/ReactiveUI.AndroidSupport/ReactiveRecyclerViewAdapter.cs
@@ -80,8 +80,8 @@ namespace ReactiveUI.Android.Support
 
         object IViewFor.ViewModel
         {
-            get { return _ViewModel; }
-            set { _ViewModel = (TViewModel)value; }
+            get { return ViewModel; }
+            set { ViewModel = (TViewModel)value; }
         }
 
         public event PropertyChangingEventHandler PropertyChanging


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fixes for ReactiveRecyclerViewAdapter and ReactiveRecyclerViewViewHolder.


**What is the current behavior? (You can also link to an open issue here)**
Binding an inherited type of ViewModel to a ViewHolder doesn't currently raise change notifications, and you aren't able to use any other type of ViewHolder than ReactiveRecyclerViewViewHolder, while the adapter should only depend on IViewFor to work.


**What is the new behavior (if this is a feature change)?**
Properly call for `this.RaiseAndSetIfChanged()` when setting a ViewModel.
Allowing the use of any type of RecyclerView.ViewHolder which complies to IViewFor.


**Does this PR introduce a breaking change?**
Only if someone doesn't expect the change notices to happen, but that's clearly not the way it should work.


**Please check if the PR fulfills these requirements**
- [x] The commit follows our guidelines: https://github.com/reactiveui/reactiveui#contribute
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
I was bored, so I made a PR. ™️ 