### PR TITLE
fix: set nuspec dependency to == (exact) version as that is being built

### DIFF
--- a/src/ReactiveUI-AndroidSupport.nuspec
+++ b/src/ReactiveUI-AndroidSupport.nuspec
@@ -7,7 +7,7 @@
     <language>en-us</language>
 
     <dependencies>
-      <dependency id="reactiveui-core" version="7.0.0" />
+      <dependency id="reactiveui-core" version="$version$" />
       <dependency id="Xamarin.Android.Support.v4" version="22.1.1.1" />
       <dependency id="Xamarin.Android.Support.v7.AppCompat" version="22.1.1.1" />
       <dependency id="Xamarin.Android.Support.v7.RecyclerView" version="22.1.1.1" />

--- a/src/ReactiveUI-Blend.nuspec
+++ b/src/ReactiveUI-Blend.nuspec
@@ -7,22 +7,22 @@
     <language>en-us</language>
     <dependencies>
       <group>
-        <dependency id="reactiveui-core" version="[7.0.0]" />
+        <dependency id="reactiveui-core" version="$version$" />
       </group>
       <group targetFramework="net45">
-        <dependency id="reactiveui-core" version="[7.0.0]" />
+        <dependency id="reactiveui-core" version="$version$" />
         <dependency id="Rx-Xaml" version="2.2.5" />
       </group>
       <group targetFramework="wp8">
-        <dependency id="reactiveui-core" version="[7.0.0]" />
+        <dependency id="reactiveui-core" version="$version$" />
         <dependency id="Rx-Xaml" version="2.2.5" />
       </group>
       <group targetFramework="Portable-Win81+WPA81">
-        <dependency id="reactiveui-core" version="[7.0.0]" />
+        <dependency id="reactiveui-core" version="$version$" />
         <dependency id="Rx-Xaml" version="2.2.5" />
       </group>
       <group targetFramework="uap10.0">
-        <dependency id="reactiveui-core" version="[7.0.0]" />
+        <dependency id="reactiveui-core" version="$version$" />
         <dependency id="System.Diagnostics.Debug" version="4.0.10" />
         <dependency id="Microsoft.Xaml.Behaviors.Uwp.Managed" version="1.1.0" />
         <dependency id="Rx-Core" version="2.2.5" />

--- a/src/ReactiveUI-Testing.nuspec
+++ b/src/ReactiveUI-Testing.nuspec
@@ -7,19 +7,19 @@
     <language>en-us</language>
     <dependencies>
       <group targetFramework="net45">
-        <dependency id="reactiveui-core" version="[7.0.0]" />
+        <dependency id="reactiveui-core" version="$version$" />
         <dependency id="Rx-Testing" version="2.2.5" />
       </group>
       <group targetFramework="WP8">
-        <dependency id="reactiveui-core" version="[7.0.0]" />
+        <dependency id="reactiveui-core" version="$version$" />
         <dependency id="Rx-Testing" version="2.2.5" />
       </group>
       <group targetFramework="Win8">
-        <dependency id="reactiveui-core" version="[7.0.0]" />
+        <dependency id="reactiveui-core" version="$version$" />
         <dependency id="Rx-Testing" version="2.2.5" />
       </group>
       <group targetFramework="uap10.0">
-        <dependency id="reactiveui-core" version="[7.0.0]" />
+        <dependency id="reactiveui-core" version="$version$" />
         <dependency id="Rx-Core" version="2.2.5" />
         <dependency id="Rx-Interfaces" version="2.2.5" />
         <dependency id="Rx-Linq" version="2.2.5" />
@@ -30,10 +30,10 @@
         <dependency id="System.Threading.Tasks" version="4.0.10" />
       </group>
       <group targetFramework="monoandroid">
-        <dependency id="reactiveui-core" version="[7.0.0]" />
+        <dependency id="reactiveui-core" version="$version$" />
       </group>
       <group targetFramework="monotouch">
-        <dependency id="reactiveui-core" version="[7.0.0]" />
+        <dependency id="reactiveui-core" version="$version$" />
       </group>
     </dependencies>
   </metadata>

--- a/src/ReactiveUI-Winforms.nuspec
+++ b/src/ReactiveUI-Winforms.nuspec
@@ -6,7 +6,7 @@
     <description>Windows Forms specific extensions to ReactiveUI</description>
     <language>en-us</language>
     <dependencies>
-      <dependency id="reactiveui-core" version="7.0.0" />
+      <dependency id="reactiveui-core" version="$version$" />
     </dependencies>
   </metadata>
   <files>

--- a/src/ReactiveUI-XamForms.nuspec
+++ b/src/ReactiveUI-XamForms.nuspec
@@ -6,7 +6,7 @@
     <description>Xamarin Forms specific extensions to ReactiveUI</description>
     <language>en-us</language>
     <dependencies>
-      <dependency id="reactiveui-core" version="7.0.0" />
+      <dependency id="reactiveui-core" version="$version$" />
       <dependency id="Xamarin.Forms" version="2.1.0.6529" />
     </dependencies>
   </metadata>

--- a/src/ReactiveUI.nuspec
+++ b/src/ReactiveUI.nuspec
@@ -6,7 +6,7 @@
     <description>A MVVM framework that integrates with the Reactive Extensions for .NET to create elegant, testable User Interfaces that run on any mobile or desktop platform. Supports Xamarin.iOS, Xamarin.Android, Xamarin.Mac, Xamarin Forms, WPF, Windows Forms, Windows Phone 8.1, Windows Store and Universal Windows Platform (UWP).</description>
     <language>en-us</language>
     <dependencies>
-      <dependency id="reactiveui-core" version="7.0.0" />
+      <dependency id="reactiveui-core" version="$version$" />
     </dependencies>
   </metadata>
 </package>


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Bug fix for https://github.com/reactiveui/ReactiveUI/issues/1147

**What is the current behavior? (You can also link to an open issue here)**

Dependencies are pinned to a version that does not exist.

**What is the new behavior (if this is a feature change)?**

Pin the version to the exact same version that is being built.

**Does this PR introduce a breaking change?**

No

**Please check if the PR fulfills these requirements**
- [x] The commit follows our guidelines: https://github.com/reactiveui/reactiveui#contribute
- [-] Tests for the changes have been added (for bug fixes / features)
- [-] Docs have been added / updated (for bug fixes / features)

**Other information**:

fixes #1147