### PR TITLE
fix: the assembly for Xamarin.Mac20 in the reactiveui-events NuGet pa…

### DIFF
--- a/src/ReactiveUI-Events.nuspec
+++ b/src/ReactiveUI-Events.nuspec
@@ -28,9 +28,9 @@
     <file src="bin/Release/Xamarin.iOS10/ReactiveUI.Events.pdb" target="lib/Xamarin.iOS10/ReactiveUI.Events.pdb" />
     <file src="bin/Release/Xamarin.iOS10/ReactiveUI.Events.xml" target="lib/Xamarin.iOS10/ReactiveUI.Events.xml" />
     <!-- Mac Mobile Unified API -->
-    <!-- <file src="bin/Release/Xamarin.Mac20/ReactiveUI.Events.dll" target="lib/Xamarin.Mac20/ReactiveUI.Events.dll" /> -->
-    <!-- <file src="bin/Release/Xamarin.Mac20/ReactiveUI.Events.pdb" target="lib/Xamarin.Mac20/ReactiveUI.Events.pdb" /> -->
-    <!-- <file src="bin/Release/Xamarin.Mac20/ReactiveUI.Events.xml" target="lib/Xamarin.Mac20/ReactiveUI.Events.xml" /> -->
+    <file src="bin/Release/Xamarin.Mac20/ReactiveUI.Events.dll" target="lib/Xamarin.Mac20/ReactiveUI.Events.dll" />
+    <file src="bin/Release/Xamarin.Mac20/ReactiveUI.Events.pdb" target="lib/Xamarin.Mac20/ReactiveUI.Events.pdb" />
+    <file src="bin/Release/Xamarin.Mac20/ReactiveUI.Events.xml" target="lib/Xamarin.Mac20/ReactiveUI.Events.xml" />
     <!-- Windows Store 8.1 -->
     <file src="bin/Release/WPA81/ReactiveUI.Events.dll" target="lib/WPA81/ReactiveUI.Events.dll" />
     <file src="bin/Release/WPA81/ReactiveUI.Events.pdb" target="lib/WPA81/ReactiveUI.Events.pdb" />

--- a/src/ReactiveUI.Events/ReactiveUI.Events_Mac.csproj
+++ b/src/ReactiveUI.Events/ReactiveUI.Events_Mac.csproj
@@ -49,7 +49,7 @@
     <DefineConstants>MONO;COCOA;UNIFIED</DefineConstants>
     <DebugSymbols>true</DebugSymbols>
     <GenerateDocumentation>True</GenerateDocumentation>
-    <DocumentationFile>bin\Release\Xamarin.Mac20\ReactiveUI.xml</DocumentationFile>
+    <DocumentationFile>bin\Release\Xamarin.Mac20\ReactiveUI.Events.xml</DocumentationFile>
     <UseRefCounting>false</UseRefCounting>
     <Profiling>false</Profiling>
   </PropertyGroup>
@@ -88,6 +88,5 @@
   <ItemGroup>
     <Folder Include="Properties\" />
   </ItemGroup>
-  <Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets" Condition=" '$(OS)' == 'Windows_NT' " />
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" Condition=" '$(OS)' == 'Windows_NT' " />
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets" />
 </Project>

--- a/src/ReactiveUI.Tests/PropertyBindingTest.cs
+++ b/src/ReactiveUI.Tests/PropertyBindingTest.cs
@@ -81,14 +81,15 @@ namespace ReactiveUI.Tests
             Assert.Equal(vm.JustADecimal.ToString(), view.SomeTextBox.Text);
             Assert.Equal(123.45m, vm.JustADecimal);
 
-            view.SomeTextBox.Text = "567.89";
+			var justAnotherDecimal = 567.89m;
+            view.SomeTextBox.Text = justAnotherDecimal.ToString();
             Assert.Equal(567.89m, vm.JustADecimal);
 
             disp.Dispose();
             vm.JustADecimal = 0;
 
             Assert.Equal(0, vm.JustADecimal);
-            Assert.Equal("567.89", view.SomeTextBox.Text);
+            Assert.Equal(justAnotherDecimal.ToString(), view.SomeTextBox.Text);
         }
 
         [Fact]


### PR DESCRIPTION
…ckage is not included #1259

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

fixed document file naming and build tools path

**What is the current behavior? (You can also link to an open issue here)**

ReactiveUI-events nuget could not be installed on Xamarin.Mac mobile framework

**What is the new behavior (if this is a feature change)?**

ReactiveUI-events nuget can be installed on Xamarin.Mac mobile framework

**Does this PR introduce a breaking change?**

No

**Please check if the PR fulfills these requirements**
- [x] The commit follows our guidelines: https://github.com/reactiveui/reactiveui#contribute
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

To install any ReactiveUI nuget for Xamarin.Mac mobile framework you must follow the steps described here: [Xamarin Forum](https://forums.xamarin.com/discussion/comment/253740#Comment_253740)