### PR TITLE
fix: pin child packages of our main project be locked to the version that's being built

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -4,6 +4,7 @@
 
 #addin "Cake.FileHelpers"
 #addin "Cake.Coveralls"
+#addin "Cake.PinNuGetDependency"
 
 //////////////////////////////////////////////////////////////////////
 // TOOLS
@@ -250,9 +251,25 @@ Task("Package")
     .IsDependentOn("BuildReactiveUI")
     .IsDependentOn("RunUnitTests")
     .IsDependentOn("UploadTestCoverage")
+    .IsDependentOn("PinNuGetDependencies")
     .Does (() =>
 {
 });
+
+Task("PinNuGetDependencies")
+    .Does (() =>
+{
+    // only pin whitelisted packages.
+    foreach(var package in packageWhitelist)
+    {
+        // only push the package which was created during this build run.
+        var packagePath = artifactDirectory + File(string.Concat(package, ".", nugetVersion, ".nupkg"));
+
+        // see https://github.com/cake-contrib/Cake.PinNuGetDependency
+        PinNuGetDependency(packagePath, "reactiveui");
+    }
+});
+
 
 Task("PublishPackages")
     .IsDependentOn("RunUnitTests")

--- a/build.cake
+++ b/build.cake
@@ -262,7 +262,7 @@ Task("PinNuGetDependencies")
     // only pin whitelisted packages.
     foreach(var package in packageWhitelist)
     {
-        // only push the package which was created during this build run.
+        // only pin the package which was created during this build run.
         var packagePath = artifactDirectory + File(string.Concat(package, ".", nugetVersion, ".nupkg"));
 
         // see https://github.com/cake-contrib/Cake.PinNuGetDependency


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

bugfix/housekeeping/chore. 

**What is the current behavior? (You can also link to an open issue here)**

RxUI v7.x had verisons pinned; we merged the v8 into develop without pinning.

**What is the new behavior (if this is a feature change)?**

Pinning is reintroduced. See https://github.com/cake-contrib/Cake.PinNuGetDependency

**Does this PR introduce a breaking change?**

Nope

**Please check if the PR fulfills these requirements**
- [x] The commit follows our guidelines: https://github.com/reactiveui/reactiveui#contribute
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

