### PR TITLE
refactor: android timepicker use .Hour|Minute instead of .Current[Hour|Minute]

### DIFF
--- a/src/ReactiveUI/Android/AndroidObservableForWidgets.cs
+++ b/src/ReactiveUI/Android/AndroidObservableForWidgets.cs
@@ -28,8 +28,8 @@ namespace ReactiveUI
                 createFromWidget<CompoundButton, CompoundButton.CheckedChangeEventArgs>(v => v.Checked, (v, h) => v.CheckedChange += h, (v, h) => v.CheckedChange -= h),
                 createFromWidget<CalendarView, CalendarView.DateChangeEventArgs>(v => v.Date, (v, h) => v.DateChange += h, (v, h) => v.DateChange -= h),
                 createFromWidget<TabHost, TabHost.TabChangeEventArgs>(v => v.CurrentTab, (v, h) => v.TabChanged += h, (v, h) => v.TabChanged -= h),
-                createFromWidget<TimePicker, TimePicker.TimeChangedEventArgs>(v => v.CurrentHour, (v, h) => v.TimeChanged += h, (v, h) => v.TimeChanged -= h),
-                createFromWidget<TimePicker, TimePicker.TimeChangedEventArgs>(v => v.CurrentMinute, (v, h) => v.TimeChanged += h, (v, h) => v.TimeChanged -= h),
+                createFromWidget<TimePicker, TimePicker.TimeChangedEventArgs>(v => v.Hour, (v, h) => v.TimeChanged += h, (v, h) => v.TimeChanged -= h),
+                createFromWidget<TimePicker, TimePicker.TimeChangedEventArgs>(v => v.Minute, (v, h) => v.TimeChanged += h, (v, h) => v.TimeChanged -= h),
                 createFromAdapterView(),
             }.ToDictionary(k => Tuple.Create(k.Type, k.Property), v => v.Func);
         }

--- a/src/ReactiveUI/Android/LinkerOverrides.cs
+++ b/src/ReactiveUI/Android/LinkerOverrides.cs
@@ -42,8 +42,8 @@ namespace ReactiveUI
             th.CurrentTab = th.CurrentTab;
 
             var tp = new TimePicker(null);
-            tp.CurrentHour = tp.CurrentHour;
-            tp.CurrentMinute = tp.CurrentMinute;
+            tp.Hour = tp.Hour;
+            tp.Minute = tp.Minute;
 
             
         }


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

refactor

**What is the current behavior? (You can also link to an open issue here)**

`.Current[Hour|Minute]` is used in the prayer to the linker gods and also in the WidgetsObservables. These two properties have been `[Obsoleted]`.

**What is the new behavior (if this is a feature change)?**

Use `.Hour|Minute` instead.

https://developer.android.com/guide/topics/ui/controls/pickers.html
https://developer.xamarin.com/guides/android/user_interface/time_picker/

**Does this PR introduce a breaking change?**

No

**Please check if the PR fulfills these requirements**
- [x] The commit follows our guidelines: https://github.com/reactiveui/reactiveui#contribute
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
