### PR TITLE
chore: failing to set the appveyor version should not be a fatal build error

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -338,7 +338,6 @@ Task("RunUnitTests")
 
 Task("UploadTestCoverage")
     .WithCriteria(() => !local)
-    .WithCriteria(() => isPullRequest)
     .WithCriteria(() => isRepository)
     .IsDependentOn("RunUnitTests")
     .Does(() =>

--- a/build.cake
+++ b/build.cake
@@ -287,6 +287,18 @@ Task("UpdateAppVeyorBuildNumber")
     .Does(() =>
 {
     AppVeyor.UpdateBuildVersion(buildVersion);
+
+}).ReportError(exception =>
+{  
+    // When a build starts, the initial identifier is an auto-incremented value supplied by AppVeyor. 
+    // As part of the build script, this version in AppVeyor is changed to be the version obtained from
+    // GitVersion. This identifier is purely cosmetic and is used by the core team to correlate a build
+    // with the pull-request. In some circumstances, such as restarting a failed/cancelled build the
+    // identifier in AppVeyor will be already updated and default behaviour is to throw an
+    // exception/cancel the build when in fact it is safe to swallow.
+    // See https://github.com/reactiveui/ReactiveUI/issues/1262
+
+    Warning("Build with version {0} already exists.", buildVersion);
 });
 
 Task("UpdateAssemblyInfo")


### PR DESCRIPTION
**Do you want to request a *feature* or report a *bug*?**

chore/bug

**What is the current behaviour?**

When a build starts, the initial identifier is an auto-incremented value supplied by AppVeyor. As part of the build script, this version in AppVeyor is changed to be the version obtained from GitVersion. This identifier is purely cosmetic and is used by the core team to correlate a build with the pull-request.

In some circumstances, such as restarting a failed/cancelled build the identifier in AppVeyor will be already updated and default behaviour is to throw an exception/cancel the build when in fact it is safe to swallow or append additional metadata (like the epoch when the build was started)

**What is the expected behavior?**

This throwing should not be a fatal build error https://github.com/reactiveui/ReactiveUI/blob/develop/build.cake#L289.

**Which versions of ReactiveUI, and which platform / OS are affected by this issue? Did this work in previous versions of ReativeUI? Please also test with the latest stable and snapshot (http://docs.reactiveui.net/en/contributing/snapshot/index.html) versions.**

v7.1.0

**Other information (e.g. stacktraces, related issues, suggestions how to fix)**

This is the root cause of the build problems experienced at https://github.com/reactiveui/ReactiveUI/pull/1252 - once this has been merged, update that PR via the update branch button and it will work again. 