### PR TITLE
housekeeping: remove duplicate Slack section

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ If you’re already familiar with [functional reactive programming](http://docs.
 If you have a question, please see if any discussions in our [GitHub issues](github.com/reactiveui/ReactiveUI/issues) or [Stack Overflow](https://stackoverflow.com/questions/tagged/reactiveui) have already answered it. If not, please [feel free to file your own](https://github.com/reactiveui/ReactiveUI/issues/new)! 
 
 We have our very own [Slack organization](https://reactivex.slack.com/) which contains some of the best user interface/reactive extension developers in the industry. All software engineers, young and old, regardless of experience are welcome to join our campfire but you'll need to send an email to [hello@reactiveui.net](mailto:hello@reactiveui.net) with the email address you'd like to be invited, and we'll send you an invite. Sit tight, it's worth it.
+
 #### Table of Contents
 * [Introduction](#introduction)
 * [Fundamentals](#fundamentals)
 * [A Compelling Example](#a-compelling-example)
-* [Slack](#slack)
 * [Support](#support)
 * [Contribute](#contribute)
 * [Showcase](#showcase)
@@ -111,10 +111,6 @@ this.WhenAnyValue(x => x.SearchQuery)
     .Throttle(TimeSpan.FromSeconds(1), RxApp.MainThreadScheduler)
     .InvokeCommand(Search);
 ```
-
-## Slack
-
-We have our very own [Slack organization](https://reactivex.slack.com/) which contains some of the best user interface/reactive extension developers in the industry. All software engineers, young and old, regardless of experience are welcome to join our campfire but you'll need to send an email to [hello@reactiveui.net](mailto:hello@reactiveui.net) with the Email address you'd like to be invited, and we'll send you an invite. Sit tight, it's worth it.
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ If you’re already familiar with [functional reactive programming](http://docs.
 
 If you have a question, please see if any discussions in our [GitHub issues](github.com/reactiveui/ReactiveUI/issues) or [Stack Overflow](https://stackoverflow.com/questions/tagged/reactiveui) have already answered it. If not, please [feel free to file your own](https://github.com/reactiveui/ReactiveUI/issues/new)! 
 
-We have our very own [Slack organization](https://reactivex.slack.com/) which contains some of the best user interface/reactive extension developers in the industry. All software engineers, young and old, regardless of experience are welcome to join our campfire but you'll need to send an email to [hello@reactiveui.net](mailto:hello@reactiveui.net) with the email address you'd like to be invited, and we'll send you an invite. Sit tight, it's worth it.
+We have our very own Slack organization which contains some of the best user interface/reactive extension developers in the industry. All software engineers, young and old, regardless of experience are welcome to join our campfire but you'll need to [send an email](https://reactiveui.net/slack/) with the email address you'd like to be invited, and we'll send you an invite. Sit tight, it's worth it.
 
 #### Table of Contents
 * [Introduction](#introduction)


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Remove duplicate slack section in README - I don't think it adds much to have it twice, and means it has to be changed twice if anything happens.

**What is the current behavior? (You can also link to an open issue here)**



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?**



**Please check if the PR fulfills these requirements**
- [ ] The commit follows our guidelines: https://github.com/reactiveui/reactiveui#contribute
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

