### PR TITLE
housekeeping: add .DS_Store files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -239,3 +239,6 @@ tools/
 artifacts/
 src/CommonAssemblyInfo.cs
 src/ReactiveUI.Events/Events_*.cs
+
+# macOS
+.DS_Store


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Make life easier for Mac users.


**What is the current behavior? (You can also link to an open issue here)**
.DS_Store files generated by macOS constantly screw up your `git status`.


**What is the new behavior (if this is a feature change)?**
Ignore .DS_Store files, since they're of no interest.


**Does this PR introduce a breaking change?**
Nope


**Please check if the PR fulfills these requirements**
- [x] The commit follows our guidelines: https://github.com/reactiveui/reactiveui#contribute
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

