### PR TITLE
fix: prefer runtime type when resolving views

### DIFF
--- a/src/ReactiveUI.Tests/ViewLocatorTests.cs
+++ b/src/ReactiveUI.Tests/ViewLocatorTests.cs
@@ -13,6 +13,10 @@ namespace ReactiveUI.Tests
     {
     }
 
+    public class FooViewModelWithWeirdName : ReactiveObject, IFooViewModel
+    {
+    }
+
     public class BarViewModel : ReactiveObject, IBarViewModel
     {
     }
@@ -82,6 +86,24 @@ namespace ReactiveUI.Tests
             using (resolver.WithResolver()) {
                 var fixture = new DefaultViewLocator();
                 FooViewModel vm = new FooViewModel();
+
+                var result = fixture.ResolveView(vm);
+                Assert.True(result is FooView);
+            }
+        }
+
+        [Fact]
+        public void TheRuntimeTypeOfTheViewModelIsUsedToResolveTheView()
+        {
+            var resolver = new ModernDependencyResolver();
+
+            resolver.InitializeSplat();
+            resolver.InitializeReactiveUI();
+            resolver.Register(() => new FooView(), typeof(FooView));
+
+            using (resolver.WithResolver()) {
+                var fixture = new DefaultViewLocator();
+                object vm = new FooViewModel();
 
                 var result = fixture.ResolveView(vm);
                 Assert.True(result is FooView);
@@ -172,7 +194,7 @@ namespace ReactiveUI.Tests
 
             using (resolver.WithResolver()) {
                 var fixture = new DefaultViewLocator();
-                IFooViewModel vm = new FooViewModel();
+                IFooViewModel vm = new FooViewModelWithWeirdName();
 
                 var result = fixture.ResolveView(vm);
                 Assert.True(result is FooView);

--- a/src/ReactiveUI/ViewLocator.cs
+++ b/src/ReactiveUI/ViewLocator.cs
@@ -48,11 +48,22 @@ namespace ReactiveUI
         /// </summary>
         /// <remarks>
         /// <para>
-        /// Given view model type <c>T</c>, this implementation will attempt to resolve the following views:
+        /// Given view model type <c>T</c> with runtime type <c>RT</c>, this implementation will attempt to resolve the following views:
         /// <list type="number">
         /// <item>
         /// <description>
-        /// Look for a service registered under the type whose name is given to us by <see cref="ViewModelToViewFunc"/> (which defaults to changing "ViewModel" to "View").
+        /// Look for a service registered under the type whose name is given to us by passing <c>RT</c> to <see cref="ViewModelToViewFunc"/> (which defaults to changing "ViewModel" to "View").
+        /// </description>
+        /// </item>
+        /// <item>
+        /// <description>
+        /// Look for a service registered under the type <c>IViewFor&lt;RT&gt;</c>.
+        /// </description>
+        /// </item>
+        /// <item>
+        /// <item>
+        /// <description>
+        /// Look for a service registered under the type whose name is given to us by passing <c>T</c> to <see cref="ViewModelToViewFunc"/> (which defaults to changing "ViewModel" to "View").
         /// </description>
         /// </item>
         /// <item>
@@ -82,7 +93,13 @@ namespace ReactiveUI
         public IViewFor ResolveView<T>(T viewModel, string contract = null)
             where T : class
         {
-            var view = this.AttemptViewResolutionFor(typeof(T), contract);
+            var view = this.AttemptViewResolutionFor(viewModel.GetType(), contract);
+
+            if (view != null) {
+                return view;
+            }
+
+            view = this.AttemptViewResolutionFor(typeof(T), contract);
 
             if (view != null) {
                 return view;


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Fixes a regression introduced recently by #1282 whereby the runtime type of the provided view model is not considered when resolving the view.

**What is the current behavior? (You can also link to an open issue here)**

Runtime type ignored, only generic type considered.

**What is the new behavior (if this is a feature change)?**

The runtime type is considered first, followed by the generic type as required.

**Does this PR introduce a breaking change?**

No, it fixes one.

**Please check if the PR fulfills these requirements**
- [X] The commit follows our guidelines: https://github.com/reactiveui/reactiveui#contribute
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)