### PR TITLE
fix: assign VM from correct thread in RoutedViewHost

### DIFF
--- a/src/ReactiveUI.XamForms/XamForms/RoutedViewHost.cs
+++ b/src/ReactiveUI.XamForms/XamForms/RoutedViewHost.cs
@@ -94,7 +94,7 @@ namespace ReactiveUI.XamForms
                         }
 
                         popToRootPending = false;
-                        return Unit.Default;
+                        return x;
                     })
                     .Subscribe());
 

--- a/src/ReactiveUI.XamForms/XamForms/RoutedViewHost.cs
+++ b/src/ReactiveUI.XamForms/XamForms/RoutedViewHost.cs
@@ -48,7 +48,7 @@ namespace ReactiveUI.XamForms
                     .Where(_ => !userInstigated)
                     .Where(x => x.Delta > 0)
                     .SelectMany(
-                        x =>
+                        async x =>
                         {
                             // XF doesn't provide a means of navigating back more than one screen at a time apart from navigating right back to the root page
                             // since we want as sensible an animation as possible, we pop to root if that makes sense. Otherwise, we pop each individual
@@ -60,46 +60,41 @@ namespace ReactiveUI.XamForms
                             {
                                 if (popToRoot)
                                 {
-                                    this.PopToRootAsync(true)
-                                        .ToObservable();
+                                    await this.PopToRootAsync(true);
                                 }
                                 else
                                 {
                                     for (var i = 0; i < x.Delta; ++i)
                                     {
-                                        this.PopAsync(i == x.Delta - 1)
-                                            .ToObservable()
-                                            .Select(_ => Unit.Default);
+                                        await this.PopAsync(i == x.Delta - 1);
                                     }
                                 }
                             }
                             finally
                             {
                                 currentlyPopping = false;
+                                ((IViewFor)this.CurrentPage).ViewModel = Router.GetCurrentViewModel();
                             }
 
-                            return Observable.Return(Unit.Default);
+                            return Unit.Default;
                         })
-                    .Do(_ => ((IViewFor)this.CurrentPage).ViewModel = Router.GetCurrentViewModel())
                     .Subscribe());
 
                 d(this.WhenAnyObservable(x => x.Router.Navigate)
                     .SelectMany(_ => PageForViewModel(Router.GetCurrentViewModel()))
-                    .SelectMany(x => {
+                    .SelectMany(async x => {
                         if (popToRootPending && this.Navigation.NavigationStack.Count > 0)
                         {
                             this.Navigation.InsertPageBefore(x, this.Navigation.NavigationStack[0]);
-                            this.PopToRootAsync()
-                                .ToObservable();
+                            await this.PopToRootAsync();
                         }
                         else
                         {
-                            this.PushAsync(x)
-                                .ToObservable();
+                            await this.PushAsync(x);
                         }
 
                         popToRootPending = false;
-                        return Observable.Return(Unit.Default);
+                        return Unit.Default;
                     })
                     .Subscribe());
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Removed a buggy checkin with attempting to replace TPL with ToObservable.  I tried changing the SelectMany to correctly return the Observables and the Do went back to being on the Thread Pool.  So for now I just moved the assignment of the VM up to the finally block of the SelectMany

**What is the current behavior? (You can also link to an open issue here)**

The VM gets assigned in the Do block. 

**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?**

It shouldn't

**Please check if the PR fulfills these requirements**
- [ ] The commit follows our guidelines: https://github.com/reactiveui/reactiveui#contribute
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

