### PR TITLE
feat: upgrade reactiveui-events for Xamarin.Forms from v2.2.0.31 to v2.3.1.114

### DIFF
--- a/src/ReactiveUI.Events/ReactiveUI.Events_XamForms.csproj
+++ b/src/ReactiveUI.Events/ReactiveUI.Events_XamForms.csproj
@@ -71,15 +71,15 @@
     <Reference Include="System.Xml.Linq" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Xamarin.Forms.Core, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\Xamarin.Forms.2.2.0.31\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.Core.dll</HintPath>
+      <HintPath>packages\Xamarin.Forms.2.3.1.114\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Xamarin.Forms.Platform, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\Xamarin.Forms.2.2.0.31\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.Platform.dll</HintPath>
+      <HintPath>packages\Xamarin.Forms.2.3.1.114\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.Platform.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Xamarin.Forms.Xaml, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\Xamarin.Forms.2.2.0.31\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.Xaml.dll</HintPath>
+      <HintPath>packages\Xamarin.Forms.2.3.1.114\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.Xaml.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -92,12 +92,12 @@
     <None Include="packages.ReactiveUI.Events_XamForms.config" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
-  <Import Project="packages\Xamarin.Forms.2.2.0.31\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets" Condition="Exists('packages\Xamarin.Forms.2.2.0.31\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets')" />
+  <Import Project="packages\Xamarin.Forms.2.3.1.114\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets" Condition="Exists('packages\Xamarin.Forms.2.3.1.114\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('packages\Xamarin.Forms.2.2.0.31\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Xamarin.Forms.2.2.0.31\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets'))" />
+    <Error Condition="!Exists('packages\Xamarin.Forms.2.3.1.114\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Xamarin.Forms.2.3.1.114\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/ReactiveUI.Events/packages.ReactiveUI.Events_XamForms.config
+++ b/src/ReactiveUI.Events/packages.ReactiveUI.Events_XamForms.config
@@ -6,5 +6,5 @@
   <package id="Rx-Main" version="2.2.5" targetFramework="portable45-net45+win8+wp8+wpa81" />
   <package id="Rx-PlatformServices" version="2.2.5" targetFramework="portable45-net45+win8+wp8+wpa81" />
   <package id="Splat" version="1.6.2" targetFramework="portable45-net45+win8+wp8+wpa81" />
-  <package id="Xamarin.Forms" version="2.2.0.31" targetFramework="portable45-net45+win8+wp8+wpa81" />
+  <package id="Xamarin.Forms" version="2.3.1.114" targetFramework="portable45-net45+win8+wp8+wpa81" />
 </packages>


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Feature (and CI chore)

**What is the current behavior? (You can also link to an open issue here)**

Generate ReactiveUI-Events for Xamarin.Forms v2.2.0.31

**What is the new behavior (if this is a feature change)?**

Generate ReactiveUI-Events for Xamarin.Forms v2.3.1.114

**Does this PR introduce a breaking change?**

No

**Please check if the PR fulfills these requirements**
- [x] The commit follows our guidelines: https://github.com/reactiveui/reactiveui#contribute
- [-] Tests for the changes have been added (for bug fixes / features)
- [-] Docs have been added / updated (for bug fixes / features)

**Other information**:

This also resolves a build error as the EventsGenerator will download the latest version of Xamarin Forms from NuGet and codegen eventhandlers from that. Now, if a new major/minor is released the packages.config needs to be manually updated to reflect this otherwise the build may fail until a commit like this one is done if new eventhandlers are surfaced in the public api of the new release of Xamarin.Forms.