### PR TITLE
Fix replacement of tildes.

### DIFF
--- a/src/EventBuilder/Program.cs
+++ b/src/EventBuilder/Program.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using Parser = CommandLine.Parser;
+using System.Text.RegularExpressions;
 
 namespace EventBuilder
 {
@@ -155,9 +156,9 @@ namespace EventBuilder
                 .Replace("System.String", "string")
                 .Replace("System.Object", "object")
                 .Replace("&lt;", "<")
-                .Replace("&gt;", ">")
-                .Replace("`1", "")
-                .Replace("`2", "");
+                .Replace("&gt;", ">");
+
+            result = Regex.Replace(result, @"`\d", "");
 
             Console.WriteLine(result);
         }


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Bug fix.

**What is the current behavior? (You can also link to an open issue here)**

Any generics with more than two parameters are not resulting in valid code being generated. iOS has recently introduced events that now have 3 parameters, so code was being generated like:

```C#
System.Action`3<PassKit.PKPaymentAuthorizationStatus,PassKit.PKShippingMethod[],PassKit.PKPaymentSummaryItem[]>
```

What is the new behavior (if this is a feature change)?**

A regular expression is used to remove all instances of tildes followed by a single digit. 


**Does this PR introduce a breaking change?**

No.


**Please check if the PR fulfills these requirements**
- [X] The commit follows our guidelines: https://github.com/reactiveui/reactiveui#contribute
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)