### PR TITLE
refactor: removed unused extension method and make class internal

### DIFF
--- a/src/ReactiveUI/CompatMixins.cs
+++ b/src/ReactiveUI/CompatMixins.cs
@@ -1,28 +1,21 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reactive.Subjects;
 
 namespace ReactiveUI
 {
-    public static class CompatMixins
+    internal static class CompatMixins
     {
         internal static void ForEach<T>(this IEnumerable<T> This, Action<T> block)
         {
             foreach (var v in This) {
-                block(v); 
+                block(v);
             }
         }
 
         internal static IEnumerable<T> SkipLast<T>(this IEnumerable<T> This, int count)
         {
             return This.Take(This.Count() - count);
-        }
-
-        internal static IObservable<T> PermaRef<T>(this IConnectableObservable<T> This)
-        {
-            This.Connect();
-            return This;
         }
     }
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Refactoring.


**What is the current behavior? (You can also link to an open issue here)**
Unused extension method, class that's public but exposes nothing.


**What is the new behavior (if this is a feature change)?**
No unused extension method, class that's internal only.


**Does this PR introduce a breaking change?**
Shouldn't do, unless someone is using the CompatMixins clas somehow.


**Please check if the PR fulfills these requirements**
- [x] The commit follows our guidelines: https://github.com/reactiveui/reactiveui#contribute
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
Found this whilst reviewing XML docs, this felt like a better thing to do than a comment that says "nothing to see here"
