### PR TITLE
revert: "chore: bootstrapper now download/installs Android API level 24

### DIFF
--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -53,4 +53,3 @@ Install-AndroidSDK 20
 Install-AndroidSDK 21
 Install-AndroidSDK 22
 Install-AndroidSDK 23
-Install-AndroidSDK 24


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

bugfix for chore

**What is the current behavior? (You can also link to an open issue here)**

API 24 attempts to be installed but fails as SDK Manager is at v23 which results in a failed build.

**What is the new behavior (if this is a feature change)?**

API 24 is not installed, when AppVeyor is upgraded this commit should be reverted.

**Does this PR introduce a breaking change?**

No

**Please check if the PR fulfills these requirements**
- [x] The commit follows our guidelines: https://github.com/reactiveui/reactiveui#contribute
- [-] Tests for the changes have been added (for bug fixes / features)
- [-] Docs have been added / updated (for bug fixes / features)

**Other information**:

This reverts commit 2a37bc12181dc715c9723aaf5fb38f338ce0f8c9.