### PR TITLE
Add WhenAnyObservable overloads that combine latest

### DIFF
--- a/src/ReactiveUI/VariadicTemplates.cs
+++ b/src/ReactiveUI/VariadicTemplates.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
@@ -11,7 +11,7 @@ using System.Text;
 
 namespace ReactiveUI
 {
-    public static class WhenAnyMixin 
+    public static class WhenAnyMixin
     {
         /// <summary>
         /// WhenAnyValue allows you to observe whenever the value of a
@@ -20,7 +20,7 @@ namespace ReactiveUI
         /// method in constructors to set up bindings between properties that also
         /// need an initial setup.
         /// </summary>
-        public static IObservable<TRet> WhenAnyValue<TSender, TRet>(this TSender This, 
+        public static IObservable<TRet> WhenAnyValue<TSender, TRet>(this TSender This,
                             Expression<Func<TSender, TRet>> property1)
         {
             return This.WhenAny(property1, (IObservedChange<TSender, TRet> c1) => c1.Value);
@@ -35,8 +35,8 @@ namespace ReactiveUI
         /// method in constructors to set up bindings between properties that also
         /// need an initial setup.
         /// </summary>
-        public static IObservable<TRet> WhenAnyValue<TSender, TRet, T1>(this TSender This, 
-                            Expression<Func<TSender, T1>> property1, 
+        public static IObservable<TRet> WhenAnyValue<TSender, TRet, T1>(this TSender This,
+                            Expression<Func<TSender, T1>> property1,
                             Func<T1, TRet> selector)
         {
             return This.WhenAny(property1,
@@ -51,14 +51,14 @@ namespace ReactiveUI
         /// constructors to set up bindings between properties that also need an
         /// initial setup.
         /// </summary>
-        public static IObservable<TRet> WhenAny<TSender, TRet, T1>(this TSender This, 
-                            Expression<Func<TSender, T1>> property1, 
+        public static IObservable<TRet> WhenAny<TSender, TRet, T1>(this TSender This,
+                            Expression<Func<TSender, T1>> property1,
                             Func<IObservedChange<TSender, T1>, TRet> selector)
         {
-                            return This.ObservableForProperty(property1, false, false).Select(selector); 
+                            return This.ObservableForProperty(property1, false, false).Select(selector);
                     }
 
-		
+
         /// <summary>
         /// WhenAny allows you to observe whenever one or more properties on an
         /// object have changed, providing an initial value when the Observable
@@ -66,12 +66,12 @@ namespace ReactiveUI
         /// constructors to set up bindings between properties that also need an
         /// initial setup.
         /// </summary>
-        public static IObservable<TRet> WhenAnyDynamic<TSender, TRet>(this TSender This, 
-                            Expression property1, 
+        public static IObservable<TRet> WhenAnyDynamic<TSender, TRet>(this TSender This,
+                            Expression property1,
                             Func<IObservedChange<TSender, object>, TRet> selector)
         {
                             return ReactiveNotifyPropertyChangedMixin
-                    .SubscribeToExpressionChain<TSender,object>(This, property1, false, false).Select(selector); 
+                    .SubscribeToExpressionChain<TSender,object>(This, property1, false, false).Select(selector);
                     }
                                                             
                 /// <summary>
@@ -81,7 +81,7 @@ namespace ReactiveUI
         /// method in constructors to set up bindings between properties that also
         /// need an initial setup.
         /// </summary>
-        public static IObservable<Tuple<T1,T2>> WhenAnyValue<TSender, T1,T2>(this TSender This, 
+        public static IObservable<Tuple<T1,T2>> WhenAnyValue<TSender, T1,T2>(this TSender This,
                             Expression<Func<TSender, T1>> property1,
                             Expression<Func<TSender, T2>> property2
             )
@@ -98,9 +98,9 @@ namespace ReactiveUI
         /// method in constructors to set up bindings between properties that also
         /// need an initial setup.
         /// </summary>
-        public static IObservable<TRet> WhenAnyValue<TSender, TRet, T1,T2>(this TSender This, 
-                            Expression<Func<TSender, T1>> property1, 
-                            Expression<Func<TSender, T2>> property2, 
+        public static IObservable<TRet> WhenAnyValue<TSender, TRet, T1,T2>(this TSender This,
+                            Expression<Func<TSender, T1>> property1,
+                            Expression<Func<TSender, T2>> property2,
                             Func<T1,T2, TRet> selector)
         {
             return This.WhenAny(property1, property2,
@@ -115,19 +115,19 @@ namespace ReactiveUI
         /// constructors to set up bindings between properties that also need an
         /// initial setup.
         /// </summary>
-        public static IObservable<TRet> WhenAny<TSender, TRet, T1,T2>(this TSender This, 
-                            Expression<Func<TSender, T1>> property1, 
-                            Expression<Func<TSender, T2>> property2, 
+        public static IObservable<TRet> WhenAny<TSender, TRet, T1,T2>(this TSender This,
+                            Expression<Func<TSender, T1>> property1,
+                            Expression<Func<TSender, T2>> property2,
                             Func<IObservedChange<TSender, T1>, IObservedChange<TSender, T2>, TRet> selector)
         {
                         return Observable.CombineLatest(
-                                    This.ObservableForProperty(property1, false, false), 
-                                    This.ObservableForProperty(property2, false, false), 
+                                    This.ObservableForProperty(property1, false, false),
+                                    This.ObservableForProperty(property2, false, false),
                                 selector
             );
                     }
 
-		
+
         /// <summary>
         /// WhenAny allows you to observe whenever one or more properties on an
         /// object have changed, providing an initial value when the Observable
@@ -135,16 +135,16 @@ namespace ReactiveUI
         /// constructors to set up bindings between properties that also need an
         /// initial setup.
         /// </summary>
-        public static IObservable<TRet> WhenAnyDynamic<TSender, TRet>(this TSender This, 
-                            Expression property1, 
-                            Expression property2, 
+        public static IObservable<TRet> WhenAnyDynamic<TSender, TRet>(this TSender This,
+                            Expression property1,
+                            Expression property2,
                             Func<IObservedChange<TSender, object>, IObservedChange<TSender, object>, TRet> selector)
         {
                         return Observable.CombineLatest(
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property1, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property1, false, false),
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property2, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property2, false, false),
                                 selector
             );
                     }
@@ -156,7 +156,7 @@ namespace ReactiveUI
         /// method in constructors to set up bindings between properties that also
         /// need an initial setup.
         /// </summary>
-        public static IObservable<Tuple<T1,T2,T3>> WhenAnyValue<TSender, T1,T2,T3>(this TSender This, 
+        public static IObservable<Tuple<T1,T2,T3>> WhenAnyValue<TSender, T1,T2,T3>(this TSender This,
                             Expression<Func<TSender, T1>> property1,
                             Expression<Func<TSender, T2>> property2,
                             Expression<Func<TSender, T3>> property3
@@ -174,10 +174,10 @@ namespace ReactiveUI
         /// method in constructors to set up bindings between properties that also
         /// need an initial setup.
         /// </summary>
-        public static IObservable<TRet> WhenAnyValue<TSender, TRet, T1,T2,T3>(this TSender This, 
-                            Expression<Func<TSender, T1>> property1, 
-                            Expression<Func<TSender, T2>> property2, 
-                            Expression<Func<TSender, T3>> property3, 
+        public static IObservable<TRet> WhenAnyValue<TSender, TRet, T1,T2,T3>(this TSender This,
+                            Expression<Func<TSender, T1>> property1,
+                            Expression<Func<TSender, T2>> property2,
+                            Expression<Func<TSender, T3>> property3,
                             Func<T1,T2,T3, TRet> selector)
         {
             return This.WhenAny(property1, property2, property3,
@@ -192,21 +192,21 @@ namespace ReactiveUI
         /// constructors to set up bindings between properties that also need an
         /// initial setup.
         /// </summary>
-        public static IObservable<TRet> WhenAny<TSender, TRet, T1,T2,T3>(this TSender This, 
-                            Expression<Func<TSender, T1>> property1, 
-                            Expression<Func<TSender, T2>> property2, 
-                            Expression<Func<TSender, T3>> property3, 
+        public static IObservable<TRet> WhenAny<TSender, TRet, T1,T2,T3>(this TSender This,
+                            Expression<Func<TSender, T1>> property1,
+                            Expression<Func<TSender, T2>> property2,
+                            Expression<Func<TSender, T3>> property3,
                             Func<IObservedChange<TSender, T1>, IObservedChange<TSender, T2>, IObservedChange<TSender, T3>, TRet> selector)
         {
                         return Observable.CombineLatest(
-                                    This.ObservableForProperty(property1, false, false), 
-                                    This.ObservableForProperty(property2, false, false), 
-                                    This.ObservableForProperty(property3, false, false), 
+                                    This.ObservableForProperty(property1, false, false),
+                                    This.ObservableForProperty(property2, false, false),
+                                    This.ObservableForProperty(property3, false, false),
                                 selector
             );
                     }
 
-		
+
         /// <summary>
         /// WhenAny allows you to observe whenever one or more properties on an
         /// object have changed, providing an initial value when the Observable
@@ -214,19 +214,19 @@ namespace ReactiveUI
         /// constructors to set up bindings between properties that also need an
         /// initial setup.
         /// </summary>
-        public static IObservable<TRet> WhenAnyDynamic<TSender, TRet>(this TSender This, 
-                            Expression property1, 
-                            Expression property2, 
-                            Expression property3, 
+        public static IObservable<TRet> WhenAnyDynamic<TSender, TRet>(this TSender This,
+                            Expression property1,
+                            Expression property2,
+                            Expression property3,
                             Func<IObservedChange<TSender, object>, IObservedChange<TSender, object>, IObservedChange<TSender, object>, TRet> selector)
         {
                         return Observable.CombineLatest(
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property1, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property1, false, false),
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property2, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property2, false, false),
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property3, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property3, false, false),
                                 selector
             );
                     }
@@ -238,7 +238,7 @@ namespace ReactiveUI
         /// method in constructors to set up bindings between properties that also
         /// need an initial setup.
         /// </summary>
-        public static IObservable<Tuple<T1,T2,T3,T4>> WhenAnyValue<TSender, T1,T2,T3,T4>(this TSender This, 
+        public static IObservable<Tuple<T1,T2,T3,T4>> WhenAnyValue<TSender, T1,T2,T3,T4>(this TSender This,
                             Expression<Func<TSender, T1>> property1,
                             Expression<Func<TSender, T2>> property2,
                             Expression<Func<TSender, T3>> property3,
@@ -257,11 +257,11 @@ namespace ReactiveUI
         /// method in constructors to set up bindings between properties that also
         /// need an initial setup.
         /// </summary>
-        public static IObservable<TRet> WhenAnyValue<TSender, TRet, T1,T2,T3,T4>(this TSender This, 
-                            Expression<Func<TSender, T1>> property1, 
-                            Expression<Func<TSender, T2>> property2, 
-                            Expression<Func<TSender, T3>> property3, 
-                            Expression<Func<TSender, T4>> property4, 
+        public static IObservable<TRet> WhenAnyValue<TSender, TRet, T1,T2,T3,T4>(this TSender This,
+                            Expression<Func<TSender, T1>> property1,
+                            Expression<Func<TSender, T2>> property2,
+                            Expression<Func<TSender, T3>> property3,
+                            Expression<Func<TSender, T4>> property4,
                             Func<T1,T2,T3,T4, TRet> selector)
         {
             return This.WhenAny(property1, property2, property3, property4,
@@ -276,23 +276,23 @@ namespace ReactiveUI
         /// constructors to set up bindings between properties that also need an
         /// initial setup.
         /// </summary>
-        public static IObservable<TRet> WhenAny<TSender, TRet, T1,T2,T3,T4>(this TSender This, 
-                            Expression<Func<TSender, T1>> property1, 
-                            Expression<Func<TSender, T2>> property2, 
-                            Expression<Func<TSender, T3>> property3, 
-                            Expression<Func<TSender, T4>> property4, 
+        public static IObservable<TRet> WhenAny<TSender, TRet, T1,T2,T3,T4>(this TSender This,
+                            Expression<Func<TSender, T1>> property1,
+                            Expression<Func<TSender, T2>> property2,
+                            Expression<Func<TSender, T3>> property3,
+                            Expression<Func<TSender, T4>> property4,
                             Func<IObservedChange<TSender, T1>, IObservedChange<TSender, T2>, IObservedChange<TSender, T3>, IObservedChange<TSender, T4>, TRet> selector)
         {
                         return Observable.CombineLatest(
-                                    This.ObservableForProperty(property1, false, false), 
-                                    This.ObservableForProperty(property2, false, false), 
-                                    This.ObservableForProperty(property3, false, false), 
-                                    This.ObservableForProperty(property4, false, false), 
+                                    This.ObservableForProperty(property1, false, false),
+                                    This.ObservableForProperty(property2, false, false),
+                                    This.ObservableForProperty(property3, false, false),
+                                    This.ObservableForProperty(property4, false, false),
                                 selector
             );
                     }
 
-		
+
         /// <summary>
         /// WhenAny allows you to observe whenever one or more properties on an
         /// object have changed, providing an initial value when the Observable
@@ -300,22 +300,22 @@ namespace ReactiveUI
         /// constructors to set up bindings between properties that also need an
         /// initial setup.
         /// </summary>
-        public static IObservable<TRet> WhenAnyDynamic<TSender, TRet>(this TSender This, 
-                            Expression property1, 
-                            Expression property2, 
-                            Expression property3, 
-                            Expression property4, 
+        public static IObservable<TRet> WhenAnyDynamic<TSender, TRet>(this TSender This,
+                            Expression property1,
+                            Expression property2,
+                            Expression property3,
+                            Expression property4,
                             Func<IObservedChange<TSender, object>, IObservedChange<TSender, object>, IObservedChange<TSender, object>, IObservedChange<TSender, object>, TRet> selector)
         {
                         return Observable.CombineLatest(
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property1, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property1, false, false),
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property2, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property2, false, false),
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property3, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property3, false, false),
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property4, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property4, false, false),
                                 selector
             );
                     }
@@ -327,7 +327,7 @@ namespace ReactiveUI
         /// method in constructors to set up bindings between properties that also
         /// need an initial setup.
         /// </summary>
-        public static IObservable<Tuple<T1,T2,T3,T4,T5>> WhenAnyValue<TSender, T1,T2,T3,T4,T5>(this TSender This, 
+        public static IObservable<Tuple<T1,T2,T3,T4,T5>> WhenAnyValue<TSender, T1,T2,T3,T4,T5>(this TSender This,
                             Expression<Func<TSender, T1>> property1,
                             Expression<Func<TSender, T2>> property2,
                             Expression<Func<TSender, T3>> property3,
@@ -347,12 +347,12 @@ namespace ReactiveUI
         /// method in constructors to set up bindings between properties that also
         /// need an initial setup.
         /// </summary>
-        public static IObservable<TRet> WhenAnyValue<TSender, TRet, T1,T2,T3,T4,T5>(this TSender This, 
-                            Expression<Func<TSender, T1>> property1, 
-                            Expression<Func<TSender, T2>> property2, 
-                            Expression<Func<TSender, T3>> property3, 
-                            Expression<Func<TSender, T4>> property4, 
-                            Expression<Func<TSender, T5>> property5, 
+        public static IObservable<TRet> WhenAnyValue<TSender, TRet, T1,T2,T3,T4,T5>(this TSender This,
+                            Expression<Func<TSender, T1>> property1,
+                            Expression<Func<TSender, T2>> property2,
+                            Expression<Func<TSender, T3>> property3,
+                            Expression<Func<TSender, T4>> property4,
+                            Expression<Func<TSender, T5>> property5,
                             Func<T1,T2,T3,T4,T5, TRet> selector)
         {
             return This.WhenAny(property1, property2, property3, property4, property5,
@@ -367,25 +367,25 @@ namespace ReactiveUI
         /// constructors to set up bindings between properties that also need an
         /// initial setup.
         /// </summary>
-        public static IObservable<TRet> WhenAny<TSender, TRet, T1,T2,T3,T4,T5>(this TSender This, 
-                            Expression<Func<TSender, T1>> property1, 
-                            Expression<Func<TSender, T2>> property2, 
-                            Expression<Func<TSender, T3>> property3, 
-                            Expression<Func<TSender, T4>> property4, 
-                            Expression<Func<TSender, T5>> property5, 
+        public static IObservable<TRet> WhenAny<TSender, TRet, T1,T2,T3,T4,T5>(this TSender This,
+                            Expression<Func<TSender, T1>> property1,
+                            Expression<Func<TSender, T2>> property2,
+                            Expression<Func<TSender, T3>> property3,
+                            Expression<Func<TSender, T4>> property4,
+                            Expression<Func<TSender, T5>> property5,
                             Func<IObservedChange<TSender, T1>, IObservedChange<TSender, T2>, IObservedChange<TSender, T3>, IObservedChange<TSender, T4>, IObservedChange<TSender, T5>, TRet> selector)
         {
                         return Observable.CombineLatest(
-                                    This.ObservableForProperty(property1, false, false), 
-                                    This.ObservableForProperty(property2, false, false), 
-                                    This.ObservableForProperty(property3, false, false), 
-                                    This.ObservableForProperty(property4, false, false), 
-                                    This.ObservableForProperty(property5, false, false), 
+                                    This.ObservableForProperty(property1, false, false),
+                                    This.ObservableForProperty(property2, false, false),
+                                    This.ObservableForProperty(property3, false, false),
+                                    This.ObservableForProperty(property4, false, false),
+                                    This.ObservableForProperty(property5, false, false),
                                 selector
             );
                     }
 
-		
+
         /// <summary>
         /// WhenAny allows you to observe whenever one or more properties on an
         /// object have changed, providing an initial value when the Observable
@@ -393,25 +393,25 @@ namespace ReactiveUI
         /// constructors to set up bindings between properties that also need an
         /// initial setup.
         /// </summary>
-        public static IObservable<TRet> WhenAnyDynamic<TSender, TRet>(this TSender This, 
-                            Expression property1, 
-                            Expression property2, 
-                            Expression property3, 
-                            Expression property4, 
-                            Expression property5, 
+        public static IObservable<TRet> WhenAnyDynamic<TSender, TRet>(this TSender This,
+                            Expression property1,
+                            Expression property2,
+                            Expression property3,
+                            Expression property4,
+                            Expression property5,
                             Func<IObservedChange<TSender, object>, IObservedChange<TSender, object>, IObservedChange<TSender, object>, IObservedChange<TSender, object>, IObservedChange<TSender, object>, TRet> selector)
         {
                         return Observable.CombineLatest(
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property1, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property1, false, false),
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property2, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property2, false, false),
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property3, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property3, false, false),
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property4, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property4, false, false),
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property5, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property5, false, false),
                                 selector
             );
                     }
@@ -423,7 +423,7 @@ namespace ReactiveUI
         /// method in constructors to set up bindings between properties that also
         /// need an initial setup.
         /// </summary>
-        public static IObservable<Tuple<T1,T2,T3,T4,T5,T6>> WhenAnyValue<TSender, T1,T2,T3,T4,T5,T6>(this TSender This, 
+        public static IObservable<Tuple<T1,T2,T3,T4,T5,T6>> WhenAnyValue<TSender, T1,T2,T3,T4,T5,T6>(this TSender This,
                             Expression<Func<TSender, T1>> property1,
                             Expression<Func<TSender, T2>> property2,
                             Expression<Func<TSender, T3>> property3,
@@ -444,13 +444,13 @@ namespace ReactiveUI
         /// method in constructors to set up bindings between properties that also
         /// need an initial setup.
         /// </summary>
-        public static IObservable<TRet> WhenAnyValue<TSender, TRet, T1,T2,T3,T4,T5,T6>(this TSender This, 
-                            Expression<Func<TSender, T1>> property1, 
-                            Expression<Func<TSender, T2>> property2, 
-                            Expression<Func<TSender, T3>> property3, 
-                            Expression<Func<TSender, T4>> property4, 
-                            Expression<Func<TSender, T5>> property5, 
-                            Expression<Func<TSender, T6>> property6, 
+        public static IObservable<TRet> WhenAnyValue<TSender, TRet, T1,T2,T3,T4,T5,T6>(this TSender This,
+                            Expression<Func<TSender, T1>> property1,
+                            Expression<Func<TSender, T2>> property2,
+                            Expression<Func<TSender, T3>> property3,
+                            Expression<Func<TSender, T4>> property4,
+                            Expression<Func<TSender, T5>> property5,
+                            Expression<Func<TSender, T6>> property6,
                             Func<T1,T2,T3,T4,T5,T6, TRet> selector)
         {
             return This.WhenAny(property1, property2, property3, property4, property5, property6,
@@ -465,27 +465,27 @@ namespace ReactiveUI
         /// constructors to set up bindings between properties that also need an
         /// initial setup.
         /// </summary>
-        public static IObservable<TRet> WhenAny<TSender, TRet, T1,T2,T3,T4,T5,T6>(this TSender This, 
-                            Expression<Func<TSender, T1>> property1, 
-                            Expression<Func<TSender, T2>> property2, 
-                            Expression<Func<TSender, T3>> property3, 
-                            Expression<Func<TSender, T4>> property4, 
-                            Expression<Func<TSender, T5>> property5, 
-                            Expression<Func<TSender, T6>> property6, 
+        public static IObservable<TRet> WhenAny<TSender, TRet, T1,T2,T3,T4,T5,T6>(this TSender This,
+                            Expression<Func<TSender, T1>> property1,
+                            Expression<Func<TSender, T2>> property2,
+                            Expression<Func<TSender, T3>> property3,
+                            Expression<Func<TSender, T4>> property4,
+                            Expression<Func<TSender, T5>> property5,
+                            Expression<Func<TSender, T6>> property6,
                             Func<IObservedChange<TSender, T1>, IObservedChange<TSender, T2>, IObservedChange<TSender, T3>, IObservedChange<TSender, T4>, IObservedChange<TSender, T5>, IObservedChange<TSender, T6>, TRet> selector)
         {
                         return Observable.CombineLatest(
-                                    This.ObservableForProperty(property1, false, false), 
-                                    This.ObservableForProperty(property2, false, false), 
-                                    This.ObservableForProperty(property3, false, false), 
-                                    This.ObservableForProperty(property4, false, false), 
-                                    This.ObservableForProperty(property5, false, false), 
-                                    This.ObservableForProperty(property6, false, false), 
+                                    This.ObservableForProperty(property1, false, false),
+                                    This.ObservableForProperty(property2, false, false),
+                                    This.ObservableForProperty(property3, false, false),
+                                    This.ObservableForProperty(property4, false, false),
+                                    This.ObservableForProperty(property5, false, false),
+                                    This.ObservableForProperty(property6, false, false),
                                 selector
             );
                     }
 
-		
+
         /// <summary>
         /// WhenAny allows you to observe whenever one or more properties on an
         /// object have changed, providing an initial value when the Observable
@@ -493,28 +493,28 @@ namespace ReactiveUI
         /// constructors to set up bindings between properties that also need an
         /// initial setup.
         /// </summary>
-        public static IObservable<TRet> WhenAnyDynamic<TSender, TRet>(this TSender This, 
-                            Expression property1, 
-                            Expression property2, 
-                            Expression property3, 
-                            Expression property4, 
-                            Expression property5, 
-                            Expression property6, 
+        public static IObservable<TRet> WhenAnyDynamic<TSender, TRet>(this TSender This,
+                            Expression property1,
+                            Expression property2,
+                            Expression property3,
+                            Expression property4,
+                            Expression property5,
+                            Expression property6,
                             Func<IObservedChange<TSender, object>, IObservedChange<TSender, object>, IObservedChange<TSender, object>, IObservedChange<TSender, object>, IObservedChange<TSender, object>, IObservedChange<TSender, object>, TRet> selector)
         {
                         return Observable.CombineLatest(
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property1, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property1, false, false),
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property2, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property2, false, false),
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property3, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property3, false, false),
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property4, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property4, false, false),
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property5, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property5, false, false),
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property6, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property6, false, false),
                                 selector
             );
                     }
@@ -526,7 +526,7 @@ namespace ReactiveUI
         /// method in constructors to set up bindings between properties that also
         /// need an initial setup.
         /// </summary>
-        public static IObservable<Tuple<T1,T2,T3,T4,T5,T6,T7>> WhenAnyValue<TSender, T1,T2,T3,T4,T5,T6,T7>(this TSender This, 
+        public static IObservable<Tuple<T1,T2,T3,T4,T5,T6,T7>> WhenAnyValue<TSender, T1,T2,T3,T4,T5,T6,T7>(this TSender This,
                             Expression<Func<TSender, T1>> property1,
                             Expression<Func<TSender, T2>> property2,
                             Expression<Func<TSender, T3>> property3,
@@ -548,14 +548,14 @@ namespace ReactiveUI
         /// method in constructors to set up bindings between properties that also
         /// need an initial setup.
         /// </summary>
-        public static IObservable<TRet> WhenAnyValue<TSender, TRet, T1,T2,T3,T4,T5,T6,T7>(this TSender This, 
-                            Expression<Func<TSender, T1>> property1, 
-                            Expression<Func<TSender, T2>> property2, 
-                            Expression<Func<TSender, T3>> property3, 
-                            Expression<Func<TSender, T4>> property4, 
-                            Expression<Func<TSender, T5>> property5, 
-                            Expression<Func<TSender, T6>> property6, 
-                            Expression<Func<TSender, T7>> property7, 
+        public static IObservable<TRet> WhenAnyValue<TSender, TRet, T1,T2,T3,T4,T5,T6,T7>(this TSender This,
+                            Expression<Func<TSender, T1>> property1,
+                            Expression<Func<TSender, T2>> property2,
+                            Expression<Func<TSender, T3>> property3,
+                            Expression<Func<TSender, T4>> property4,
+                            Expression<Func<TSender, T5>> property5,
+                            Expression<Func<TSender, T6>> property6,
+                            Expression<Func<TSender, T7>> property7,
                             Func<T1,T2,T3,T4,T5,T6,T7, TRet> selector)
         {
             return This.WhenAny(property1, property2, property3, property4, property5, property6, property7,
@@ -570,29 +570,29 @@ namespace ReactiveUI
         /// constructors to set up bindings between properties that also need an
         /// initial setup.
         /// </summary>
-        public static IObservable<TRet> WhenAny<TSender, TRet, T1,T2,T3,T4,T5,T6,T7>(this TSender This, 
-                            Expression<Func<TSender, T1>> property1, 
-                            Expression<Func<TSender, T2>> property2, 
-                            Expression<Func<TSender, T3>> property3, 
-                            Expression<Func<TSender, T4>> property4, 
-                            Expression<Func<TSender, T5>> property5, 
-                            Expression<Func<TSender, T6>> property6, 
-                            Expression<Func<TSender, T7>> property7, 
+        public static IObservable<TRet> WhenAny<TSender, TRet, T1,T2,T3,T4,T5,T6,T7>(this TSender This,
+                            Expression<Func<TSender, T1>> property1,
+                            Expression<Func<TSender, T2>> property2,
+                            Expression<Func<TSender, T3>> property3,
+                            Expression<Func<TSender, T4>> property4,
+                            Expression<Func<TSender, T5>> property5,
+                            Expression<Func<TSender, T6>> property6,
+                            Expression<Func<TSender, T7>> property7,
                             Func<IObservedChange<TSender, T1>, IObservedChange<TSender, T2>, IObservedChange<TSender, T3>, IObservedChange<TSender, T4>, IObservedChange<TSender, T5>, IObservedChange<TSender, T6>, IObservedChange<TSender, T7>, TRet> selector)
         {
                         return Observable.CombineLatest(
-                                    This.ObservableForProperty(property1, false, false), 
-                                    This.ObservableForProperty(property2, false, false), 
-                                    This.ObservableForProperty(property3, false, false), 
-                                    This.ObservableForProperty(property4, false, false), 
-                                    This.ObservableForProperty(property5, false, false), 
-                                    This.ObservableForProperty(property6, false, false), 
-                                    This.ObservableForProperty(property7, false, false), 
+                                    This.ObservableForProperty(property1, false, false),
+                                    This.ObservableForProperty(property2, false, false),
+                                    This.ObservableForProperty(property3, false, false),
+                                    This.ObservableForProperty(property4, false, false),
+                                    This.ObservableForProperty(property5, false, false),
+                                    This.ObservableForProperty(property6, false, false),
+                                    This.ObservableForProperty(property7, false, false),
                                 selector
             );
                     }
 
-		
+
         /// <summary>
         /// WhenAny allows you to observe whenever one or more properties on an
         /// object have changed, providing an initial value when the Observable
@@ -600,31 +600,31 @@ namespace ReactiveUI
         /// constructors to set up bindings between properties that also need an
         /// initial setup.
         /// </summary>
-        public static IObservable<TRet> WhenAnyDynamic<TSender, TRet>(this TSender This, 
-                            Expression property1, 
-                            Expression property2, 
-                            Expression property3, 
-                            Expression property4, 
-                            Expression property5, 
-                            Expression property6, 
-                            Expression property7, 
+        public static IObservable<TRet> WhenAnyDynamic<TSender, TRet>(this TSender This,
+                            Expression property1,
+                            Expression property2,
+                            Expression property3,
+                            Expression property4,
+                            Expression property5,
+                            Expression property6,
+                            Expression property7,
                             Func<IObservedChange<TSender, object>, IObservedChange<TSender, object>, IObservedChange<TSender, object>, IObservedChange<TSender, object>, IObservedChange<TSender, object>, IObservedChange<TSender, object>, IObservedChange<TSender, object>, TRet> selector)
         {
                         return Observable.CombineLatest(
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property1, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property1, false, false),
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property2, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property2, false, false),
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property3, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property3, false, false),
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property4, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property4, false, false),
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property5, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property5, false, false),
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property6, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property6, false, false),
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property7, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property7, false, false),
                                 selector
             );
                     }
@@ -637,15 +637,15 @@ namespace ReactiveUI
         /// method in constructors to set up bindings between properties that also
         /// need an initial setup.
         /// </summary>
-        public static IObservable<TRet> WhenAnyValue<TSender, TRet, T1,T2,T3,T4,T5,T6,T7,T8>(this TSender This, 
-                            Expression<Func<TSender, T1>> property1, 
-                            Expression<Func<TSender, T2>> property2, 
-                            Expression<Func<TSender, T3>> property3, 
-                            Expression<Func<TSender, T4>> property4, 
-                            Expression<Func<TSender, T5>> property5, 
-                            Expression<Func<TSender, T6>> property6, 
-                            Expression<Func<TSender, T7>> property7, 
-                            Expression<Func<TSender, T8>> property8, 
+        public static IObservable<TRet> WhenAnyValue<TSender, TRet, T1,T2,T3,T4,T5,T6,T7,T8>(this TSender This,
+                            Expression<Func<TSender, T1>> property1,
+                            Expression<Func<TSender, T2>> property2,
+                            Expression<Func<TSender, T3>> property3,
+                            Expression<Func<TSender, T4>> property4,
+                            Expression<Func<TSender, T5>> property5,
+                            Expression<Func<TSender, T6>> property6,
+                            Expression<Func<TSender, T7>> property7,
+                            Expression<Func<TSender, T8>> property8,
                             Func<T1,T2,T3,T4,T5,T6,T7,T8, TRet> selector)
         {
             return This.WhenAny(property1, property2, property3, property4, property5, property6, property7, property8,
@@ -660,31 +660,31 @@ namespace ReactiveUI
         /// constructors to set up bindings between properties that also need an
         /// initial setup.
         /// </summary>
-        public static IObservable<TRet> WhenAny<TSender, TRet, T1,T2,T3,T4,T5,T6,T7,T8>(this TSender This, 
-                            Expression<Func<TSender, T1>> property1, 
-                            Expression<Func<TSender, T2>> property2, 
-                            Expression<Func<TSender, T3>> property3, 
-                            Expression<Func<TSender, T4>> property4, 
-                            Expression<Func<TSender, T5>> property5, 
-                            Expression<Func<TSender, T6>> property6, 
-                            Expression<Func<TSender, T7>> property7, 
-                            Expression<Func<TSender, T8>> property8, 
+        public static IObservable<TRet> WhenAny<TSender, TRet, T1,T2,T3,T4,T5,T6,T7,T8>(this TSender This,
+                            Expression<Func<TSender, T1>> property1,
+                            Expression<Func<TSender, T2>> property2,
+                            Expression<Func<TSender, T3>> property3,
+                            Expression<Func<TSender, T4>> property4,
+                            Expression<Func<TSender, T5>> property5,
+                            Expression<Func<TSender, T6>> property6,
+                            Expression<Func<TSender, T7>> property7,
+                            Expression<Func<TSender, T8>> property8,
                             Func<IObservedChange<TSender, T1>, IObservedChange<TSender, T2>, IObservedChange<TSender, T3>, IObservedChange<TSender, T4>, IObservedChange<TSender, T5>, IObservedChange<TSender, T6>, IObservedChange<TSender, T7>, IObservedChange<TSender, T8>, TRet> selector)
         {
                         return Observable.CombineLatest(
-                                    This.ObservableForProperty(property1, false, false), 
-                                    This.ObservableForProperty(property2, false, false), 
-                                    This.ObservableForProperty(property3, false, false), 
-                                    This.ObservableForProperty(property4, false, false), 
-                                    This.ObservableForProperty(property5, false, false), 
-                                    This.ObservableForProperty(property6, false, false), 
-                                    This.ObservableForProperty(property7, false, false), 
-                                    This.ObservableForProperty(property8, false, false), 
+                                    This.ObservableForProperty(property1, false, false),
+                                    This.ObservableForProperty(property2, false, false),
+                                    This.ObservableForProperty(property3, false, false),
+                                    This.ObservableForProperty(property4, false, false),
+                                    This.ObservableForProperty(property5, false, false),
+                                    This.ObservableForProperty(property6, false, false),
+                                    This.ObservableForProperty(property7, false, false),
+                                    This.ObservableForProperty(property8, false, false),
                                 selector
             );
                     }
 
-		
+
         /// <summary>
         /// WhenAny allows you to observe whenever one or more properties on an
         /// object have changed, providing an initial value when the Observable
@@ -692,34 +692,34 @@ namespace ReactiveUI
         /// constructors to set up bindings between properties that also need an
         /// initial setup.
         /// </summary>
-        public static IObservable<TRet> WhenAnyDynamic<TSender, TRet>(this TSender This, 
-                            Expression property1, 
-                            Expression property2, 
-                            Expression property3, 
-                            Expression property4, 
-                            Expression property5, 
-                            Expression property6, 
-                            Expression property7, 
-                            Expression property8, 
+        public static IObservable<TRet> WhenAnyDynamic<TSender, TRet>(this TSender This,
+                            Expression property1,
+                            Expression property2,
+                            Expression property3,
+                            Expression property4,
+                            Expression property5,
+                            Expression property6,
+                            Expression property7,
+                            Expression property8,
                             Func<IObservedChange<TSender, object>, IObservedChange<TSender, object>, IObservedChange<TSender, object>, IObservedChange<TSender, object>, IObservedChange<TSender, object>, IObservedChange<TSender, object>, IObservedChange<TSender, object>, IObservedChange<TSender, object>, TRet> selector)
         {
                         return Observable.CombineLatest(
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property1, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property1, false, false),
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property2, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property2, false, false),
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property3, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property3, false, false),
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property4, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property4, false, false),
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property5, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property5, false, false),
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property6, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property6, false, false),
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property7, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property7, false, false),
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property8, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property8, false, false),
                                 selector
             );
                     }
@@ -732,16 +732,16 @@ namespace ReactiveUI
         /// method in constructors to set up bindings between properties that also
         /// need an initial setup.
         /// </summary>
-        public static IObservable<TRet> WhenAnyValue<TSender, TRet, T1,T2,T3,T4,T5,T6,T7,T8,T9>(this TSender This, 
-                            Expression<Func<TSender, T1>> property1, 
-                            Expression<Func<TSender, T2>> property2, 
-                            Expression<Func<TSender, T3>> property3, 
-                            Expression<Func<TSender, T4>> property4, 
-                            Expression<Func<TSender, T5>> property5, 
-                            Expression<Func<TSender, T6>> property6, 
-                            Expression<Func<TSender, T7>> property7, 
-                            Expression<Func<TSender, T8>> property8, 
-                            Expression<Func<TSender, T9>> property9, 
+        public static IObservable<TRet> WhenAnyValue<TSender, TRet, T1,T2,T3,T4,T5,T6,T7,T8,T9>(this TSender This,
+                            Expression<Func<TSender, T1>> property1,
+                            Expression<Func<TSender, T2>> property2,
+                            Expression<Func<TSender, T3>> property3,
+                            Expression<Func<TSender, T4>> property4,
+                            Expression<Func<TSender, T5>> property5,
+                            Expression<Func<TSender, T6>> property6,
+                            Expression<Func<TSender, T7>> property7,
+                            Expression<Func<TSender, T8>> property8,
+                            Expression<Func<TSender, T9>> property9,
                             Func<T1,T2,T3,T4,T5,T6,T7,T8,T9, TRet> selector)
         {
             return This.WhenAny(property1, property2, property3, property4, property5, property6, property7, property8, property9,
@@ -756,33 +756,33 @@ namespace ReactiveUI
         /// constructors to set up bindings between properties that also need an
         /// initial setup.
         /// </summary>
-        public static IObservable<TRet> WhenAny<TSender, TRet, T1,T2,T3,T4,T5,T6,T7,T8,T9>(this TSender This, 
-                            Expression<Func<TSender, T1>> property1, 
-                            Expression<Func<TSender, T2>> property2, 
-                            Expression<Func<TSender, T3>> property3, 
-                            Expression<Func<TSender, T4>> property4, 
-                            Expression<Func<TSender, T5>> property5, 
-                            Expression<Func<TSender, T6>> property6, 
-                            Expression<Func<TSender, T7>> property7, 
-                            Expression<Func<TSender, T8>> property8, 
-                            Expression<Func<TSender, T9>> property9, 
+        public static IObservable<TRet> WhenAny<TSender, TRet, T1,T2,T3,T4,T5,T6,T7,T8,T9>(this TSender This,
+                            Expression<Func<TSender, T1>> property1,
+                            Expression<Func<TSender, T2>> property2,
+                            Expression<Func<TSender, T3>> property3,
+                            Expression<Func<TSender, T4>> property4,
+                            Expression<Func<TSender, T5>> property5,
+                            Expression<Func<TSender, T6>> property6,
+                            Expression<Func<TSender, T7>> property7,
+                            Expression<Func<TSender, T8>> property8,
+                            Expression<Func<TSender, T9>> property9,
                             Func<IObservedChange<TSender, T1>, IObservedChange<TSender, T2>, IObservedChange<TSender, T3>, IObservedChange<TSender, T4>, IObservedChange<TSender, T5>, IObservedChange<TSender, T6>, IObservedChange<TSender, T7>, IObservedChange<TSender, T8>, IObservedChange<TSender, T9>, TRet> selector)
         {
                         return Observable.CombineLatest(
-                                    This.ObservableForProperty(property1, false, false), 
-                                    This.ObservableForProperty(property2, false, false), 
-                                    This.ObservableForProperty(property3, false, false), 
-                                    This.ObservableForProperty(property4, false, false), 
-                                    This.ObservableForProperty(property5, false, false), 
-                                    This.ObservableForProperty(property6, false, false), 
-                                    This.ObservableForProperty(property7, false, false), 
-                                    This.ObservableForProperty(property8, false, false), 
-                                    This.ObservableForProperty(property9, false, false), 
+                                    This.ObservableForProperty(property1, false, false),
+                                    This.ObservableForProperty(property2, false, false),
+                                    This.ObservableForProperty(property3, false, false),
+                                    This.ObservableForProperty(property4, false, false),
+                                    This.ObservableForProperty(property5, false, false),
+                                    This.ObservableForProperty(property6, false, false),
+                                    This.ObservableForProperty(property7, false, false),
+                                    This.ObservableForProperty(property8, false, false),
+                                    This.ObservableForProperty(property9, false, false),
                                 selector
             );
                     }
 
-		
+
         /// <summary>
         /// WhenAny allows you to observe whenever one or more properties on an
         /// object have changed, providing an initial value when the Observable
@@ -790,37 +790,37 @@ namespace ReactiveUI
         /// constructors to set up bindings between properties that also need an
         /// initial setup.
         /// </summary>
-        public static IObservable<TRet> WhenAnyDynamic<TSender, TRet>(this TSender This, 
-                            Expression property1, 
-                            Expression property2, 
-                            Expression property3, 
-                            Expression property4, 
-                            Expression property5, 
-                            Expression property6, 
-                            Expression property7, 
-                            Expression property8, 
-                            Expression property9, 
+        public static IObservable<TRet> WhenAnyDynamic<TSender, TRet>(this TSender This,
+                            Expression property1,
+                            Expression property2,
+                            Expression property3,
+                            Expression property4,
+                            Expression property5,
+                            Expression property6,
+                            Expression property7,
+                            Expression property8,
+                            Expression property9,
                             Func<IObservedChange<TSender, object>, IObservedChange<TSender, object>, IObservedChange<TSender, object>, IObservedChange<TSender, object>, IObservedChange<TSender, object>, IObservedChange<TSender, object>, IObservedChange<TSender, object>, IObservedChange<TSender, object>, IObservedChange<TSender, object>, TRet> selector)
         {
                         return Observable.CombineLatest(
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property1, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property1, false, false),
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property2, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property2, false, false),
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property3, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property3, false, false),
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property4, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property4, false, false),
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property5, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property5, false, false),
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property6, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property6, false, false),
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property7, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property7, false, false),
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property8, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property8, false, false),
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property9, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property9, false, false),
                                 selector
             );
                     }
@@ -833,17 +833,17 @@ namespace ReactiveUI
         /// method in constructors to set up bindings between properties that also
         /// need an initial setup.
         /// </summary>
-        public static IObservable<TRet> WhenAnyValue<TSender, TRet, T1,T2,T3,T4,T5,T6,T7,T8,T9,T10>(this TSender This, 
-                            Expression<Func<TSender, T1>> property1, 
-                            Expression<Func<TSender, T2>> property2, 
-                            Expression<Func<TSender, T3>> property3, 
-                            Expression<Func<TSender, T4>> property4, 
-                            Expression<Func<TSender, T5>> property5, 
-                            Expression<Func<TSender, T6>> property6, 
-                            Expression<Func<TSender, T7>> property7, 
-                            Expression<Func<TSender, T8>> property8, 
-                            Expression<Func<TSender, T9>> property9, 
-                            Expression<Func<TSender, T10>> property10, 
+        public static IObservable<TRet> WhenAnyValue<TSender, TRet, T1,T2,T3,T4,T5,T6,T7,T8,T9,T10>(this TSender This,
+                            Expression<Func<TSender, T1>> property1,
+                            Expression<Func<TSender, T2>> property2,
+                            Expression<Func<TSender, T3>> property3,
+                            Expression<Func<TSender, T4>> property4,
+                            Expression<Func<TSender, T5>> property5,
+                            Expression<Func<TSender, T6>> property6,
+                            Expression<Func<TSender, T7>> property7,
+                            Expression<Func<TSender, T8>> property8,
+                            Expression<Func<TSender, T9>> property9,
+                            Expression<Func<TSender, T10>> property10,
                             Func<T1,T2,T3,T4,T5,T6,T7,T8,T9,T10, TRet> selector)
         {
             return This.WhenAny(property1, property2, property3, property4, property5, property6, property7, property8, property9, property10,
@@ -858,35 +858,35 @@ namespace ReactiveUI
         /// constructors to set up bindings between properties that also need an
         /// initial setup.
         /// </summary>
-        public static IObservable<TRet> WhenAny<TSender, TRet, T1,T2,T3,T4,T5,T6,T7,T8,T9,T10>(this TSender This, 
-                            Expression<Func<TSender, T1>> property1, 
-                            Expression<Func<TSender, T2>> property2, 
-                            Expression<Func<TSender, T3>> property3, 
-                            Expression<Func<TSender, T4>> property4, 
-                            Expression<Func<TSender, T5>> property5, 
-                            Expression<Func<TSender, T6>> property6, 
-                            Expression<Func<TSender, T7>> property7, 
-                            Expression<Func<TSender, T8>> property8, 
-                            Expression<Func<TSender, T9>> property9, 
-                            Expression<Func<TSender, T10>> property10, 
+        public static IObservable<TRet> WhenAny<TSender, TRet, T1,T2,T3,T4,T5,T6,T7,T8,T9,T10>(this TSender This,
+                            Expression<Func<TSender, T1>> property1,
+                            Expression<Func<TSender, T2>> property2,
+                            Expression<Func<TSender, T3>> property3,
+                            Expression<Func<TSender, T4>> property4,
+                            Expression<Func<TSender, T5>> property5,
+                            Expression<Func<TSender, T6>> property6,
+                            Expression<Func<TSender, T7>> property7,
+                            Expression<Func<TSender, T8>> property8,
+                            Expression<Func<TSender, T9>> property9,
+                            Expression<Func<TSender, T10>> property10,
                             Func<IObservedChange<TSender, T1>, IObservedChange<TSender, T2>, IObservedChange<TSender, T3>, IObservedChange<TSender, T4>, IObservedChange<TSender, T5>, IObservedChange<TSender, T6>, IObservedChange<TSender, T7>, IObservedChange<TSender, T8>, IObservedChange<TSender, T9>, IObservedChange<TSender, T10>, TRet> selector)
         {
                         return Observable.CombineLatest(
-                                    This.ObservableForProperty(property1, false, false), 
-                                    This.ObservableForProperty(property2, false, false), 
-                                    This.ObservableForProperty(property3, false, false), 
-                                    This.ObservableForProperty(property4, false, false), 
-                                    This.ObservableForProperty(property5, false, false), 
-                                    This.ObservableForProperty(property6, false, false), 
-                                    This.ObservableForProperty(property7, false, false), 
-                                    This.ObservableForProperty(property8, false, false), 
-                                    This.ObservableForProperty(property9, false, false), 
-                                    This.ObservableForProperty(property10, false, false), 
+                                    This.ObservableForProperty(property1, false, false),
+                                    This.ObservableForProperty(property2, false, false),
+                                    This.ObservableForProperty(property3, false, false),
+                                    This.ObservableForProperty(property4, false, false),
+                                    This.ObservableForProperty(property5, false, false),
+                                    This.ObservableForProperty(property6, false, false),
+                                    This.ObservableForProperty(property7, false, false),
+                                    This.ObservableForProperty(property8, false, false),
+                                    This.ObservableForProperty(property9, false, false),
+                                    This.ObservableForProperty(property10, false, false),
                                 selector
             );
                     }
 
-		
+
         /// <summary>
         /// WhenAny allows you to observe whenever one or more properties on an
         /// object have changed, providing an initial value when the Observable
@@ -894,40 +894,40 @@ namespace ReactiveUI
         /// constructors to set up bindings between properties that also need an
         /// initial setup.
         /// </summary>
-        public static IObservable<TRet> WhenAnyDynamic<TSender, TRet>(this TSender This, 
-                            Expression property1, 
-                            Expression property2, 
-                            Expression property3, 
-                            Expression property4, 
-                            Expression property5, 
-                            Expression property6, 
-                            Expression property7, 
-                            Expression property8, 
-                            Expression property9, 
-                            Expression property10, 
+        public static IObservable<TRet> WhenAnyDynamic<TSender, TRet>(this TSender This,
+                            Expression property1,
+                            Expression property2,
+                            Expression property3,
+                            Expression property4,
+                            Expression property5,
+                            Expression property6,
+                            Expression property7,
+                            Expression property8,
+                            Expression property9,
+                            Expression property10,
                             Func<IObservedChange<TSender, object>, IObservedChange<TSender, object>, IObservedChange<TSender, object>, IObservedChange<TSender, object>, IObservedChange<TSender, object>, IObservedChange<TSender, object>, IObservedChange<TSender, object>, IObservedChange<TSender, object>, IObservedChange<TSender, object>, IObservedChange<TSender, object>, TRet> selector)
         {
                         return Observable.CombineLatest(
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property1, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property1, false, false),
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property2, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property2, false, false),
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property3, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property3, false, false),
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property4, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property4, false, false),
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property5, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property5, false, false),
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property6, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property6, false, false),
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property7, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property7, false, false),
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property8, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property8, false, false),
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property9, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property9, false, false),
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property10, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property10, false, false),
                                 selector
             );
                     }
@@ -940,18 +940,18 @@ namespace ReactiveUI
         /// method in constructors to set up bindings between properties that also
         /// need an initial setup.
         /// </summary>
-        public static IObservable<TRet> WhenAnyValue<TSender, TRet, T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11>(this TSender This, 
-                            Expression<Func<TSender, T1>> property1, 
-                            Expression<Func<TSender, T2>> property2, 
-                            Expression<Func<TSender, T3>> property3, 
-                            Expression<Func<TSender, T4>> property4, 
-                            Expression<Func<TSender, T5>> property5, 
-                            Expression<Func<TSender, T6>> property6, 
-                            Expression<Func<TSender, T7>> property7, 
-                            Expression<Func<TSender, T8>> property8, 
-                            Expression<Func<TSender, T9>> property9, 
-                            Expression<Func<TSender, T10>> property10, 
-                            Expression<Func<TSender, T11>> property11, 
+        public static IObservable<TRet> WhenAnyValue<TSender, TRet, T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11>(this TSender This,
+                            Expression<Func<TSender, T1>> property1,
+                            Expression<Func<TSender, T2>> property2,
+                            Expression<Func<TSender, T3>> property3,
+                            Expression<Func<TSender, T4>> property4,
+                            Expression<Func<TSender, T5>> property5,
+                            Expression<Func<TSender, T6>> property6,
+                            Expression<Func<TSender, T7>> property7,
+                            Expression<Func<TSender, T8>> property8,
+                            Expression<Func<TSender, T9>> property9,
+                            Expression<Func<TSender, T10>> property10,
+                            Expression<Func<TSender, T11>> property11,
                             Func<T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11, TRet> selector)
         {
             return This.WhenAny(property1, property2, property3, property4, property5, property6, property7, property8, property9, property10, property11,
@@ -966,37 +966,37 @@ namespace ReactiveUI
         /// constructors to set up bindings between properties that also need an
         /// initial setup.
         /// </summary>
-        public static IObservable<TRet> WhenAny<TSender, TRet, T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11>(this TSender This, 
-                            Expression<Func<TSender, T1>> property1, 
-                            Expression<Func<TSender, T2>> property2, 
-                            Expression<Func<TSender, T3>> property3, 
-                            Expression<Func<TSender, T4>> property4, 
-                            Expression<Func<TSender, T5>> property5, 
-                            Expression<Func<TSender, T6>> property6, 
-                            Expression<Func<TSender, T7>> property7, 
-                            Expression<Func<TSender, T8>> property8, 
-                            Expression<Func<TSender, T9>> property9, 
-                            Expression<Func<TSender, T10>> property10, 
-                            Expression<Func<TSender, T11>> property11, 
+        public static IObservable<TRet> WhenAny<TSender, TRet, T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11>(this TSender This,
+                            Expression<Func<TSender, T1>> property1,
+                            Expression<Func<TSender, T2>> property2,
+                            Expression<Func<TSender, T3>> property3,
+                            Expression<Func<TSender, T4>> property4,
+                            Expression<Func<TSender, T5>> property5,
+                            Expression<Func<TSender, T6>> property6,
+                            Expression<Func<TSender, T7>> property7,
+                            Expression<Func<TSender, T8>> property8,
+                            Expression<Func<TSender, T9>> property9,
+                            Expression<Func<TSender, T10>> property10,
+                            Expression<Func<TSender, T11>> property11,
                             Func<IObservedChange<TSender, T1>, IObservedChange<TSender, T2>, IObservedChange<TSender, T3>, IObservedChange<TSender, T4>, IObservedChange<TSender, T5>, IObservedChange<TSender, T6>, IObservedChange<TSender, T7>, IObservedChange<TSender, T8>, IObservedChange<TSender, T9>, IObservedChange<TSender, T10>, IObservedChange<TSender, T11>, TRet> selector)
         {
                         return Observable.CombineLatest(
-                                    This.ObservableForProperty(property1, false, false), 
-                                    This.ObservableForProperty(property2, false, false), 
-                                    This.ObservableForProperty(property3, false, false), 
-                                    This.ObservableForProperty(property4, false, false), 
-                                    This.ObservableForProperty(property5, false, false), 
-                                    This.ObservableForProperty(property6, false, false), 
-                                    This.ObservableForProperty(property7, false, false), 
-                                    This.ObservableForProperty(property8, false, false), 
-                                    This.ObservableForProperty(property9, false, false), 
-                                    This.ObservableForProperty(property10, false, false), 
-                                    This.ObservableForProperty(property11, false, false), 
+                                    This.ObservableForProperty(property1, false, false),
+                                    This.ObservableForProperty(property2, false, false),
+                                    This.ObservableForProperty(property3, false, false),
+                                    This.ObservableForProperty(property4, false, false),
+                                    This.ObservableForProperty(property5, false, false),
+                                    This.ObservableForProperty(property6, false, false),
+                                    This.ObservableForProperty(property7, false, false),
+                                    This.ObservableForProperty(property8, false, false),
+                                    This.ObservableForProperty(property9, false, false),
+                                    This.ObservableForProperty(property10, false, false),
+                                    This.ObservableForProperty(property11, false, false),
                                 selector
             );
                     }
 
-		
+
         /// <summary>
         /// WhenAny allows you to observe whenever one or more properties on an
         /// object have changed, providing an initial value when the Observable
@@ -1004,43 +1004,43 @@ namespace ReactiveUI
         /// constructors to set up bindings between properties that also need an
         /// initial setup.
         /// </summary>
-        public static IObservable<TRet> WhenAnyDynamic<TSender, TRet>(this TSender This, 
-                            Expression property1, 
-                            Expression property2, 
-                            Expression property3, 
-                            Expression property4, 
-                            Expression property5, 
-                            Expression property6, 
-                            Expression property7, 
-                            Expression property8, 
-                            Expression property9, 
-                            Expression property10, 
-                            Expression property11, 
+        public static IObservable<TRet> WhenAnyDynamic<TSender, TRet>(this TSender This,
+                            Expression property1,
+                            Expression property2,
+                            Expression property3,
+                            Expression property4,
+                            Expression property5,
+                            Expression property6,
+                            Expression property7,
+                            Expression property8,
+                            Expression property9,
+                            Expression property10,
+                            Expression property11,
                             Func<IObservedChange<TSender, object>, IObservedChange<TSender, object>, IObservedChange<TSender, object>, IObservedChange<TSender, object>, IObservedChange<TSender, object>, IObservedChange<TSender, object>, IObservedChange<TSender, object>, IObservedChange<TSender, object>, IObservedChange<TSender, object>, IObservedChange<TSender, object>, IObservedChange<TSender, object>, TRet> selector)
         {
                         return Observable.CombineLatest(
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property1, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property1, false, false),
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property2, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property2, false, false),
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property3, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property3, false, false),
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property4, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property4, false, false),
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property5, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property5, false, false),
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property6, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property6, false, false),
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property7, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property7, false, false),
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property8, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property8, false, false),
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property9, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property9, false, false),
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property10, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property10, false, false),
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property11, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property11, false, false),
                                 selector
             );
                     }
@@ -1053,19 +1053,19 @@ namespace ReactiveUI
         /// method in constructors to set up bindings between properties that also
         /// need an initial setup.
         /// </summary>
-        public static IObservable<TRet> WhenAnyValue<TSender, TRet, T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12>(this TSender This, 
-                            Expression<Func<TSender, T1>> property1, 
-                            Expression<Func<TSender, T2>> property2, 
-                            Expression<Func<TSender, T3>> property3, 
-                            Expression<Func<TSender, T4>> property4, 
-                            Expression<Func<TSender, T5>> property5, 
-                            Expression<Func<TSender, T6>> property6, 
-                            Expression<Func<TSender, T7>> property7, 
-                            Expression<Func<TSender, T8>> property8, 
-                            Expression<Func<TSender, T9>> property9, 
-                            Expression<Func<TSender, T10>> property10, 
-                            Expression<Func<TSender, T11>> property11, 
-                            Expression<Func<TSender, T12>> property12, 
+        public static IObservable<TRet> WhenAnyValue<TSender, TRet, T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12>(this TSender This,
+                            Expression<Func<TSender, T1>> property1,
+                            Expression<Func<TSender, T2>> property2,
+                            Expression<Func<TSender, T3>> property3,
+                            Expression<Func<TSender, T4>> property4,
+                            Expression<Func<TSender, T5>> property5,
+                            Expression<Func<TSender, T6>> property6,
+                            Expression<Func<TSender, T7>> property7,
+                            Expression<Func<TSender, T8>> property8,
+                            Expression<Func<TSender, T9>> property9,
+                            Expression<Func<TSender, T10>> property10,
+                            Expression<Func<TSender, T11>> property11,
+                            Expression<Func<TSender, T12>> property12,
                             Func<T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12, TRet> selector)
         {
             return This.WhenAny(property1, property2, property3, property4, property5, property6, property7, property8, property9, property10, property11, property12,
@@ -1080,39 +1080,39 @@ namespace ReactiveUI
         /// constructors to set up bindings between properties that also need an
         /// initial setup.
         /// </summary>
-        public static IObservable<TRet> WhenAny<TSender, TRet, T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12>(this TSender This, 
-                            Expression<Func<TSender, T1>> property1, 
-                            Expression<Func<TSender, T2>> property2, 
-                            Expression<Func<TSender, T3>> property3, 
-                            Expression<Func<TSender, T4>> property4, 
-                            Expression<Func<TSender, T5>> property5, 
-                            Expression<Func<TSender, T6>> property6, 
-                            Expression<Func<TSender, T7>> property7, 
-                            Expression<Func<TSender, T8>> property8, 
-                            Expression<Func<TSender, T9>> property9, 
-                            Expression<Func<TSender, T10>> property10, 
-                            Expression<Func<TSender, T11>> property11, 
-                            Expression<Func<TSender, T12>> property12, 
+        public static IObservable<TRet> WhenAny<TSender, TRet, T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12>(this TSender This,
+                            Expression<Func<TSender, T1>> property1,
+                            Expression<Func<TSender, T2>> property2,
+                            Expression<Func<TSender, T3>> property3,
+                            Expression<Func<TSender, T4>> property4,
+                            Expression<Func<TSender, T5>> property5,
+                            Expression<Func<TSender, T6>> property6,
+                            Expression<Func<TSender, T7>> property7,
+                            Expression<Func<TSender, T8>> property8,
+                            Expression<Func<TSender, T9>> property9,
+                            Expression<Func<TSender, T10>> property10,
+                            Expression<Func<TSender, T11>> property11,
+                            Expression<Func<TSender, T12>> property12,
                             Func<IObservedChange<TSender, T1>, IObservedChange<TSender, T2>, IObservedChange<TSender, T3>, IObservedChange<TSender, T4>, IObservedChange<TSender, T5>, IObservedChange<TSender, T6>, IObservedChange<TSender, T7>, IObservedChange<TSender, T8>, IObservedChange<TSender, T9>, IObservedChange<TSender, T10>, IObservedChange<TSender, T11>, IObservedChange<TSender, T12>, TRet> selector)
         {
                         return Observable.CombineLatest(
-                                    This.ObservableForProperty(property1, false, false), 
-                                    This.ObservableForProperty(property2, false, false), 
-                                    This.ObservableForProperty(property3, false, false), 
-                                    This.ObservableForProperty(property4, false, false), 
-                                    This.ObservableForProperty(property5, false, false), 
-                                    This.ObservableForProperty(property6, false, false), 
-                                    This.ObservableForProperty(property7, false, false), 
-                                    This.ObservableForProperty(property8, false, false), 
-                                    This.ObservableForProperty(property9, false, false), 
-                                    This.ObservableForProperty(property10, false, false), 
-                                    This.ObservableForProperty(property11, false, false), 
-                                    This.ObservableForProperty(property12, false, false), 
+                                    This.ObservableForProperty(property1, false, false),
+                                    This.ObservableForProperty(property2, false, false),
+                                    This.ObservableForProperty(property3, false, false),
+                                    This.ObservableForProperty(property4, false, false),
+                                    This.ObservableForProperty(property5, false, false),
+                                    This.ObservableForProperty(property6, false, false),
+                                    This.ObservableForProperty(property7, false, false),
+                                    This.ObservableForProperty(property8, false, false),
+                                    This.ObservableForProperty(property9, false, false),
+                                    This.ObservableForProperty(property10, false, false),
+                                    This.ObservableForProperty(property11, false, false),
+                                    This.ObservableForProperty(property12, false, false),
                                 selector
             );
                     }
 
-		
+
         /// <summary>
         /// WhenAny allows you to observe whenever one or more properties on an
         /// object have changed, providing an initial value when the Observable
@@ -1120,46 +1120,46 @@ namespace ReactiveUI
         /// constructors to set up bindings between properties that also need an
         /// initial setup.
         /// </summary>
-        public static IObservable<TRet> WhenAnyDynamic<TSender, TRet>(this TSender This, 
-                            Expression property1, 
-                            Expression property2, 
-                            Expression property3, 
-                            Expression property4, 
-                            Expression property5, 
-                            Expression property6, 
-                            Expression property7, 
-                            Expression property8, 
-                            Expression property9, 
-                            Expression property10, 
-                            Expression property11, 
-                            Expression property12, 
+        public static IObservable<TRet> WhenAnyDynamic<TSender, TRet>(this TSender This,
+                            Expression property1,
+                            Expression property2,
+                            Expression property3,
+                            Expression property4,
+                            Expression property5,
+                            Expression property6,
+                            Expression property7,
+                            Expression property8,
+                            Expression property9,
+                            Expression property10,
+                            Expression property11,
+                            Expression property12,
                             Func<IObservedChange<TSender, object>, IObservedChange<TSender, object>, IObservedChange<TSender, object>, IObservedChange<TSender, object>, IObservedChange<TSender, object>, IObservedChange<TSender, object>, IObservedChange<TSender, object>, IObservedChange<TSender, object>, IObservedChange<TSender, object>, IObservedChange<TSender, object>, IObservedChange<TSender, object>, IObservedChange<TSender, object>, TRet> selector)
         {
                         return Observable.CombineLatest(
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property1, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property1, false, false),
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property2, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property2, false, false),
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property3, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property3, false, false),
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property4, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property4, false, false),
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property5, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property5, false, false),
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property6, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property6, false, false),
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property7, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property7, false, false),
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property8, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property8, false, false),
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property9, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property9, false, false),
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property10, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property10, false, false),
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property11, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property11, false, false),
                                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property12, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property12, false, false),
                                 selector
             );
                     }
@@ -1174,60 +1174,204 @@ namespace ReactiveUI
 
         public static IObservable<TRet> WhenAnyObservable<TSender, TRet>(this TSender This, Expression<Func<TSender, IObservable<TRet>>> obs1, Expression<Func<TSender, IObservable<TRet>>> obs2)
         {
-            return This.WhenAny(obs1, obs2, (o1, o2) => new[] {o1.Value.EmptyIfNull(), o2.Value.EmptyIfNull() })
+            return This.WhenAny(obs1, obs2, (o1, o2) => new[] {o1.Value.EmptyIfNull(), o2.Value.EmptyIfNull()})
                 .Select(x => x.Merge()).Switch();
         }
         public static IObservable<TRet> WhenAnyObservable<TSender, TRet>(this TSender This, Expression<Func<TSender, IObservable<TRet>>> obs1, Expression<Func<TSender, IObservable<TRet>>> obs2, Expression<Func<TSender, IObservable<TRet>>> obs3)
         {
-            return This.WhenAny(obs1, obs2, obs3, (o1, o2, o3) => new[] {o1.Value.EmptyIfNull(), o2.Value.EmptyIfNull(), o3.Value.EmptyIfNull() })
+            return This.WhenAny(obs1, obs2, obs3, (o1, o2, o3) => new[] {o1.Value.EmptyIfNull(), o2.Value.EmptyIfNull(), o3.Value.EmptyIfNull()})
                 .Select(x => x.Merge()).Switch();
         }
         public static IObservable<TRet> WhenAnyObservable<TSender, TRet>(this TSender This, Expression<Func<TSender, IObservable<TRet>>> obs1, Expression<Func<TSender, IObservable<TRet>>> obs2, Expression<Func<TSender, IObservable<TRet>>> obs3, Expression<Func<TSender, IObservable<TRet>>> obs4)
         {
-            return This.WhenAny(obs1, obs2, obs3, obs4, (o1, o2, o3, o4) => new[] {o1.Value.EmptyIfNull(), o2.Value.EmptyIfNull(), o3.Value.EmptyIfNull(), o4.Value.EmptyIfNull() })
+            return This.WhenAny(obs1, obs2, obs3, obs4, (o1, o2, o3, o4) => new[] {o1.Value.EmptyIfNull(), o2.Value.EmptyIfNull(), o3.Value.EmptyIfNull(), o4.Value.EmptyIfNull()})
                 .Select(x => x.Merge()).Switch();
         }
         public static IObservable<TRet> WhenAnyObservable<TSender, TRet>(this TSender This, Expression<Func<TSender, IObservable<TRet>>> obs1, Expression<Func<TSender, IObservable<TRet>>> obs2, Expression<Func<TSender, IObservable<TRet>>> obs3, Expression<Func<TSender, IObservable<TRet>>> obs4, Expression<Func<TSender, IObservable<TRet>>> obs5)
         {
-            return This.WhenAny(obs1, obs2, obs3, obs4, obs5, (o1, o2, o3, o4, o5) => new[] {o1.Value.EmptyIfNull(), o2.Value.EmptyIfNull(), o3.Value.EmptyIfNull(), o4.Value.EmptyIfNull(), o5.Value.EmptyIfNull() })
+            return This.WhenAny(obs1, obs2, obs3, obs4, obs5, (o1, o2, o3, o4, o5) => new[] {o1.Value.EmptyIfNull(), o2.Value.EmptyIfNull(), o3.Value.EmptyIfNull(), o4.Value.EmptyIfNull(), o5.Value.EmptyIfNull()})
                 .Select(x => x.Merge()).Switch();
         }
         public static IObservable<TRet> WhenAnyObservable<TSender, TRet>(this TSender This, Expression<Func<TSender, IObservable<TRet>>> obs1, Expression<Func<TSender, IObservable<TRet>>> obs2, Expression<Func<TSender, IObservable<TRet>>> obs3, Expression<Func<TSender, IObservable<TRet>>> obs4, Expression<Func<TSender, IObservable<TRet>>> obs5, Expression<Func<TSender, IObservable<TRet>>> obs6)
         {
-            return This.WhenAny(obs1, obs2, obs3, obs4, obs5, obs6, (o1, o2, o3, o4, o5, o6) => new[] {o1.Value.EmptyIfNull(), o2.Value.EmptyIfNull(), o3.Value.EmptyIfNull(), o4.Value.EmptyIfNull(), o5.Value.EmptyIfNull(), o6.Value.EmptyIfNull() })
+            return This.WhenAny(obs1, obs2, obs3, obs4, obs5, obs6, (o1, o2, o3, o4, o5, o6) => new[] {o1.Value.EmptyIfNull(), o2.Value.EmptyIfNull(), o3.Value.EmptyIfNull(), o4.Value.EmptyIfNull(), o5.Value.EmptyIfNull(), o6.Value.EmptyIfNull()})
                 .Select(x => x.Merge()).Switch();
         }
         public static IObservable<TRet> WhenAnyObservable<TSender, TRet>(this TSender This, Expression<Func<TSender, IObservable<TRet>>> obs1, Expression<Func<TSender, IObservable<TRet>>> obs2, Expression<Func<TSender, IObservable<TRet>>> obs3, Expression<Func<TSender, IObservable<TRet>>> obs4, Expression<Func<TSender, IObservable<TRet>>> obs5, Expression<Func<TSender, IObservable<TRet>>> obs6, Expression<Func<TSender, IObservable<TRet>>> obs7)
         {
-            return This.WhenAny(obs1, obs2, obs3, obs4, obs5, obs6, obs7, (o1, o2, o3, o4, o5, o6, o7) => new[] {o1.Value.EmptyIfNull(), o2.Value.EmptyIfNull(), o3.Value.EmptyIfNull(), o4.Value.EmptyIfNull(), o5.Value.EmptyIfNull(), o6.Value.EmptyIfNull(), o7.Value.EmptyIfNull() })
+            return This.WhenAny(obs1, obs2, obs3, obs4, obs5, obs6, obs7, (o1, o2, o3, o4, o5, o6, o7) => new[] {o1.Value.EmptyIfNull(), o2.Value.EmptyIfNull(), o3.Value.EmptyIfNull(), o4.Value.EmptyIfNull(), o5.Value.EmptyIfNull(), o6.Value.EmptyIfNull(), o7.Value.EmptyIfNull()})
                 .Select(x => x.Merge()).Switch();
         }
         public static IObservable<TRet> WhenAnyObservable<TSender, TRet>(this TSender This, Expression<Func<TSender, IObservable<TRet>>> obs1, Expression<Func<TSender, IObservable<TRet>>> obs2, Expression<Func<TSender, IObservable<TRet>>> obs3, Expression<Func<TSender, IObservable<TRet>>> obs4, Expression<Func<TSender, IObservable<TRet>>> obs5, Expression<Func<TSender, IObservable<TRet>>> obs6, Expression<Func<TSender, IObservable<TRet>>> obs7, Expression<Func<TSender, IObservable<TRet>>> obs8)
         {
-            return This.WhenAny(obs1, obs2, obs3, obs4, obs5, obs6, obs7, obs8, (o1, o2, o3, o4, o5, o6, o7, o8) => new[] {o1.Value.EmptyIfNull(), o2.Value.EmptyIfNull(), o3.Value.EmptyIfNull(), o4.Value.EmptyIfNull(), o5.Value.EmptyIfNull(), o6.Value.EmptyIfNull(), o7.Value.EmptyIfNull(), o8.Value.EmptyIfNull() })
+            return This.WhenAny(obs1, obs2, obs3, obs4, obs5, obs6, obs7, obs8, (o1, o2, o3, o4, o5, o6, o7, o8) => new[] {o1.Value.EmptyIfNull(), o2.Value.EmptyIfNull(), o3.Value.EmptyIfNull(), o4.Value.EmptyIfNull(), o5.Value.EmptyIfNull(), o6.Value.EmptyIfNull(), o7.Value.EmptyIfNull(), o8.Value.EmptyIfNull()})
                 .Select(x => x.Merge()).Switch();
         }
         public static IObservable<TRet> WhenAnyObservable<TSender, TRet>(this TSender This, Expression<Func<TSender, IObservable<TRet>>> obs1, Expression<Func<TSender, IObservable<TRet>>> obs2, Expression<Func<TSender, IObservable<TRet>>> obs3, Expression<Func<TSender, IObservable<TRet>>> obs4, Expression<Func<TSender, IObservable<TRet>>> obs5, Expression<Func<TSender, IObservable<TRet>>> obs6, Expression<Func<TSender, IObservable<TRet>>> obs7, Expression<Func<TSender, IObservable<TRet>>> obs8, Expression<Func<TSender, IObservable<TRet>>> obs9)
         {
-            return This.WhenAny(obs1, obs2, obs3, obs4, obs5, obs6, obs7, obs8, obs9, (o1, o2, o3, o4, o5, o6, o7, o8, o9) => new[] {o1.Value.EmptyIfNull(), o2.Value.EmptyIfNull(), o3.Value.EmptyIfNull(), o4.Value.EmptyIfNull(), o5.Value.EmptyIfNull(), o6.Value.EmptyIfNull(), o7.Value.EmptyIfNull(), o8.Value.EmptyIfNull(), o9.Value.EmptyIfNull() })
+            return This.WhenAny(obs1, obs2, obs3, obs4, obs5, obs6, obs7, obs8, obs9, (o1, o2, o3, o4, o5, o6, o7, o8, o9) => new[] {o1.Value.EmptyIfNull(), o2.Value.EmptyIfNull(), o3.Value.EmptyIfNull(), o4.Value.EmptyIfNull(), o5.Value.EmptyIfNull(), o6.Value.EmptyIfNull(), o7.Value.EmptyIfNull(), o8.Value.EmptyIfNull(), o9.Value.EmptyIfNull()})
                 .Select(x => x.Merge()).Switch();
         }
         public static IObservable<TRet> WhenAnyObservable<TSender, TRet>(this TSender This, Expression<Func<TSender, IObservable<TRet>>> obs1, Expression<Func<TSender, IObservable<TRet>>> obs2, Expression<Func<TSender, IObservable<TRet>>> obs3, Expression<Func<TSender, IObservable<TRet>>> obs4, Expression<Func<TSender, IObservable<TRet>>> obs5, Expression<Func<TSender, IObservable<TRet>>> obs6, Expression<Func<TSender, IObservable<TRet>>> obs7, Expression<Func<TSender, IObservable<TRet>>> obs8, Expression<Func<TSender, IObservable<TRet>>> obs9, Expression<Func<TSender, IObservable<TRet>>> obs10)
         {
-            return This.WhenAny(obs1, obs2, obs3, obs4, obs5, obs6, obs7, obs8, obs9, obs10, (o1, o2, o3, o4, o5, o6, o7, o8, o9, o10) => new[] {o1.Value.EmptyIfNull(), o2.Value.EmptyIfNull(), o3.Value.EmptyIfNull(), o4.Value.EmptyIfNull(), o5.Value.EmptyIfNull(), o6.Value.EmptyIfNull(), o7.Value.EmptyIfNull(), o8.Value.EmptyIfNull(), o9.Value.EmptyIfNull(), o10.Value.EmptyIfNull() })
+            return This.WhenAny(obs1, obs2, obs3, obs4, obs5, obs6, obs7, obs8, obs9, obs10, (o1, o2, o3, o4, o5, o6, o7, o8, o9, o10) => new[] {o1.Value.EmptyIfNull(), o2.Value.EmptyIfNull(), o3.Value.EmptyIfNull(), o4.Value.EmptyIfNull(), o5.Value.EmptyIfNull(), o6.Value.EmptyIfNull(), o7.Value.EmptyIfNull(), o8.Value.EmptyIfNull(), o9.Value.EmptyIfNull(), o10.Value.EmptyIfNull()})
                 .Select(x => x.Merge()).Switch();
         }
         public static IObservable<TRet> WhenAnyObservable<TSender, TRet>(this TSender This, Expression<Func<TSender, IObservable<TRet>>> obs1, Expression<Func<TSender, IObservable<TRet>>> obs2, Expression<Func<TSender, IObservable<TRet>>> obs3, Expression<Func<TSender, IObservable<TRet>>> obs4, Expression<Func<TSender, IObservable<TRet>>> obs5, Expression<Func<TSender, IObservable<TRet>>> obs6, Expression<Func<TSender, IObservable<TRet>>> obs7, Expression<Func<TSender, IObservable<TRet>>> obs8, Expression<Func<TSender, IObservable<TRet>>> obs9, Expression<Func<TSender, IObservable<TRet>>> obs10, Expression<Func<TSender, IObservable<TRet>>> obs11)
         {
-            return This.WhenAny(obs1, obs2, obs3, obs4, obs5, obs6, obs7, obs8, obs9, obs10, obs11, (o1, o2, o3, o4, o5, o6, o7, o8, o9, o10, o11) => new[] {o1.Value.EmptyIfNull(), o2.Value.EmptyIfNull(), o3.Value.EmptyIfNull(), o4.Value.EmptyIfNull(), o5.Value.EmptyIfNull(), o6.Value.EmptyIfNull(), o7.Value.EmptyIfNull(), o8.Value.EmptyIfNull(), o9.Value.EmptyIfNull(), o10.Value.EmptyIfNull(), o11.Value.EmptyIfNull() })
+            return This.WhenAny(obs1, obs2, obs3, obs4, obs5, obs6, obs7, obs8, obs9, obs10, obs11, (o1, o2, o3, o4, o5, o6, o7, o8, o9, o10, o11) => new[] {o1.Value.EmptyIfNull(), o2.Value.EmptyIfNull(), o3.Value.EmptyIfNull(), o4.Value.EmptyIfNull(), o5.Value.EmptyIfNull(), o6.Value.EmptyIfNull(), o7.Value.EmptyIfNull(), o8.Value.EmptyIfNull(), o9.Value.EmptyIfNull(), o10.Value.EmptyIfNull(), o11.Value.EmptyIfNull()})
                 .Select(x => x.Merge()).Switch();
         }
         public static IObservable<TRet> WhenAnyObservable<TSender, TRet>(this TSender This, Expression<Func<TSender, IObservable<TRet>>> obs1, Expression<Func<TSender, IObservable<TRet>>> obs2, Expression<Func<TSender, IObservable<TRet>>> obs3, Expression<Func<TSender, IObservable<TRet>>> obs4, Expression<Func<TSender, IObservable<TRet>>> obs5, Expression<Func<TSender, IObservable<TRet>>> obs6, Expression<Func<TSender, IObservable<TRet>>> obs7, Expression<Func<TSender, IObservable<TRet>>> obs8, Expression<Func<TSender, IObservable<TRet>>> obs9, Expression<Func<TSender, IObservable<TRet>>> obs10, Expression<Func<TSender, IObservable<TRet>>> obs11, Expression<Func<TSender, IObservable<TRet>>> obs12)
         {
-            return This.WhenAny(obs1, obs2, obs3, obs4, obs5, obs6, obs7, obs8, obs9, obs10, obs11, obs12, (o1, o2, o3, o4, o5, o6, o7, o8, o9, o10, o11, o12) => new[] {o1.Value.EmptyIfNull(), o2.Value.EmptyIfNull(), o3.Value.EmptyIfNull(), o4.Value.EmptyIfNull(), o5.Value.EmptyIfNull(), o6.Value.EmptyIfNull(), o7.Value.EmptyIfNull(), o8.Value.EmptyIfNull(), o9.Value.EmptyIfNull(), o10.Value.EmptyIfNull(), o11.Value.EmptyIfNull(), o12.Value.EmptyIfNull() })
+            return This.WhenAny(obs1, obs2, obs3, obs4, obs5, obs6, obs7, obs8, obs9, obs10, obs11, obs12, (o1, o2, o3, o4, o5, o6, o7, o8, o9, o10, o11, o12) => new[] {o1.Value.EmptyIfNull(), o2.Value.EmptyIfNull(), o3.Value.EmptyIfNull(), o4.Value.EmptyIfNull(), o5.Value.EmptyIfNull(), o6.Value.EmptyIfNull(), o7.Value.EmptyIfNull(), o8.Value.EmptyIfNull(), o9.Value.EmptyIfNull(), o10.Value.EmptyIfNull(), o11.Value.EmptyIfNull(), o12.Value.EmptyIfNull()})
                 .Select(x => x.Merge()).Switch();
         }
-    }
+
+        public static IObservable<TRet> WhenAnyObservable<TSender, TRet, T1,T2>(this TSender This,
+                            Expression<Func<TSender, IObservable<T1>>> obs1,
+                            Expression<Func<TSender, IObservable<T2>>> obs2,
+                            Func<T1, T2, TRet> selector)
+        {
+            return This.WhenAny(obs1, obs2, (o1, o2) => Observable.CombineLatest(o1.Value.EmptyIfNull(), o2.Value.EmptyIfNull(), selector))
+                .Switch();
+        }
+        public static IObservable<TRet> WhenAnyObservable<TSender, TRet, T1,T2,T3>(this TSender This,
+                            Expression<Func<TSender, IObservable<T1>>> obs1,
+                            Expression<Func<TSender, IObservable<T2>>> obs2,
+                            Expression<Func<TSender, IObservable<T3>>> obs3,
+                            Func<T1, T2, T3, TRet> selector)
+        {
+            return This.WhenAny(obs1, obs2, obs3, (o1, o2, o3) => Observable.CombineLatest(o1.Value.EmptyIfNull(), o2.Value.EmptyIfNull(), o3.Value.EmptyIfNull(), selector))
+                .Switch();
+        }
+        public static IObservable<TRet> WhenAnyObservable<TSender, TRet, T1,T2,T3,T4>(this TSender This,
+                            Expression<Func<TSender, IObservable<T1>>> obs1,
+                            Expression<Func<TSender, IObservable<T2>>> obs2,
+                            Expression<Func<TSender, IObservable<T3>>> obs3,
+                            Expression<Func<TSender, IObservable<T4>>> obs4,
+                            Func<T1, T2, T3, T4, TRet> selector)
+        {
+            return This.WhenAny(obs1, obs2, obs3, obs4, (o1, o2, o3, o4) => Observable.CombineLatest(o1.Value.EmptyIfNull(), o2.Value.EmptyIfNull(), o3.Value.EmptyIfNull(), o4.Value.EmptyIfNull(), selector))
+                .Switch();
+        }
+        public static IObservable<TRet> WhenAnyObservable<TSender, TRet, T1,T2,T3,T4,T5>(this TSender This,
+                            Expression<Func<TSender, IObservable<T1>>> obs1,
+                            Expression<Func<TSender, IObservable<T2>>> obs2,
+                            Expression<Func<TSender, IObservable<T3>>> obs3,
+                            Expression<Func<TSender, IObservable<T4>>> obs4,
+                            Expression<Func<TSender, IObservable<T5>>> obs5,
+                            Func<T1, T2, T3, T4, T5, TRet> selector)
+        {
+            return This.WhenAny(obs1, obs2, obs3, obs4, obs5, (o1, o2, o3, o4, o5) => Observable.CombineLatest(o1.Value.EmptyIfNull(), o2.Value.EmptyIfNull(), o3.Value.EmptyIfNull(), o4.Value.EmptyIfNull(), o5.Value.EmptyIfNull(), selector))
+                .Switch();
+        }
+        public static IObservable<TRet> WhenAnyObservable<TSender, TRet, T1,T2,T3,T4,T5,T6>(this TSender This,
+                            Expression<Func<TSender, IObservable<T1>>> obs1,
+                            Expression<Func<TSender, IObservable<T2>>> obs2,
+                            Expression<Func<TSender, IObservable<T3>>> obs3,
+                            Expression<Func<TSender, IObservable<T4>>> obs4,
+                            Expression<Func<TSender, IObservable<T5>>> obs5,
+                            Expression<Func<TSender, IObservable<T6>>> obs6,
+                            Func<T1, T2, T3, T4, T5, T6, TRet> selector)
+        {
+            return This.WhenAny(obs1, obs2, obs3, obs4, obs5, obs6, (o1, o2, o3, o4, o5, o6) => Observable.CombineLatest(o1.Value.EmptyIfNull(), o2.Value.EmptyIfNull(), o3.Value.EmptyIfNull(), o4.Value.EmptyIfNull(), o5.Value.EmptyIfNull(), o6.Value.EmptyIfNull(), selector))
+                .Switch();
+        }
+        public static IObservable<TRet> WhenAnyObservable<TSender, TRet, T1,T2,T3,T4,T5,T6,T7>(this TSender This,
+                            Expression<Func<TSender, IObservable<T1>>> obs1,
+                            Expression<Func<TSender, IObservable<T2>>> obs2,
+                            Expression<Func<TSender, IObservable<T3>>> obs3,
+                            Expression<Func<TSender, IObservable<T4>>> obs4,
+                            Expression<Func<TSender, IObservable<T5>>> obs5,
+                            Expression<Func<TSender, IObservable<T6>>> obs6,
+                            Expression<Func<TSender, IObservable<T7>>> obs7,
+                            Func<T1, T2, T3, T4, T5, T6, T7, TRet> selector)
+        {
+            return This.WhenAny(obs1, obs2, obs3, obs4, obs5, obs6, obs7, (o1, o2, o3, o4, o5, o6, o7) => Observable.CombineLatest(o1.Value.EmptyIfNull(), o2.Value.EmptyIfNull(), o3.Value.EmptyIfNull(), o4.Value.EmptyIfNull(), o5.Value.EmptyIfNull(), o6.Value.EmptyIfNull(), o7.Value.EmptyIfNull(), selector))
+                .Switch();
+        }
+        public static IObservable<TRet> WhenAnyObservable<TSender, TRet, T1,T2,T3,T4,T5,T6,T7,T8>(this TSender This,
+                            Expression<Func<TSender, IObservable<T1>>> obs1,
+                            Expression<Func<TSender, IObservable<T2>>> obs2,
+                            Expression<Func<TSender, IObservable<T3>>> obs3,
+                            Expression<Func<TSender, IObservable<T4>>> obs4,
+                            Expression<Func<TSender, IObservable<T5>>> obs5,
+                            Expression<Func<TSender, IObservable<T6>>> obs6,
+                            Expression<Func<TSender, IObservable<T7>>> obs7,
+                            Expression<Func<TSender, IObservable<T8>>> obs8,
+                            Func<T1, T2, T3, T4, T5, T6, T7, T8, TRet> selector)
+        {
+            return This.WhenAny(obs1, obs2, obs3, obs4, obs5, obs6, obs7, obs8, (o1, o2, o3, o4, o5, o6, o7, o8) => Observable.CombineLatest(o1.Value.EmptyIfNull(), o2.Value.EmptyIfNull(), o3.Value.EmptyIfNull(), o4.Value.EmptyIfNull(), o5.Value.EmptyIfNull(), o6.Value.EmptyIfNull(), o7.Value.EmptyIfNull(), o8.Value.EmptyIfNull(), selector))
+                .Switch();
+        }
+        public static IObservable<TRet> WhenAnyObservable<TSender, TRet, T1,T2,T3,T4,T5,T6,T7,T8,T9>(this TSender This,
+                            Expression<Func<TSender, IObservable<T1>>> obs1,
+                            Expression<Func<TSender, IObservable<T2>>> obs2,
+                            Expression<Func<TSender, IObservable<T3>>> obs3,
+                            Expression<Func<TSender, IObservable<T4>>> obs4,
+                            Expression<Func<TSender, IObservable<T5>>> obs5,
+                            Expression<Func<TSender, IObservable<T6>>> obs6,
+                            Expression<Func<TSender, IObservable<T7>>> obs7,
+                            Expression<Func<TSender, IObservable<T8>>> obs8,
+                            Expression<Func<TSender, IObservable<T9>>> obs9,
+                            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TRet> selector)
+        {
+            return This.WhenAny(obs1, obs2, obs3, obs4, obs5, obs6, obs7, obs8, obs9, (o1, o2, o3, o4, o5, o6, o7, o8, o9) => Observable.CombineLatest(o1.Value.EmptyIfNull(), o2.Value.EmptyIfNull(), o3.Value.EmptyIfNull(), o4.Value.EmptyIfNull(), o5.Value.EmptyIfNull(), o6.Value.EmptyIfNull(), o7.Value.EmptyIfNull(), o8.Value.EmptyIfNull(), o9.Value.EmptyIfNull(), selector))
+                .Switch();
+        }
+        public static IObservable<TRet> WhenAnyObservable<TSender, TRet, T1,T2,T3,T4,T5,T6,T7,T8,T9,T10>(this TSender This,
+                            Expression<Func<TSender, IObservable<T1>>> obs1,
+                            Expression<Func<TSender, IObservable<T2>>> obs2,
+                            Expression<Func<TSender, IObservable<T3>>> obs3,
+                            Expression<Func<TSender, IObservable<T4>>> obs4,
+                            Expression<Func<TSender, IObservable<T5>>> obs5,
+                            Expression<Func<TSender, IObservable<T6>>> obs6,
+                            Expression<Func<TSender, IObservable<T7>>> obs7,
+                            Expression<Func<TSender, IObservable<T8>>> obs8,
+                            Expression<Func<TSender, IObservable<T9>>> obs9,
+                            Expression<Func<TSender, IObservable<T10>>> obs10,
+                            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TRet> selector)
+        {
+            return This.WhenAny(obs1, obs2, obs3, obs4, obs5, obs6, obs7, obs8, obs9, obs10, (o1, o2, o3, o4, o5, o6, o7, o8, o9, o10) => Observable.CombineLatest(o1.Value.EmptyIfNull(), o2.Value.EmptyIfNull(), o3.Value.EmptyIfNull(), o4.Value.EmptyIfNull(), o5.Value.EmptyIfNull(), o6.Value.EmptyIfNull(), o7.Value.EmptyIfNull(), o8.Value.EmptyIfNull(), o9.Value.EmptyIfNull(), o10.Value.EmptyIfNull(), selector))
+                .Switch();
+        }
+        public static IObservable<TRet> WhenAnyObservable<TSender, TRet, T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11>(this TSender This,
+                            Expression<Func<TSender, IObservable<T1>>> obs1,
+                            Expression<Func<TSender, IObservable<T2>>> obs2,
+                            Expression<Func<TSender, IObservable<T3>>> obs3,
+                            Expression<Func<TSender, IObservable<T4>>> obs4,
+                            Expression<Func<TSender, IObservable<T5>>> obs5,
+                            Expression<Func<TSender, IObservable<T6>>> obs6,
+                            Expression<Func<TSender, IObservable<T7>>> obs7,
+                            Expression<Func<TSender, IObservable<T8>>> obs8,
+                            Expression<Func<TSender, IObservable<T9>>> obs9,
+                            Expression<Func<TSender, IObservable<T10>>> obs10,
+                            Expression<Func<TSender, IObservable<T11>>> obs11,
+                            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TRet> selector)
+        {
+            return This.WhenAny(obs1, obs2, obs3, obs4, obs5, obs6, obs7, obs8, obs9, obs10, obs11, (o1, o2, o3, o4, o5, o6, o7, o8, o9, o10, o11) => Observable.CombineLatest(o1.Value.EmptyIfNull(), o2.Value.EmptyIfNull(), o3.Value.EmptyIfNull(), o4.Value.EmptyIfNull(), o5.Value.EmptyIfNull(), o6.Value.EmptyIfNull(), o7.Value.EmptyIfNull(), o8.Value.EmptyIfNull(), o9.Value.EmptyIfNull(), o10.Value.EmptyIfNull(), o11.Value.EmptyIfNull(), selector))
+                .Switch();
+        }
+        public static IObservable<TRet> WhenAnyObservable<TSender, TRet, T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12>(this TSender This,
+                            Expression<Func<TSender, IObservable<T1>>> obs1,
+                            Expression<Func<TSender, IObservable<T2>>> obs2,
+                            Expression<Func<TSender, IObservable<T3>>> obs3,
+                            Expression<Func<TSender, IObservable<T4>>> obs4,
+                            Expression<Func<TSender, IObservable<T5>>> obs5,
+                            Expression<Func<TSender, IObservable<T6>>> obs6,
+                            Expression<Func<TSender, IObservable<T7>>> obs7,
+                            Expression<Func<TSender, IObservable<T8>>> obs8,
+                            Expression<Func<TSender, IObservable<T9>>> obs9,
+                            Expression<Func<TSender, IObservable<T10>>> obs10,
+                            Expression<Func<TSender, IObservable<T11>>> obs11,
+                            Expression<Func<TSender, IObservable<T12>>> obs12,
+                            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TRet> selector)
+        {
+            return This.WhenAny(obs1, obs2, obs3, obs4, obs5, obs6, obs7, obs8, obs9, obs10, obs11, obs12, (o1, o2, o3, o4, o5, o6, o7, o8, o9, o10, o11, o12) => Observable.CombineLatest(o1.Value.EmptyIfNull(), o2.Value.EmptyIfNull(), o3.Value.EmptyIfNull(), o4.Value.EmptyIfNull(), o5.Value.EmptyIfNull(), o6.Value.EmptyIfNull(), o7.Value.EmptyIfNull(), o8.Value.EmptyIfNull(), o9.Value.EmptyIfNull(), o10.Value.EmptyIfNull(), o11.Value.EmptyIfNull(), o12.Value.EmptyIfNull(), selector))
+                .Switch();
+        }
+}
 
     internal static class ObservableExtensions
     {

--- a/src/ReactiveUI/VariadicTemplates.tt
+++ b/src/ReactiveUI/VariadicTemplates.tt
@@ -22,7 +22,7 @@ int maxFuncLength = 12;
 
 namespace ReactiveUI
 {
-    public static class WhenAnyMixin 
+    public static class WhenAnyMixin
     {
         /// <summary>
         /// WhenAnyValue allows you to observe whenever the value of a
@@ -31,7 +31,7 @@ namespace ReactiveUI
         /// method in constructors to set up bindings between properties that also
         /// need an initial setup.
         /// </summary>
-        public static IObservable<TRet> WhenAnyValue<TSender, TRet>(this TSender This, 
+        public static IObservable<TRet> WhenAnyValue<TSender, TRet>(this TSender This,
                             Expression<Func<TSender, TRet>> property1)
         {
             return This.WhenAny(property1, (IObservedChange<TSender, TRet> c1) => c1.Value);
@@ -54,7 +54,7 @@ namespace ReactiveUI
         /// method in constructors to set up bindings between properties that also
         /// need an initial setup.
         /// </summary>
-        public static IObservable<Tuple<<#= String.Join(",", templParams) #>>> WhenAnyValue<TSender, <#= String.Join(",", templParams) #>>(this TSender This, 
+        public static IObservable<Tuple<<#= String.Join(",", templParams) #>>> WhenAnyValue<TSender, <#= String.Join(",", templParams) #>>(this TSender This,
             <# for(int i=1; i <= length; i++) { #>
                 Expression<Func<TSender, T<#=i#>>> property<#=i#><# if (i != length) { #>,<# } #>
 
@@ -73,9 +73,9 @@ namespace ReactiveUI
         /// method in constructors to set up bindings between properties that also
         /// need an initial setup.
         /// </summary>
-        public static IObservable<TRet> WhenAnyValue<TSender, TRet, <#= String.Join(",", templParams) #>>(this TSender This, 
+        public static IObservable<TRet> WhenAnyValue<TSender, TRet, <#= String.Join(",", templParams) #>>(this TSender This,
             <# for(int i=1; i <= length; i++) { #>
-                Expression<Func<TSender, T<#=i#>>> property<#=i#>, 
+                Expression<Func<TSender, T<#=i#>>> property<#=i#>,
             <# } #>
                 Func<<#= String.Join(",", templParams) #>, TRet> selector)
         {
@@ -91,25 +91,25 @@ namespace ReactiveUI
         /// constructors to set up bindings between properties that also need an
         /// initial setup.
         /// </summary>
-        public static IObservable<TRet> WhenAny<TSender, TRet, <#= String.Join(",", templParams) #>>(this TSender This, 
+        public static IObservable<TRet> WhenAny<TSender, TRet, <#= String.Join(",", templParams) #>>(this TSender This,
             <# for(int i=1; i <= length; i++) { #>
-                Expression<Func<TSender, T<#=i#>>> property<#=i#>, 
+                Expression<Func<TSender, T<#=i#>>> property<#=i#>,
             <# } #>
                 Func<<#= selectorTypeParams #>, TRet> selector)
         {
             <# if (length == 1){ #>
-                return This.ObservableForProperty(property<#=1#>, false, false).Select(selector); 
+                return This.ObservableForProperty(property<#=1#>, false, false).Select(selector);
             <# }else{ #>
             return Observable.CombineLatest(
                 <# for(int i=1; i <= length; i++) { #>
-                    This.ObservableForProperty(property<#=i#>, false, false), 
+                    This.ObservableForProperty(property<#=i#>, false, false),
                 <# } #>
                 selector
             );
             <# } #>
         }
 
-		
+
         /// <summary>
         /// WhenAny allows you to observe whenever one or more properties on an
         /// object have changed, providing an initial value when the Observable
@@ -117,20 +117,20 @@ namespace ReactiveUI
         /// constructors to set up bindings between properties that also need an
         /// initial setup.
         /// </summary>
-        public static IObservable<TRet> WhenAnyDynamic<TSender, TRet>(this TSender This, 
+        public static IObservable<TRet> WhenAnyDynamic<TSender, TRet>(this TSender This,
             <# for(int i=1; i <= length; i++) { #>
-                Expression property<#=i#>, 
+                Expression property<#=i#>,
             <# } #>
                 Func<<#= dynamicSelectorTypeParams #>, TRet> selector)
         {
             <# if (length == 1){ #>
                 return ReactiveNotifyPropertyChangedMixin
-                    .SubscribeToExpressionChain<TSender,object>(This, property<#=1#>, false, false).Select(selector); 
+                    .SubscribeToExpressionChain<TSender,object>(This, property<#=1#>, false, false).Select(selector);
             <# }else{ #>
             return Observable.CombineLatest(
                 <# for(int i=1; i <= length; i++) { #>
                     ReactiveNotifyPropertyChangedMixin
-                        .SubscribeToExpressionChain<TSender,object>(This, property<#=i#>, false, false), 
+                        .SubscribeToExpressionChain<TSender,object>(This, property<#=i#>, false, false),
                 <# } #>
                 selector
             );
@@ -156,7 +156,23 @@ namespace ReactiveUI
                 .Select(x => x.Merge()).Switch();
         }
 <# } #>
-    }
+
+<# for(int length=2; length <= maxFuncLength; length++) { #>
+<# var templParams = Enumerable.Range(1, length).Select(x => "T" + x.ToString()); #>
+<# string varsStr = String.Join(", ", Enumerable.Range(1, length).Select(x => "obs" + x.ToString())); #>
+<# string valsStr = String.Join(", ", Enumerable.Range(1, length).Select(x => "o" + x.ToString() + ".Value.EmptyIfNull()")); #>
+<# string selectorTypeParams = String.Join(", ", templParams); #>
+        public static IObservable<TRet> WhenAnyObservable<TSender, TRet, <#= String.Join(",", templParams) #>>(this TSender This,
+            <# for(int i=1; i <= length; i++) { #>
+                Expression<Func<TSender, IObservable<T<#=i#>>>> obs<#=i#>,
+            <# } #>
+                Func<<#= selectorTypeParams #>, TRet> selector)
+        {
+            return This.WhenAny(<#= varsStr #>, (<#=varsStr.Replace("obs", "o")#>) => Observable.CombineLatest(<#= valsStr #>, selector))
+                .Switch();
+        }
+<# } #>
+}
 
     internal static class ObservableExtensions
     {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Feature.

**What is the current behavior? (You can also link to an open issue here)**

The `WhenAnyObservable` operator does not work in the same fashion as other `WhenAny*` operators. All observables must be the same type, and the resulting observable sequence is the result of a `Merge` of those observables. Consider this:

```C#
public IObservable<bool> First { ... }

public IObservable<bool> Second { ... }

public IObservable<string> Third { ... }

// elsewhere
this
    .WhenAnyObservable(x => x.First, x => x.Second)
    .Select( /* er, umm, how do I distinguish whether the value came from First or Second? */ )

// somewhere else
this
    .WhenAnyObservable(x => x.First, x => x.Third)  // oops, this is not even possible
```

**What is the new behavior (if this is a feature change)?**

This PR adds overloads of `WhenAnyObservable` that work in the same fashion as other `WhenAny*` operators. Each observable can be of a different type, and a selector must be provided to combine the results. In our example above, it would look like this:

```C#
this
    .WhenAnyObservable(x => x.First, x => x.Second, (first, second) => /* do whatever here to select an appropriate value */)

this
    .WhenAnyObservable(x => x.First, x => x.Third, (first, third) => /* do whatever here to select an appropriate value */)
```

**Does this PR introduce a breaking change?**

No.

**Please check if the PR fulfills these requirements**
- [X] The commit follows our guidelines: https://github.com/reactiveui/reactiveui#contribute
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
