### PR TITLE
 fix: reactiveui packages should be pinned and only work with packages from the same release

### DIFF
--- a/src/ReactiveUI-AndroidSupport.nuspec
+++ b/src/ReactiveUI-AndroidSupport.nuspec
@@ -7,7 +7,7 @@
     <language>en-us</language>
 
     <dependencies>
-      <dependency id="reactiveui-core" version="$version$" />
+      <dependency id="reactiveui-core" version="[$version$]" />
       <dependency id="Xamarin.Android.Support.v4" version="22.1.1.1" />
       <dependency id="Xamarin.Android.Support.v7.AppCompat" version="22.1.1.1" />
       <dependency id="Xamarin.Android.Support.v7.RecyclerView" version="22.1.1.1" />

--- a/src/ReactiveUI-Blend.nuspec
+++ b/src/ReactiveUI-Blend.nuspec
@@ -7,22 +7,22 @@
     <language>en-us</language>
     <dependencies>
       <group>
-        <dependency id="reactiveui-core" version="$version$" />
+        <dependency id="reactiveui-core" version="[$version$]" />
       </group>
       <group targetFramework="net45">
-        <dependency id="reactiveui-core" version="$version$" />
+        <dependency id="reactiveui-core" version="[$version$]" />
         <dependency id="Rx-Xaml" version="2.2.5" />
       </group>
       <group targetFramework="wp8">
-        <dependency id="reactiveui-core" version="$version$" />
+        <dependency id="reactiveui-core" version="[$version$]" />
         <dependency id="Rx-Xaml" version="2.2.5" />
       </group>
       <group targetFramework="Portable-Win81+WPA81">
-        <dependency id="reactiveui-core" version="$version$" />
+        <dependency id="reactiveui-core" version="[$version$]" />
         <dependency id="Rx-Xaml" version="2.2.5" />
       </group>
       <group targetFramework="uap10.0">
-        <dependency id="reactiveui-core" version="$version$" />
+        <dependency id="reactiveui-core" version="[$version$]" />
         <dependency id="System.Diagnostics.Debug" version="4.0.10" />
         <dependency id="Microsoft.Xaml.Behaviors.Uwp.Managed" version="1.1.0" />
         <dependency id="Rx-Core" version="2.2.5" />

--- a/src/ReactiveUI-Testing.nuspec
+++ b/src/ReactiveUI-Testing.nuspec
@@ -7,15 +7,15 @@
     <language>en-us</language>
     <dependencies>
       <group targetFramework="net45">
-        <dependency id="reactiveui-core" version="$version$" />
+        <dependency id="reactiveui-core" version="[$version$]" />
         <dependency id="Rx-Testing" version="2.2.5" />
       </group>
       <group targetFramework="Win8">
-        <dependency id="reactiveui-core" version="$version$" />
+        <dependency id="reactiveui-core" version="[$version$]" />
         <dependency id="Rx-Testing" version="2.2.5" />
       </group>
       <group targetFramework="uap10.0">
-        <dependency id="reactiveui-core" version="$version$" />
+        <dependency id="reactiveui-core" version="[$version$]" />
         <dependency id="Rx-Core" version="2.2.5" />
         <dependency id="Rx-Interfaces" version="2.2.5" />
         <dependency id="Rx-Linq" version="2.2.5" />
@@ -26,10 +26,10 @@
         <dependency id="System.Threading.Tasks" version="4.0.10" />
       </group>
       <group targetFramework="monoandroid">
-        <dependency id="reactiveui-core" version="$version$" />
+        <dependency id="reactiveui-core" version="[$version$]" />
       </group>
       <group targetFramework="monotouch">
-        <dependency id="reactiveui-core" version="$version$" />
+        <dependency id="reactiveui-core" version="[$version$]" />
       </group>
     </dependencies>
   </metadata>

--- a/src/ReactiveUI-Winforms.nuspec
+++ b/src/ReactiveUI-Winforms.nuspec
@@ -6,7 +6,7 @@
     <description>Windows Forms specific extensions to ReactiveUI</description>
     <language>en-us</language>
     <dependencies>
-      <dependency id="reactiveui-core" version="$version$" />
+      <dependency id="reactiveui-core" version="[$version$]" />
     </dependencies>
   </metadata>
   <files>

--- a/src/ReactiveUI-XamForms.nuspec
+++ b/src/ReactiveUI-XamForms.nuspec
@@ -6,7 +6,7 @@
     <description>Xamarin Forms specific extensions to ReactiveUI</description>
     <language>en-us</language>
     <dependencies>
-      <dependency id="reactiveui-core" version="$version$" />
+      <dependency id="reactiveui-core" version="[$version$]" />
       <dependency id="Xamarin.Forms" version="2.3.1.114" />
     </dependencies>
   </metadata>

--- a/src/ReactiveUI.nuspec
+++ b/src/ReactiveUI.nuspec
@@ -6,7 +6,7 @@
     <description>A MVVM framework that integrates with the Reactive Extensions for .NET to create elegant, testable User Interfaces that run on any mobile or desktop platform. Supports Xamarin.iOS, Xamarin.Android, Xamarin.Mac, Xamarin Forms, WPF, Windows Forms, Windows Phone 8.1, Windows Store and Universal Windows Platform (UWP).</description>
     <language>en-us</language>
     <dependencies>
-      <dependency id="reactiveui-core" version="$version$" />
+      <dependency id="reactiveui-core" version="[$version$]" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Bug fix.

**What is the current behavior? (You can also link to an open issue here)**

The packages are unpinned; `version="$version$"` means "Minimum version, inclusive" as per https://docs.nuget.org/ndocs/create-packages/dependency-versions


**What is the new behavior (if this is a feature change)?**

The packages are now pinned; `version="[$version$]"` means "Exact version match" as per https://docs.nuget.org/ndocs/create-packages/dependency-versions


**Does this PR introduce a breaking change?**

No, even if it did we don't want to support this behaviour. For maintainer sanity, we version ReactiveUI and package as a pinned group - all packages in a release will always be the same version and only work with that version which makes it impossible for a consumer to run into situations where they use reactiveui-core at 7.1.0 but reactiveui-xamforms at 7.0.0. Additionally all assemblies share the same CommonAssemblyInfo.cs which is updated just before compile time by the build infrastructure.

**Please check if the PR fulfills these requirements**
- [x] The commit follows our guidelines: https://github.com/reactiveui/reactiveui#contribute
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

https://docs.reactiveui.net/en/contributing/framework/semantic-versioning.html has been updated.

**Other information**:

Thankyou @martijn00 for spotting this.