### PR TITLE
docs: email geoff, not paul for slack invitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ this.WhenAnyValue(x => x.SearchQuery)
 
 # Slack
 
-We have our very own [Slack organization](https://reactivex.slack.com/) which contains some of the best user interface/reactive extension developers in the industry. All software engineers, young and old, regardless of experience are welcome to join our campfire but you'll need to send an email to [paul@paulbetts.org](mailto:paul@paulbetts.org) with the Email address you'd like to be invited, and we'll send you an invite. Sit tight, it's worth it.
+We have our very own [Slack organization](https://reactivex.slack.com/) which contains some of the best user interface/reactive extension developers in the industry. All software engineers, young and old, regardless of experience are welcome to join our campfire but you'll need to send an email to [ghuntley@ghuntley.com](mailto:ghuntley@ghuntley.com) with the Email address you'd like to be invited, and we'll send you an invite. Sit tight, it's worth it.
 
 # Support
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

doc

**What is the current behavior? (You can also link to an open issue here)**

Directed the community to send Paul an email to obtain an invite.

**What is the new behavior (if this is a feature change)?**

Directed the community to send Geoff an email to obtain an invite.

**Does this PR introduce a breaking change?**

no

**Please check if the PR fulfills these requirements**
- [x] The commit follows our guidelines: https://github.com/reactiveui/reactiveui#contribute
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:


