### PR TITLE
resolve code-generation of events with iOS 10

### DIFF
--- a/src/EventBuilder/Program.cs
+++ b/src/EventBuilder/Program.cs
@@ -37,7 +37,7 @@ namespace EventBuilder
             if (Debugger.IsAttached)
             {
                 //args = "--help ".Split(' ');
-                args = "--platform=mac".Split(' ');
+                args = "--platform=ios".Split(' ');
                 //args = new[]
                 //{
                 //    "--platform=none",
@@ -157,7 +157,8 @@ namespace EventBuilder
                 .Replace("&lt;", "<")
                 .Replace("&gt;", ">")
                 .Replace("`1", "")
-                .Replace("`2", "");
+                .Replace("`2", "")
+                .Replace("`3", "");
 
             Console.WriteLine(result);
         }


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

bug fix

**What is the current behavior? (You can also link to an open issue here)**

Code generation of Xamarin.iOS with iOS 10 events does not work.

**What is the new behavior (if this is a feature change)?**

A few of the PassKit API's added in iOS 10 take three params on their Action<T> which is the first time we have seen this across any platform. Resolved by doing the usual quick and dirty fix of String.Replace("`3", "") - if there's ever a Action<T> that takes 4 paramaters you'll need to add another string.Replace line.

Example - this

```
readonly SingleAwaitSubject<Tuple<PassKit.PKPaymentAuthorizationController, PassKit.PKContact, System.Action`3<PassKit.PKPaymentAuthorizationStatus,PassKit.PKShippingMethod[],PassKit.PKPaymentSummaryItem[]>>> _DidSelectShippingContact
```

Is now

```
readonly SingleAwaitSubject<Tuple<PassKit.PKPaymentAuthorizationController, PassKit.PKContact, System.Action<PassKit.PKPaymentAuthorizationStatus,PassKit.PKShippingMethod[],PassKit.PKPaymentSummaryItem[]>>> _DidSelectShippingContact
```

**Does this PR introduce a breaking change?**

No

**Please check if the PR fulfills these requirements**
- [x] The commit follows our guidelines: https://github.com/reactiveui/reactiveui#contribute
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
