### PR TITLE
Updatable list reactivelistadapter

### DIFF
--- a/src/ReactiveUI/Android/ReactiveListAdapter.cs
+++ b/src/ReactiveUI/Android/ReactiveListAdapter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Reactive;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Threading;
@@ -44,7 +45,11 @@ namespace ReactiveUI
                 .Subscribe(backingList => {
                     this.list = backingList;
 
-                    _backingListUpdatesObservable.Disposable = this.list.Changed.Subscribe(_ => NotifyDataSetChanged());
+                    _backingListUpdatesObservable.Disposable = 
+                        this.list.Changed
+                            .Select(_ => Unit.Default)
+                            .StartWith(Unit.Default)
+                            .Subscribe(_ => NotifyDataSetChanged());
                 });
         }
 

--- a/src/ReactiveUI/Android/ReactiveListAdapter.cs
+++ b/src/ReactiveUI/Android/ReactiveListAdapter.cs
@@ -31,22 +31,22 @@ namespace ReactiveUI
             _inner = this.list.Changed.Subscribe(_ => NotifyDataSetChanged());
         }
 
-		public ReactiveListAdapter(
-			IObservable<IReadOnlyReactiveList<TViewModel>> backingListObservable,
-			Func<TViewModel, ViewGroup, View> viewCreator,
-			Action<TViewModel, View> viewInitializer = null)
-		{
-			this.viewCreator = viewCreator;
-			this.viewInitializer = viewInitializer;
+        public ReactiveListAdapter(
+            IObservable<IReadOnlyReactiveList<TViewModel>> backingListObservable,
+            Func<TViewModel, ViewGroup, View> viewCreator,
+            Action<TViewModel, View> viewInitializer = null)
+        {
+            this.viewCreator = viewCreator;
+            this.viewInitializer = viewInitializer;
 
-			_inner = backingListObservable
-				.StartWith(new ReactiveList<TViewModel>())
-				.Subscribe(backingList => {
-					this.list = backingList;
+            _inner = backingListObservable
+                .StartWith(new ReactiveList<TViewModel>())
+                .Subscribe(backingList => {
+                    this.list = backingList;
 
-					_backingListUpdatesObservable.Disposable = this.list.Changed.Subscribe(_ => NotifyDataSetChanged());
-				});
-		}
+                    _backingListUpdatesObservable.Disposable = this.list.Changed.Subscribe(_ => NotifyDataSetChanged());
+                });
+        }
 
         public override TViewModel this[int position] {
             get { return list[position]; }
@@ -89,7 +89,7 @@ namespace ReactiveUI
         {
             base.Dispose(disposing);
             Interlocked.Exchange(ref _inner, Disposable.Empty).Dispose();
-			_backingListUpdatesObservable?.Dispose();
+            _backingListUpdatesObservable?.Dispose();
         }
     }
 }

--- a/src/ReactiveUI/Android/ReactiveListAdapter.cs
+++ b/src/ReactiveUI/Android/ReactiveListAdapter.cs
@@ -18,7 +18,7 @@ namespace ReactiveUI
         readonly Action<TViewModel, View> viewInitializer;
 
         IDisposable _inner;
-		SerialDisposable _backingListUpdatesObservable = new SerialDisposable();
+        SerialDisposable _backingListUpdatesObservable = new SerialDisposable();
 
         public ReactiveListAdapter(
             IReadOnlyReactiveList<TViewModel> backingList,


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
This change adds the ability to swap out the backing list for a ReactiveListAdapter. Sometimes your ViewModel is not ready when you are setting up the adapter or maybe you need to swap out your backing list, this new constructor allows for the ability to replace the list implementation and keep everything working as expected.


**What is the current behavior? (You can also link to an open issue here)**
Currently, you must assign the backing list into the constructor and you cannot reassign it.


**What is the new behavior (if this is a feature change)?**
There is a new constructor which allows for the replacement of the backing list in a ReactiveListAdapter.


**Does this PR introduce a breaking change?**
I don't believe so.


**Please check if the PR fulfills these requirements**
- [x] The commit follows our guidelines: https://github.com/reactiveui/reactiveui#contribute
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
In terms of docs and tests, I have a sample Android app that I tested it out with, but I am not 100% sure what the best way to test this generically would be... 
