### PR TITLE
feature: added generic reactive controllers and views for iOS and Mac

### DIFF
--- a/src/ReactiveUI/Cocoa/ReactiveCollectionReusableView.cs
+++ b/src/ReactiveUI/Cocoa/ReactiveCollectionReusableView.cs
@@ -1,19 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Diagnostics.Contracts;
-using System.Drawing;
-using System.Linq;
 using System.Reactive;
-using System.Reactive.Concurrency;
-using System.Reactive.Disposables;
 using System.Reactive.Subjects;
-using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Runtime.Serialization;
-using System.Threading;
-using ReactiveUI;
-using Splat;
 using System.Reactive.Linq;
 
 #if UNIFIED
@@ -21,13 +9,14 @@ using CoreGraphics;
 using Foundation;
 using UIKit;
 #else
+using System.Drawing;
 using MonoTouch.Foundation;
 using MonoTouch.UIKit;
 #endif
 
 namespace ReactiveUI
 {
-    public abstract class ReactiveCollectionReusableView : UICollectionReusableView, 
+    public abstract class ReactiveCollectionReusableView : UICollectionReusableView,
         IReactiveNotifyPropertyChanged<ReactiveCollectionReusableView>, IHandleObservableErrors, IReactiveObject, ICanActivate
     {
 #if UNIFIED
@@ -43,7 +32,7 @@ namespace ReactiveUI
 
         public event PropertyChangingEventHandler PropertyChanging;
 
-        void IReactiveObject.RaisePropertyChanging(PropertyChangingEventArgs args) 
+        void IReactiveObject.RaisePropertyChanging(PropertyChangingEventArgs args)
         {
             var handler = PropertyChanging;
             if (handler != null) {
@@ -53,7 +42,7 @@ namespace ReactiveUI
 
         public event PropertyChangedEventHandler PropertyChanged;
 
-        void IReactiveObject.RaisePropertyChanged(PropertyChangedEventArgs args) 
+        void IReactiveObject.RaisePropertyChanged(PropertyChangedEventArgs args)
         {
             var handler = PropertyChanged;
             if (handler != null) {
@@ -109,6 +98,31 @@ namespace ReactiveUI
         {
             base.RemoveFromSuperview();
             deactivated.OnNext(Unit.Default);
+        }
+    }
+
+    public abstract class ReactiveCollectionReusableView<TViewModel> : ReactiveCollectionReusableView, IViewFor<TViewModel>
+        where TViewModel : class
+    {
+        protected ReactiveCollectionReusableView() { }
+        protected ReactiveCollectionReusableView(IntPtr handle) : base(handle) { }
+        protected ReactiveCollectionReusableView(NSObjectFlag t) : base(t) { }
+        protected ReactiveCollectionReusableView(NSCoder coder) : base(coder) { }
+#if UNIFIED
+        protected ReactiveCollectionReusableView(CGRect frame) : base(frame) { }
+#else
+        protected ReactiveCollectionReusableView(RectangleF frame) : base(frame) { }
+#endif
+
+        TViewModel _viewModel;
+        public TViewModel ViewModel {
+            get { return _viewModel; }
+            set { this.RaiseAndSetIfChanged(ref _viewModel, value); }
+        }
+
+        object IViewFor.ViewModel {
+            get { return ViewModel; }
+            set { ViewModel = (TViewModel)value; }
         }
     }
 }

--- a/src/ReactiveUI/Cocoa/ReactiveCollectionView.cs
+++ b/src/ReactiveUI/Cocoa/ReactiveCollectionView.cs
@@ -1,19 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Diagnostics.Contracts;
-using System.Drawing;
-using System.Linq;
 using System.Reactive;
 using System.Reactive.Concurrency;
-using System.Reactive.Disposables;
 using System.Reactive.Subjects;
-using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Runtime.Serialization;
-using System.Threading;
-using ReactiveUI;
-using Splat;
 using System.Reactive.Linq;
 
 #if UNIFIED
@@ -21,13 +10,14 @@ using CoreGraphics;
 using Foundation;
 using UIKit;
 #else
+using System.Drawing;
 using MonoTouch.Foundation;
 using MonoTouch.UIKit;
 #endif
 
 namespace ReactiveUI
 {
-    public abstract class ReactiveCollectionView : UICollectionView, 
+    public abstract class ReactiveCollectionView : UICollectionView,
         IReactiveNotifyPropertyChanged<ReactiveCollectionView>, IHandleObservableErrors, IReactiveObject, ICanActivate, ICanForceManualActivation
     {
 #if UNIFIED
@@ -110,10 +100,34 @@ namespace ReactiveUI
             deactivated.OnNext(Unit.Default);
         }
 
-        void ICanForceManualActivation.Activate(bool activate) 
+        void ICanForceManualActivation.Activate(bool activate)
         {
-            RxApp.MainThreadScheduler.Schedule(() => 
-		        (activate ? activated : deactivated).OnNext(Unit.Default));
+            RxApp.MainThreadScheduler.Schedule(() =>
+                (activate ? activated : deactivated).OnNext(Unit.Default));
+        }
+    }
+
+    public abstract class ReactiveCollectionView<TViewModel> : ReactiveCollectionView, IViewFor<TViewModel>
+        where TViewModel : class
+    {
+        protected ReactiveCollectionView(IntPtr handle) : base(handle) { }
+        protected ReactiveCollectionView(NSObjectFlag t) : base(t) { }
+        protected ReactiveCollectionView(NSCoder coder) : base(coder) { }
+#if UNIFIED
+        protected ReactiveCollectionView(CGRect frame, UICollectionViewLayout layout) : base(frame, layout) { }
+#else
+        protected ReactiveCollectionView(RectangleF frame, UICollectionViewLayout layout) : base(frame, layout) { }
+#endif
+
+        TViewModel _viewModel;
+        public TViewModel ViewModel {
+            get { return _viewModel; }
+            set { this.RaiseAndSetIfChanged(ref _viewModel, value); }
+        }
+
+        object IViewFor.ViewModel {
+            get { return ViewModel; }
+            set { ViewModel = (TViewModel)value; }
         }
     }
 }

--- a/src/ReactiveUI/Cocoa/ReactiveCollectionViewCell.cs
+++ b/src/ReactiveUI/Cocoa/ReactiveCollectionViewCell.cs
@@ -1,19 +1,8 @@
 using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Diagnostics.Contracts;
-using System.Drawing;
-using System.Linq;
 using System.Reactive;
 using System.Reactive.Concurrency;
-using System.Reactive.Disposables;
 using System.Reactive.Subjects;
-using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Runtime.Serialization;
-using System.Threading;
-using ReactiveUI;
-using Splat;
 using System.Reactive.Linq;
 
 #if UNIFIED
@@ -21,6 +10,7 @@ using CoreGraphics;
 using Foundation;
 using UIKit;
 #else
+using System.Drawing;
 using MonoTouch.Foundation;
 using MonoTouch.UIKit;
 #endif
@@ -30,16 +20,16 @@ namespace ReactiveUI
     public abstract class ReactiveCollectionViewCell : UICollectionViewCell, IReactiveNotifyPropertyChanged<ReactiveCollectionViewCell>, IHandleObservableErrors, IReactiveObject, ICanActivate
     {
 #if UNIFIED
-        public ReactiveCollectionViewCell(CGRect frame) : base (frame) { setupRxObj(); }
+        protected ReactiveCollectionViewCell(CGRect frame) : base(frame) { setupRxObj(); }
 #else
-        public ReactiveCollectionViewCell(RectangleF frame) : base (frame) { setupRxObj(); }
+        protected ReactiveCollectionViewCell(RectangleF frame) : base (frame) { setupRxObj(); }
 #endif
 
-        public ReactiveCollectionViewCell(NSObjectFlag t) : base (t) { setupRxObj(); }
-        public ReactiveCollectionViewCell(NSCoder coder) : base (NSObjectFlag.Empty) { setupRxObj(); }
-        public ReactiveCollectionViewCell() : base() { setupRxObj(); }
+        protected ReactiveCollectionViewCell(NSObjectFlag t) : base(t) { setupRxObj(); }
+        protected ReactiveCollectionViewCell(NSCoder coder) : base(NSObjectFlag.Empty) { setupRxObj(); }
+        protected ReactiveCollectionViewCell() : base() { setupRxObj(); }
 
-        protected ReactiveCollectionViewCell(IntPtr handle) : base (handle) { setupRxObj(); }
+        protected ReactiveCollectionViewCell(IntPtr handle) : base(handle) { setupRxObj(); }
 
         public event PropertyChangingEventHandler PropertyChanging {
             add { PropertyChangingEventManager.AddHandler(this, value); }
@@ -103,6 +93,31 @@ namespace ReactiveUI
         {
             base.WillMoveToSuperview(newsuper);
             RxApp.MainThreadScheduler.Schedule(() => (newsuper != null ? activated : deactivated).OnNext(Unit.Default));
+        }
+    }
+
+    public abstract class ReactiveCollectionViewCell<TViewModel> : ReactiveCollectionViewCell, IViewFor<TViewModel>
+        where TViewModel : class
+    {
+        protected ReactiveCollectionViewCell(NSObjectFlag t) : base(t) { }
+        protected ReactiveCollectionViewCell(NSCoder coder) : base(NSObjectFlag.Empty) { }
+        protected ReactiveCollectionViewCell() : base() { }
+#if UNIFIED
+        protected ReactiveCollectionViewCell(CGRect frame) : base(frame) { }
+#else
+        protected ReactiveCollectionViewCell(RectangleF frame) : base (frame) { }
+#endif
+        protected ReactiveCollectionViewCell(IntPtr handle) : base(handle) { }
+
+        TViewModel _viewModel;
+        public TViewModel ViewModel {
+            get { return _viewModel; }
+            set { this.RaiseAndSetIfChanged(ref _viewModel, value); }
+        }
+
+        object IViewFor.ViewModel {
+            get { return ViewModel; }
+            set { ViewModel = (TViewModel)value; }
         }
     }
 }

--- a/src/ReactiveUI/Cocoa/ReactiveCollectionViewController.cs
+++ b/src/ReactiveUI/Cocoa/ReactiveCollectionViewController.cs
@@ -1,19 +1,7 @@
 using System;
-using ReactiveUI;
-using System.Runtime.Serialization;
 using System.ComponentModel;
-using System.Reflection;
 using System.Reactive;
 using System.Reactive.Subjects;
-using System.Reactive.Concurrency;
-using System.Linq;
-using System.Threading;
-using System.Reactive.Disposables;
-using System.Diagnostics.Contracts;
-using System.Runtime.CompilerServices;
-using System.Collections.Generic;
-using System.Drawing;
-using Splat;
 using System.Reactive.Linq;
 
 #if UNIFIED
@@ -88,7 +76,7 @@ namespace ReactiveUI
         {
             return this.suppressChangeNotifications();
         }
-                
+
         Subject<Unit> activated = new Subject<Unit>();
         public IObservable<Unit> Activated { get { return activated.AsObservable(); } }
         Subject<Unit> deactivated = new Subject<Unit>();
@@ -106,6 +94,28 @@ namespace ReactiveUI
             base.ViewDidDisappear(animated);
             deactivated.OnNext(Unit.Default);
             this.ActivateSubviews(false);
+        }
+    }
+
+    public abstract class ReactiveCollectionViewController<TViewModel> : ReactiveCollectionViewController, IViewFor<TViewModel>
+        where TViewModel : class
+    {
+        protected ReactiveCollectionViewController(UICollectionViewLayout withLayout) : base(withLayout) { }
+        protected ReactiveCollectionViewController(string nibName, NSBundle bundle) : base(nibName, bundle) { }
+        protected ReactiveCollectionViewController(IntPtr handle) : base(handle) { }
+        protected ReactiveCollectionViewController(NSObjectFlag t) : base(t) { }
+        protected ReactiveCollectionViewController(NSCoder coder) : base(coder) { }
+        protected ReactiveCollectionViewController() { }
+
+        TViewModel _viewModel;
+        public TViewModel ViewModel {
+            get { return _viewModel; }
+            set { this.RaiseAndSetIfChanged(ref _viewModel, value); }
+        }
+
+        object IViewFor.ViewModel {
+            get { return ViewModel; }
+            set { ViewModel = (TViewModel)value; }
         }
     }
 }

--- a/src/ReactiveUI/Cocoa/ReactiveImageView.cs
+++ b/src/ReactiveUI/Cocoa/ReactiveImageView.cs
@@ -1,22 +1,22 @@
 using System;
 using System.ComponentModel;
-using System.Drawing;
 using System.Reactive;
 using System.Reactive.Concurrency;
 using System.Reactive.Subjects;
-using ReactiveUI;
 using System.Reactive.Linq;
 
 #if UNIFIED
 using CoreGraphics;
 using Foundation;
 #elif UIKIT
+using System.Drawing;
 using MonoTouch.Foundation;
 using MonoTouch.UIKit;
 using NSImageView = MonoTouch.UIKit.UIImageView;
 using NSImage = MonoTouch.UIKit.UIImage;
 using NSView = MonoTouch.UIKit.UIView;
 #else
+using System.Drawing;
 using MonoMac.AppKit;
 #endif
 
@@ -35,18 +35,18 @@ namespace ReactiveUI
     public abstract class ReactiveImageView : NSImageView, IReactiveNotifyPropertyChanged<ReactiveImageView>, IHandleObservableErrors, IReactiveObject, ICanActivate, ICanForceManualActivation
     {
 #if UNIFIED
-        public ReactiveImageView(CGRect frame) : base(frame) { }
+        protected ReactiveImageView(CGRect frame) : base(frame) { }
 #else
-        public ReactiveImageView(RectangleF frame) : base(frame) { }
+        protected ReactiveImageView(RectangleF frame) : base(frame) { }
 #endif
 
-        public ReactiveImageView() { }
+        protected ReactiveImageView() { }
 
 #if UIKIT
-        public ReactiveImageView(NSImage image) : base(image) { }
-        public ReactiveImageView(NSObjectFlag t) : base(t) { }
-        public ReactiveImageView(NSImage image, NSImage highlightedImage) : base(image, highlightedImage) { }
-        public ReactiveImageView(NSCoder coder) : base(coder) { }
+        protected ReactiveImageView(NSImage image) : base(image) { }
+        protected ReactiveImageView(NSObjectFlag t) : base(t) { }
+        protected ReactiveImageView(NSImage image, NSImage highlightedImage) : base(image, highlightedImage) { }
+        protected ReactiveImageView(NSCoder coder) : base(coder) { }
 #endif
 
         protected ReactiveImageView(IntPtr handle) : base(handle) { }
@@ -86,12 +86,13 @@ namespace ReactiveUI
             get { return this.getChangedObservable(); }
         }
 
-        public IDisposable SuppressChangeNotifications() {
+        public IDisposable SuppressChangeNotifications()
+        {
             return this.suppressChangeNotifications();
         }
 
         public IObservable<Exception> ThrownExceptions { get { return this.getThrownExceptionsObservable(); } }
-        
+
         Subject<Unit> activated = new Subject<Unit>();
         public IObservable<Unit> Activated { get { return activated.AsObservable(); } }
         Subject<Unit> deactivated = new Subject<Unit>();
@@ -111,10 +112,42 @@ namespace ReactiveUI
             RxApp.MainThreadScheduler.Schedule(() => (newsuper != null ? activated : deactivated).OnNext(Unit.Default));
         }
 
-        void ICanForceManualActivation.Activate(bool activate) 
+        void ICanForceManualActivation.Activate(bool activate)
         {
-            RxApp.MainThreadScheduler.Schedule(() => 
+            RxApp.MainThreadScheduler.Schedule(() =>
                 (activate ? activated : deactivated).OnNext(Unit.Default));
+        }
+    }
+
+    public abstract class ReactiveImageView<TViewModel> : ReactiveImageView, IViewFor<TViewModel>
+        where TViewModel : class
+    {
+#if UNIFIED
+        protected ReactiveImageView(CGRect frame) : base(frame) { }
+#else
+        protected ReactiveImageView(RectangleF frame) : base(frame) { }
+#endif
+
+        protected ReactiveImageView() { }
+
+#if UIKIT
+        protected ReactiveImageView(NSImage image) : base(image) { }
+        protected ReactiveImageView(NSObjectFlag t) : base(t) { }
+        protected ReactiveImageView(NSImage image, NSImage highlightedImage) : base(image, highlightedImage) { }
+        protected ReactiveImageView(NSCoder coder) : base(coder) { }
+#endif
+
+        protected ReactiveImageView(IntPtr handle) : base(handle) { }
+
+        TViewModel _viewModel;
+        public TViewModel ViewModel {
+            get { return _viewModel; }
+            set { this.RaiseAndSetIfChanged(ref _viewModel, value); }
+        }
+
+        object IViewFor.ViewModel {
+            get { return ViewModel; }
+            set { ViewModel = (TViewModel)value; }
         }
     }
 }

--- a/src/ReactiveUI/Cocoa/ReactiveNSView.cs
+++ b/src/ReactiveUI/Cocoa/ReactiveNSView.cs
@@ -1,6 +1,5 @@
 using System;
 using System.ComponentModel;
-using System.Drawing;
 using System.Reactive;
 using System.Reactive.Concurrency;
 using System.Reactive.Subjects;
@@ -10,10 +9,12 @@ using System.Reactive.Linq;
 using CoreGraphics;
 using Foundation;
 #elif UIKIT
+using System.Drawing;
 using MonoTouch.Foundation;
 using MonoTouch.UIKit;
 using NSView = MonoTouch.UIKit.UIView;
 #else
+using System.Drawing;
 using MonoMac.AppKit;
 using MonoMac.Foundation;
 #endif
@@ -33,30 +34,14 @@ namespace ReactiveUI
     /// </summary>
     public class ReactiveView : NSView, IReactiveNotifyPropertyChanged<ReactiveView>, IHandleObservableErrors, IReactiveObject, ICanActivate, ICanForceManualActivation
     {
-        protected ReactiveView() : base()
-        {
-        }
-
-        protected ReactiveView(NSCoder c) : base(c)
-        {
-        }
-
-        protected ReactiveView(NSObjectFlag f) : base(f)
-        {
-        }
-
-        protected ReactiveView(IntPtr handle) : base(handle)
-        {
-        }
-
+        protected ReactiveView() { }
+        protected ReactiveView(NSCoder c) : base(c) { }
+        protected ReactiveView(NSObjectFlag f) : base(f) { }
+        protected ReactiveView(IntPtr handle) : base(handle) { }
 #if UNIFIED
-        protected ReactiveView(CGRect frame) : base(frame)
-        {
-        }
+        protected ReactiveView(CGRect frame) : base(frame) { }
 #else
-        protected ReactiveView(RectangleF size) : base(size)
-        {
-        }
+        protected ReactiveView(RectangleF size) : base(size) { }
 #endif
 
         public event PropertyChangingEventHandler PropertyChanging {
@@ -107,7 +92,7 @@ namespace ReactiveUI
         }
 
         public IObservable<Exception> ThrownExceptions { get { return this.getThrownExceptionsObservable(); } }
-        
+
         Subject<Unit> activated = new Subject<Unit>();
         public IObservable<Unit> Activated { get { return activated.AsObservable(); } }
         Subject<Unit> deactivated = new Subject<Unit>();
@@ -130,10 +115,35 @@ namespace ReactiveUI
             RxApp.MainThreadScheduler.Schedule(() => (newsuper != null ? activated : deactivated).OnNext(Unit.Default));
         }
 
-        void ICanForceManualActivation.Activate(bool activate) 
+        void ICanForceManualActivation.Activate(bool activate)
         {
-            RxApp.MainThreadScheduler.Schedule(() => 
+            RxApp.MainThreadScheduler.Schedule(() =>
                 (activate ? activated : deactivated).OnNext(Unit.Default));
+        }
+    }
+
+    public abstract class ReactiveView<TViewModel> : ReactiveView, IViewFor<TViewModel>
+        where TViewModel : class
+    {
+        protected ReactiveView() { }
+        protected ReactiveView(NSCoder c) : base(c) { }
+        protected ReactiveView(NSObjectFlag f) : base(f) { }
+        protected ReactiveView(IntPtr handle) : base(handle) { }
+#if UNIFIED
+        protected ReactiveView(CGRect frame) : base(frame) { }
+#else
+        protected ReactiveView(RectangleF size) : base(size) { }
+#endif
+
+        TViewModel _viewModel;
+        public TViewModel ViewModel {
+            get { return _viewModel; }
+            set { this.RaiseAndSetIfChanged(ref _viewModel, value); }
+        }
+
+        object IViewFor.ViewModel {
+            get { return ViewModel; }
+            set { ViewModel = (TViewModel)value; }
         }
     }
 }

--- a/src/ReactiveUI/Cocoa/ReactiveNSViewController.cs
+++ b/src/ReactiveUI/Cocoa/ReactiveNSViewController.cs
@@ -21,7 +21,7 @@ using UIKit;
 using NSViewController = UIKit.UIViewController;
 using NSView = UIKit.UIView;
 #elif UNIFIED && COCOA
-using AppKit;
+using AppKit; 
 #endif
 
 namespace ReactiveUI
@@ -30,31 +30,17 @@ namespace ReactiveUI
     /// This is an View that is both an NSViewController and has ReactiveObject powers 
     /// (i.e. you can call RaiseAndSetIfChanged)
     /// </summary>
-    public class ReactiveViewController : NSViewController, 
-	    IReactiveNotifyPropertyChanged<ReactiveViewController>, IHandleObservableErrors, IReactiveObject
+    public class ReactiveViewController : NSViewController,
+        IReactiveNotifyPropertyChanged<ReactiveViewController>, IHandleObservableErrors, IReactiveObject
 #if UIKIT
         , ICanActivate
 #endif
     {
-        protected ReactiveViewController() : base()
-        {
-        }
-
-        protected ReactiveViewController(NSCoder c) : base(c)
-        {
-        }
-
-        protected ReactiveViewController(NSObjectFlag f) : base(f)
-        {
-        }
-
-        protected ReactiveViewController(IntPtr handle) : base(handle)
-        {
-        }
-
-        protected ReactiveViewController(string nibNameOrNull, NSBundle nibBundleOrNull) : base(nibNameOrNull, nibBundleOrNull)
-        {
-        }
+        protected ReactiveViewController() { }
+        protected ReactiveViewController(NSCoder c) : base(c) { }
+        protected ReactiveViewController(NSObjectFlag f) : base(f) { }
+        protected ReactiveViewController(IntPtr handle) : base(handle) { }
+        protected ReactiveViewController(string nibNameOrNull, NSBundle nibBundleOrNull) : base(nibNameOrNull, nibBundleOrNull) { }
 
         public event PropertyChangingEventHandler PropertyChanging {
             add { PropertyChangingEventManager.AddHandler(this, value); }
@@ -104,7 +90,7 @@ namespace ReactiveUI
         {
             return this.suppressChangeNotifications();
         }
-                
+
 #if UIKIT
         Subject<Unit> activated = new Subject<Unit>();
         public IObservable<Unit> Activated { get { return activated.AsObservable(); } }
@@ -127,16 +113,37 @@ namespace ReactiveUI
 #endif
     }
 
+    public abstract class ReactiveViewController<TViewModel> : ReactiveViewController, IViewFor<TViewModel>
+        where TViewModel : class
+    {
+        protected ReactiveViewController() { }
+        protected ReactiveViewController(NSCoder c) : base(c) { }
+        protected ReactiveViewController(NSObjectFlag f) : base(f) { }
+        protected ReactiveViewController(IntPtr handle) : base(handle) { }
+        protected ReactiveViewController(string nibNameOrNull, NSBundle nibBundleOrNull) : base(nibNameOrNull, nibBundleOrNull) { }
+
+        TViewModel _viewModel;
+        public TViewModel ViewModel {
+            get { return _viewModel; }
+            set { this.RaiseAndSetIfChanged(ref _viewModel, value); }
+        }
+
+        object IViewFor.ViewModel {
+            get { return ViewModel; }
+            set { ViewModel = (TViewModel)value; }
+        }
+    }
+
     // TODO: Update this once we support 64-bit Xamarin.Mac
 #if UIKIT || UNIFIED
-    static class UIViewControllerMixins 
+    static class UIViewControllerMixins
     {
-        internal static void ActivateSubviews(this NSViewController This, bool activate) 
+        internal static void ActivateSubviews(this NSViewController This, bool activate)
         {
             This.View.ActivateSubviews(activate);
         }
 
-        static void ActivateSubviews(this NSView This, bool activate) 
+        static void ActivateSubviews(this NSView This, bool activate)
         {
             foreach (var view in This.Subviews) {
                 var subview = view as ICanForceManualActivation;

--- a/src/ReactiveUI/Cocoa/ReactiveNavigationController.cs
+++ b/src/ReactiveUI/Cocoa/ReactiveNavigationController.cs
@@ -1,19 +1,7 @@
 ﻿using System;
-using ReactiveUI;
-using System.Runtime.Serialization;
 using System.ComponentModel;
-using System.Reflection;
 using System.Reactive;
 using System.Reactive.Subjects;
-using System.Reactive.Concurrency;
-using System.Linq;
-using System.Threading;
-using System.Reactive.Disposables;
-using System.Diagnostics.Contracts;
-using System.Runtime.CompilerServices;
-using System.Collections.Generic;
-using System.Drawing;
-using Splat;
 using System.Reactive.Linq;
 
 #if UNIFIED
@@ -107,6 +95,29 @@ namespace ReactiveUI
             base.ViewDidDisappear(animated);
             deactivated.OnNext(Unit.Default);
             this.ActivateSubviews(false);
+        }
+    }
+
+    public abstract class ReactiveNavigationController<TViewModel> : ReactiveNavigationController, IViewFor<TViewModel>
+        where TViewModel : class
+    {
+        protected ReactiveNavigationController(UIViewController rootViewController) : base(rootViewController) { }
+        protected ReactiveNavigationController(Type navigationBarType, Type toolbarType) : base(navigationBarType, toolbarType) { }
+        protected ReactiveNavigationController(string nibName, NSBundle bundle) : base(nibName, bundle) { }
+        protected ReactiveNavigationController(IntPtr handle) : base(handle) { }
+        protected ReactiveNavigationController(NSObjectFlag t) : base(t) { }
+        protected ReactiveNavigationController(NSCoder coder) : base(coder) { }
+        protected ReactiveNavigationController() { }
+
+        TViewModel _viewModel;
+        public TViewModel ViewModel {
+            get { return _viewModel; }
+            set { this.RaiseAndSetIfChanged(ref _viewModel, value); }
+        }
+
+        object IViewFor.ViewModel {
+            get { return ViewModel; }
+            set { ViewModel = (TViewModel)value; }
         }
     }
 }

--- a/src/ReactiveUI/Cocoa/ReactivePageViewController.cs
+++ b/src/ReactiveUI/Cocoa/ReactivePageViewController.cs
@@ -1,19 +1,7 @@
 ﻿using System;
-using ReactiveUI;
-using System.Runtime.Serialization;
 using System.ComponentModel;
-using System.Reflection;
 using System.Reactive;
 using System.Reactive.Subjects;
-using System.Reactive.Concurrency;
-using System.Linq;
-using System.Threading;
-using System.Reactive.Disposables;
-using System.Diagnostics.Contracts;
-using System.Runtime.CompilerServices;
-using System.Collections.Generic;
-using System.Drawing;
-using Splat;
 using System.Reactive.Linq;
 
 #if UNIFIED
@@ -26,7 +14,7 @@ using MonoTouch.UIKit;
 
 namespace ReactiveUI
 {
-    public abstract class ReactivePageViewController : UIPageViewController, 
+    public abstract class ReactivePageViewController : UIPageViewController,
         IReactiveNotifyPropertyChanged<ReactivePageViewController>, IHandleObservableErrors, IReactiveObject, ICanActivate
     {
         protected ReactivePageViewController(UIPageViewControllerTransitionStyle style, UIPageViewControllerNavigationOrientation orientation) : base(style, orientation) { setupRxObj(); }
@@ -109,6 +97,31 @@ namespace ReactiveUI
             base.ViewDidDisappear(animated);
             deactivated.OnNext(Unit.Default);
             this.ActivateSubviews(false);
+        }
+    }
+
+    public abstract class ReactivePageViewController<TViewModel> : ReactivePageViewController, IViewFor<TViewModel>
+        where TViewModel : class
+    {
+        protected ReactivePageViewController(UIPageViewControllerTransitionStyle style, UIPageViewControllerNavigationOrientation orientation) : base(style, orientation) { }
+        protected ReactivePageViewController(UIPageViewControllerTransitionStyle style, UIPageViewControllerNavigationOrientation orientation, NSDictionary options) : base(style, orientation, options) { }
+        protected ReactivePageViewController(UIPageViewControllerTransitionStyle style, UIPageViewControllerNavigationOrientation orientation, UIPageViewControllerSpineLocation spineLocation) : base(style, orientation, spineLocation) { }
+        protected ReactivePageViewController(UIPageViewControllerTransitionStyle style, UIPageViewControllerNavigationOrientation orientation, UIPageViewControllerSpineLocation spineLocation, float interPageSpacing) : base(style, orientation, spineLocation, interPageSpacing) { }
+        protected ReactivePageViewController(string nibName, NSBundle bundle) : base(nibName, bundle) { }
+        protected ReactivePageViewController(IntPtr handle) : base(handle) { }
+        protected ReactivePageViewController(NSObjectFlag t) : base(t) { }
+        protected ReactivePageViewController(NSCoder coder) : base(coder) { }
+        protected ReactivePageViewController() { }
+
+        TViewModel _viewModel;
+        public TViewModel ViewModel {
+            get { return _viewModel; }
+            set { this.RaiseAndSetIfChanged(ref _viewModel, value); }
+        }
+
+        object IViewFor.ViewModel {
+            get { return ViewModel; }
+            set { ViewModel = (TViewModel)value; }
         }
     }
 }

--- a/src/ReactiveUI/Cocoa/ReactiveSplitViewController.cs
+++ b/src/ReactiveUI/Cocoa/ReactiveSplitViewController.cs
@@ -37,8 +37,7 @@ namespace ReactiveUI
         protected ReactiveSplitViewController(NSCoder coder) : base(coder) { setupRxObj(); }
         protected ReactiveSplitViewController() { setupRxObj(); }
 
-        public event PropertyChangingEventHandler PropertyChanging
-        {
+        public event PropertyChangingEventHandler PropertyChanging {
             add { PropertyChangingEventManager.AddHandler(this, value); }
             remove { PropertyChangingEventManager.RemoveHandler(this, value); }
         }
@@ -48,8 +47,7 @@ namespace ReactiveUI
             PropertyChangingEventManager.DeliverEvent(this, args);
         }
 
-        public event PropertyChangedEventHandler PropertyChanged
-        {
+        public event PropertyChangedEventHandler PropertyChanged {
             add { PropertyChangedEventManager.AddHandler(this, value); }
             remove { PropertyChangedEventManager.RemoveHandler(this, value); }
         }
@@ -63,16 +61,14 @@ namespace ReactiveUI
         /// Represents an Observable that fires *before* a property is about to
         /// be changed.
         /// </summary>
-        public IObservable<IReactivePropertyChangedEventArgs<ReactiveSplitViewController>> Changing
-        {
+        public IObservable<IReactivePropertyChangedEventArgs<ReactiveSplitViewController>> Changing {
             get { return this.getChangingObservable(); }
         }
 
         /// <summary>
         /// Represents an Observable that fires *after* a property has changed.
         /// </summary>
-        public IObservable<IReactivePropertyChangedEventArgs<ReactiveSplitViewController>> Changed
-        {
+        public IObservable<IReactivePropertyChangedEventArgs<ReactiveSplitViewController>> Changed {
             get { return this.getChangedObservable(); }
         }
 
@@ -132,5 +128,28 @@ namespace ReactiveUI
 #endif
         }
 #endif
+    }
+
+    public abstract class ReactiveSplitViewController<TViewModel> : ReactiveSplitViewController, IViewFor<TViewModel>
+        where TViewModel : class
+    {
+#if UIKIT
+        protected ReactiveSplitViewController(string nibName, NSBundle bundle) : base(nibName, bundle) { }
+#endif
+        protected ReactiveSplitViewController(IntPtr handle) : base(handle) { }
+        protected ReactiveSplitViewController(NSObjectFlag t) : base(t) { }
+        protected ReactiveSplitViewController(NSCoder coder) : base(coder) { }
+        protected ReactiveSplitViewController() { }
+
+        TViewModel _viewModel;
+        public TViewModel ViewModel {
+            get { return _viewModel; }
+            set { this.RaiseAndSetIfChanged(ref _viewModel, value); }
+        }
+
+        object IViewFor.ViewModel {
+            get { return ViewModel; }
+            set { ViewModel = (TViewModel)value; }
+        }
     }
 }

--- a/src/ReactiveUI/Cocoa/ReactiveTabBarController.cs
+++ b/src/ReactiveUI/Cocoa/ReactiveTabBarController.cs
@@ -1,19 +1,7 @@
 ﻿using System;
-using ReactiveUI;
-using System.Runtime.Serialization;
 using System.ComponentModel;
-using System.Reflection;
 using System.Reactive;
 using System.Reactive.Subjects;
-using System.Reactive.Concurrency;
-using System.Linq;
-using System.Threading;
-using System.Reactive.Disposables;
-using System.Diagnostics.Contracts;
-using System.Runtime.CompilerServices;
-using System.Collections.Generic;
-using System.Drawing;
-using Splat;
 using System.Reactive.Linq;
 
 #if UNIFIED
@@ -26,7 +14,7 @@ using MonoTouch.UIKit;
 
 namespace ReactiveUI
 {
-    public abstract class ReactiveTabBarController : UITabBarController, 
+    public abstract class ReactiveTabBarController : UITabBarController,
     IReactiveNotifyPropertyChanged<ReactiveTabBarController>, IHandleObservableErrors, IReactiveObject, ICanActivate
     {
         protected ReactiveTabBarController(string nibName, NSBundle bundle) : base(nibName, bundle) { setupRxObj(); }
@@ -105,6 +93,27 @@ namespace ReactiveUI
             base.ViewDidDisappear(animated);
             deactivated.OnNext(Unit.Default);
             this.ActivateSubviews(false);
+        }
+    }
+
+    public abstract class ReactiveTabBarController<TViewModel> : ReactiveTabBarController, IViewFor<TViewModel>
+        where TViewModel : class
+    {
+        protected ReactiveTabBarController(string nibName, NSBundle bundle) : base(nibName, bundle) { }
+        protected ReactiveTabBarController(IntPtr handle) : base(handle) { }
+        protected ReactiveTabBarController(NSObjectFlag t) : base(t) { }
+        protected ReactiveTabBarController(NSCoder coder) : base(coder) { }
+        protected ReactiveTabBarController() { }
+
+        TViewModel _viewModel;
+        public TViewModel ViewModel {
+            get { return _viewModel; }
+            set { this.RaiseAndSetIfChanged(ref _viewModel, value); }
+        }
+
+        object IViewFor.ViewModel {
+            get { return ViewModel; }
+            set { ViewModel = (TViewModel)value; }
         }
     }
 }

--- a/src/ReactiveUI/Cocoa/ReactiveTableView.cs
+++ b/src/ReactiveUI/Cocoa/ReactiveTableView.cs
@@ -1,19 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Diagnostics.Contracts;
-using System.Drawing;
-using System.Linq;
 using System.Reactive;
 using System.Reactive.Concurrency;
-using System.Reactive.Disposables;
 using System.Reactive.Subjects;
-using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Runtime.Serialization;
-using System.Threading;
-using ReactiveUI;
-using Splat;
 using System.Reactive.Linq;
 
 #if UNIFIED
@@ -21,6 +10,7 @@ using CoreGraphics;
 using Foundation;
 using UIKit;
 #else
+using System.Drawing;
 using MonoTouch.Foundation;
 using MonoTouch.UIKit;
 #endif
@@ -30,16 +20,16 @@ namespace ReactiveUI
     public abstract class ReactiveTableView : UITableView, IReactiveNotifyPropertyChanged<ReactiveTableView>, IHandleObservableErrors, IReactiveObject, ICanActivate, ICanForceManualActivation
     {
 #if UNIFIED
-        public ReactiveTableView(CGRect frame) : base(frame) { }
-        public ReactiveTableView(CGRect frame, UITableViewStyle style) : base(frame, style) { }
+        protected ReactiveTableView(CGRect frame) : base(frame) { }
+        protected ReactiveTableView(CGRect frame, UITableViewStyle style) : base(frame, style) { }
 #else
-        public ReactiveTableView(RectangleF frame) : base(frame) { }
-        public ReactiveTableView(RectangleF frame, UITableViewStyle style) : base(frame, style) { }
+        protected ReactiveTableView(RectangleF frame) : base(frame) { }
+        protected ReactiveTableView(RectangleF frame, UITableViewStyle style) : base(frame, style) { }
 #endif
 
-        public ReactiveTableView(NSObjectFlag t) : base(t) { }
-        public ReactiveTableView(NSCoder coder) : base(coder) { }
-        public ReactiveTableView() { }
+        protected ReactiveTableView(NSObjectFlag t) : base(t) { }
+        protected ReactiveTableView(NSCoder coder) : base(coder) { }
+        protected ReactiveTableView() { }
 
         protected ReactiveTableView(IntPtr handle) : base(handle) { }
 
@@ -78,7 +68,8 @@ namespace ReactiveUI
             get { return this.getChangedObservable(); }
         }
 
-        public IDisposable SuppressChangeNotifications() {
+        public IDisposable SuppressChangeNotifications()
+        {
             return this.suppressChangeNotifications();
         }
 
@@ -95,10 +86,39 @@ namespace ReactiveUI
             RxApp.MainThreadScheduler.Schedule(() => (newsuper != null ? activated : deactivated).OnNext(Unit.Default));
         }
 
-        void ICanForceManualActivation.Activate(bool activate) 
+        void ICanForceManualActivation.Activate(bool activate)
         {
-            RxApp.MainThreadScheduler.Schedule(() => 
+            RxApp.MainThreadScheduler.Schedule(() =>
                 (activate ? activated : deactivated).OnNext(Unit.Default));
+        }
+    }
+
+    public abstract class ReactiveTableView<TViewModel> : ReactiveTableView, IViewFor<TViewModel>
+        where TViewModel : class
+    {
+#if UNIFIED
+        protected ReactiveTableView(CGRect frame) : base(frame) { }
+        protected ReactiveTableView(CGRect frame, UITableViewStyle style) : base(frame, style) { }
+#else
+        protected ReactiveTableView(RectangleF frame) : base(frame) { }
+        protected ReactiveTableView(RectangleF frame, UITableViewStyle style) : base(frame, style) { }
+#endif
+
+        protected ReactiveTableView(NSObjectFlag t) : base(t) { }
+        protected ReactiveTableView(NSCoder coder) : base(coder) { }
+        protected ReactiveTableView() { }
+
+        protected ReactiveTableView(IntPtr handle) : base(handle) { }
+
+        TViewModel _viewModel;
+        public TViewModel ViewModel {
+            get { return _viewModel; }
+            set { this.RaiseAndSetIfChanged(ref _viewModel, value); }
+        }
+
+        object IViewFor.ViewModel {
+            get { return ViewModel; }
+            set { ViewModel = (TViewModel)value; }
         }
     }
 }

--- a/src/ReactiveUI/Cocoa/ReactiveTableViewCell.cs
+++ b/src/ReactiveUI/Cocoa/ReactiveTableViewCell.cs
@@ -1,19 +1,8 @@
 using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Diagnostics.Contracts;
-using System.Drawing;
-using System.Linq;
 using System.Reactive;
 using System.Reactive.Concurrency;
-using System.Reactive.Disposables;
 using System.Reactive.Subjects;
-using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Runtime.Serialization;
-using System.Threading;
-using ReactiveUI;
-using Splat;
 using System.Reactive.Linq;
 
 #if UNIFIED
@@ -21,6 +10,7 @@ using CoreGraphics;
 using Foundation;
 using UIKit;
 #else
+using System.Drawing;
 using MonoTouch.Foundation;
 using MonoTouch.UIKit;
 #endif
@@ -30,17 +20,17 @@ namespace ReactiveUI
     public abstract class ReactiveTableViewCell : UITableViewCell, IReactiveNotifyPropertyChanged<ReactiveTableViewCell>, IHandleObservableErrors, IReactiveObject, ICanActivate
     {
 #if UNIFIED
-        public ReactiveTableViewCell(CGRect frame) : base (frame) { setupRxObj(); }
+        protected ReactiveTableViewCell(CGRect frame) : base(frame) { setupRxObj(); }
 #else
-        public ReactiveTableViewCell(RectangleF frame) : base (frame) { setupRxObj(); }
+        protected ReactiveTableViewCell(RectangleF frame) : base (frame) { setupRxObj(); }
 #endif
 
-        public ReactiveTableViewCell(NSObjectFlag t) : base (t) { setupRxObj(); }
-        public ReactiveTableViewCell(NSCoder coder) : base (NSObjectFlag.Empty) { setupRxObj(); }
-        public ReactiveTableViewCell() : base() { setupRxObj(); }
-        public ReactiveTableViewCell(UITableViewCellStyle style, string reuseIdentifier) : base(style, reuseIdentifier) { setupRxObj(); }
-        public ReactiveTableViewCell(UITableViewCellStyle style, NSString reuseIdentifier) : base(style, reuseIdentifier) { setupRxObj(); }
-        protected ReactiveTableViewCell(IntPtr handle) : base (handle) { setupRxObj(); }
+        protected ReactiveTableViewCell(NSObjectFlag t) : base(t) { setupRxObj(); }
+        protected ReactiveTableViewCell(NSCoder coder) : base(NSObjectFlag.Empty) { setupRxObj(); }
+        protected ReactiveTableViewCell() : base() { setupRxObj(); }
+        protected ReactiveTableViewCell(UITableViewCellStyle style, string reuseIdentifier) : base(style, reuseIdentifier) { setupRxObj(); }
+        protected ReactiveTableViewCell(UITableViewCellStyle style, NSString reuseIdentifier) : base(style, reuseIdentifier) { setupRxObj(); }
+        protected ReactiveTableViewCell(IntPtr handle) : base(handle) { setupRxObj(); }
 
         public event PropertyChangingEventHandler PropertyChanging {
             add { PropertyChangingEventManager.AddHandler(this, value); }
@@ -94,7 +84,7 @@ namespace ReactiveUI
         {
             return this.suppressChangeNotifications();
         }
-                
+
         Subject<Unit> activated = new Subject<Unit>();
         public IObservable<Unit> Activated { get { return activated.AsObservable(); } }
         Subject<Unit> deactivated = new Subject<Unit>();
@@ -104,6 +94,34 @@ namespace ReactiveUI
         {
             base.WillMoveToSuperview(newsuper);
             RxApp.MainThreadScheduler.Schedule(() => (newsuper != null ? activated : deactivated).OnNext(Unit.Default));
+        }
+    }
+
+    public abstract class ReactiveTableViewCell<TViewModel> : ReactiveTableViewCell, IViewFor<TViewModel>
+        where TViewModel : class
+    {
+#if UNIFIED
+        protected ReactiveTableViewCell(CGRect frame) : base(frame) { }
+#else
+        protected ReactiveTableViewCell(RectangleF frame) : base (frame) { }
+#endif
+
+        protected ReactiveTableViewCell(NSObjectFlag t) : base(t) { }
+        protected ReactiveTableViewCell(NSCoder coder) : base(NSObjectFlag.Empty) { }
+        protected ReactiveTableViewCell() : base() { }
+        protected ReactiveTableViewCell(UITableViewCellStyle style, string reuseIdentifier) : base(style, reuseIdentifier) { }
+        protected ReactiveTableViewCell(UITableViewCellStyle style, NSString reuseIdentifier) : base(style, reuseIdentifier) { }
+        protected ReactiveTableViewCell(IntPtr handle) : base(handle) { }
+
+        TViewModel _viewModel;
+        public TViewModel ViewModel {
+            get { return _viewModel; }
+            set { this.RaiseAndSetIfChanged(ref _viewModel, value); }
+        }
+
+        object IViewFor.ViewModel {
+            get { return ViewModel; }
+            set { ViewModel = (TViewModel)value; }
         }
     }
 }

--- a/src/ReactiveUI/Cocoa/ReactiveTableViewController.cs
+++ b/src/ReactiveUI/Cocoa/ReactiveTableViewController.cs
@@ -1,19 +1,7 @@
 using System;
-using ReactiveUI;
-using System.Runtime.Serialization;
 using System.ComponentModel;
-using System.Reflection;
 using System.Reactive;
 using System.Reactive.Subjects;
-using System.Reactive.Concurrency;
-using System.Linq;
-using System.Threading;
-using System.Reactive.Disposables;
-using System.Diagnostics.Contracts;
-using System.Runtime.CompilerServices;
-using System.Collections.Generic;
-using System.Drawing;
-using Splat;
 using System.Reactive.Linq;
 
 #if UNIFIED
@@ -30,8 +18,8 @@ using NSTableViewStyle = MonoTouch.UIKit.UITableViewStyle;
 
 namespace ReactiveUI
 {
-    public abstract class ReactiveTableViewController : NSTableViewController, 
-	IReactiveNotifyPropertyChanged<ReactiveTableViewController>, IHandleObservableErrors, IReactiveObject, ICanActivate
+    public abstract class ReactiveTableViewController : NSTableViewController,
+    IReactiveNotifyPropertyChanged<ReactiveTableViewController>, IHandleObservableErrors, IReactiveObject, ICanActivate
     {
         protected ReactiveTableViewController(NSTableViewStyle withStyle) : base(withStyle) { setupRxObj(); }
         protected ReactiveTableViewController(string nibName, NSBundle bundle) : base(nibName, bundle) { setupRxObj(); }
@@ -110,6 +98,28 @@ namespace ReactiveUI
             base.ViewDidDisappear(animated);
             deactivated.OnNext(Unit.Default);
             this.ActivateSubviews(false);
+        }
+    }
+
+    public abstract class ReactiveTableViewController<TViewModel> : ReactiveTableViewController, IViewFor<TViewModel>
+        where TViewModel : class
+    {
+        protected ReactiveTableViewController(NSTableViewStyle withStyle) : base(withStyle) { }
+        protected ReactiveTableViewController(string nibName, NSBundle bundle) : base(nibName, bundle) { }
+        protected ReactiveTableViewController(IntPtr handle) : base(handle) { }
+        protected ReactiveTableViewController(NSObjectFlag t) : base(t) { }
+        protected ReactiveTableViewController(NSCoder coder) : base(coder) { }
+        protected ReactiveTableViewController() { }
+
+        TViewModel _viewModel;
+        public TViewModel ViewModel {
+            get { return _viewModel; }
+            set { this.RaiseAndSetIfChanged(ref _viewModel, value); }
+        }
+
+        object IViewFor.ViewModel {
+            get { return ViewModel; }
+            set { ViewModel = (TViewModel)value; }
         }
     }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
I've added generic versions of every Reactive ViewController and View / Control on iOS and Mac to allow easier assignment of ViewModels with such classes. 
We use these classes in all of our projects, and it's kind of cumbersome to copy them every time, or to create a special package.

It's also spoken of in https://github.com/reactiveui/ReactiveUI/issues/1029.


**What is the current behavior? (You can also link to an open issue here)**
You have to create/add these versions to all of your projects.


**What is the new behavior (if this is a feature change)?**
They're factory-installed!


**Does this PR introduce a breaking change?**
It shouldn't, since the non-generic versions are still there. I took the liberty of cleaning up unused usings though. But this is a case of "If it builds, it works."


**Please check if the PR fulfills these requirements**
- [x] The commit follows our guidelines: https://github.com/reactiveui/reactiveui#contribute
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

