### PR TITLE
fix: resolve crash when using ViewModelViewHost with Xamarin Forms

### DIFF
--- a/src/ReactiveUI.XamForms/XamForms/ViewModelViewHost.cs
+++ b/src/ReactiveUI.XamForms/XamForms/ViewModelViewHost.cs
@@ -49,7 +49,7 @@ namespace ReactiveUI.XamForms
         }
         public static readonly BindableProperty ViewContractObservableProperty = BindableProperty.Create(
             nameof(ViewContractObservable),
-            typeof(string),
+            typeof(IObservable<string>),
             typeof(ViewModelViewHost),
             Observable.Never<string>(),
             BindingMode.OneWay);


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Bug fix.

**What is the current behavior? (You can also link to an open issue here)**

Crash when using `ViewModelViewHost` on XF.

**What is the new behavior (if this is a feature change)?**

Fix the `BindableProperty` metadata on `ViewModelViewHost`.

**Does this PR introduce a breaking change?**

No.

**Please check if the PR fulfills these requirements**
- [X] The commit follows our guidelines: https://github.com/reactiveui/reactiveui#contribute
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


