### PR TITLE
chore: add NCrunch configuration

### DIFF
--- a/src/Microsoft.Reactive.Testing/Microsoft.Reactive.Testing_Android.v3.ncrunchproject
+++ b/src/Microsoft.Reactive.Testing/Microsoft.Reactive.Testing_Android.v3.ncrunchproject
@@ -1,0 +1,6 @@
+﻿<ProjectConfiguration>
+  <Settings>
+    <IgnoreThisComponentCompletely>True</IgnoreThisComponentCompletely>
+    <PreviouslyBuiltSuccessfully>True</PreviouslyBuiltSuccessfully>
+  </Settings>
+</ProjectConfiguration>

--- a/src/Microsoft.Reactive.Testing/Microsoft.Reactive.Testing_Mac.v3.ncrunchproject
+++ b/src/Microsoft.Reactive.Testing/Microsoft.Reactive.Testing_Mac.v3.ncrunchproject
@@ -1,0 +1,6 @@
+﻿<ProjectConfiguration>
+  <Settings>
+    <IgnoreThisComponentCompletely>True</IgnoreThisComponentCompletely>
+    <PreviouslyBuiltSuccessfully>True</PreviouslyBuiltSuccessfully>
+  </Settings>
+</ProjectConfiguration>

--- a/src/Microsoft.Reactive.Testing/Microsoft.Reactive.Testing_iOS.v3.ncrunchproject
+++ b/src/Microsoft.Reactive.Testing/Microsoft.Reactive.Testing_iOS.v3.ncrunchproject
@@ -1,0 +1,6 @@
+﻿<ProjectConfiguration>
+  <Settings>
+    <IgnoreThisComponentCompletely>True</IgnoreThisComponentCompletely>
+    <PreviouslyBuiltSuccessfully>True</PreviouslyBuiltSuccessfully>
+  </Settings>
+</ProjectConfiguration>

--- a/src/ReactiveUI.AndroidSupport/ReactiveUI.AndroidSupport.v3.ncrunchproject
+++ b/src/ReactiveUI.AndroidSupport/ReactiveUI.AndroidSupport.v3.ncrunchproject
@@ -1,0 +1,6 @@
+﻿<ProjectConfiguration>
+  <Settings>
+    <IgnoreThisComponentCompletely>True</IgnoreThisComponentCompletely>
+    <PreviouslyBuiltSuccessfully>True</PreviouslyBuiltSuccessfully>
+  </Settings>
+</ProjectConfiguration>

--- a/src/ReactiveUI.Blend/ReactiveUI.Blend_Net45.v3.ncrunchproject
+++ b/src/ReactiveUI.Blend/ReactiveUI.Blend_Net45.v3.ncrunchproject
@@ -1,0 +1,6 @@
+﻿<ProjectConfiguration>
+  <Settings>
+    <IgnoreThisComponentCompletely>False</IgnoreThisComponentCompletely>
+    <PreviouslyBuiltSuccessfully>True</PreviouslyBuiltSuccessfully>
+  </Settings>
+</ProjectConfiguration>

--- a/src/ReactiveUI.Blend/ReactiveUI.Blend_UWP.v3.ncrunchproject
+++ b/src/ReactiveUI.Blend/ReactiveUI.Blend_UWP.v3.ncrunchproject
@@ -1,0 +1,5 @@
+﻿<ProjectConfiguration>
+  <Settings>
+    <IgnoreThisComponentCompletely>True</IgnoreThisComponentCompletely>
+  </Settings>
+</ProjectConfiguration>

--- a/src/ReactiveUI.Blend/ReactiveUI.Blend_WinRT.v3.ncrunchproject
+++ b/src/ReactiveUI.Blend/ReactiveUI.Blend_WinRT.v3.ncrunchproject
@@ -1,0 +1,6 @@
+﻿<ProjectConfiguration>
+  <Settings>
+    <IgnoreThisComponentCompletely>True</IgnoreThisComponentCompletely>
+    <PreviouslyBuiltSuccessfully>True</PreviouslyBuiltSuccessfully>
+  </Settings>
+</ProjectConfiguration>

--- a/src/ReactiveUI.Testing/ReactiveUI.Testing_Android.v3.ncrunchproject
+++ b/src/ReactiveUI.Testing/ReactiveUI.Testing_Android.v3.ncrunchproject
@@ -1,0 +1,5 @@
+﻿<ProjectConfiguration>
+  <Settings>
+    <IgnoreThisComponentCompletely>True</IgnoreThisComponentCompletely>
+  </Settings>
+</ProjectConfiguration>

--- a/src/ReactiveUI.Testing/ReactiveUI.Testing_Mac.v3.ncrunchproject
+++ b/src/ReactiveUI.Testing/ReactiveUI.Testing_Mac.v3.ncrunchproject
@@ -1,0 +1,5 @@
+﻿<ProjectConfiguration>
+  <Settings>
+    <IgnoreThisComponentCompletely>True</IgnoreThisComponentCompletely>
+  </Settings>
+</ProjectConfiguration>

--- a/src/ReactiveUI.Testing/ReactiveUI.Testing_Net45.v3.ncrunchproject
+++ b/src/ReactiveUI.Testing/ReactiveUI.Testing_Net45.v3.ncrunchproject
@@ -1,0 +1,6 @@
+﻿<ProjectConfiguration>
+  <Settings>
+    <IgnoreThisComponentCompletely>False</IgnoreThisComponentCompletely>
+    <PreviouslyBuiltSuccessfully>True</PreviouslyBuiltSuccessfully>
+  </Settings>
+</ProjectConfiguration>

--- a/src/ReactiveUI.Testing/ReactiveUI.Testing_UWP.v3.ncrunchproject
+++ b/src/ReactiveUI.Testing/ReactiveUI.Testing_UWP.v3.ncrunchproject
@@ -1,0 +1,5 @@
+﻿<ProjectConfiguration>
+  <Settings>
+    <IgnoreThisComponentCompletely>True</IgnoreThisComponentCompletely>
+  </Settings>
+</ProjectConfiguration>

--- a/src/ReactiveUI.Testing/ReactiveUI.Testing_WinRT.v3.ncrunchproject
+++ b/src/ReactiveUI.Testing/ReactiveUI.Testing_WinRT.v3.ncrunchproject
@@ -1,0 +1,6 @@
+﻿<ProjectConfiguration>
+  <Settings>
+    <IgnoreThisComponentCompletely>True</IgnoreThisComponentCompletely>
+    <PreviouslyBuiltSuccessfully>True</PreviouslyBuiltSuccessfully>
+  </Settings>
+</ProjectConfiguration>

--- a/src/ReactiveUI.Testing/ReactiveUI.Testing_iOS.v3.ncrunchproject
+++ b/src/ReactiveUI.Testing/ReactiveUI.Testing_iOS.v3.ncrunchproject
@@ -1,0 +1,5 @@
+﻿<ProjectConfiguration>
+  <Settings>
+    <IgnoreThisComponentCompletely>True</IgnoreThisComponentCompletely>
+  </Settings>
+</ProjectConfiguration>

--- a/src/ReactiveUI.Winforms/ReactiveUI.Winforms_Net45.v3.ncrunchproject
+++ b/src/ReactiveUI.Winforms/ReactiveUI.Winforms_Net45.v3.ncrunchproject
@@ -1,0 +1,6 @@
+﻿<ProjectConfiguration>
+  <Settings>
+    <IgnoreThisComponentCompletely>False</IgnoreThisComponentCompletely>
+    <PreviouslyBuiltSuccessfully>True</PreviouslyBuiltSuccessfully>
+  </Settings>
+</ProjectConfiguration>

--- a/src/ReactiveUI.v3.ncrunchsolution
+++ b/src/ReactiveUI.v3.ncrunchsolution
@@ -1,0 +1,6 @@
+﻿<SolutionConfiguration>
+  <Settings>
+    <AllowParallelTestExecution>True</AllowParallelTestExecution>
+    <SolutionConfigured>True</SolutionConfigured>
+  </Settings>
+</SolutionConfiguration>

--- a/src/ReactiveUI/ReactiveUI.v3.ncrunchproject
+++ b/src/ReactiveUI/ReactiveUI.v3.ncrunchproject
@@ -1,0 +1,6 @@
+﻿<ProjectConfiguration>
+  <Settings>
+    <IgnoreThisComponentCompletely>True</IgnoreThisComponentCompletely>
+    <PreviouslyBuiltSuccessfully>True</PreviouslyBuiltSuccessfully>
+  </Settings>
+</ProjectConfiguration>

--- a/src/ReactiveUI/ReactiveUI_Android.v3.ncrunchproject
+++ b/src/ReactiveUI/ReactiveUI_Android.v3.ncrunchproject
@@ -1,0 +1,6 @@
+﻿<ProjectConfiguration>
+  <Settings>
+    <IgnoreThisComponentCompletely>True</IgnoreThisComponentCompletely>
+    <PreviouslyBuiltSuccessfully>True</PreviouslyBuiltSuccessfully>
+  </Settings>
+</ProjectConfiguration>

--- a/src/ReactiveUI/ReactiveUI_Mac.v3.ncrunchproject
+++ b/src/ReactiveUI/ReactiveUI_Mac.v3.ncrunchproject
@@ -1,0 +1,5 @@
+﻿<ProjectConfiguration>
+  <Settings>
+    <IgnoreThisComponentCompletely>True</IgnoreThisComponentCompletely>
+  </Settings>
+</ProjectConfiguration>

--- a/src/ReactiveUI/ReactiveUI_UWP.v3.ncrunchproject
+++ b/src/ReactiveUI/ReactiveUI_UWP.v3.ncrunchproject
@@ -1,0 +1,5 @@
+﻿<ProjectConfiguration>
+  <Settings>
+    <IgnoreThisComponentCompletely>True</IgnoreThisComponentCompletely>
+  </Settings>
+</ProjectConfiguration>

--- a/src/ReactiveUI/ReactiveUI_WinRT.v3.ncrunchproject
+++ b/src/ReactiveUI/ReactiveUI_WinRT.v3.ncrunchproject
@@ -1,0 +1,6 @@
+﻿<ProjectConfiguration>
+  <Settings>
+    <IgnoreThisComponentCompletely>True</IgnoreThisComponentCompletely>
+    <PreviouslyBuiltSuccessfully>True</PreviouslyBuiltSuccessfully>
+  </Settings>
+</ProjectConfiguration>

--- a/src/ReactiveUI/ReactiveUI_iOS.v3.ncrunchproject
+++ b/src/ReactiveUI/ReactiveUI_iOS.v3.ncrunchproject
@@ -1,0 +1,5 @@
+﻿<ProjectConfiguration>
+  <Settings>
+    <IgnoreThisComponentCompletely>True</IgnoreThisComponentCompletely>
+  </Settings>
+</ProjectConfiguration>


### PR DESCRIPTION
Add NCrunch v3 configuration files. All projects other than NET45 are
ignored, meaning this is for running tests on Windows (the only platform
NCrunch supports).

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Developer tooling.

**What is the current behavior? (You can also link to an open issue here)**

No NCrunch config, meaning NCrunch users such as myself either forgo it or add config each time they pull ReactiveUI source afresh.

**What is the new behavior (if this is a feature change)?**

Add NCrunch v3 configuration files.

**Does this PR introduce a breaking change?**

No.
