### PR TITLE
chore: resolve build failures by disabling sonarqube integration

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,8 +22,6 @@ xamarin:
   ios: true
 build_script:
 - ps: >-
-    ./MSBuild.SonarQube.Runner begin /k:ReactiveUI /n:"ReactiveUI" /v:latest /d:sonar.host.url=https://sonarqube.com /d:sonar.login=$env:SONAR_API_KEY /d:sonar.vb.file.suffixes=.no_vb6_files
-
 
     ./bootstrap.ps1
 
@@ -34,5 +32,3 @@ artifacts:
 - path: '**/bin/*'
 - path: src/ReactiveUI.Events/Events_*.cs
 - path: artifacts/*
-on_finish:
-- ps: ./MSBuild.SonarQube.Runner.exe end /d:sonar.login=$env:SONAR_API_KEY


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Chore

**What is the current behavior? (You can also link to an open issue here)**

New version of the Sonarcube agent has been published and in doing so they have changed the command line arguments (breaking change) without notifying consumers. 

https://sonarqube.com/dashboard/index?id=ReactiveUI

**What is the new behavior (if this is a feature change)?**

Disabled Sonarqube until have more time to investigate. Builds will be green after this change is merged in.

**Does this PR introduce a breaking change?**

No

**Please check if the PR fulfills these requirements**
- [x] The commit follows our guidelines: https://github.com/reactiveui/reactiveui#contribute
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
