### PR TITLE
refactor: reactiveui-testing for iOS migrated from Monotouch to Xamarin.iOS

### DIFF
--- a/src/ReactiveUI.Testing/ReactiveUI.Testing_iOS.csproj
+++ b/src/ReactiveUI.Testing/ReactiveUI.Testing_iOS.csproj
@@ -41,7 +41,6 @@
     <CodesignKey>iPhone Developer</CodesignKey>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="MonoTouch.NUnitLite" />
     <Reference Include="System" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
@@ -65,7 +64,6 @@
   <ItemGroup>
     <Folder Include="Resources\" />
   </ItemGroup>
-  <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.MonoTouch.CSharp.targets" />
   <ItemGroup>
     <Compile Include="..\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Refactor

**What is the current behavior? (You can also link to an open issue here)**

`reactiveui-testing` for iOS targets Monotouch which has been obsoleted by Xamarin and no longer compiles. Project does not compile because of this.

**What is the new behavior (if this is a feature change)?**

Migrated to Xamarin.iOS

**Does this PR introduce a breaking change?**

No

**Please check if the PR fulfills these requirements**
- [x] The commit follows our guidelines: https://github.com/reactiveui/reactiveui#contribute
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**