### PR TITLE
feat: update reactiveui-xamforms nuspec dependency from v2.1.0.6529 to v2.3.1.114

### DIFF
--- a/src/ReactiveUI-XamForms.nuspec
+++ b/src/ReactiveUI-XamForms.nuspec
@@ -7,7 +7,7 @@
     <language>en-us</language>
     <dependencies>
       <dependency id="reactiveui-core" version="$version$" />
-      <dependency id="Xamarin.Forms" version="2.1.0.6529" />
+      <dependency id="Xamarin.Forms" version="2.3.1.114" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Feature

**What is the current behavior? (You can also link to an open issue here)**

```
    <dependencies>
      <dependency id="reactiveui-core" version="$version$" />
      <dependency id="Xamarin.Forms" version="2.1.0.6529" />
    </dependencies>
```

**What is the new behavior (if this is a feature change)?**

```
    <dependencies>
      <dependency id="reactiveui-core" version="$version$" />
      <dependency id="Xamarin.Forms" version="2.3.1.114" />
    </dependencies>
```

**Does this PR introduce a breaking change?**

No

**Please check if the PR fulfills these requirements**
- [x] The commit follows our guidelines: https://github.com/reactiveui/reactiveui#contribute
- [-] Tests for the changes have been added (for bug fixes / features)
- [-] Docs have been added / updated (for bug fixes / features)

**Other information**:
