### PR TITLE
chore: bootstrapper now download/installs Android API level 24

### DIFF
--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -53,3 +53,4 @@ Install-AndroidSDK 20
 Install-AndroidSDK 21
 Install-AndroidSDK 22
 Install-AndroidSDK 23
+Install-AndroidSDK 24


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

chore

**What is the current behavior? (You can also link to an open issue here)**

Android API Levels 10-23 are automatically installed on the CI host (AppVeyor) before building the framework.

**What is the new behavior (if this is a feature change)?**

Android API 24 is also downloaded, thus 10-24 are automatically installed on the CI host (AppVeyor) before building the framework.

**Does this PR introduce a breaking change?**

No

**Please check if the PR fulfills these requirements**
- [x] The commit follows our guidelines: https://github.com/reactiveui/reactiveui#contribute
- [-] Tests for the changes have been added (for bug fixes / features)
- [-] Docs have been added / updated (for bug fixes / features)

**Other information**:


