### PR TITLE
Removed all obsolete UNIFIED symbol checks

### DIFF
--- a/src/Microsoft.Reactive.Testing/Microsoft.Reactive.Testing_iOS.csproj
+++ b/src/Microsoft.Reactive.Testing/Microsoft.Reactive.Testing_iOS.csproj
@@ -20,7 +20,7 @@
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\Xamarin.iOS10</OutputPath>
     <IntermediateOutputPath>obj\Debug\Xamarin.iOS10</IntermediateOutputPath>
-    <DefineConstants>DEBUG;UNIFIED</DefineConstants>
+    <DefineConstants>DEBUG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
@@ -30,7 +30,7 @@
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\Xamarin.iOS10</OutputPath>
     <IntermediateOutputPath>obj\Release\Xamarin.iOS10</IntermediateOutputPath>
-    <DefineConstants>UNIFIED</DefineConstants>
+    <DefineConstants></DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>

--- a/src/ReactiveUI.Events/ReactiveUI.Events_Mac.csproj
+++ b/src/ReactiveUI.Events/ReactiveUI.Events_Mac.csproj
@@ -19,7 +19,7 @@
     <Optimize>False</Optimize>
     <OutputPath>bin\Debug\Xamarin.Mac20</OutputPath>
     <IntermediateOutputPath>obj\Debug\Xamarin.Mac20</IntermediateOutputPath>
-    <DefineConstants>DEBUG;MONO;COCOA;UNIFIED</DefineConstants>
+    <DefineConstants>DEBUG;MONO;COCOA</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <EnablePackageSigning>False</EnablePackageSigning>
@@ -46,7 +46,7 @@
     <CreatePackage>False</CreatePackage>
     <CodeSigningKey>Mac Developer</CodeSigningKey>
     <UseSGen>False</UseSGen>
-    <DefineConstants>MONO;COCOA;UNIFIED</DefineConstants>
+    <DefineConstants>MONO;COCOA</DefineConstants>
     <DebugSymbols>true</DebugSymbols>
     <GenerateDocumentation>True</GenerateDocumentation>
     <DocumentationFile>bin\Release\Xamarin.Mac20\ReactiveUI.xml</DocumentationFile>

--- a/src/ReactiveUI.Events/ReactiveUI.Events_iOS.csproj
+++ b/src/ReactiveUI.Events/ReactiveUI.Events_iOS.csproj
@@ -20,7 +20,7 @@
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\Xamarin.iOS10\</OutputPath>
     <IntermediateOutputPath>obj\Debug\Xamarin.iOS10</IntermediateOutputPath>
-    <DefineConstants>DEBUG;UNIFIED</DefineConstants>
+    <DefineConstants>DEBUG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
@@ -32,7 +32,7 @@
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\Xamarin.iOS10\</OutputPath>
     <IntermediateOutputPath>obj\Release\Xamarin.iOS10</IntermediateOutputPath>
-    <DefineConstants>UNIFIED</DefineConstants>
+    <DefineConstants></DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>

--- a/src/ReactiveUI.Testing/ReactiveUI.Testing_iOS.csproj
+++ b/src/ReactiveUI.Testing/ReactiveUI.Testing_iOS.csproj
@@ -20,7 +20,7 @@
     <Optimize>False</Optimize>
     <OutputPath>bin\Debug\Xamarin.iOS10</OutputPath>
     <IntermediateOutputPath>obj\Debug\Xamarin.iOS10</IntermediateOutputPath>
-    <DefineConstants>DEBUG;MONO;UIKIT;UNIFIED</DefineConstants>
+    <DefineConstants>DEBUG;MONO;UIKIT</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>False</ConsolePause>
@@ -35,7 +35,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>False</ConsolePause>
-    <DefineConstants>MONO;UIKIT;UNIFIED</DefineConstants>
+    <DefineConstants>MONO;UIKIT</DefineConstants>
     <DocumentationFile>bin\Release\Xamarin.iOS10\ReactiveUI.Testing.XML</DocumentationFile>
     <GenerateDocumentation>True</GenerateDocumentation>
     <CodesignKey>iPhone Developer</CodesignKey>

--- a/src/ReactiveUI/Cocoa/AppKitAutoSuspendHelper.cs
+++ b/src/ReactiveUI/Cocoa/AppKitAutoSuspendHelper.cs
@@ -1,18 +1,12 @@
 using System;
 using System.Reactive;
 using System.Reactive.Concurrency;
-using System.Reactive.Subjects;
-using System.Reactive.Linq;
 using System.Reactive.Disposables;
-using Splat;
-
-#if UNIFIED
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
 using AppKit;
 using Foundation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-#endif
+using Splat;
 
 namespace ReactiveUI
 {
@@ -33,7 +27,7 @@ namespace ReactiveUI
             RxApp.SuspensionHost.ShouldPersistState = shouldPersistState;
 
             var untimelyDemise = new Subject<Unit>();
-            AppDomain.CurrentDomain.UnhandledException += (o, e) => 
+            AppDomain.CurrentDomain.UnhandledException += (o, e) =>
                 untimelyDemise.OnNext(Unit.Default);
 
             RxApp.SuspensionHost.ShouldInvalidateState = untimelyDemise;

--- a/src/ReactiveUI/Cocoa/AutoLayoutViewModelViewHost.cs
+++ b/src/ReactiveUI/Cocoa/AutoLayoutViewModelViewHost.cs
@@ -1,12 +1,8 @@
 using System;
-#if UNIFIED && UIKIT
+#if UIKIT
 using NSView = UIKit.UIView;
-#elif UNIFIED && COCOA
-using AppKit;
-#elif UIKIT
-using NSView = MonoTouch.UIKit.UIView;
 #else
-using MonoMac.AppKit;
+using AppKit;
 #endif
 
 namespace ReactiveUI

--- a/src/ReactiveUI/Cocoa/AutoSuspendHelper.cs
+++ b/src/ReactiveUI/Cocoa/AutoSuspendHelper.cs
@@ -1,21 +1,14 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reactive;
+using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
-using System.Collections.Generic;
-using System.Reactive.Disposables;
-using ReactiveUI;
-using Splat;
-
-#if UNIFIED
 using Foundation;
+using Splat;
 using UIKit;
 using NSAction = System.Action;
-#else
-using MonoTouch.Foundation;
-using MonoTouch.UIKit;
-#endif
 
 namespace ReactiveUI
 {
@@ -43,7 +36,7 @@ namespace ReactiveUI
             RxApp.SuspensionHost.IsUnpausing = _activated.Select(_ => Unit.Default);
 
             var untimelyDeath = new Subject<Unit>();
-            AppDomain.CurrentDomain.UnhandledException += (o,e) => untimelyDeath.OnNext(Unit.Default);
+            AppDomain.CurrentDomain.UnhandledException += (o, e) => untimelyDeath.OnNext(Unit.Default);
 
             RxApp.SuspensionHost.ShouldInvalidateState = untimelyDeath;
 

--- a/src/ReactiveUI/Cocoa/Converters/DateTimeToNSDateConverter.cs
+++ b/src/ReactiveUI/Cocoa/Converters/DateTimeToNSDateConverter.cs
@@ -1,13 +1,5 @@
 ﻿using System;
-using System.Globalization;
-using System.Linq;
-using ReactiveUI;
-
-#if UNIFIED
 using Foundation;
-#else
-using MonoTouch.Foundation;
-#endif
 
 namespace ReactiveUI
 {
@@ -27,12 +19,12 @@ namespace ReactiveUI
             result = null;
 
             if (val.GetType() == typeof(DateTime) && toType == typeof(NSDate)) {
-                var dt = (DateTime) val;
-                result = (NSDate) dt;
+                var dt = (DateTime)val;
+                result = (NSDate)dt;
                 return true;
-            } else if(val.GetType() == typeof(NSDate) && toType == typeof(DateTime)) {
-                var dt = (NSDate) val;
-                result = (DateTime) dt;
+            } else if (val.GetType() == typeof(NSDate) && toType == typeof(DateTime)) {
+                var dt = (NSDate)val;
+                result = (DateTime)dt;
                 return true;
             }
 

--- a/src/ReactiveUI/Cocoa/JsonSuspensionDriver.cs
+++ b/src/ReactiveUI/Cocoa/JsonSuspensionDriver.cs
@@ -1,14 +1,9 @@
 using System;
-using System.Reactive.Linq;
-using System.Reactive;
 using System.IO;
+using System.Reactive;
+using System.Reactive.Linq;
 using System.Runtime.Serialization.Formatters.Binary;
-
-#if UNIFIED
 using Foundation;
-#else
-using MonoTouch.Foundation;
-#endif
 
 namespace ReactiveUI
 {
@@ -24,13 +19,13 @@ namespace ReactiveUI
                 using (var st = File.OpenRead(target)) {
                     result = serializer.Deserialize(st);
                 }
-                    
+
                 return Observable.Return(result);
             } catch (Exception ex) {
                 return Observable.Throw<object>(ex);
             }
         }
-        
+
         public IObservable<Unit> SaveState(object state)
         {
             try {
@@ -42,12 +37,12 @@ namespace ReactiveUI
                 }
 
                 return Observables.Unit;
-                
-            } catch(Exception ex) {
+
+            } catch (Exception ex) {
                 return Observable.Throw<Unit>(ex);
             }
         }
-        
+
         public IObservable<Unit> InvalidateState()
         {
             try {
@@ -55,8 +50,8 @@ namespace ReactiveUI
                 File.Delete(target);
 
                 return Observables.Unit;
-                
-            } catch(Exception ex) {
+
+            } catch (Exception ex) {
                 return Observable.Throw<Unit>(ex);
             }
         }
@@ -64,12 +59,12 @@ namespace ReactiveUI
         string CreateAppDirectory(NSSearchPathDirectory targetDir, string subDir = "Data")
         {
             NSError err;
-            
+
             var fm = new NSFileManager();
             var url = fm.GetUrl(targetDir, NSSearchPathDomain.All, null, true, out err);
             var ret = Path.Combine(url.RelativePath, NSBundle.MainBundle.BundleIdentifier, subDir);
             if (!Directory.Exists(ret)) Directory.CreateDirectory(ret);
-            
+
             return ret;
         }
     }

--- a/src/ReactiveUI/Cocoa/KVOObservableForProperty.cs
+++ b/src/ReactiveUI/Cocoa/KVOObservableForProperty.cs
@@ -5,20 +5,9 @@ using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
-using ReactiveUI;
+using Foundation;
 using Splat;
 
-#if UNIFIED && UIKIT
-using UIKit;
-using Foundation;
-#elif UNIFIED && COCOA
-using Foundation;
-#elif UIKIT
-using MonoTouch.UIKit;
-using MonoTouch.Foundation;
-#else
-using MonoMac.Foundation;
-#endif
 
 namespace ReactiveUI
 {
@@ -45,7 +34,7 @@ namespace ReactiveUI
                     return false;
                 }
 
-                while(thisType != null) {
+                while (thisType != null) {
                     if (thisType.GetMembers(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly).Any(x => x.Name == pair.Item2)) {
                         // NB: This is a not-completely correct way to detect if
                         // an object is defined in an Obj-C class (it will fail if
@@ -78,7 +67,7 @@ namespace ReactiveUI
             var propertyName = expression.GetMemberInfo().Name;
 
             return Observable.Create<IObservedChange<object, object>>(subj => {
-                var bobs = new BlockObserveValueDelegate((key,s,_) => {
+                var bobs = new BlockObserveValueDelegate((key, s, _) => {
                     subj.OnNext(new ObservedChange<object, object>(s, expression));
                 });
                 var pin = GCHandle.Alloc(bobs);
@@ -115,7 +104,7 @@ namespace ReactiveUI
             return Char.ToLowerInvariant(propertyName[0]).ToString() + propertyName.Substring(1);
         }
     }
-    
+
     class BlockObserveValueDelegate : NSObject
     {
         Action<string, NSObject, NSDictionary> _block;
@@ -123,8 +112,8 @@ namespace ReactiveUI
         {
             _block = block;
         }
-    
-        public override void ObserveValue (NSString keyPath, NSObject ofObject, NSDictionary change, IntPtr context)
+
+        public override void ObserveValue(NSString keyPath, NSObject ofObject, NSDictionary change, IntPtr context)
         {
             _block(keyPath, ofObject, change);
         }

--- a/src/ReactiveUI/Cocoa/LinkerOverrides.cs
+++ b/src/ReactiveUI/Cocoa/LinkerOverrides.cs
@@ -1,15 +1,5 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-#if UNIFIED
-using Foundation;
 using UIKit;
-#else
-using MonoTouch.Foundation;
-using MonoTouch.UIKit;
-#endif
 
 namespace ReactiveUI.Cocoa
 {
@@ -22,7 +12,7 @@ namespace ReactiveUI.Cocoa
     {
         public void KeepMe()
         {
-           // UIButon
+            // UIButon
             var btn = new UIButton();
             var title = btn.Title(UIControlState.Disabled);
             btn.SetTitle("foo", UIControlState.Disabled);
@@ -31,7 +21,7 @@ namespace ReactiveUI.Cocoa
             // UISlider
             var slider = new UISlider();
             slider.Value = slider.Value; // Get and set
-            
+
 
             // UITextView
             var tv = new UITextView();
@@ -40,7 +30,7 @@ namespace ReactiveUI.Cocoa
             // UITextField
             var tf = new UITextField();
             tv.Text = tf.Text;
-            
+
             // var UIImageView
             var iv = new UIImageView();
             iv.Image = iv.Image;

--- a/src/ReactiveUI/Cocoa/NSRunloopScheduler.cs
+++ b/src/ReactiveUI/Cocoa/NSRunloopScheduler.cs
@@ -1,19 +1,9 @@
 using System;
 using System.Reactive.Concurrency;
 using System.Reactive.Disposables;
-
-#if UNIFIED
 using CoreFoundation;
 using Foundation;
 using NSAction = System.Action;
-#elif UIKIT
-using MonoTouch.UIKit;
-using MonoTouch.Foundation;
-using MonoTouch.CoreFoundation;
-#else
-using MonoMac.Foundation;
-using MonoMac.CoreFoundation;
-#endif
 
 namespace ReactiveUI
 {
@@ -34,7 +24,7 @@ namespace ReactiveUI
             DispatchQueue.MainQueue.DispatchAsync(new NSAction(() => {
                 if (!innerDisp.IsDisposed) innerDisp.Disposable = action(this, state);
             }));
-            
+
             return innerDisp;
         }
 
@@ -43,7 +33,7 @@ namespace ReactiveUI
             if (dueTime <= Now) {
                 return Schedule(state, action);
             }
-            
+
             return Schedule(state, dueTime - Now, action);
         }
 
@@ -52,14 +42,10 @@ namespace ReactiveUI
             var innerDisp = Disposable.Empty;
             bool isCancelled = false;
 
-#if UNIFIED
             var timer = NSTimer.CreateScheduledTimer(dueTime, _ => {
-#else
-            var timer = NSTimer.CreateScheduledTimer(dueTime, () => {
-#endif
                 if (!isCancelled) innerDisp = action(this, state);
             });
-            
+
             return Disposable.Create(() => {
                 isCancelled = true;
                 timer.Invalidate();

--- a/src/ReactiveUI/Cocoa/PlatformOperations.cs
+++ b/src/ReactiveUI/Cocoa/PlatformOperations.cs
@@ -7,10 +7,8 @@ namespace ReactiveUI
     {
         public string GetOrientation()
         {
-#if UNIFIED && UIKIT
+#if UIKIT
             return UIKit.UIDevice.CurrentDevice.Orientation.ToString();
-#elif UIKIT
-            return MonoTouch.UIKit.UIDevice.CurrentDevice.Orientation.ToString();
 #else
             return null;
 #endif

--- a/src/ReactiveUI/Cocoa/ReactiveCollectionReusableView.cs
+++ b/src/ReactiveUI/Cocoa/ReactiveCollectionReusableView.cs
@@ -1,30 +1,18 @@
 ﻿using System;
 using System.ComponentModel;
 using System.Reactive;
-using System.Reactive.Subjects;
 using System.Reactive.Linq;
-
-#if UNIFIED
+using System.Reactive.Subjects;
 using CoreGraphics;
 using Foundation;
 using UIKit;
-#else
-using System.Drawing;
-using MonoTouch.Foundation;
-using MonoTouch.UIKit;
-#endif
 
 namespace ReactiveUI
 {
     public abstract class ReactiveCollectionReusableView : UICollectionReusableView,
         IReactiveNotifyPropertyChanged<ReactiveCollectionReusableView>, IHandleObservableErrors, IReactiveObject, ICanActivate
     {
-#if UNIFIED
         protected ReactiveCollectionReusableView(CGRect frame) : base(frame) { setupRxObj(); }
-#else
-        protected ReactiveCollectionReusableView(RectangleF frame) : base(frame) { setupRxObj(); }
-#endif
-
         protected ReactiveCollectionReusableView() : base() { setupRxObj(); }
         protected ReactiveCollectionReusableView(IntPtr handle) : base(handle) { setupRxObj(); }
         protected ReactiveCollectionReusableView(NSObjectFlag t) : base(t) { setupRxObj(); }
@@ -108,11 +96,7 @@ namespace ReactiveUI
         protected ReactiveCollectionReusableView(IntPtr handle) : base(handle) { }
         protected ReactiveCollectionReusableView(NSObjectFlag t) : base(t) { }
         protected ReactiveCollectionReusableView(NSCoder coder) : base(coder) { }
-#if UNIFIED
         protected ReactiveCollectionReusableView(CGRect frame) : base(frame) { }
-#else
-        protected ReactiveCollectionReusableView(RectangleF frame) : base(frame) { }
-#endif
 
         TViewModel _viewModel;
         public TViewModel ViewModel {

--- a/src/ReactiveUI/Cocoa/ReactiveCollectionView.cs
+++ b/src/ReactiveUI/Cocoa/ReactiveCollectionView.cs
@@ -2,30 +2,18 @@
 using System.ComponentModel;
 using System.Reactive;
 using System.Reactive.Concurrency;
-using System.Reactive.Subjects;
 using System.Reactive.Linq;
-
-#if UNIFIED
+using System.Reactive.Subjects;
 using CoreGraphics;
 using Foundation;
 using UIKit;
-#else
-using System.Drawing;
-using MonoTouch.Foundation;
-using MonoTouch.UIKit;
-#endif
 
 namespace ReactiveUI
 {
     public abstract class ReactiveCollectionView : UICollectionView,
         IReactiveNotifyPropertyChanged<ReactiveCollectionView>, IHandleObservableErrors, IReactiveObject, ICanActivate, ICanForceManualActivation
     {
-#if UNIFIED
         protected ReactiveCollectionView(CGRect frame, UICollectionViewLayout layout) : base(frame, layout) { setupRxObj(); }
-#else
-        protected ReactiveCollectionView(RectangleF frame, UICollectionViewLayout layout) : base(frame, layout) { setupRxObj(); }
-#endif
-
         protected ReactiveCollectionView(IntPtr handle) : base(handle) { setupRxObj(); }
         protected ReactiveCollectionView(NSObjectFlag t) : base(t) { setupRxObj(); }
         protected ReactiveCollectionView(NSCoder coder) : base(coder) { setupRxObj(); }
@@ -113,11 +101,7 @@ namespace ReactiveUI
         protected ReactiveCollectionView(IntPtr handle) : base(handle) { }
         protected ReactiveCollectionView(NSObjectFlag t) : base(t) { }
         protected ReactiveCollectionView(NSCoder coder) : base(coder) { }
-#if UNIFIED
         protected ReactiveCollectionView(CGRect frame, UICollectionViewLayout layout) : base(frame, layout) { }
-#else
-        protected ReactiveCollectionView(RectangleF frame, UICollectionViewLayout layout) : base(frame, layout) { }
-#endif
 
         TViewModel _viewModel;
         public TViewModel ViewModel {

--- a/src/ReactiveUI/Cocoa/ReactiveCollectionViewCell.cs
+++ b/src/ReactiveUI/Cocoa/ReactiveCollectionViewCell.cs
@@ -4,31 +4,18 @@ using System.Reactive;
 using System.Reactive.Concurrency;
 using System.Reactive.Subjects;
 using System.Reactive.Linq;
-
-#if UNIFIED
 using CoreGraphics;
 using Foundation;
 using UIKit;
-#else
-using System.Drawing;
-using MonoTouch.Foundation;
-using MonoTouch.UIKit;
-#endif
 
 namespace ReactiveUI
 {
     public abstract class ReactiveCollectionViewCell : UICollectionViewCell, IReactiveNotifyPropertyChanged<ReactiveCollectionViewCell>, IHandleObservableErrors, IReactiveObject, ICanActivate
     {
-#if UNIFIED
         protected ReactiveCollectionViewCell(CGRect frame) : base(frame) { setupRxObj(); }
-#else
-        protected ReactiveCollectionViewCell(RectangleF frame) : base (frame) { setupRxObj(); }
-#endif
-
         protected ReactiveCollectionViewCell(NSObjectFlag t) : base(t) { setupRxObj(); }
         protected ReactiveCollectionViewCell(NSCoder coder) : base(NSObjectFlag.Empty) { setupRxObj(); }
         protected ReactiveCollectionViewCell() : base() { setupRxObj(); }
-
         protected ReactiveCollectionViewCell(IntPtr handle) : base(handle) { setupRxObj(); }
 
         public event PropertyChangingEventHandler PropertyChanging {
@@ -102,11 +89,7 @@ namespace ReactiveUI
         protected ReactiveCollectionViewCell(NSObjectFlag t) : base(t) { }
         protected ReactiveCollectionViewCell(NSCoder coder) : base(NSObjectFlag.Empty) { }
         protected ReactiveCollectionViewCell() : base() { }
-#if UNIFIED
         protected ReactiveCollectionViewCell(CGRect frame) : base(frame) { }
-#else
-        protected ReactiveCollectionViewCell(RectangleF frame) : base (frame) { }
-#endif
         protected ReactiveCollectionViewCell(IntPtr handle) : base(handle) { }
 
         TViewModel _viewModel;

--- a/src/ReactiveUI/Cocoa/ReactiveCollectionViewController.cs
+++ b/src/ReactiveUI/Cocoa/ReactiveCollectionViewController.cs
@@ -3,14 +3,8 @@ using System.ComponentModel;
 using System.Reactive;
 using System.Reactive.Subjects;
 using System.Reactive.Linq;
-
-#if UNIFIED
 using Foundation;
 using UIKit;
-#else
-using MonoTouch.Foundation;
-using MonoTouch.UIKit;
-#endif
 
 namespace ReactiveUI
 {

--- a/src/ReactiveUI/Cocoa/ReactiveCollectionViewSource.cs
+++ b/src/ReactiveUI/Cocoa/ReactiveCollectionViewSource.cs
@@ -1,24 +1,16 @@
 using System;
-using System.ComponentModel;
 using System.Collections.Generic;
-using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Diagnostics;
 using System.Linq;
 using System.Reactive.Concurrency;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
-
-using Splat;
-using System.Diagnostics;
-
-#if UNIFIED
 using Foundation;
+using Splat;
 using UIKit;
 using NSAction = System.Action;
-#else
-using MonoTouch.Foundation;
-using MonoTouch.UIKit;
-#endif
 
 namespace ReactiveUI
 {
@@ -60,8 +52,7 @@ namespace ReactiveUI
             this.isReloadingData = new BehaviorSubject<bool>(false);
         }
 
-        public IObservable<bool> IsReloadingData
-        {
+        public IObservable<bool> IsReloadingData {
             get { return this.isReloadingData.AsObservable(); }
         }
 
@@ -70,8 +61,7 @@ namespace ReactiveUI
             ++inFlightReloads;
             view.ReloadData();
 
-            if (inFlightReloads == 1)
-            {
+            if (inFlightReloads == 1) {
                 Debug.Assert(!this.isReloadingData.Value);
                 this.isReloadingData.OnNext(true);
             }
@@ -104,8 +94,7 @@ namespace ReactiveUI
         {
             --inFlightReloads;
 
-            if (inFlightReloads == 0)
-            {
+            if (inFlightReloads == 0) {
                 // this is required because sometimes iOS schedules further work that results in calls to GetCell
                 // that work could happen after FinishReloadData unless we force layout here
                 // of course, we can't have that work running after IsReloading ticks to false because otherwise
@@ -129,17 +118,20 @@ namespace ReactiveUI
         readonly Subject<object> elementSelected = new Subject<object>();
 
         public ReactiveCollectionViewSource(UICollectionView collectionView, IReactiveNotifyCollectionChanged<TSource> collection, NSString cellKey, Action<UICollectionViewCell> initializeCellAction = null)
-            : this(collectionView) {
+            : this(collectionView)
+        {
             this.Data = new[] { new CollectionViewSectionInformation<TSource, UICollectionViewCell>(collection, cellKey, initializeCellAction) };
         }
 
         [Obsolete("Please bind your view model to the Data property.")]
         public ReactiveCollectionViewSource(UICollectionView collectionView, IReadOnlyList<CollectionViewSectionInformation<TSource>> sectionInformation)
-            : this(collectionView) {
+            : this(collectionView)
+        {
             this.Data = sectionInformation;
         }
 
-        public ReactiveCollectionViewSource(UICollectionView collectionView) {
+        public ReactiveCollectionViewSource(UICollectionView collectionView)
+        {
             setupRxObj();
             var adapter = new UICollectionViewAdapter(collectionView);
             this.commonSource = new CommonReactiveSource<TSource, UICollectionView, UICollectionViewCell, CollectionViewSectionInformation<TSource>>(adapter);
@@ -153,11 +145,10 @@ namespace ReactiveUI
         /// then the source will react to changes to the contents of the list as well.
         /// </summary>
         /// <value>The data.</value>
-        public IReadOnlyList<CollectionViewSectionInformation<TSource>> Data
-        {
+        public IReadOnlyList<CollectionViewSectionInformation<TSource>> Data {
             get { return commonSource.SectionInfo; }
             set {
-                if (commonSource.SectionInfo == value)  return;
+                if (commonSource.SectionInfo == value) return;
 
                 this.raisePropertyChanging("Data");
                 commonSource.SectionInfo = value;
@@ -177,20 +168,12 @@ namespace ReactiveUI
             return commonSource.GetCell(indexPath);
         }
 
-#if UNIFIED
         public override nint NumberOfSections(UICollectionView collectionView)
-#else
-        public override int NumberOfSections(UICollectionView collectionView)
-#endif
         {
             return commonSource.NumberOfSections();
         }
 
-#if UNIFIED
         public override nint GetItemsCount(UICollectionView collectionView, nint section)
-#else
-        public override int GetItemsCount(UICollectionView collectionView, int section)
-#endif
         {
             return commonSource.RowsInSection((int)section);
         }
@@ -309,7 +292,7 @@ namespace ReactiveUI
         /// <param name="initSource">Optionally initializes some property of
         /// the <see cref="ReactiveCollectionViewSource"/>.</param>
         /// <typeparam name="TCell">Type of the <see cref="UICollectionViewCell"/>.</typeparam>
-        public static IDisposable BindTo<TSource,TCell>(
+        public static IDisposable BindTo<TSource, TCell>(
             this IObservable<IReactiveNotifyCollectionChanged<TSource>> sourceObservable,
             UICollectionView collectionView,
             NSString cellKey,

--- a/src/ReactiveUI/Cocoa/ReactiveControl.cs
+++ b/src/ReactiveUI/Cocoa/ReactiveControl.cs
@@ -4,42 +4,24 @@ using System.Reactive;
 using System.Reactive.Concurrency;
 using System.Reactive.Subjects;
 using System.Reactive.Linq;
-
-#if UNIFIED
 using Foundation;
 using CoreGraphics;
-#elif UIKIT
-using System.Drawing;
-using MonoTouch.Foundation;
-using MonoTouch.UIKit;
-#else
-using System.Drawing;
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using UIControl = MonoMac.AppKit.NSControl;
-#endif
 
-#if UNIFIED && UIKIT
+#if UIKIT
 using UIKit;
-#elif UNIFIED && COCOA
+#else
 using AppKit;
 using UIControl = AppKit.NSControl;
 #endif
-
 
 namespace ReactiveUI
 {
     public class ReactiveControl : UIControl, IReactiveNotifyPropertyChanged<ReactiveControl>, IHandleObservableErrors, IReactiveObject, ICanActivate, ICanForceManualActivation
     {
-#if UNIFIED
-        protected ReactiveControl(CGRect frame) : base(frame) { }
-#else
-        protected ReactiveControl(RectangleF frame) : base(frame) { }
-#endif
-
         protected ReactiveControl() { }
         protected ReactiveControl(NSCoder c) : base(c) { }
         protected ReactiveControl(NSObjectFlag f) : base(f) { }
+        protected ReactiveControl(CGRect frame) : base(frame) { }
         protected ReactiveControl(IntPtr handle) : base(handle) { }
 
         public event PropertyChangingEventHandler PropertyChanging {
@@ -124,11 +106,7 @@ namespace ReactiveUI
         protected ReactiveControl(NSCoder c) : base(c) { }
         protected ReactiveControl(NSObjectFlag f) : base(f) { }
         protected ReactiveControl(IntPtr handle) : base(handle) { }
-#if UNIFIED
         protected ReactiveControl(CGRect frame) : base(frame) { }
-#else
-        protected ReactiveControl(RectangleF frame) : base(frame) { }
-#endif
 
         TViewModel _viewModel;
         public TViewModel ViewModel {

--- a/src/ReactiveUI/Cocoa/ReactiveImageView.cs
+++ b/src/ReactiveUI/Cocoa/ReactiveImageView.cs
@@ -4,28 +4,15 @@ using System.Reactive;
 using System.Reactive.Concurrency;
 using System.Reactive.Subjects;
 using System.Reactive.Linq;
-
-#if UNIFIED
 using CoreGraphics;
 using Foundation;
-#elif UIKIT
-using System.Drawing;
-using MonoTouch.Foundation;
-using MonoTouch.UIKit;
-using NSImageView = MonoTouch.UIKit.UIImageView;
-using NSImage = MonoTouch.UIKit.UIImage;
-using NSView = MonoTouch.UIKit.UIView;
-#else
-using System.Drawing;
-using MonoMac.AppKit;
-#endif
 
-#if UNIFIED && UIKIT
+#if UIKIT
 using UIKit;
 using NSImage = UIKit.UIImage;
 using NSImageView = UIKit.UIImageView;
 using NSView = UIKit.UIView;
-#elif UNIFIED && COCOA
+#else
 using AppKit;
 #endif
 
@@ -34,13 +21,8 @@ namespace ReactiveUI
 {
     public abstract class ReactiveImageView : NSImageView, IReactiveNotifyPropertyChanged<ReactiveImageView>, IHandleObservableErrors, IReactiveObject, ICanActivate, ICanForceManualActivation
     {
-#if UNIFIED
-        protected ReactiveImageView(CGRect frame) : base(frame) { }
-#else
-        protected ReactiveImageView(RectangleF frame) : base(frame) { }
-#endif
-
         protected ReactiveImageView() { }
+        protected ReactiveImageView(CGRect frame) : base(frame) { }
 
 #if UIKIT
         protected ReactiveImageView(NSImage image) : base(image) { }
@@ -122,13 +104,8 @@ namespace ReactiveUI
     public abstract class ReactiveImageView<TViewModel> : ReactiveImageView, IViewFor<TViewModel>
         where TViewModel : class
     {
-#if UNIFIED
-        protected ReactiveImageView(CGRect frame) : base(frame) { }
-#else
-        protected ReactiveImageView(RectangleF frame) : base(frame) { }
-#endif
-
         protected ReactiveImageView() { }
+        protected ReactiveImageView(CGRect frame) : base(frame) { }
 
 #if UIKIT
         protected ReactiveImageView(NSImage image) : base(image) { }

--- a/src/ReactiveUI/Cocoa/ReactiveNSView.cs
+++ b/src/ReactiveUI/Cocoa/ReactiveNSView.cs
@@ -4,25 +4,13 @@ using System.Reactive;
 using System.Reactive.Concurrency;
 using System.Reactive.Subjects;
 using System.Reactive.Linq;
-
-#if UNIFIED
 using CoreGraphics;
 using Foundation;
-#elif UIKIT
-using System.Drawing;
-using MonoTouch.Foundation;
-using MonoTouch.UIKit;
-using NSView = MonoTouch.UIKit.UIView;
-#else
-using System.Drawing;
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-#endif
 
-#if UNIFIED && UIKIT
+#if UIKIT
 using NSView = UIKit.UIView;
 using UIKit;
-#elif UNIFIED && COCOA
+#else
 using AppKit;
 #endif
 
@@ -38,11 +26,7 @@ namespace ReactiveUI
         protected ReactiveView(NSCoder c) : base(c) { }
         protected ReactiveView(NSObjectFlag f) : base(f) { }
         protected ReactiveView(IntPtr handle) : base(handle) { }
-#if UNIFIED
         protected ReactiveView(CGRect frame) : base(frame) { }
-#else
-        protected ReactiveView(RectangleF size) : base(size) { }
-#endif
 
         public event PropertyChangingEventHandler PropertyChanging {
             add { PropertyChangingEventManager.AddHandler(this, value); }
@@ -129,11 +113,7 @@ namespace ReactiveUI
         protected ReactiveView(NSCoder c) : base(c) { }
         protected ReactiveView(NSObjectFlag f) : base(f) { }
         protected ReactiveView(IntPtr handle) : base(handle) { }
-#if UNIFIED
         protected ReactiveView(CGRect frame) : base(frame) { }
-#else
-        protected ReactiveView(RectangleF size) : base(size) { }
-#endif
 
         TViewModel _viewModel;
         public TViewModel ViewModel {

--- a/src/ReactiveUI/Cocoa/ReactiveNSWindowController.cs
+++ b/src/ReactiveUI/Cocoa/ReactiveNSWindowController.cs
@@ -2,14 +2,8 @@ using System;
 using System.ComponentModel;
 using System.Reactive.Subjects;
 using System.Reactive;
-
-#if UNIFIED
 using AppKit;
 using Foundation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-#endif
 
 namespace ReactiveUI
 {
@@ -25,7 +19,7 @@ namespace ReactiveUI
 
         public event PropertyChangingEventHandler PropertyChanging;
 
-        void IReactiveObject.RaisePropertyChanging(PropertyChangingEventArgs args) 
+        void IReactiveObject.RaisePropertyChanging(PropertyChangingEventArgs args)
         {
             var handler = PropertyChanging;
             if (handler != null) {
@@ -35,7 +29,7 @@ namespace ReactiveUI
 
         public event PropertyChangedEventHandler PropertyChanged;
 
-        void IReactiveObject.RaisePropertyChanged(PropertyChangedEventArgs args) 
+        void IReactiveObject.RaisePropertyChanged(PropertyChangedEventArgs args)
         {
             var handler = PropertyChanged;
             if (handler != null) {

--- a/src/ReactiveUI/Cocoa/ReactiveNavigationController.cs
+++ b/src/ReactiveUI/Cocoa/ReactiveNavigationController.cs
@@ -3,14 +3,8 @@ using System.ComponentModel;
 using System.Reactive;
 using System.Reactive.Subjects;
 using System.Reactive.Linq;
-
-#if UNIFIED
 using Foundation;
 using UIKit;
-#else
-using MonoTouch.Foundation;
-using MonoTouch.UIKit;
-#endif
 
 namespace ReactiveUI
 {

--- a/src/ReactiveUI/Cocoa/ReactivePageViewController.cs
+++ b/src/ReactiveUI/Cocoa/ReactivePageViewController.cs
@@ -3,14 +3,8 @@ using System.ComponentModel;
 using System.Reactive;
 using System.Reactive.Subjects;
 using System.Reactive.Linq;
-
-#if UNIFIED
 using Foundation;
 using UIKit;
-#else
-using MonoTouch.Foundation;
-using MonoTouch.UIKit;
-#endif
 
 namespace ReactiveUI
 {

--- a/src/ReactiveUI/Cocoa/ReactiveSplitViewController.cs
+++ b/src/ReactiveUI/Cocoa/ReactiveSplitViewController.cs
@@ -3,24 +3,13 @@ using System.ComponentModel;
 using System.Reactive;
 using System.Reactive.Subjects;
 using System.Reactive.Linq;
-
-#if UNIFIED
 using Foundation;
-#elif UIKIT
-using MonoTouch.UIKit;
-using MonoTouch.Foundation;
-using NSSplitViewController = MonoTouch.UIKit.UISplitViewController;
-using NSView = MonoTouch.UIKit.UIView;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-#endif
 
-#if UNIFIED && UIKIT
+#if UIKIT
 using UIKit;
 using NSSplitViewController = UIKit.UISplitViewController;
 using NSView = UIKit.UIView;
-#elif UNIFIED && COCOA
+#else
 using AppKit;
 #endif
 
@@ -114,18 +103,14 @@ namespace ReactiveUI
         {
             base.ViewWillAppear();
             activated.OnNext(Unit.Default);
-#if UNIFIED
             this.ActivateSubviews(true);
-#endif
         }
 
         public override void ViewDidDisappear()
         {
             base.ViewDidDisappear();
             deactivated.OnNext(Unit.Default);
-#if UNIFIED
             this.ActivateSubviews(false);
-#endif
         }
 #endif
     }

--- a/src/ReactiveUI/Cocoa/ReactiveTabBarController.cs
+++ b/src/ReactiveUI/Cocoa/ReactiveTabBarController.cs
@@ -3,14 +3,8 @@ using System.ComponentModel;
 using System.Reactive;
 using System.Reactive.Subjects;
 using System.Reactive.Linq;
-
-#if UNIFIED
 using Foundation;
 using UIKit;
-#else
-using MonoTouch.Foundation;
-using MonoTouch.UIKit;
-#endif
 
 namespace ReactiveUI
 {

--- a/src/ReactiveUI/Cocoa/ReactiveTableView.cs
+++ b/src/ReactiveUI/Cocoa/ReactiveTableView.cs
@@ -4,33 +4,19 @@ using System.Reactive;
 using System.Reactive.Concurrency;
 using System.Reactive.Subjects;
 using System.Reactive.Linq;
-
-#if UNIFIED
 using CoreGraphics;
 using Foundation;
 using UIKit;
-#else
-using System.Drawing;
-using MonoTouch.Foundation;
-using MonoTouch.UIKit;
-#endif
 
 namespace ReactiveUI
 {
     public abstract class ReactiveTableView : UITableView, IReactiveNotifyPropertyChanged<ReactiveTableView>, IHandleObservableErrors, IReactiveObject, ICanActivate, ICanForceManualActivation
     {
-#if UNIFIED
-        protected ReactiveTableView(CGRect frame) : base(frame) { }
-        protected ReactiveTableView(CGRect frame, UITableViewStyle style) : base(frame, style) { }
-#else
-        protected ReactiveTableView(RectangleF frame) : base(frame) { }
-        protected ReactiveTableView(RectangleF frame, UITableViewStyle style) : base(frame, style) { }
-#endif
-
+        protected ReactiveTableView() { }
         protected ReactiveTableView(NSObjectFlag t) : base(t) { }
         protected ReactiveTableView(NSCoder coder) : base(coder) { }
-        protected ReactiveTableView() { }
-
+        protected ReactiveTableView(CGRect frame) : base(frame) { }
+        protected ReactiveTableView(CGRect frame, UITableViewStyle style) : base(frame, style) { }
         protected ReactiveTableView(IntPtr handle) : base(handle) { }
 
         public event PropertyChangingEventHandler PropertyChanging {
@@ -96,18 +82,11 @@ namespace ReactiveUI
     public abstract class ReactiveTableView<TViewModel> : ReactiveTableView, IViewFor<TViewModel>
         where TViewModel : class
     {
-#if UNIFIED
-        protected ReactiveTableView(CGRect frame) : base(frame) { }
-        protected ReactiveTableView(CGRect frame, UITableViewStyle style) : base(frame, style) { }
-#else
-        protected ReactiveTableView(RectangleF frame) : base(frame) { }
-        protected ReactiveTableView(RectangleF frame, UITableViewStyle style) : base(frame, style) { }
-#endif
-
+        protected ReactiveTableView() { }
         protected ReactiveTableView(NSObjectFlag t) : base(t) { }
         protected ReactiveTableView(NSCoder coder) : base(coder) { }
-        protected ReactiveTableView() { }
-
+        protected ReactiveTableView(CGRect frame) : base(frame) { }
+        protected ReactiveTableView(CGRect frame, UITableViewStyle style) : base(frame, style) { }
         protected ReactiveTableView(IntPtr handle) : base(handle) { }
 
         TViewModel _viewModel;

--- a/src/ReactiveUI/Cocoa/ReactiveTableViewCell.cs
+++ b/src/ReactiveUI/Cocoa/ReactiveTableViewCell.cs
@@ -4,27 +4,15 @@ using System.Reactive;
 using System.Reactive.Concurrency;
 using System.Reactive.Subjects;
 using System.Reactive.Linq;
-
-#if UNIFIED
 using CoreGraphics;
 using Foundation;
 using UIKit;
-#else
-using System.Drawing;
-using MonoTouch.Foundation;
-using MonoTouch.UIKit;
-#endif
 
 namespace ReactiveUI
 {
     public abstract class ReactiveTableViewCell : UITableViewCell, IReactiveNotifyPropertyChanged<ReactiveTableViewCell>, IHandleObservableErrors, IReactiveObject, ICanActivate
     {
-#if UNIFIED
         protected ReactiveTableViewCell(CGRect frame) : base(frame) { setupRxObj(); }
-#else
-        protected ReactiveTableViewCell(RectangleF frame) : base (frame) { setupRxObj(); }
-#endif
-
         protected ReactiveTableViewCell(NSObjectFlag t) : base(t) { setupRxObj(); }
         protected ReactiveTableViewCell(NSCoder coder) : base(NSObjectFlag.Empty) { setupRxObj(); }
         protected ReactiveTableViewCell() : base() { setupRxObj(); }
@@ -100,12 +88,7 @@ namespace ReactiveUI
     public abstract class ReactiveTableViewCell<TViewModel> : ReactiveTableViewCell, IViewFor<TViewModel>
         where TViewModel : class
     {
-#if UNIFIED
         protected ReactiveTableViewCell(CGRect frame) : base(frame) { }
-#else
-        protected ReactiveTableViewCell(RectangleF frame) : base (frame) { }
-#endif
-
         protected ReactiveTableViewCell(NSObjectFlag t) : base(t) { }
         protected ReactiveTableViewCell(NSCoder coder) : base(NSObjectFlag.Empty) { }
         protected ReactiveTableViewCell() : base() { }

--- a/src/ReactiveUI/Cocoa/ReactiveTableViewController.cs
+++ b/src/ReactiveUI/Cocoa/ReactiveTableViewController.cs
@@ -1,20 +1,11 @@
 using System;
 using System.ComponentModel;
 using System.Reactive;
-using System.Reactive.Subjects;
 using System.Reactive.Linq;
-
-#if UNIFIED
+using System.Reactive.Subjects;
 using Foundation;
-using UIKit;
 using NSTableViewController = UIKit.UITableViewController;
 using NSTableViewStyle = UIKit.UITableViewStyle;
-#else
-using MonoTouch.Foundation;
-using MonoTouch.UIKit;
-using NSTableViewController = MonoTouch.UIKit.UITableViewController;
-using NSTableViewStyle = MonoTouch.UIKit.UITableViewStyle;
-#endif
 
 namespace ReactiveUI
 {

--- a/src/ReactiveUI/Cocoa/ReactiveTableViewSource.cs
+++ b/src/ReactiveUI/Cocoa/ReactiveTableViewSource.cs
@@ -1,22 +1,15 @@
 using System;
-using System.ComponentModel;
 using System.Collections.Generic;
-using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Diagnostics;
 using System.Linq;
 using System.Reactive.Concurrency;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
-using Splat;
-using System.Diagnostics;
-
-#if UNIFIED
 using Foundation;
+using Splat;
 using UIKit;
-#else
-using MonoTouch.Foundation;
-using MonoTouch.UIKit;
-#endif
 
 namespace ReactiveUI
 {
@@ -70,8 +63,7 @@ namespace ReactiveUI
             this.isReloadingData = new BehaviorSubject<bool>(false);
         }
 
-        public IObservable<bool> IsReloadingData
-        {
+        public IObservable<bool> IsReloadingData {
             get { return this.isReloadingData.AsObservable(); }
         }
 
@@ -80,8 +72,7 @@ namespace ReactiveUI
             ++inFlightReloads;
             view.ReloadData();
 
-            if (inFlightReloads == 1)
-            {
+            if (inFlightReloads == 1) {
                 Debug.Assert(!this.isReloadingData.Value);
                 this.isReloadingData.OnNext(true);
             }
@@ -130,8 +121,7 @@ namespace ReactiveUI
         {
             --inFlightReloads;
 
-            if (inFlightReloads == 0)
-            {
+            if (inFlightReloads == 0) {
                 // this is required because sometimes iOS schedules further work that results in calls to GetCell
                 // that work could happen after FinishReloadData unless we force layout here
                 // of course, we can't have that work running after IsReloading ticks to false because otherwise
@@ -170,7 +160,7 @@ namespace ReactiveUI
         /// </summary>
         /// <param name="view">Function that creates header's <see cref="UIView"/>.</param>
         /// <param name="height">Height of the header.</param>
-        public TableSectionHeader (Func<UIView> view, float height)
+        public TableSectionHeader(Func<UIView> view, float height)
         {
             this.View = view;
             this.Height = height;
@@ -180,7 +170,7 @@ namespace ReactiveUI
         /// Initializes a new instance of the <see cref="ReactiveUI.Cocoa.TableSectionHeader"/> class.
         /// </summary>
         /// <param name="title">Title to use.</param>
-        public TableSectionHeader (string title)
+        public TableSectionHeader(string title)
         {
             this.Title = title;
         }
@@ -198,17 +188,20 @@ namespace ReactiveUI
         readonly Subject<object> elementSelected = new Subject<object>();
 
         public ReactiveTableViewSource(UITableView tableView, IReactiveNotifyCollectionChanged<TSource> collection, NSString cellKey, float sizeHint, Action<UITableViewCell> initializeCellAction = null)
-            : this(tableView) {
-            this.Data = new[] { new TableSectionInformation<TSource, UITableViewCell>(collection, cellKey, sizeHint, initializeCellAction)};
+            : this(tableView)
+        {
+            this.Data = new[] { new TableSectionInformation<TSource, UITableViewCell>(collection, cellKey, sizeHint, initializeCellAction) };
         }
 
         [Obsolete("Please bind your view model to the Data property.")]
         public ReactiveTableViewSource(UITableView tableView, IReadOnlyList<TableSectionInformation<TSource>> sectionInformation)
-            : this(tableView) {
+            : this(tableView)
+        {
             this.Data = sectionInformation;
         }
 
-        public ReactiveTableViewSource(UITableView tableView) {
+        public ReactiveTableViewSource(UITableView tableView)
+        {
             setupRxObj();
             var adapter = new UITableViewAdapter(tableView);
             this.commonSource = new CommonReactiveSource<TSource, UITableView, UITableViewCell, TableSectionInformation<TSource>>(adapter);
@@ -222,11 +215,10 @@ namespace ReactiveUI
         /// then the source will react to changes to the contents of the list as well.
         /// </summary>
         /// <value>The data.</value>
-        public IReadOnlyList<TableSectionInformation<TSource>> Data
-        {
+        public IReadOnlyList<TableSectionInformation<TSource>> Data {
             get { return commonSource.SectionInfo; }
             set {
-                if (commonSource.SectionInfo == value)  return;
+                if (commonSource.SectionInfo == value) return;
 
                 this.raisePropertyChanging("Data");
                 commonSource.SectionInfo = value;
@@ -246,25 +238,16 @@ namespace ReactiveUI
             return commonSource.GetCell(indexPath);
         }
 
-#if UNIFIED
         public override nint NumberOfSections(UITableView tableView)
-#else
-        public override int NumberOfSections(UITableView tableView)
-#endif
         {
             return commonSource.NumberOfSections();
         }
 
-#if UNIFIED
         public override nint RowsInSection(UITableView tableview, nint section)
-#else
-        public override int RowsInSection(UITableView tableview, int section)
-#endif
         {
             // iOS may call this method even when we have no sections, but only if we've overridden
             // EstimatedHeight(UITableView, NSIndexPath) in our UITableViewSource
-            if (section >= commonSource.NumberOfSections())
-            {
+            if (section >= commonSource.NumberOfSections()) {
                 return 0;
             }
 
@@ -292,44 +275,30 @@ namespace ReactiveUI
             base.Dispose(disposing);
         }
 
-#if UNIFIED
         public override nfloat GetHeightForRow(UITableView tableView, NSIndexPath indexPath)
-#else
-        public override float GetHeightForRow(UITableView tableView, NSIndexPath indexPath)
-#endif
         {
             return commonSource.SectionInfo[indexPath.Section].SizeHint;
         }
 
-#if UNIFIED
         public override nfloat GetHeightForHeader(UITableView tableView, nint section)
-#else
-        public override float GetHeightForHeader(UITableView tableView, int section)
-#endif
         {
             // iOS may call this method even when we have no sections, but only if we've overridden
             // EstimatedHeight(UITableView, NSIndexPath) in our UITableViewSource
-            if (section >= commonSource.NumberOfSections())
-            {
+            if (section >= commonSource.NumberOfSections()) {
                 return 0;
             }
 
             var header = commonSource.SectionInfo[(int)section].Header;
 
             // NB: -1 is a magic # that causes iOS to use the regular height. go figure.
-            return header == null || header.View == null ? -1 : header.Height; 
+            return header == null || header.View == null ? -1 : header.Height;
         }
 
-#if UNIFIED
         public override nfloat GetHeightForFooter(UITableView tableView, nint section)
-#else
-        public override float GetHeightForFooter(UITableView tableView, int section)
-#endif
         {
             // iOS may call this method even when we have no sections, but only if we've overridden
             // EstimatedHeight(UITableView, NSIndexPath) in our UITableViewSource
-            if (section >= commonSource.NumberOfSections())
-            {
+            if (section >= commonSource.NumberOfSections()) {
                 return 0;
             }
 
@@ -337,41 +306,25 @@ namespace ReactiveUI
             return footer == null || footer.View == null ? -1 : footer.Height;
         }
 
-#if UNIFIED
         public override string TitleForHeader(UITableView tableView, nint section)
-#else
-        public override string TitleForHeader(UITableView tableView, int section)
-#endif
         {
             var header = commonSource.SectionInfo[(int)section].Header;
             return header == null || header.Title == null ? null : header.Title;
         }
 
-#if UNIFIED
         public override string TitleForFooter(UITableView tableView, nint section)
-#else
-        public override string TitleForFooter(UITableView tableView, int section)
-#endif
         {
             var footer = commonSource.SectionInfo[(int)section].Footer;
             return footer == null || footer.Title == null ? null : footer.Title;
         }
 
-#if UNIFIED
         public override UIView GetViewForHeader(UITableView tableView, nint section)
-#else
-        public override UIView GetViewForHeader(UITableView tableView, int section)
-#endif
         {
             var header = commonSource.SectionInfo[(int)section].Header;
             return header == null || header.View == null ? null : header.View.Invoke();
         }
 
-#if UNIFIED
         public override UIView GetViewForFooter(UITableView tableView, nint section)
-#else
-        public override UIView GetViewForFooter(UITableView tableView, int section)
-#endif
         {
             var footer = commonSource.SectionInfo[(int)section].Footer;
             return footer == null || footer.View == null ? null : footer.View.Invoke();

--- a/src/ReactiveUI/Cocoa/RoutedViewHost.cs
+++ b/src/ReactiveUI/Cocoa/RoutedViewHost.cs
@@ -1,21 +1,14 @@
 using System;
 using System.Reactive.Linq;
-using ReactiveUI;
 using System.Collections.Specialized;
 using System.Reactive.Disposables;
 
-#if UNIFIED && UIKIT
+#if UIKIT
 using UIKit;
 using NSView = UIKit.UIView;
 using NSViewController = UIKit.UIViewController;
-#elif UNIFIED && COCOA
-using AppKit;
-#elif UIKIT
-using MonoTouch.UIKit;
-using NSView = MonoTouch.UIKit.UIView;
-using NSViewController = MonoTouch.UIKit.UIViewController;
 #else
-using MonoMac.AppKit;
+using AppKit;
 #endif
 
 namespace ReactiveUI
@@ -34,12 +27,12 @@ namespace ReactiveUI
 
         public RoutingState Router {
             get { return router; }
-            set { this.RaiseAndSetIfChanged (ref router, value); }
+            set { this.RaiseAndSetIfChanged(ref router, value); }
         }
 
         public IObservable<string> ViewContractObservable {
             get { return viewContractObservable; }
-            set { this.RaiseAndSetIfChanged (ref viewContractObservable, value); }
+            set { this.RaiseAndSetIfChanged(ref viewContractObservable, value); }
         }
 
         public IViewLocator ViewLocator {
@@ -47,124 +40,124 @@ namespace ReactiveUI
             set { this.viewLocator = value; }
         }
 
-        public RoutedViewHost ()
+        public RoutedViewHost()
         {
-            this.ViewContractObservable = Observable.Return<string> (null);
-            this.titleUpdater = new SerialDisposable ();
+            this.ViewContractObservable = Observable.Return<string>(null);
+            this.titleUpdater = new SerialDisposable();
 
-            this.WhenActivated (
+            this.WhenActivated(
                 d => {
-                    d (this
-                        .WhenAnyValue (x => x.Router)
-                        .Where (x => x != null && x.NavigationStack.Count > 0 && this.ViewControllers.Length == 0)
-                        .Subscribe (x => {
+                    d(this
+                        .WhenAnyValue(x => x.Router)
+                        .Where(x => x != null && x.NavigationStack.Count > 0 && this.ViewControllers.Length == 0)
+                        .Subscribe(x => {
                             this.routerInstigated = true;
                             NSViewController view = null;
 
                             foreach (var viewModel in x.NavigationStack) {
-                                view = this.ResolveView (this.Router.GetCurrentViewModel (), null);
-                                this.PushViewController (view, false);
+                                view = this.ResolveView(this.Router.GetCurrentViewModel(), null);
+                                this.PushViewController(view, false);
                             }
 
-                            this.titleUpdater.Disposable = this.Router.GetCurrentViewModel ()
-                                .WhenAnyValue (y => y.UrlPathSegment)
-                                .Subscribe (y => view.NavigationItem.Title = y);
+                            this.titleUpdater.Disposable = this.Router.GetCurrentViewModel()
+                                .WhenAnyValue(y => y.UrlPathSegment)
+                                .Subscribe(y => view.NavigationItem.Title = y);
 
                             this.routerInstigated = false;
                         }));
 
-                    d (this
-                        .WhenAnyValue (x => x.Router)
-                        .Where (x => x != null)
-                        .Select (x => x.NavigationStack.ItemsAdded)
-                        .Switch ()
-                        .Where (x => x != null)
-                        .Select (contract => new { View = this.ResolveView (this.Router.GetCurrentViewModel (), /*contract*/null), Animate = this.Router.NavigationStack.Count > 1 })
-                        .Subscribe (x => {
+                    d(this
+                        .WhenAnyValue(x => x.Router)
+                        .Where(x => x != null)
+                        .Select(x => x.NavigationStack.ItemsAdded)
+                        .Switch()
+                        .Where(x => x != null)
+                        .Select(contract => new { View = this.ResolveView(this.Router.GetCurrentViewModel(), /*contract*/null), Animate = this.Router.NavigationStack.Count > 1 })
+                        .Subscribe(x => {
                             if (this.routerInstigated) {
                                 return;
                             }
 
-                            this.titleUpdater.Disposable = this.Router.GetCurrentViewModel ()
-                                .WhenAnyValue (y => y.UrlPathSegment)
-                                .Subscribe (y => x.View.NavigationItem.Title = y);
+                            this.titleUpdater.Disposable = this.Router.GetCurrentViewModel()
+                                .WhenAnyValue(y => y.UrlPathSegment)
+                                .Subscribe(y => x.View.NavigationItem.Title = y);
 
                             this.routerInstigated = true;
 
                             // super important that animate is false if it's the first view being pushed, otherwise iOS gets hella confused
                             // and calls PushViewController twice
-                            this.PushViewController (x.View, x.Animate);
+                            this.PushViewController(x.View, x.Animate);
 
                             this.routerInstigated = false;
                         }));
 
-                    d (this
-                        .WhenAnyObservable (x => x.Router.NavigationStack.Changed)
-                        .Where (x => x.Action == NotifyCollectionChangedAction.Reset)
-                        .Subscribe (_ => {
+                    d(this
+                        .WhenAnyObservable(x => x.Router.NavigationStack.Changed)
+                        .Where(x => x.Action == NotifyCollectionChangedAction.Reset)
+                        .Subscribe(_ => {
                             this.routerInstigated = true;
-                            this.PopToRootViewController (true);
+                            this.PopToRootViewController(true);
                             this.routerInstigated = false;
                         }));
 
-                    d (this
-                        .WhenAnyObservable (x => x.Router.NavigateBack)
-                        .Subscribe (x => {
+                    d(this
+                        .WhenAnyObservable(x => x.Router.NavigateBack)
+                        .Subscribe(x => {
                             this.routerInstigated = true;
-                            this.PopViewController (true);
+                            this.PopViewController(true);
                             this.routerInstigated = false;
                         }));
                 });
         }
 
-        public override void PushViewController (NSViewController viewController, bool animated)
+        public override void PushViewController(NSViewController viewController, bool animated)
         {
-            base.PushViewController (viewController, animated);
+            base.PushViewController(viewController, animated);
 
             if (!this.routerInstigated) {
                 // code must be pushing a view directly against nav controller rather than using the router, so we need to manually sync up the router state
                 // TODO: what should we _actually_ do here? Soft-check the view and VM type and ignore if they're not IViewFor/IRoutableViewModel?
                 var view = (IViewFor)viewController;
                 var viewModel = (IRoutableViewModel)view.ViewModel;
-                this.Router.NavigationStack.Add (viewModel);
+                this.Router.NavigationStack.Add(viewModel);
             }
         }
 
-        public override NSViewController PopViewController (bool animated)
+        public override NSViewController PopViewController(bool animated)
         {
             if (!this.routerInstigated) {
                 // user must have clicked Back button in nav controller, so we need to manually sync up the router state
-                this.Router.NavigationStack.RemoveAt (this.router.NavigationStack.Count - 1);
+                this.Router.NavigationStack.RemoveAt(this.router.NavigationStack.Count - 1);
             }
 
-            return base.PopViewController (animated);
+            return base.PopViewController(animated);
         }
 
-        private UIViewController ResolveView (IRoutableViewModel viewModel, string contract)
+        private UIViewController ResolveView(IRoutableViewModel viewModel, string contract)
         {
             if (viewModel == null) {
                 return null;
             }
 
             var viewLocator = this.ViewLocator ?? ReactiveUI.ViewLocator.Current;
-            var view = viewLocator.ResolveView (viewModel, contract);
+            var view = viewLocator.ResolveView(viewModel, contract);
 
             if (view == null) {
-                throw new Exception (
-                    string.Format (
+                throw new Exception(
+                    string.Format(
                         "Couldn't find a view for view model. You probably need to register an IViewFor<{0}>",
-                        viewModel.GetType ().Name));
+                        viewModel.GetType().Name));
             }
 
             view.ViewModel = viewModel;
             var viewController = view as UIViewController;
 
             if (viewController == null) {
-                throw new Exception (
-                    string.Format (
+                throw new Exception(
+                    string.Format(
                         "View type {0} for view model type {1} is not a UIViewController",
-                        view.GetType ().Name,
-                        viewModel.GetType ().Name));
+                        view.GetType().Name,
+                        viewModel.GetType().Name));
             }
 
             return viewController;
@@ -180,52 +173,52 @@ namespace ReactiveUI
     /// This is a bit different than the XAML's RoutedViewHost in the sense
     /// that this isn't a Control itself, it only manipulates other Views.
     /// </summary>
-    [Obsolete ("Use RoutedViewHost instead. This class will be removed in a later release.")]
+    [Obsolete("Use RoutedViewHost instead. This class will be removed in a later release.")]
     public class RoutedViewHostLegacy : ReactiveObject
     {
         RoutingState _Router;
         public RoutingState Router {
             get { return _Router; }
-            set { this.RaiseAndSetIfChanged (ref _Router, value); }
+            set { this.RaiseAndSetIfChanged(ref _Router, value); }
         }
 
         IObservable<string> _ViewContractObservable;
         public IObservable<string> ViewContractObservable {
             get { return _ViewContractObservable; }
-            set { this.RaiseAndSetIfChanged (ref _ViewContractObservable, value); }
+            set { this.RaiseAndSetIfChanged(ref _ViewContractObservable, value); }
         }
 
         NSViewController _DefaultContent;
         public NSViewController DefaultContent {
             get { return _DefaultContent; }
-            set { this.RaiseAndSetIfChanged (ref _DefaultContent, value); }
+            set { this.RaiseAndSetIfChanged(ref _DefaultContent, value); }
         }
 
         public IViewLocator ViewLocator { get; set; }
 
-        public RoutedViewHostLegacy (NSView targetView)
+        public RoutedViewHostLegacy(NSView targetView)
         {
             NSView viewLastAdded = null;
 
-            ViewContractObservable = Observable.Return (default (string));
+            ViewContractObservable = Observable.Return(default(string));
 
-            var vmAndContract = Observable.CombineLatest (
-                this.WhenAnyObservable (x => x.Router.CurrentViewModel),
-                this.WhenAnyObservable (x => x.ViewContractObservable),
+            var vmAndContract = Observable.CombineLatest(
+                this.WhenAnyObservable(x => x.Router.CurrentViewModel),
+                this.WhenAnyObservable(x => x.ViewContractObservable),
                 (vm, contract) => new { ViewModel = vm, Contract = contract, });
 
-            vmAndContract.Subscribe (x => {
+            vmAndContract.Subscribe(x => {
                 if (viewLastAdded != null)
-                    viewLastAdded.RemoveFromSuperview ();
+                    viewLastAdded.RemoveFromSuperview();
 
                 if (x.ViewModel == null) {
                     if (DefaultContent != null)
-                        targetView.AddSubview (DefaultContent.View);
+                        targetView.AddSubview(DefaultContent.View);
                     return;
                 }
 
                 var viewLocator = ViewLocator ?? ReactiveUI.ViewLocator.Current;
-                var view = viewLocator.ResolveView (x.ViewModel, x.Contract) ?? viewLocator.ResolveView (x.ViewModel, null);
+                var view = viewLocator.ResolveView(x.ViewModel, x.Contract) ?? viewLocator.ResolveView(x.ViewModel, null);
                 view.ViewModel = x.ViewModel;
 
                 if (view is NSViewController) {
@@ -233,10 +226,10 @@ namespace ReactiveUI
                 } else if (view is NSView) {
                     viewLastAdded = (NSView)view;
                 } else {
-                    throw new Exception (String.Format ("'{0}' must be an NSViewController or NSView", view.GetType ().FullName));
+                    throw new Exception(String.Format("'{0}' must be an NSViewController or NSView", view.GetType().FullName));
                 }
 
-                targetView.AddSubview (viewLastAdded);
+                targetView.AddSubview(viewLastAdded);
             }, RxApp.DefaultExceptionHandler.OnNext);
         }
     }

--- a/src/ReactiveUI/Cocoa/TargetActionCommandBinder.cs
+++ b/src/ReactiveUI/Cocoa/TargetActionCommandBinder.cs
@@ -4,24 +4,12 @@ using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reflection;
 using System.Windows.Input;
-using ReactiveUI;
-
-#if UNIFIED
 using Foundation;
 using ObjCRuntime;
-#elif UIKIT
-using MonoTouch.Foundation;
-using MonoTouch.ObjCRuntime;
-using MonoTouch.UIKit;
-#else
-using MonoMac.Foundation;
-using MonoMac.AppKit;
-using MonoMac.ObjCRuntime;
-#endif
 
-#if UNIFIED && UIKIT
+#if UIKIT
 using UIKit;
-#elif UNIFIED && COCOA
+#else
 using AppKit;
 #endif
 
@@ -36,7 +24,7 @@ namespace ReactiveUI
     public class TargetActionCommandBinder : ICreatesCommandBinding
     {
         readonly Type[] validTypes;
-        public TargetActionCommandBinder() 
+        public TargetActionCommandBinder()
         {
 #if UIKIT
             validTypes = new[] {
@@ -78,7 +66,7 @@ namespace ReactiveUI
             var actionDisp = Disposable.Create(() => targetSetter(target, null, null));
 
             var enabledSetter = Reflection.GetValueSetterForProperty(target.GetType().GetRuntimeProperty("Enabled"));
-            if(enabledSetter == null) return actionDisp;
+            if (enabledSetter == null) return actionDisp;
 
             // initial enabled state
             enabledSetter(target, command.CanExecute(latestParam), null);
@@ -117,7 +105,7 @@ namespace ReactiveUI
 #endif
         }
 
-        public IDisposable BindCommandToObject<TEventArgs>(ICommand command, object target, IObservable<object> commandParameter, string eventName) 
+        public IDisposable BindCommandToObject<TEventArgs>(ICommand command, object target, IObservable<object> commandParameter, string eventName)
             where TEventArgs : EventArgs
         {
             throw new NotImplementedException();

--- a/src/ReactiveUI/Cocoa/UIControlCommandExtensions.cs
+++ b/src/ReactiveUI/Cocoa/UIControlCommandExtensions.cs
@@ -1,12 +1,7 @@
 using System;
 using System.Windows.Input;
 using System.Reactive.Disposables;
-
-#if UNIFIED
 using UIKit;
-#else
-using MonoTouch.UIKit;
-#endif
 
 namespace ReactiveUI
 {
@@ -14,7 +9,7 @@ namespace ReactiveUI
     {
         public static IDisposable BindToTarget(this ICommand This, UIControl control, UIControlEvent events)
         {
-            var ev = new EventHandler((o,e) => {
+            var ev = new EventHandler((o, e) => {
                 if (!This.CanExecute(null)) return;
                 This.Execute(null);
             });

--- a/src/ReactiveUI/Cocoa/UIKitCommandBinders.cs
+++ b/src/ReactiveUI/Cocoa/UIKitCommandBinders.cs
@@ -1,19 +1,6 @@
 using System;
 using System.Reflection;
-using ReactiveUI;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reactive.Linq;
-using System.Runtime.InteropServices;
-using System.Reactive.Disposables;
-
-#if UNIFIED
-using Foundation;
 using UIKit;
-#else
-using MonoTouch.Foundation;
-using MonoTouch.UIKit;
-#endif
 
 namespace ReactiveUI
 {
@@ -21,11 +8,11 @@ namespace ReactiveUI
     {
         public static Lazy<UIKitCommandBinders> Instance = new Lazy<UIKitCommandBinders>();
 
-        public UIKitCommandBinders ()
+        public UIKitCommandBinders()
         {
-            Register(typeof(UIControl), 9, (cmd, t, cp)=> ForTargetAction(cmd, t, cp, typeof(UIControl).GetRuntimeProperty("Enabled")));
-            Register(typeof(UIRefreshControl), 10, (cmd, t, cp)=> ForEvent(cmd, t, cp, "ValueChanged", typeof(UIRefreshControl).GetRuntimeProperty("Enabled")));
-            Register(typeof(UIBarButtonItem), 10, (cmd, t, cp)=> ForEvent(cmd, t, cp, "Clicked", typeof(UIBarButtonItem).GetRuntimeProperty("Enabled")));
+            Register(typeof(UIControl), 9, (cmd, t, cp) => ForTargetAction(cmd, t, cp, typeof(UIControl).GetRuntimeProperty("Enabled")));
+            Register(typeof(UIRefreshControl), 10, (cmd, t, cp) => ForEvent(cmd, t, cp, "ValueChanged", typeof(UIRefreshControl).GetRuntimeProperty("Enabled")));
+            Register(typeof(UIBarButtonItem), 10, (cmd, t, cp) => ForEvent(cmd, t, cp, "Clicked", typeof(UIBarButtonItem).GetRuntimeProperty("Enabled")));
         }
     }
 }

--- a/src/ReactiveUI/Cocoa/UIKitObservableForProperty.cs
+++ b/src/ReactiveUI/Cocoa/UIKitObservableForProperty.cs
@@ -1,18 +1,5 @@
 using System;
-using ReactiveUI;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reactive.Linq;
-using System.Runtime.InteropServices;
-using System.Reactive.Disposables;
-
-#if UNIFIED
-using Foundation;
 using UIKit;
-#else
-using MonoTouch.Foundation;
-using MonoTouch.UIKit;
-#endif
 
 namespace ReactiveUI
 {
@@ -21,16 +8,16 @@ namespace ReactiveUI
     {
         public static Lazy<UIKitObservableForProperty> Instance = new Lazy<UIKitObservableForProperty>();
 
-        public UIKitObservableForProperty ()
+        public UIKitObservableForProperty()
         {
-            Register(typeof(UIControl), "Value", 20, (s, p)=> ObservableFromUIControlEvent(s, p, UIControlEvent.ValueChanged));
+            Register(typeof(UIControl), "Value", 20, (s, p) => ObservableFromUIControlEvent(s, p, UIControlEvent.ValueChanged));
             Register(typeof(UITextField), "Text", 30, (s, p) => ObservableFromNotification(s, p, UITextField.TextFieldTextDidChangeNotification));
             Register(typeof(UITextView), "Text", 30, (s, p) => ObservableFromNotification(s, p, UITextView.TextDidChangeNotification));
-            Register(typeof(UIDatePicker), "Date", 30, (s, p)=> ObservableFromUIControlEvent(s, p, UIControlEvent.ValueChanged));
-            Register(typeof(UISegmentedControl), "SelectedSegment", 30, (s, p)=> ObservableFromUIControlEvent(s, p, UIControlEvent.ValueChanged));
-            Register(typeof(UISwitch), "On", 30, (s, p)=> ObservableFromUIControlEvent(s, p, UIControlEvent.ValueChanged));
-            Register(typeof(UISegmentedControl), "SelectedSegment", 30, (s, p)=> ObservableFromUIControlEvent(s, p, UIControlEvent.ValueChanged));
-            
+            Register(typeof(UIDatePicker), "Date", 30, (s, p) => ObservableFromUIControlEvent(s, p, UIControlEvent.ValueChanged));
+            Register(typeof(UISegmentedControl), "SelectedSegment", 30, (s, p) => ObservableFromUIControlEvent(s, p, UIControlEvent.ValueChanged));
+            Register(typeof(UISwitch), "On", 30, (s, p) => ObservableFromUIControlEvent(s, p, UIControlEvent.ValueChanged));
+            Register(typeof(UISegmentedControl), "SelectedSegment", 30, (s, p) => ObservableFromUIControlEvent(s, p, UIControlEvent.ValueChanged));
+
             // Warning: This will stomp the Control's delegate
             Register(typeof(UITabBar), "SelectedItem", 30, (s, p) => ObservableFromEvent(s, p, "ItemSelected"));
 

--- a/src/ReactiveUI/Cocoa/UIKitObservableForPropertyBase.cs
+++ b/src/ReactiveUI/Cocoa/UIKitObservableForPropertyBase.cs
@@ -1,18 +1,11 @@
 using System;
-using ReactiveUI;
-using System.Reactive.Disposables;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reactive.Linq;
 using System.Linq.Expressions;
-
-#if UNIFIED
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
 using Foundation;
 using UIKit;
-#else
-using MonoTouch.Foundation;
-using MonoTouch.UIKit;
-#endif
 
 namespace ReactiveUI
 {
@@ -25,12 +18,12 @@ namespace ReactiveUI
                 return 0;
 
             var match = config.Keys
-                .Where(x=> x.IsAssignableFrom(type) && config[x].Keys.Contains(propertyName))
-                .Select(x=> config[x][propertyName])
-                .OrderByDescending(x=> x.Affinity)
+                .Where(x => x.IsAssignableFrom(type) && config[x].Keys.Contains(propertyName))
+                .Select(x => config[x][propertyName])
+                .OrderByDescending(x => x.Affinity)
                 .FirstOrDefault();
 
-            if(match == null)
+            if (match == null)
                 return 0;
 
             return match.Affinity;
@@ -45,15 +38,15 @@ namespace ReactiveUI
             var propertyName = expression.GetMemberInfo().Name;
 
             var match = config.Keys
-                .Where(x=> x.IsAssignableFrom(type) && config[x].Keys.Contains(propertyName))
-                .Select(x=> config[x][propertyName])
-                .OrderByDescending(x=> x.Affinity)
+                .Where(x => x.IsAssignableFrom(type) && config[x].Keys.Contains(propertyName))
+                .Select(x => config[x][propertyName])
+                .OrderByDescending(x => x.Affinity)
                 .FirstOrDefault();
 
-            if(match == null)
+            if (match == null)
                 throw new NotSupportedException(string.Format("Notifications for {0}.{1} are not supported", type.Name, propertyName));
 
-            return match.CreateObservable((NSObject) sender, expression);
+            return match.CreateObservable((NSObject)sender, expression);
         }
 
         internal class ObservablePropertyInfo
@@ -77,8 +70,7 @@ namespace ReactiveUI
         protected void Register(Type type, string property, int affinity, Func<NSObject, Expression, IObservable<IObservedChange<object, object>>> createObservable)
         {
             Dictionary<string, ObservablePropertyInfo> typeProperties;
-            if(!config.TryGetValue(type, out typeProperties))
-            {
+            if (!config.TryGetValue(type, out typeProperties)) {
                 typeProperties = new Dictionary<string, ObservablePropertyInfo>();
                 config[type] = typeProperties;
             }
@@ -96,19 +88,16 @@ namespace ReactiveUI
         /// <param name="evt">The control event to listen for</param>
         protected static IObservable<IObservedChange<object, object>> ObservableFromUIControlEvent(NSObject sender, Expression expression, UIControlEvent evt)
         {
-            return Observable.Create<IObservedChange<object, object>>(subj =>
-            {
-                var control = (UIControl) sender;
+            return Observable.Create<IObservedChange<object, object>>(subj => {
+                var control = (UIControl)sender;
 
-                EventHandler handler = (s,e)=>
-                {
+                EventHandler handler = (s, e) => {
                     subj.OnNext(new ObservedChange<object, object>(sender, expression));
                 };
 
                 control.AddTarget(handler, evt);
 
-                return Disposable.Create(() =>
-                {
+                return Disposable.Create(() => {
                     control.RemoveTarget(handler, evt);
                 });
             });
@@ -123,15 +112,12 @@ namespace ReactiveUI
         /// <param name="notification">Notification.</param>
         protected static IObservable<IObservedChange<object, object>> ObservableFromNotification(NSObject sender, Expression expression, NSString notification)
         {
-            return Observable.Create<IObservedChange<object, object>>(subj =>
-            {
-                var handle = NSNotificationCenter.DefaultCenter.AddObserver (notification, (e)=>
-                {
+            return Observable.Create<IObservedChange<object, object>>(subj => {
+                var handle = NSNotificationCenter.DefaultCenter.AddObserver(notification, (e) => {
                     subj.OnNext(new ObservedChange<object, object>(sender, expression));
                 }, sender);
 
-                return Disposable.Create(() =>
-                {
+                return Disposable.Create(() => {
                     NSNotificationCenter.DefaultCenter.RemoveObserver(handle);
                 });
             });
@@ -146,10 +132,8 @@ namespace ReactiveUI
         /// <param name="notification">Notification.</param>
         protected static IObservable<IObservedChange<object, object>> ObservableFromEvent(NSObject sender, Expression expression, string eventName)
         {
-            return Observable.Create<IObservedChange<object, object>>(subj =>
-            {
-                return Observable.FromEventPattern(sender, eventName).Subscribe((e) =>
-                {
+            return Observable.Create<IObservedChange<object, object>>(subj => {
+                return Observable.FromEventPattern(sender, eventName).Subscribe((e) => {
                     subj.OnNext(new ObservedChange<object, object>(sender, expression));
                 });
             });

--- a/src/ReactiveUI/Cocoa/ViewModelViewHost.cs
+++ b/src/ReactiveUI/Cocoa/ViewModelViewHost.cs
@@ -1,20 +1,13 @@
 using System;
 using System.Reactive.Linq;
-using ReactiveUI;
 using System.Reactive.Disposables;
 
-#if UNIFIED && UIKIT
+#if UIKIT
 using UIKit;
 using NSView = UIKit.UIView;
 using NSViewController = UIKit.UIViewController;
-#elif UNIFIED && COCOA
-using AppKit;
-#elif UIKIT
-using MonoTouch.UIKit;
-using NSView = MonoTouch.UIKit.UIView;
-using NSViewController = MonoTouch.UIKit.UIViewController;
 #else
-using MonoMac.AppKit;
+using AppKit;
 #endif
 
 namespace ReactiveUI
@@ -38,32 +31,27 @@ namespace ReactiveUI
             this.Initialize();
         }
 
-        public IViewLocator ViewLocator
-        {
+        public IViewLocator ViewLocator {
             get { return viewLocator; }
             set { this.RaiseAndSetIfChanged(ref viewLocator, value); }
         }
 
-        public NSViewController DefaultContent
-        {
+        public NSViewController DefaultContent {
             get { return defaultContent; }
             set { this.RaiseAndSetIfChanged(ref defaultContent, value); }
         }
 
-        public IReactiveObject ViewModel
-        {
+        public IReactiveObject ViewModel {
             get { return viewModel; }
             set { this.RaiseAndSetIfChanged(ref viewModel, value); }
         }
 
-        public IObservable<string> ViewContractObservable
-        {
+        public IObservable<string> ViewContractObservable {
             get { return viewContractObservable; }
             set { this.RaiseAndSetIfChanged(ref viewContractObservable, value); }
         }
 
-        public string ViewContract
-        {
+        public string ViewContract {
             get { return this.viewContract.Value; }
             set { ViewContractObservable = Observable.Return(value); }
         }
@@ -88,17 +76,14 @@ namespace ReactiveUI
             viewChange
                 .ObserveOn(RxApp.MainThreadScheduler)
                 .Subscribe(
-                    x =>
-                    {
+                    x => {
                         var viewLocator = ViewLocator ?? ReactiveUI.ViewLocator.Current;
                         var view = viewLocator.ResolveView(x.ViewModel, x.Contract);
 
-                        if (view == null)
-                        {
+                        if (view == null) {
                             var message = string.Format("Unable to resolve view for \"{0}\"", x.ViewModel.GetType());
 
-                            if (x.Contract != null)
-                            {
+                            if (x.Contract != null) {
                                 message += string.Format(" and contract \"{0}\"", x.Contract.GetType());
                             }
 
@@ -108,11 +93,10 @@ namespace ReactiveUI
 
                         var viewController = view as NSViewController;
 
-                        if (viewController == null)
-                        {
+                        if (viewController == null) {
                             throw new Exception(
                                 string.Format(
-                                    "Resolved view type '{0}' is not a '{1}'.", 
+                                    "Resolved view type '{0}' is not a '{1}'.",
                                     viewController.GetType().FullName,
                                     typeof(NSViewController).FullName));
                         }
@@ -135,8 +119,7 @@ namespace ReactiveUI
         {
             base.Dispose(disposing);
 
-            if (disposing)
-            {
+            if (disposing) {
                 this.currentView.Dispose();
                 this.viewContract.Dispose();
             }
@@ -182,14 +165,14 @@ namespace ReactiveUI
     /// that this isn't a Control itself, it only manipulates other Views.
     /// </summary>
     [Obsolete("Use ViewModelViewHost instead. This class will be removed in a later release.")]
-    public class ViewModelViewHostLegacy : ReactiveObject 
+    public class ViewModelViewHostLegacy : ReactiveObject
     {
         /// <summary>
         /// Gets or sets a value indicating whether this <see cref="ReactiveUI.Cocoa.ViewModelViewHost"/>
         /// will automatically create Auto Layout constraints tying the sub view to the parent view.
         /// </summary>
         /// <value><c>true</c> if add layout contraints to sub view; otherwise, <c>false</c>.</value>
-        public bool AddAutoLayoutConstraintsToSubView { get; set; } 
+        public bool AddAutoLayoutConstraintsToSubView { get; set; }
 
         public ViewModelViewHostLegacy(NSView targetView)
         {
@@ -246,10 +229,10 @@ namespace ReactiveUI
 
                 if (AddAutoLayoutConstraintsToSubView) {
                     // Add edge constraints so that subview trails changes in parent
-                    addEdgeConstraint(NSLayoutAttribute.Left,  targetView, viewLastAdded);
+                    addEdgeConstraint(NSLayoutAttribute.Left, targetView, viewLastAdded);
                     addEdgeConstraint(NSLayoutAttribute.Right, targetView, viewLastAdded);
                     addEdgeConstraint(NSLayoutAttribute.Top, targetView, viewLastAdded);
-                    addEdgeConstraint(NSLayoutAttribute.Bottom,  targetView, viewLastAdded);
+                    addEdgeConstraint(NSLayoutAttribute.Bottom, targetView, viewLastAdded);
                 }
             });
         }
@@ -271,13 +254,13 @@ namespace ReactiveUI
             get { return _ViewModel; }
             set { this.RaiseAndSetIfChanged(ref _ViewModel, value); }
         }
-        
+
         IObservable<string> _ViewContractObservable;
         public IObservable<string> ViewContractObservable {
             get { return _ViewContractObservable; }
             set { this.RaiseAndSetIfChanged(ref _ViewContractObservable, value); }
         }
-       
+
         public IViewLocator ViewLocator { get; set; }
     }
 }

--- a/src/ReactiveUI/Platform/FlexibleCommandBinder.cs
+++ b/src/ReactiveUI/Platform/FlexibleCommandBinder.cs
@@ -5,7 +5,9 @@ using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reflection;
 using System.Windows.Input;
+#if UIKIT
 using UIKit;
+#endif
 
 namespace ReactiveUI
 {
@@ -112,6 +114,7 @@ namespace ReactiveUI
             return compDisp;
         }
 
+#if UIKIT
         /// <summary>
         /// Creates a commands binding from event and a property
         /// </summary>
@@ -148,6 +151,7 @@ namespace ReactiveUI
 
             return compDisp;
         }
+#endif
     }
 }
 

--- a/src/ReactiveUI/Platform/FlexibleCommandBinder.cs
+++ b/src/ReactiveUI/Platform/FlexibleCommandBinder.cs
@@ -1,17 +1,12 @@
 using System;
-using System.Reactive.Disposables;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reflection;
 using System.Windows.Input;
-using System.Linq.Expressions;
-
-#if UNIFIED
 using UIKit;
-#elif UIKIT
-using MonoTouch.UIKit;
-#endif
+
 namespace ReactiveUI
 {
     public abstract class FlexibleCommandBinder : ICreatesCommandBinding
@@ -25,7 +20,7 @@ namespace ReactiveUI
                 .OrderByDescending(x => config[x].Affinity)
                 .FirstOrDefault();
 
-            if(match == null) return 0;
+            if (match == null) return 0;
 
             var typeProperties = config[match];
             return typeProperties.Affinity;
@@ -36,11 +31,11 @@ namespace ReactiveUI
             var type = target.GetType();
 
             var match = config.Keys
-                .Where(x=> x.IsAssignableFrom(type))
-                .OrderByDescending(x=> config[x].Affinity)
+                .Where(x => x.IsAssignableFrom(type))
+                .OrderByDescending(x => config[x].Affinity)
                 .FirstOrDefault();
 
-            if(match == null) {
+            if (match == null) {
                 throw new NotSupportedException(string.Format("CommandBinding for {0} is not supported", type.Name));
             }
 
@@ -102,7 +97,7 @@ namespace ReactiveUI
             });
 
             var enabledSetter = Reflection.GetValueSetterForProperty(enabledProperty);
-            if(enabledSetter == null) return actionDisp;
+            if (enabledSetter == null) return actionDisp;
 
             // initial enabled state
             enabledSetter(target, command.CanExecute(latestParam), null);
@@ -117,7 +112,6 @@ namespace ReactiveUI
             return compDisp;
         }
 
-#if UIKIT
         /// <summary>
         /// Creates a commands binding from event and a property
         /// </summary>
@@ -131,13 +125,13 @@ namespace ReactiveUI
 
             var ctl = target as UIControl;
             if (ctl != null) {
-                var eh = new EventHandler((o,e) => {
+                var eh = new EventHandler((o, e) => {
                     if (command.CanExecute(latestParam)) command.Execute(latestParam);
                 });
 
                 ctl.AddTarget(eh, UIControlEvent.TouchUpInside);
                 actionDisp = Disposable.Create(() => ctl.RemoveTarget(eh, UIControlEvent.TouchUpInside));
-            } 
+            }
 
             var enabledSetter = Reflection.GetValueSetterForProperty(enabledProperty);
             if (enabledSetter == null) return actionDisp;
@@ -154,7 +148,6 @@ namespace ReactiveUI
 
             return compDisp;
         }
-        #endif 
     }
 }
 

--- a/src/ReactiveUI/Platform/Registrations.cs
+++ b/src/ReactiveUI/Platform/Registrations.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Reactive.Concurrency;
 
 namespace ReactiveUI
 {

--- a/src/ReactiveUI/Platform/Registrations.cs
+++ b/src/ReactiveUI/Platform/Registrations.cs
@@ -1,23 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Windows;
-using System.Reactive.Concurrency;
-
-#if UNIFIED && UIKIT
-using UIKit;
-using NSApplication = UIKit.UIApplication;
-#elif UIKIT
-using MonoTouch.UIKit;
-using NSApplication = MonoTouch.UIKit.UIApplication;
-#endif 
-
-#if COCOA && !UIKIT && !UNIFIED
-using MonoMac.AppKit;
-#endif
 
 namespace ReactiveUI
 {

--- a/src/ReactiveUI/ReactiveUI_Mac.csproj
+++ b/src/ReactiveUI/ReactiveUI_Mac.csproj
@@ -19,7 +19,7 @@
     <Optimize>False</Optimize>
     <OutputPath>bin\Debug\Xamarin.Mac20</OutputPath>
     <IntermediateOutputPath>obj\Debug\Xamarin.Mac20</IntermediateOutputPath>
-    <DefineConstants>DEBUG;MONO;COCOA;UNIFIED</DefineConstants>
+    <DefineConstants>DEBUG;MONO;COCOA</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <EnablePackageSigning>False</EnablePackageSigning>
@@ -46,7 +46,7 @@
     <CreatePackage>False</CreatePackage>
     <CodeSigningKey>Mac Developer</CodeSigningKey>
     <UseSGen>False</UseSGen>
-    <DefineConstants>MONO;COCOA;UNIFIED</DefineConstants>
+    <DefineConstants>MONO;COCOA</DefineConstants>
     <DebugSymbols>true</DebugSymbols>
     <GenerateDocumentation>True</GenerateDocumentation>
     <DocumentationFile>bin\Release\Xamarin.Mac20\ReactiveUI.xml</DocumentationFile>

--- a/src/ReactiveUI/ReactiveUI_iOS.csproj
+++ b/src/ReactiveUI/ReactiveUI_iOS.csproj
@@ -20,7 +20,7 @@
     <Optimize>False</Optimize>
     <OutputPath>bin\Debug\Xamarin.iOS10</OutputPath>
     <IntermediateOutputPath>obj\Debug\Xamarin.iOS10</IntermediateOutputPath>
-    <DefineConstants>DEBUG;MONO;UIKIT;COCOA;UNIFIED</DefineConstants>
+    <DefineConstants>DEBUG;MONO;UIKIT;COCOA</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>False</ConsolePause>
@@ -35,7 +35,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>False</ConsolePause>
-    <DefineConstants>MONO;UIKIT;COCOA;UNIFIED</DefineConstants>
+    <DefineConstants>MONO;UIKIT;COCOA</DefineConstants>
     <DocumentationFile>bin\Release\Xamarin.iOS10\ReactiveUI.xml</DocumentationFile>
     <GenerateDocumentation>True</GenerateDocumentation>
     <CodesignKey>iPhone Developer</CodesignKey>


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Remove all obsolete UNIFIED symbol checks, as requested in #1222.


**What is the current behavior? (You can also link to an open issue here)**
There's checks for whether the unified framework is used.


**What is the new behavior (if this is a feature change)?**
These checks are no longer required, as it's no longer supported.


**Does this PR introduce a breaking change?**
Nope.


**Please check if the PR fulfills these requirements**
- [x] The commit follows our guidelines: https://github.com/reactiveui/reactiveui#contribute
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
Can't really check if the Mac version builds, Xamarin Studio seriously chokes on the Mac library projects. Can't find references to AppKit etc. So I'm hoping the build works.

I've also removed a lot of unused using statements. And maybe some old code standards have been refactored by my IDE settings. But they should comply with the latest standards used throughout the project.