### PR TITLE
refactor: ignore CS[1591,0618,0105,0672] on reactiveui-events because that code is codegened

### DIFF
--- a/src/EventBuilder/DefaultTemplate.mustache
+++ b/src/EventBuilder/DefaultTemplate.mustache
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#pragma warning disable 1591,0618,0105,0672
+
+using System;
 using System.Reactive;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
@@ -88,3 +90,5 @@ namespace {{Name}}.Rx
 {{/Types}}
 }
 {{/DelegateNamespaces}}
+
+#pragma warning restore 1591,0618,0105,0672


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

refactor/chore on `reactiveui-events`

**What is the current behavior? (You can also link to an open issue here)**

CS[1591,0618,0105,0672] are enabled and spam the build logs with useless information which makes reviewing the logs harder. We don't need these warnings because `reactiveui-events` is all automatically code generated.

**What is the new behavior (if this is a feature change)?**

CS[1591,0618,0105,0672] are disabled

**Does this PR introduce a breaking change?**

No

**Please check if the PR fulfills these requirements**
- [x] The commit follows our guidelines: https://github.com/reactiveui/reactiveui#contribute
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
