### PR TITLE
fix: add UseInvariantCultureAttribute and apply to relevant tests

### DIFF
--- a/src/ReactiveUI.Tests/PropertyBindingTest.cs
+++ b/src/ReactiveUI.Tests/PropertyBindingTest.cs
@@ -66,7 +66,7 @@ namespace ReactiveUI.Tests
 
     public class PropertyBindingTest
     {
-        [Fact]
+        [Fact, UseInvariantCulture]
         public void TwoWayBindWithFuncConvertersSmokeTest()
         {
             var vm = new PropertyBindViewModel();


### PR DESCRIPTION
feat:, style: add an XUnit attribute to allow test running on invariant culture, this will avoid failed tests because of e.g. decimal separator differences

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

feature to prevent failed tests because of culture dependent decimal separators

**What is the current behavior? (You can also link to an open issue here)**

TwoWayBindWithFuncConvertersSmokeTest will fail on German locale

**What is the new behavior (if this is a feature change)?**

TwoWayBindWithFuncConvertersSmokeTest will succeed on German locale

**Does this PR introduce a breaking change?**

No!

**Please check if the PR fulfills these requirements**
- [X ] The commit follows our guidelines: https://github.com/reactiveui/reactiveui#contribute
- [X] Tests for the changes have been added (for bug fixes / features)

[Fact, UseInvariantCulture]
TwoWayBindWithFuncConvertersSmokeTest

- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

Rebracer restyled existing code from Utility.cs no other modifications haven been applied
