### PR TITLE
housekeeping: retrieve System.Windows.Interactivity from NuGet so contributors don't need to install the SDK

### DIFF
--- a/src/ReactiveUI.Blend/ReactiveUI.Blend.csproj
+++ b/src/ReactiveUI.Blend/ReactiveUI.Blend.csproj
@@ -22,6 +22,7 @@
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="PresentationFramework.Aero" />
+    <PackageReference Include="Expression.Blend.Sdk" Version="1.0.2" /> 
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'uap10.0' ">
@@ -31,9 +32,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ReactiveUI\ReactiveUI.csproj" />
-    <Reference Include="System.Windows.Interactivity">
-      <HintPath>C:\Program Files (x86)\Microsoft SDKs\Expression\Blend\.NETFramework\v4.5\Libraries\System.Windows.Interactivity.dll</HintPath>
-    </Reference>
   </ItemGroup>
 
   <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

housekeeping to make contributing easier

**What is the current behavior? (You can also link to an open issue here)**

Contributors would need to install a specific SDK

**What is the new behavior (if this is a feature change)?**

We use the NuGet package instead, removing this pain!

**Does this PR introduce a breaking change?**

Nope

**Please check if the PR fulfills these requirements**
- [x] The commit follows our guidelines: https://github.com/reactiveui/reactiveui#contribute
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

