### PR TITLE
Fix ViewModelViewHost memory leak

### DIFF
--- a/src/ReactiveUI/Xaml/ViewModelViewHost.cs
+++ b/src/ReactiveUI/Xaml/ViewModelViewHost.cs
@@ -54,7 +54,7 @@ namespace ReactiveUI
 
         public string ViewContract
         {
-            get { return this.viewContract; }
+            get { return viewContract; }
             set { ViewContractObservable = Observable.Return(value); }
         }
 
@@ -101,21 +101,20 @@ namespace ReactiveUI
                     }
 
                     var viewLocator = ViewLocator ?? ReactiveUI.ViewLocator.Current;
-                    var view = viewLocator.ResolveView(x.ViewModel, x.Contract) ?? viewLocator.ResolveView(x.ViewModel, null);
+                    var view = viewLocator.ResolveView(x.ViewModel, x.Contract) ?? viewLocator.ResolveView(x.ViewModel);
 
                     if (view == null) {
-                        throw new Exception(String.Format("Couldn't find view for '{0}'.", x.ViewModel));
+                        throw new Exception($"Couldn't find view for '{x.ViewModel}'.");
                     }
 
                     view.ViewModel = x.ViewModel;
                     Content = view;
                 }));
-            });
 
-            this
-                .WhenAnyObservable(x => x.ViewContractObservable)
-                .ObserveOn(RxApp.MainThreadScheduler)
-                .Subscribe(x => this.viewContract = x);
+                d(this.WhenAnyObservable(x => x.ViewContractObservable)
+                    .ObserveOn(RxApp.MainThreadScheduler)
+                    .Subscribe(x => viewContract = x));
+            });
         }
 
         static void somethingChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)

--- a/src/ReactiveUI/Xaml/ViewModelViewHost.cs
+++ b/src/ReactiveUI/Xaml/ViewModelViewHost.cs
@@ -54,7 +54,7 @@ namespace ReactiveUI
 
         public string ViewContract
         {
-            get { return viewContract; }
+            get { return this.viewContract; }
             set { ViewContractObservable = Observable.Return(value); }
         }
 

--- a/src/ReactiveUI/Xaml/ViewModelViewHost.cs
+++ b/src/ReactiveUI/Xaml/ViewModelViewHost.cs
@@ -101,7 +101,7 @@ namespace ReactiveUI
                     }
 
                     var viewLocator = ViewLocator ?? ReactiveUI.ViewLocator.Current;
-                    var view = viewLocator.ResolveView(x.ViewModel, x.Contract) ?? viewLocator.ResolveView(x.ViewModel);
+                    var view = viewLocator.ResolveView(x.ViewModel, x.Contract) ?? viewLocator.ResolveView(x.ViewModel, null);
 
                     if (view == null) {
                         throw new Exception($"Couldn't find view for '{x.ViewModel}'.");


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Bug fix

**What is the current behavior? (You can also link to an open issue here)**

The ViewModelViewHost leaks memory on XAML platforms.

**What is the new behavior (if this is a feature change)?**

The subscription to the SizeChangedEvent will be disposed via WhenActivated and it no longer leaks memory.

**Does this PR introduce a breaking change?**

No

**Please check if the PR fulfills these requirements**
- [x] The commit follows our guidelines: https://github.com/reactiveui/reactiveui#contribute
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

