### PR TITLE
fix: subscription leakage in ReactiveCommand

### DIFF
--- a/src/ReactiveUI.Tests/ReactiveCommandTest.cs
+++ b/src/ReactiveUI.Tests/ReactiveCommandTest.cs
@@ -101,6 +101,19 @@ namespace ReactiveUI.Tests
         }
 
         [Fact]
+        public void CanExecuteIsUnsubscribedAfterCommandDisposal()
+        {
+            var canExecuteSubject = new Subject<bool>();
+            var fixture = ReactiveCommand.Create(() => Observable.Return(Unit.Default), canExecuteSubject);
+
+            Assert.True(canExecuteSubject.HasObservers);
+
+            fixture.Dispose();
+
+            Assert.False(canExecuteSubject.HasObservers);
+        }
+
+        [Fact]
         public void CanExecuteTicksFailuresThroughThrownExceptions()
         {
             var canExecuteSubject = new Subject<bool>();

--- a/src/ReactiveUI/ReactiveCommand.cs
+++ b/src/ReactiveUI/ReactiveCommand.cs
@@ -776,11 +776,9 @@ namespace ReactiveUI
 
             this.exceptions = new ScheduledSubject<Exception>(outputScheduler, RxApp.DefaultExceptionHandler);
 
-            this
+            this.canExecuteSubscription = this
                 .canExecute
                 .Subscribe(_ => this.OnCanExecuteChanged());
-
-            this.canExecuteSubscription = this.canExecute.Subscribe();
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
Hi! I've described my issue today on the slack channel but nobody replies to me so I found the problem myself :smile: That's my original message:

[SlackMessage]
Hello everyone! I have a problem: the `ViewModel` is leaking if I use any property of the `Model` inside `canExecute` argument of any `ReactiveCommand`. The `Model` lives for the entire life of the application but `ViewModel` should be removed when I close its tab. I use RxUI 7.0. The example:
```c#
var canDeepCopy = this.WhenAnyValue(vm => vm.Model.Id).Select(id => id != Constants.NewEntityId);
this.DeepCopy = ReactiveCommand.Create(this.HandleDeepCopy, canDeepCopy);
```
If I replace `canDeepCopy` value by `Observable.Return(true)` `ViewModel` is not leaking anymore. I even tried to dispose `DeepCopy` command but it didn't give any results. By the way I have another command in this `ViewModel` which doesn't use the `Model` inside its `canExecute` and this command doesn't cause the leakage of the `ViewModel`.
My application is written in WPF.
I can't find any information whether I should dispose reactive commands or not.
https://docs.reactiveui.net/en/design-guidelines/use-this-on-left-of-whenany.html Here I found that there can be the problems if lifetime of the object on which we call `WhenAny` is longer than lifetime of our object. But there is no info about whether it cause the problems if I use such long-life dependency inside the expression argument of `WhenAny`.
[/SlackMessage]

The actual problem was the leakage of subscription to `canExecute`. There are two subscriptions and I don't know why do we need the second one so I just removed it. But the first one which do the actual work is not disposed so I fixed it. I've tested these changes in my project and everything works fine now.