### PR TITLE
chore: remove CommonAssemblyInfo from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -237,7 +237,6 @@ tools/
 
 # ReactiveUI
 artifacts/
-src/CommonAssemblyInfo.cs
 src/ReactiveUI.Events/Events_*.cs
 
 # macOS


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
A little tidying up after #1332.

**What is the current behavior? (You can also link to an open issue here)**
An extra file is gitignored

**What is the new behavior (if this is a feature change)?**
It's not gitignored, but it's also not included either.

**Does this PR introduce a breaking change?**
No.


**Please check if the PR fulfills these requirements**
- [x] The commit follows our guidelines: https://github.com/reactiveui/reactiveui#contribute
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

