### PR TITLE
refactor: use xamarin.mac framework for reactiveui/reactiveui-testing/microsoft-reactive-testing

### DIFF
--- a/src/Microsoft.Reactive.Testing/Microsoft.Reactive.Testing_Mac.csproj
+++ b/src/Microsoft.Reactive.Testing/Microsoft.Reactive.Testing_Mac.csproj
@@ -6,10 +6,12 @@
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{AA27F817-FAD2-4622-B68A-651A8AA9E076}</ProjectGuid>
+    <ProjectTypeGuids>{A3F8F2AB-B479-4A4A-A458-A89E7DC349F1};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <RootNamespace>Microsoft.Reactive.Testing</RootNamespace>
     <AssemblyName>Microsoft.Reactive.Testing</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+    <TargetFrameworkIdentifier>Xamarin.Mac</TargetFrameworkIdentifier>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/ReactiveUI.Testing/ReactiveUI.Testing_Mac.csproj
+++ b/src/ReactiveUI.Testing/ReactiveUI.Testing_Mac.csproj
@@ -1,16 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{E1F2AD19-276E-4D05-A41A-89AA133CECFC}</ProjectGuid>
+    <ProjectTypeGuids>{A3F8F2AB-B479-4A4A-A458-A89E7DC349F1};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ReactiveUI.Testing</RootNamespace>
     <AssemblyName>ReactiveUI.Testing</AssemblyName>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+    <TargetFrameworkIdentifier>Xamarin.Mac</TargetFrameworkIdentifier>
     <SccProjectName>
     </SccProjectName>
     <SccLocalPath>
@@ -19,7 +21,6 @@
     </SccAuxPath>
     <SccProvider>
     </SccProvider>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>
@@ -46,7 +47,6 @@
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
     <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.Xaml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Xml" />

--- a/src/ReactiveUI/ReactiveUI_Mac.csproj
+++ b/src/ReactiveUI/ReactiveUI_Mac.csproj
@@ -159,5 +159,4 @@
     <None Include="packages.ReactiveUI_Mac.config" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets" Condition=" '$(OS)' == 'Windows_NT' " />
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" Condition=" '$(OS)' == 'Windows_NT' " />
 </Project>


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

refactor

**What is the current behavior? (You can also link to an open issue here)**

`reactiveui-events` uses Xamarin.Mac as target framework.
`reactiveui` uses NET45 as target framework.
`reactiveui-testing` uses NET45 as target framework.
`Microsoft.Reactive.Testing_Mac` uses NET45 as target framework.

**What is the new behavior (if this is a feature change)?**

Xamarin.Mac used as target framework for all of above instead of NET45. This resolves a few `msbuild` compiler warnings.

**Does this PR introduce a breaking change?**

No

**Please check if the PR fulfills these requirements**
- [x] The commit follows our guidelines: https://github.com/reactiveui/reactiveui#contribute
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**: