### PR TITLE
View locator changes

### DIFF
--- a/src/ReactiveUI.Tests/ViewLocatorTests.cs
+++ b/src/ReactiveUI.Tests/ViewLocatorTests.cs
@@ -1,5 +1,4 @@
 using System;
-using ReactiveUI;
 using Splat;
 using Xunit;
 
@@ -71,6 +70,10 @@ namespace ReactiveUI.Tests
 
         public IFooViewModel ViewModel { get; set; }
     }
+
+    public interface StrangeInterfaceNotFollowingConvention { }
+
+    public class StrangeClassNotFollowingConvention : StrangeInterfaceNotFollowingConvention { }
 
     public class DefaultViewLocatorTests
     {
@@ -331,6 +334,24 @@ namespace ReactiveUI.Tests
                 var ex = Assert.Throws<InvalidOperationException>(() => fixture.ResolveView(vm));
                 Assert.Equal("This is a test failure.", ex.Message);
             }
+        }
+
+        [Fact]
+        public void WithOddInterfaceNameDoesntThrowException()
+        {
+            var resolver = new ModernDependencyResolver();
+
+            resolver.InitializeSplat();
+            resolver.InitializeReactiveUI();
+
+            using (resolver.WithResolver()) {
+                var fixture = new DefaultViewLocator();
+
+                var vm = new StrangeClassNotFollowingConvention();
+
+                fixture.ResolveView((StrangeInterfaceNotFollowingConvention)vm);
+            }
+
         }
     }
 }

--- a/src/ReactiveUI.Tests/ViewLocatorTests.cs
+++ b/src/ReactiveUI.Tests/ViewLocatorTests.cs
@@ -75,6 +75,25 @@ namespace ReactiveUI.Tests
 
     public class StrangeClassNotFollowingConvention : StrangeInterfaceNotFollowingConvention { }
 
+    public interface IRoutableFooViewModel : IRoutableViewModel { }
+
+    public class RoutableFooViewModel : ReactiveObject, IRoutableFooViewModel
+    {
+        public IScreen HostScreen { get; set; }
+        public string UrlPathSegment { get; set; }
+    }
+
+    public class RoutableFooView : IViewFor<IRoutableFooViewModel>
+    {
+        object IViewFor.ViewModel
+        {
+            get { return ViewModel; }
+            set { ViewModel = (IRoutableFooViewModel)value; }
+        }
+        public IRoutableFooViewModel ViewModel { get; set; }
+    }
+
+
     public class DefaultViewLocatorTests
     {
         [Fact]
@@ -351,7 +370,24 @@ namespace ReactiveUI.Tests
 
                 fixture.ResolveView((StrangeInterfaceNotFollowingConvention)vm);
             }
+        }
 
+        [Fact]
+        public void CanResolveViewFromViewModelWithIRoutableViewModelType()
+        {
+            var resolver = new ModernDependencyResolver();
+
+            resolver.InitializeSplat();
+            resolver.InitializeReactiveUI();
+            resolver.Register(() => new RoutableFooView(), typeof(IViewFor<IRoutableFooViewModel>));
+
+            using (resolver.WithResolver()) {
+                var fixture = new DefaultViewLocator();
+                var vm = new RoutableFooViewModel();
+
+                var result = fixture.ResolveView<IRoutableViewModel>(vm);
+                Assert.IsType<RoutableFooView>(result);
+            }
         }
     }
 }

--- a/src/ReactiveUI/ViewLocator.cs
+++ b/src/ReactiveUI/ViewLocator.cs
@@ -106,7 +106,10 @@ namespace ReactiveUI
             }
 
             var toggledType = ToggleViewModelType(viewModel);
-            view = this.AttemptViewResolutionFor(toggledType, contract);
+
+            if (toggledType != null) {
+                view = this.AttemptViewResolutionFor(toggledType, contract);
+            }
 
             if (view != null) {
                 return view;

--- a/src/ReactiveUI/ViewLocator.cs
+++ b/src/ReactiveUI/ViewLocator.cs
@@ -105,11 +105,13 @@ namespace ReactiveUI
                 return view;
             }
 
-            var toggledType = ToggleViewModelType(viewModel);
+            view = this.AttemptViewResolutionFor(ToggleViewModelType(viewModel.GetType()), contract);
 
-            if (toggledType != null) {
-                view = this.AttemptViewResolutionFor(toggledType, contract);
+            if (view != null) {
+                return view;
             }
+
+            view = this.AttemptViewResolutionFor(ToggleViewModelType(typeof(T)), contract);
 
             if (view != null) {
                 return view;
@@ -121,6 +123,7 @@ namespace ReactiveUI
 
         private IViewFor AttemptViewResolutionFor(Type viewModelType, string contract)
         {
+            if (viewModelType == null) return null;
             var viewModelTypeName = viewModelType.AssemblyQualifiedName;
             var proposedViewTypeName = this.ViewModelToViewFunc(viewModelTypeName);
             var view = this.AttemptViewResolution(proposedViewTypeName, contract);
@@ -170,9 +173,8 @@ namespace ReactiveUI
             }
         }
 
-        private static Type ToggleViewModelType<T>(T viewModel)
+        private static Type ToggleViewModelType(Type viewModelType)
         {
-            var viewModelType = typeof(T);
             var viewModelTypeName = viewModelType.AssemblyQualifiedName;
 
             if (viewModelType.GetTypeInfo().IsInterface) {

--- a/src/ReactiveUI/ViewLocator.cs
+++ b/src/ReactiveUI/ViewLocator.cs
@@ -78,7 +78,7 @@ namespace ReactiveUI
         /// </item>
         /// <item>
         /// <description>
-        /// Repeat steps 1 and 2 with the type resolved from the modified name.
+        /// Repeat steps 1-4 with the type resolved from the modified name.
         /// </description>
         /// </item>
         /// </list>


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Fix

**What is the current behavior? (You can also link to an open issue here)**
#1299 and #1298 the view locator doesn't correctly resolve a couple of cases, and can't handle oddly named interfaces well.

**What is the new behavior (if this is a feature change)?**
Handle IRoutableViewModel style VMs, and handle interfaces that don't meet conventions.


**Does this PR introduce a breaking change?**
It sort of undoes a breaking change introduced in 7.2 with the refactorings around the view locator.


**Please check if the PR fulfills these requirements**
- [x] The commit follows our guidelines: https://github.com/reactiveui/reactiveui#contribute
- [x] Tests for the changes have been added (for bug fixes / features)

**Other information**:
This could conceivably be two separate PRs, but I think it's actually clearer to do it in one
