### PR TITLE
fix: mac targets can now build on XS, VS, command line

### DIFF
--- a/src/ReactiveUI.Events/ReactiveUI.Events_Mac.csproj
+++ b/src/ReactiveUI.Events/ReactiveUI.Events_Mac.csproj
@@ -88,6 +88,5 @@
   <ItemGroup>
     <Folder Include="Properties\" />
   </ItemGroup>
-  <Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets" Condition=" '$(OS)' == 'Windows_NT' " />
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" Condition=" '$(OS)' == 'Windows_NT' " />
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets" />
 </Project>

--- a/src/ReactiveUI.Testing/ReactiveUI.Testing_Mac.csproj
+++ b/src/ReactiveUI.Testing/ReactiveUI.Testing_Mac.csproj
@@ -73,14 +73,7 @@
   <ItemGroup>
     <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets" />
   <ItemGroup>
     <ProjectReference Include="..\ReactiveUI\ReactiveUI_Mac.csproj">
       <Project>{0913BF79-061F-4667-ADF9-8E6CDA6D1213}</Project>

--- a/src/ReactiveUI/ReactiveUI_Mac.csproj
+++ b/src/ReactiveUI/ReactiveUI_Mac.csproj
@@ -158,5 +158,5 @@
   <ItemGroup>
     <None Include="packages.ReactiveUI_Mac.config" />
   </ItemGroup>
-  <Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets" Condition=" '$(OS)' == 'Windows_NT' " />
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets" />
 </Project>


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

ReactiveUI.Events_Mac, ReactiveUI_Mac, ReactiveUI.Testing_Mac could not be build inside Xamarin Studio

**What is the current behavior? (You can also link to an open issue here)**

ReactiveUI.Events_Mac, ReactiveUI_Mac, ReactiveUI.Testing_Mac can be build inside Xamarin Studio, Visual Studio, Windows command line

**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?**



**Please check if the PR fulfills these requirements**
- [x] The commit follows our guidelines: https://github.com/reactiveui/reactiveui#contribute
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

Related to changes from #1175