### PR TITLE
housekeeping: github labels updated to rename uwp & wpf, drop windows phone/store, add tizen

### DIFF
--- a/GitReleaseManager.yaml
+++ b/GitReleaseManager.yaml
@@ -14,9 +14,9 @@ issue-labels-include:
 - reactiveui-core
 - reactiveui-events
 - windows-forms
-- windows-phone-store-uwp
-- uwp
-- wpf
+- universal-windows-platform
+- windows-presentation-framework
+- tizen
 - xamarin-android
 - xamarin-forms
 - xamarin-ios
@@ -35,15 +35,15 @@ issue-labels-alias:
     - name:    windows-forms
       header:  Windows Forms
       plural:  Windows Forms
-    - name:    windows-phone-store-uwp
-      header:  Windows Phone, Store and Universal
-      plural:  Windows Phone, Store and Universal
-    - name:    uwp
-      header:  Windows Universal Platform
-      plural:  Windows Universal Platform
-    - name:    wpf
+    - name:    universal-windows-platform
+      header:  Universal Windows Platform
+      plural:  Universal Windows Platform
+    - name:    windows-presentation-framework
       header:  Windows Presentation Framework
       plural:  Windows Presentation Framework
+    - tizen:   tizen
+      header:  Tizen
+      plural:  Tizen
     - name:    xamarin-android
       header:  Xamarin Android
       plural:  Xamarin Android


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Housekeeping

**What is the new behavior (if this is a feature change)?**

updated GitReleaseManager configuration to match the GitHub label changes introduced as part of the upcoming netstandard release.

**Does this PR introduce a breaking change?**

no

**Please check if the PR fulfills these requirements**
- [x] The commit follows our guidelines: https://github.com/reactiveui/reactiveui#contribute
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)