### PR TITLE
feature: allow WireUpControls to find View members

### DIFF
--- a/src/ReactiveUI/Android/ControlFetcherMixin.cs
+++ b/src/ReactiveUI/Android/ControlFetcherMixin.cs
@@ -78,7 +78,7 @@ namespace ReactiveUI
         public static void WireUpControls(this ILayoutViewHost This)
         {
             var members = This.GetType().GetRuntimeProperties()
-                .Where(m => m.PropertyType.IsSubclassOf(typeof(View)) || m.PropertyType == typeof(View));
+                .Where(m => typeof(View).IsAssignableFrom(m.PropertyType));
 
             members.ToList().ForEach(m => {
                 try {
@@ -100,7 +100,7 @@ namespace ReactiveUI
         public static void WireUpControls(this View This)
         {
             var members = This.GetType().GetRuntimeProperties()
-                .Where(m => m.PropertyType.IsSubclassOf(typeof(View)) || m.PropertyType == typeof(View));
+                .Where(m => typeof(View).IsAssignableFrom(m.PropertyType));
 
             members.ToList().ForEach(m => {
                 try {
@@ -124,7 +124,7 @@ namespace ReactiveUI
         public static void WireUpControls(this Fragment This, View inflatedView)
         {
             var members = This.GetType().GetRuntimeProperties()
-                .Where(m => m.PropertyType.IsSubclassOf(typeof(View)) || m.PropertyType == typeof(View));
+                .Where(m => typeof(View).IsAssignableFrom(m.PropertyType));
 
             members.ToList().ForEach(m => {
                 try {
@@ -146,7 +146,7 @@ namespace ReactiveUI
         public static void WireUpControls(this Activity This)
         {
             var members = This.GetType().GetRuntimeProperties()
-                .Where(m => m.PropertyType.IsSubclassOf(typeof(View)) || m.PropertyType == typeof(View));
+                .Where(m => typeof(View).IsAssignableFrom(m.PropertyType));
 
             members.ToList().ForEach(m => {
                 try {

--- a/src/ReactiveUI/Android/ControlFetcherMixin.cs
+++ b/src/ReactiveUI/Android/ControlFetcherMixin.cs
@@ -78,7 +78,7 @@ namespace ReactiveUI
         public static void WireUpControls(this ILayoutViewHost This)
         {
             var members = This.GetType().GetRuntimeProperties()
-                .Where(m => m.PropertyType.IsSubclassOf(typeof(View)));
+                .Where(m => m.PropertyType.IsSubclassOf(typeof(View)) || m.PropertyType == typeof(View));
 
             members.ToList().ForEach(m => {
                 try {
@@ -100,7 +100,7 @@ namespace ReactiveUI
         public static void WireUpControls(this View This)
         {
             var members = This.GetType().GetRuntimeProperties()
-                .Where(m => m.PropertyType.IsSubclassOf(typeof(View)));
+                .Where(m => m.PropertyType.IsSubclassOf(typeof(View)) || m.PropertyType == typeof(View));
 
             members.ToList().ForEach(m => {
                 try {
@@ -124,7 +124,7 @@ namespace ReactiveUI
         public static void WireUpControls(this Fragment This, View inflatedView)
         {
             var members = This.GetType().GetRuntimeProperties()
-                .Where(m => m.PropertyType.IsSubclassOf(typeof(View)));
+                .Where(m => m.PropertyType.IsSubclassOf(typeof(View)) || m.PropertyType == typeof(View));
 
             members.ToList().ForEach(m => {
                 try {
@@ -146,7 +146,7 @@ namespace ReactiveUI
         public static void WireUpControls(this Activity This)
         {
             var members = This.GetType().GetRuntimeProperties()
-                .Where(m => m.PropertyType.IsSubclassOf(typeof(View)));
+                .Where(m => m.PropertyType.IsSubclassOf(typeof(View)) || m.PropertyType == typeof(View));
 
             members.ToList().ForEach(m => {
                 try {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
This will allow `WireUpControls()` to wire up View properties, and not just subclasses of it.


**What is the current behavior? (You can also link to an open issue here)**
`WireUpControls()` doesn't currently wire up View properties, just subclasses.


**What is the new behavior (if this is a feature change)?**
`WireUpControls()` now also wires up View properties.


**Does this PR introduce a breaking change?**
It shouldn't, unless you were expecting `null` values on your View properties. If you were working around this with manual `FindViewById` calls you're assigning the same view twice to the same property, worst-case. (Considering you weren't using duplicate names for views or controls in the first place.)


**Please check if the PR fulfills these requirements**
- [x] The commit follows our guidelines: https://github.com/reactiveui/reactiveui#contribute
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

