### PR TITLE
chore: update to xunit 2

### DIFF
--- a/src/ReactiveUI.Tests/ActivationTests.cs
+++ b/src/ReactiveUI.Tests/ActivationTests.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Linq;
 using System.Reactive;
+using System.Reactive.Concurrency;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
@@ -280,7 +281,7 @@ namespace ReactiveUI.Tests
         public void ActivatingTicksActivatedObservable()
         {
             var viewModelActivator = new ViewModelActivator();
-            var activated = viewModelActivator.Activated.CreateCollection();
+            var activated = viewModelActivator.Activated.CreateCollection(scheduler: ImmediateScheduler.Instance);
 
             viewModelActivator.Activate();
 
@@ -291,7 +292,7 @@ namespace ReactiveUI.Tests
         public void DeactivatingIgnoringRefCountTicksDeactivatedObservable()
         {
             var viewModelActivator = new ViewModelActivator();
-            var deactivated = viewModelActivator.Deactivated.CreateCollection();
+            var deactivated = viewModelActivator.Deactivated.CreateCollection(scheduler: ImmediateScheduler.Instance);
 
             viewModelActivator.Deactivate(true);
 
@@ -302,7 +303,7 @@ namespace ReactiveUI.Tests
         public void DeactivatingCountDoesntTickDeactivatedObservable()
         {
             var viewModelActivator = new ViewModelActivator();
-            var deactivated = viewModelActivator.Deactivated.CreateCollection();
+            var deactivated = viewModelActivator.Deactivated.CreateCollection(scheduler: ImmediateScheduler.Instance);
 
             viewModelActivator.Deactivate(false);
 
@@ -313,7 +314,7 @@ namespace ReactiveUI.Tests
         public void DeactivatingFollowingActivatingTicksDeactivatedObservable()
         {
             var viewModelActivator = new ViewModelActivator();
-            var deactivated = viewModelActivator.Deactivated.CreateCollection();
+            var deactivated = viewModelActivator.Deactivated.CreateCollection(scheduler: ImmediateScheduler.Instance);
 
             viewModelActivator.Activate();
             viewModelActivator.Deactivate(false);

--- a/src/ReactiveUI.Tests/AutoPersistHelperTest.cs
+++ b/src/ReactiveUI.Tests/AutoPersistHelperTest.cs
@@ -3,16 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reactive;
 using System.Reactive.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Reactive.Subjects;
 using Microsoft.Reactive.Testing;
 using ReactiveUI.Testing;
 using Xunit;
-using System.Reactive.Subjects;
 
 namespace ReactiveUI.Tests
 {

--- a/src/ReactiveUI.Tests/CommandBindingTests.cs
+++ b/src/ReactiveUI.Tests/CommandBindingTests.cs
@@ -44,7 +44,7 @@ namespace ReactiveUI.Tests
 
     public class CreatesCommandBindingTests
     {
-        [Fact]
+        [WpfFact]
         public void CommandBinderBindsToButton()
         {
             var fixture = new CreatesCommandBindingViaCommandParameter();
@@ -87,7 +87,7 @@ namespace ReactiveUI.Tests
             Assert.False(wasCalled);
         }
 
-        [Fact]
+        [WpfFact]
         public void EventBinderBindsToExplicitInheritedEvent()
         {
             var fixture = new FakeView();
@@ -95,7 +95,7 @@ namespace ReactiveUI.Tests
         }
 
 #if !SILVERLIGHT
-        [Fact]
+        [WpfFact]
         public void EventBinderBindsToImplicitEvent()
         {
             var input = new Button();
@@ -191,7 +191,7 @@ namespace ReactiveUI.Tests
 
     public class CommandBindingImplementationTests
     {
-        [Fact]
+        [WpfFact]
         public void CommandBindByNameWireup()
         {
             var vm = new CommandBindViewModel();
@@ -210,7 +210,7 @@ namespace ReactiveUI.Tests
             Assert.Null(view.Command1.Command);
         }
 
-        [Fact]
+        [WpfFact]
         public void CommandBindNestedCommandWireup()
         {
             var vm = new CommandBindViewModel()
@@ -225,7 +225,7 @@ namespace ReactiveUI.Tests
             Assert.Equal(vm.NestedViewModel.NestedCommand, view.Command1.Command);
         }
 
-        [Fact]
+        [WpfFact]
         public void CommandBindSetsInitialEnabledState_True()
         {
             var vm = new CommandBindViewModel();
@@ -240,7 +240,7 @@ namespace ReactiveUI.Tests
             Assert.True(view.Command1.IsEnabled);
         }
 
-        [Fact]
+        [WpfFact]
         public void CommandBindSetsDisablesCommandWhenCanExecuteChanged()
         {
             var vm = new CommandBindViewModel();
@@ -259,7 +259,7 @@ namespace ReactiveUI.Tests
             Assert.False(view.Command1.IsEnabled);
         }
 
-        [Fact]
+        [WpfFact]
         public void CommandBindSetsInitialEnabledState_False()
         {
             var vm = new CommandBindViewModel();
@@ -274,8 +274,7 @@ namespace ReactiveUI.Tests
             Assert.False(view.Command1.IsEnabled);
         }
 
-
-        [Fact]
+        [WpfFact]
         public void CommandBindRaisesCanExecuteChangedOnBind()
         {
             var vm = new CommandBindViewModel();
@@ -299,7 +298,7 @@ namespace ReactiveUI.Tests
         }
 
 #if !SILVERLIGHT
-        [Fact]
+        [WpfFact]
         public void CommandBindToExplicitEventWireup()
         {
             var vm = new CommandBindViewModel();
@@ -319,7 +318,7 @@ namespace ReactiveUI.Tests
         }
 #endif
 
-        [Fact]
+        [WpfFact]
         public void CommandBindWithParameterExpression()
         {
             var vm = new CommandBindViewModel();
@@ -340,7 +339,7 @@ namespace ReactiveUI.Tests
             Assert.Equal(13, received);
         }
 
-        [Fact]
+        [WpfFact]
         public void CommandBindWithParameterObservable()
         {
             var vm = new CommandBindViewModel();

--- a/src/ReactiveUI.Tests/DependencyResolverTests.cs
+++ b/src/ReactiveUI.Tests/DependencyResolverTests.cs
@@ -80,7 +80,7 @@ namespace ReactiveUI.Tests
             resolver.RegisterViewsForViewModels(GetType().Assembly);
         }
 
-        [Fact]
+        [WpfFact]
         public void RegisterViewsForViewModelShouldRegisterAllViews()
         {
             using (resolver.WithResolver()) {
@@ -90,7 +90,7 @@ namespace ReactiveUI.Tests
             }
         }
 
-        [Fact]
+        [WpfFact]
         public void RegisterViewsForViewModelShouldIncludeContracts()
         {
             using (resolver.WithResolver()) {
@@ -98,7 +98,7 @@ namespace ReactiveUI.Tests
             }
         }
 
-        [Fact]
+        [WpfFact]
         public void NonContractRegistrationsShouldResolveCorrectly()
         {
             using (resolver.WithResolver()) {
@@ -106,7 +106,7 @@ namespace ReactiveUI.Tests
             }
         }
 
-        [Fact]
+        [WpfFact]
         public void ContractRegistrationsShouldResolveCorrectly()
         {
             using (resolver.WithResolver()) {
@@ -122,7 +122,7 @@ namespace ReactiveUI.Tests
             }
         }
 
-        [Fact]
+        [WpfFact]
         public void SingleInstanceViewsShouldOnlyBeInstantiatedOnce()
         {
             using (resolver.WithResolver()) {
@@ -138,7 +138,7 @@ namespace ReactiveUI.Tests
             }
         }
 
-        [Fact]
+        [WpfFact]
         public void SingleInstanceViewsWithContractShouldResolveCorrectly()
         {
             using (resolver.WithResolver()) {

--- a/src/ReactiveUI.Tests/MessageBusTest.cs
+++ b/src/ReactiveUI.Tests/MessageBusTest.cs
@@ -2,21 +2,14 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Reactive.Testing;
+using ReactiveUI.Testing;
+using System;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
-using Xunit;
-using System;
-using System.Linq;
-using System.Collections.Generic;
-using ReactiveUI;
-using System.IO;
-using System.Text;
-using ReactiveUI.Testing;
-using ReactiveUI.Tests;
 using System.Threading;
-
-using Microsoft.Reactive.Testing;
 using System.Threading.Tasks;
+using Xunit;
 
 namespace ReactiveUI.Tests
 {
@@ -121,18 +114,18 @@ namespace ReactiveUI.Tests
         }
 
         [Fact]
-        public void MessageBusThreadingTest()
+        public async Task MessageBusThreadingTest()
         {
             var mb = new MessageBus();
             int? listenedThread = null;
             int? otherThread = null;
             int thisThread = Thread.CurrentThread.ManagedThreadId;
 
-            Task.Run(() => {
+            await Task.Run(() => {
                 otherThread = Thread.CurrentThread.ManagedThreadId;
                 mb.Listen<int>().Subscribe(_ => listenedThread = Thread.CurrentThread.ManagedThreadId);
                 mb.SendMessage<int>(42);
-            }).Wait();
+            });
 
             Assert.NotEqual(listenedThread.Value, thisThread);
             Assert.Equal(listenedThread.Value, otherThread.Value);

--- a/src/ReactiveUI.Tests/MessageBusTest.cs
+++ b/src/ReactiveUI.Tests/MessageBusTest.cs
@@ -5,10 +5,13 @@
 using Microsoft.Reactive.Testing;
 using ReactiveUI.Testing;
 using System;
+using System.Reactive.Concurrency;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Reactive.Testing;
+using ReactiveUI.Testing;
 using Xunit;
 
 namespace ReactiveUI.Tests
@@ -18,17 +21,17 @@ namespace ReactiveUI.Tests
         [Fact]
         public void MessageBusSmokeTest()
         {
-            var input = new[] {1, 2, 3, 4};
+            var input = new[] { 1, 2, 3, 4 };
 
             var result = (new TestScheduler()).With(sched => {
                 var source = new Subject<int>();
                 var fixture = new MessageBus();
 
                 fixture.RegisterMessageSource(source, "Test");
-                Assert.False(fixture.IsRegistered(typeof (int)));
-                Assert.False(fixture.IsRegistered(typeof (int), "Foo"));
+                Assert.False(fixture.IsRegistered(typeof(int)));
+                Assert.False(fixture.IsRegistered(typeof(int), "Foo"));
 
-                var output = fixture.Listen<int>("Test").CreateCollection();
+                var output = fixture.Listen<int>("Test").CreateCollection(scheduler: ImmediateScheduler.Instance);
 
                 input.Run(source.OnNext);
 
@@ -39,20 +42,19 @@ namespace ReactiveUI.Tests
             input.AssertAreEqual(result);
         }
 
-
         [Fact]
-        public void ExplicitSendMessageShouldWorkEvenAfterRegisteringSource() 
+        public void ExplicitSendMessageShouldWorkEvenAfterRegisteringSource()
         {
             var fixture = new MessageBus();
             fixture.RegisterMessageSource(Observable<int>.Never);
-         
+
             bool messageReceived = false;
             fixture.Listen<int>().Subscribe(_ => messageReceived = true);
-         
+
             fixture.SendMessage(42);
             Assert.True(messageReceived);
         }
-     
+
         [Fact]
         public void ListeningBeforeRegisteringASourceShouldWork()
         {

--- a/src/ReactiveUI.Tests/ObservableAsPropertyHelperTest.cs
+++ b/src/ReactiveUI.Tests/ObservableAsPropertyHelperTest.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Reactive.Concurrency;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
@@ -209,9 +210,9 @@ namespace ReactiveUI.Tests
             var dontcare = (fixture.FirstThreeLettersOfOneWord ?? "").Substring(0, 0);
 
             var resultChanging = fixture.ObservableForProperty(x => x.FirstThreeLettersOfOneWord, beforeChange: true)
-                .CreateCollection();
+                .CreateCollection(scheduler: ImmediateScheduler.Instance);
             var resultChanged = fixture.ObservableForProperty(x => x.FirstThreeLettersOfOneWord, beforeChange: false)
-                .CreateCollection();
+                .CreateCollection(scheduler: ImmediateScheduler.Instance);
 
             Assert.Empty(resultChanging);
             Assert.Empty(resultChanged);

--- a/src/ReactiveUI.Tests/Platforms/winforms/ActivationTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/ActivationTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
@@ -31,7 +31,7 @@ namespace ReactiveUI.Tests.Winforms
 
             Assert.NotNull(formActivator);
         }
-      
+
 
         [Fact]
         public void CanFetchActivatorForControl()
@@ -81,7 +81,7 @@ namespace ReactiveUI.Tests.Winforms
         public void SmokeTestUserControl()
         {
             var target = new ReactiveUI.Winforms.ActivationForViewFetcher();
-            using(var userControl = new TestControl())
+            using (var userControl = new TestControl())
             using (var parent = new TestForm()) {
                 var userControlActivator = target.GetActivationForView(userControl);
 

--- a/src/ReactiveUI.Tests/Platforms/winforms/DefaultPropertyBindingTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/DefaultPropertyBindingTests.cs
@@ -4,10 +4,11 @@
 
 using System;
 using System.Linq.Expressions;
+using System.Reactive.Concurrency;
 using System.Reactive.Disposables;
 using System.Windows.Forms;
-using Xunit;
 using ReactiveUI.Winforms;
+using Xunit;
 
 namespace ReactiveUI.Tests.Winforms
 {
@@ -22,7 +23,7 @@ namespace ReactiveUI.Tests.Winforms
             Assert.NotEqual(0, fixture.GetAffinityForObject(typeof(TextBox), "Text"));
 
             Expression<Func<TextBox, string>> expression = x => x.Text;
-            var output = fixture.GetNotificationForProperty(input, expression.Body).CreateCollection();
+            var output = fixture.GetNotificationForProperty(input, expression.Body).CreateCollection(scheduler: ImmediateScheduler.Instance);
             Assert.Equal(0, output.Count);
 
             input.Text = "Foo";
@@ -45,7 +46,7 @@ namespace ReactiveUI.Tests.Winforms
             Assert.NotEqual(0, fixture.GetAffinityForObject(typeof(ToolStripButton), "Checked"));
 
             Expression<Func<ToolStripButton, bool>> expression = x => x.Checked;
-            var output = fixture.GetNotificationForProperty(input, expression.Body).CreateCollection();
+            var output = fixture.GetNotificationForProperty(input, expression.Body).CreateCollection(scheduler: ImmediateScheduler.Instance);
             Assert.Equal(0, output.Count);
 
             input.Checked = true;
@@ -69,7 +70,7 @@ namespace ReactiveUI.Tests.Winforms
             Assert.NotEqual(0, fixture.GetAffinityForObject(typeof(AThirdPartyNamespace.ThirdPartyControl), "Value"));
 
             Expression<Func<AThirdPartyNamespace.ThirdPartyControl, string>> expression = x => x.Value;
-            var output = fixture.GetNotificationForProperty(input, expression.Body).CreateCollection();
+            var output = fixture.GetNotificationForProperty(input, expression.Body).CreateCollection(scheduler: ImmediateScheduler.Instance);
             Assert.Equal(0, output.Count);
 
             input.Value = "Foo";
@@ -87,14 +88,14 @@ namespace ReactiveUI.Tests.Winforms
         public void CanBindViewModelToWinformControls()
         {
             var vm = new FakeWinformViewModel();
-            var view = new FakeWinformsView(){ViewModel = vm};
+            var view = new FakeWinformsView() { ViewModel = vm };
 
             vm.SomeText = "Foo";
             Assert.NotEqual(vm.SomeText, view.Property3.Text);
 
             var disp = view.Bind(vm, x => x.SomeText, x => x.Property3.Text);
             vm.SomeText = "Bar";
-            Assert.Equal(vm.SomeText,view.Property3.Text);
+            Assert.Equal(vm.SomeText, view.Property3.Text);
 
             view.Property3.Text = "Bar2";
             Assert.Equal(vm.SomeText, view.Property3.Text);
@@ -142,7 +143,8 @@ namespace ReactiveUI.Tests.Winforms
 
     public class FakeWinformViewModel : ReactiveObject, IRoutableViewModel
     {
-        public string UrlPathSegment {
+        public string UrlPathSegment
+        {
             get { return "fake"; }
         }
 
@@ -154,49 +156,57 @@ namespace ReactiveUI.Tests.Winforms
         }
 
         int someInteger;
-        public int SomeInteger {
+        public int SomeInteger
+        {
             get { return this.someInteger; }
             set { this.RaiseAndSetIfChanged(ref this.someInteger, value); }
         }
 
         string someText;
-        public string SomeText {
+        public string SomeText
+        {
             get { return this.someText; }
             set { this.RaiseAndSetIfChanged(ref this.someText, value); }
         }
 
         double someDouble;
-        public double SomeDouble {
+        public double SomeDouble
+        {
             get { return this.someDouble; }
             set { this.RaiseAndSetIfChanged(ref this.someDouble, value); }
         }
 
         string _property1;
-        public string Property1 {
+        public string Property1
+        {
             get { return _property1; }
             set { this.RaiseAndSetIfChanged(ref _property1, value); }
         }
 
         string _property2;
-        public string Property2 {
+        public string Property2
+        {
             get { return _property2; }
             set { this.RaiseAndSetIfChanged(ref _property2, value); }
         }
 
         string _property3;
-        public string Property3 {
+        public string Property3
+        {
             get { return _property3; }
             set { this.RaiseAndSetIfChanged(ref _property3, value); }
         }
 
         string _property4;
-        public string Property4 {
+        public string Property4
+        {
             get { return _property4; }
             set { this.RaiseAndSetIfChanged(ref _property4, value); }
         }
 
         bool _someBooleanProperty;
-        public bool BooleanProperty {
+        public bool BooleanProperty
+        {
             get { return _someBooleanProperty; }
             set { this.RaiseAndSetIfChanged(ref _someBooleanProperty, value); }
         }
@@ -204,7 +214,8 @@ namespace ReactiveUI.Tests.Winforms
 
     public class FakeWinformsView : Control, IViewFor<FakeWinformViewModel>
     {
-        object IViewFor.ViewModel {
+        object IViewFor.ViewModel
+        {
             get { return ViewModel; }
             set { ViewModel = (FakeWinformViewModel)value; }
         }
@@ -221,7 +232,7 @@ namespace ReactiveUI.Tests.Winforms
 
         public FakeWinformsView()
         {
-            this.Property1= new System.Windows.Forms.Button();
+            this.Property1 = new System.Windows.Forms.Button();
             this.Property2 = new Label();
             this.Property3 = new TextBox();
             this.Property4 = new RichTextBox();
@@ -237,9 +248,11 @@ namespace AThirdPartyNamespace
     {
         string value;
 
-        public string Value {
+        public string Value
+        {
             get { return this.value; }
-            set {
+            set
+            {
                 if (this.value != value) {
                     this.value = value;
                     this.OnValueChanged();

--- a/src/ReactiveUI.Tests/Platforms/xaml/ActivationForViewFetcherTest.cs
+++ b/src/ReactiveUI.Tests/Platforms/xaml/ActivationForViewFetcherTest.cs
@@ -33,7 +33,7 @@ namespace ReactiveUI.Tests
             var activation = new ActivationForViewFetcher();
 
             var obs = activation.GetActivationForView(uc);
-            var activated = obs.CreateCollection();
+            var activated = obs.CreateCollection(scheduler: ImmediateScheduler.Instance);
 
             RoutedEventArgs loaded = new RoutedEventArgs();
             loaded.RoutedEvent = FrameworkElement.LoadedEvent;
@@ -58,7 +58,7 @@ namespace ReactiveUI.Tests
             var activation = new ActivationForViewFetcher();
 
             var obs = activation.GetActivationForView(uc);
-            var activated = obs.CreateCollection();
+            var activated = obs.CreateCollection(scheduler: ImmediateScheduler.Instance);
 
             RoutedEventArgs loaded = new RoutedEventArgs();
             loaded.RoutedEvent = FrameworkElement.LoadedEvent;
@@ -88,7 +88,7 @@ namespace ReactiveUI.Tests
             var activation = new ActivationForViewFetcher();
 
             var obs = activation.GetActivationForView(uc);
-            var activated = obs.CreateCollection();
+            var activated = obs.CreateCollection(scheduler: ImmediateScheduler.Instance);
 
             RoutedEventArgs loaded = new RoutedEventArgs();
             loaded.RoutedEvent = FrameworkElement.LoadedEvent;

--- a/src/ReactiveUI.Tests/Platforms/xaml/ActivationForViewFetcherTest.cs
+++ b/src/ReactiveUI.Tests/Platforms/xaml/ActivationForViewFetcherTest.cs
@@ -2,9 +2,12 @@
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Reactive.Testing;
+using ReactiveUI.Testing;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reactive.Concurrency;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
@@ -23,7 +26,7 @@ namespace ReactiveUI.Tests
             }
         }
 
-        [Fact]
+        [WpfFact]
         public void FrameworkElementIsActivatedAndDeactivated()
         {
             var uc = new TestUserControl();
@@ -47,7 +50,7 @@ namespace ReactiveUI.Tests
             new[] { true, false }.AssertAreEqual(activated);
         }
 
-        [Fact]
+        [WpfFact]
         public void IsHitTestVisibleActivatesFrameworkElement()
         {
             var uc = new TestUserControl();
@@ -78,7 +81,7 @@ namespace ReactiveUI.Tests
             new[] { true, false }.AssertAreEqual(activated);
         }
 
-        [Fact]
+        [WpfFact]
         public void IsHitTestVisibleDeactivatesFrameworkElement()
         {
             var uc = new TestUserControl();
@@ -99,14 +102,14 @@ namespace ReactiveUI.Tests
             new[] { true, false }.AssertAreEqual(activated);
         }
 
-        [Fact]
+        [WpfFact]
         public void FrameworkElementIsActivatedAndDeactivatedWithHitTest()
         {
             var uc = new TestUserControl();
             var activation = new ActivationForViewFetcher();
 
             var obs = activation.GetActivationForView(uc);
-            var activated = obs.CreateCollection();
+            var activated = obs.CreateCollection(scheduler: ImmediateScheduler.Instance);
 
             RoutedEventArgs loaded = new RoutedEventArgs();
             loaded.RoutedEvent = FrameworkElement.LoadedEvent;

--- a/src/ReactiveUI.Tests/Platforms/xaml/DependencyObjectObservableForPropertyTest.cs
+++ b/src/ReactiveUI.Tests/Platforms/xaml/DependencyObjectObservableForPropertyTest.cs
@@ -6,21 +6,20 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
-using System.Text;
+using System.Reactive.Concurrency;
 using System.Windows;
 using System.Windows.Controls;
-using ReactiveUI;
 using Xunit;
-using System.Reactive.Concurrency;
 
 namespace ReactiveUI.Tests
 {
     public class DepObjFixture : FrameworkElement
     {
-        public static readonly DependencyProperty TestStringProperty = 
+        public static readonly DependencyProperty TestStringProperty =
             DependencyProperty.Register("TestString", typeof(string), typeof(DepObjFixture), new PropertyMetadata(null));
 
-        public string TestString {
+        public string TestString
+        {
             get { return (string)GetValue(TestStringProperty); }
             set { SetValue(TestStringProperty, value); }
         }
@@ -28,7 +27,8 @@ namespace ReactiveUI.Tests
 
     public class DerivedDepObjFixture : DepObjFixture
     {
-        public string AnotherTestString {
+        public string AnotherTestString
+        {
             get { return (string)GetValue(AnotherTestStringProperty); }
             set { SetValue(AnotherTestStringProperty, value); }
         }
@@ -43,8 +43,8 @@ namespace ReactiveUI.Tests
         {
             var fixture = new DepObjFixture();
             var binder = new DependencyObjectObservableForProperty();
-            Assert.NotEqual(0, binder.GetAffinityForObject(typeof (DepObjFixture), "TestString"));
-            Assert.Equal(0, binder.GetAffinityForObject(typeof (DepObjFixture), "DoesntExist"));
+            Assert.NotEqual(0, binder.GetAffinityForObject(typeof(DepObjFixture), "TestString"));
+            Assert.Equal(0, binder.GetAffinityForObject(typeof(DepObjFixture), "DoesntExist"));
 
             var results = new List<IObservedChange<object, object>>();
             Expression<Func<DepObjFixture, object>> expression = x => x.TestString;
@@ -65,8 +65,8 @@ namespace ReactiveUI.Tests
         {
             var fixture = new DerivedDepObjFixture();
             var binder = new DependencyObjectObservableForProperty();
-            Assert.NotEqual(0, binder.GetAffinityForObject(typeof (DerivedDepObjFixture), "TestString"));
-            Assert.Equal(0, binder.GetAffinityForObject(typeof (DerivedDepObjFixture), "DoesntExist"));
+            Assert.NotEqual(0, binder.GetAffinityForObject(typeof(DerivedDepObjFixture), "TestString"));
+            Assert.Equal(0, binder.GetAffinityForObject(typeof(DerivedDepObjFixture), "DoesntExist"));
 
             var results = new List<IObservedChange<object, object>>();
             Expression<Func<DerivedDepObjFixture, object>> expression = x => x.TestString;
@@ -85,10 +85,10 @@ namespace ReactiveUI.Tests
         [WpfFact]
         public void WhenAnyWithDependencyObjectTest()
         {
-            var inputs = new[] {"Foo", "Bar", "Baz"};
+            var inputs = new[] { "Foo", "Bar", "Baz" };
             var fixture = new DepObjFixture();
 
-            var outputs = fixture.WhenAnyValue(x => x.TestString).CreateCollection();
+            var outputs = fixture.WhenAnyValue(x => x.TestString).CreateCollection(scheduler: ImmediateScheduler.Instance);
             inputs.ForEach(x => fixture.TestString = x);
 
             Assert.Null(outputs.First());

--- a/src/ReactiveUI.Tests/Platforms/xaml/DependencyObjectObservableForPropertyTest.cs
+++ b/src/ReactiveUI.Tests/Platforms/xaml/DependencyObjectObservableForPropertyTest.cs
@@ -11,6 +11,7 @@ using System.Windows;
 using System.Windows.Controls;
 using ReactiveUI;
 using Xunit;
+using System.Reactive.Concurrency;
 
 namespace ReactiveUI.Tests
 {
@@ -37,7 +38,7 @@ namespace ReactiveUI.Tests
 
     public class DependencyObjectObservableForPropertyTest
     {
-        [Fact]
+        [WpfFact]
         public void DependencyObjectObservableForPropertySmokeTest()
         {
             var fixture = new DepObjFixture();
@@ -59,7 +60,7 @@ namespace ReactiveUI.Tests
             disp2.Dispose();
         }
 
-        [Fact]
+        [WpfFact]
         public void DerivedDependencyObjectObservableForPropertySmokeTest()
         {
             var fixture = new DerivedDepObjFixture();
@@ -81,7 +82,7 @@ namespace ReactiveUI.Tests
             disp2.Dispose();
         }
 
-        [Fact]
+        [WpfFact]
         public void WhenAnyWithDependencyObjectTest()
         {
             var inputs = new[] {"Foo", "Bar", "Baz"};
@@ -95,7 +96,7 @@ namespace ReactiveUI.Tests
             Assert.True(inputs.Zip(outputs.Skip(1), (expected, actual) => expected == actual).All(x => x));
         }
 
-        [Fact]
+        [WpfFact]
         public void ListBoxSelectedItemTest()
         {
             var input = new ListBox();
@@ -103,7 +104,7 @@ namespace ReactiveUI.Tests
             input.Items.Add("Bar");
             input.Items.Add("Baz");
 
-            var output = input.WhenAnyValue(x => x.SelectedItem).CreateCollection();
+            var output = input.WhenAnyValue(x => x.SelectedItem).CreateCollection(scheduler: ImmediateScheduler.Instance);
             Assert.Equal(1, output.Count);
 
             input.SelectedIndex = 1;

--- a/src/ReactiveUI.Tests/PropertyBindingTest.cs
+++ b/src/ReactiveUI.Tests/PropertyBindingTest.cs
@@ -70,7 +70,7 @@ namespace ReactiveUI.Tests
 
     public class PropertyBindingTest
     {
-        [Fact, UseInvariantCulture]
+        [WpfFact, UseInvariantCulture]
         public void TwoWayBindWithFuncConvertersSmokeTest()
         {
             var vm = new PropertyBindViewModel();
@@ -95,7 +95,7 @@ namespace ReactiveUI.Tests
             Assert.Equal("567.89", view.SomeTextBox.Text);
         }
 
-        [Fact]
+        [WpfFact]
         public void TwoWayBindSmokeTest()
         {
             var vm = new PropertyBindViewModel();
@@ -120,7 +120,7 @@ namespace ReactiveUI.Tests
             Assert.NotEqual(vm.Property1, view.SomeTextBox.Text);
         }
 
-        [Fact]
+        [WpfFact]
         public void TypeConvertedTwoWayBindSmokeTest()
         {
             var vm = new PropertyBindViewModel();
@@ -183,7 +183,7 @@ namespace ReactiveUI.Tests
             Assert.Equal(13, vm.JustAInt32);
         }
 
-        [Fact]
+        [WpfFact]
         public void BindingIntoModelObjects()
         {
             var vm = new PropertyBindViewModel();
@@ -193,7 +193,7 @@ namespace ReactiveUI.Tests
             Assert.Equal("Baz", view.SomeTextBox.Text);
         }
 
-        [Fact]
+        [WpfFact]
         public void ViewModelNullableToViewNonNullable()
         {
             var vm = new PropertyBindViewModel();
@@ -212,7 +212,7 @@ namespace ReactiveUI.Tests
             Assert.Equal(0.0, view.FakeControl.JustADouble);
         }
 
-        [Fact]
+        [WpfFact]
         public void ViewModelNonNullableToViewNullable()
         {
             var vm = new PropertyBindViewModel();
@@ -231,7 +231,7 @@ namespace ReactiveUI.Tests
             Assert.Equal(0.0, vm.JustADouble);
         }
 
-        [Fact]
+        [WpfFact]
         public void ViewModelNullableToViewNullable()
         {
             var vm = new PropertyBindViewModel();
@@ -250,7 +250,7 @@ namespace ReactiveUI.Tests
             Assert.Equal(0.0, vm.NullableDouble);
         }
 
-        [Fact]
+        [WpfFact]
         public void ViewModelIndexerToView()
         {
             var vm = new PropertyBindViewModel();
@@ -260,7 +260,7 @@ namespace ReactiveUI.Tests
             Assert.Equal("Foo", view.SomeTextBox.Text);
         }
 
-        [Fact]
+        [WpfFact]
         public void ViewModelIndexerToViewChanges()
         {
             var vm = new PropertyBindViewModel();
@@ -274,7 +274,7 @@ namespace ReactiveUI.Tests
             Assert.Equal("Bar", view.SomeTextBox.Text);
         }
 
-        [Fact]
+        [WpfFact]
         public void ViewModelIndexerPropertyToView()
         {
             var vm = new PropertyBindViewModel();
@@ -284,7 +284,7 @@ namespace ReactiveUI.Tests
             Assert.Equal("3", view.SomeTextBox.Text);
         }
 
-        [Fact]
+        [WpfFact]
         public void BindToShouldntInitiallySetToNull()
         {
             var vm = new PropertyBindViewModel();
@@ -297,7 +297,7 @@ namespace ReactiveUI.Tests
             Assert.Equal(vm.Model.AnotherThing, view.FakeControl.NullHatingString);
         }
 
-        [Fact]
+        [WpfFact]
         public void BindToTypeConversionSmokeTest()
         {
             var vm = new PropertyBindViewModel();
@@ -312,7 +312,7 @@ namespace ReactiveUI.Tests
             Assert.Equal(vm.JustADouble.ToString(), view.FakeControl.NullHatingString);
         }
 
-        [Fact]
+        [WpfFact]
         public void BindToNullShouldThrowHelpfulError() {
             var view = new PropertyBindView() {ViewModel = null};
 
@@ -323,7 +323,7 @@ namespace ReactiveUI.Tests
         }
 
 #if !MONO
-        [Fact]
+        [WpfFact]
         public void TwoWayBindToSelectedItemOfItemsControl()
         {
         	var vm = new PropertyBindViewModel();
@@ -342,7 +342,7 @@ namespace ReactiveUI.Tests
         	Assert.Equal("bbb", view.FakeItemsControl.SelectedItem);
         }
 
-        [Fact]
+        [WpfFact]
         public void ItemsControlShouldGetADataTemplate()
         {
             var vm = new PropertyBindViewModel();
@@ -354,7 +354,7 @@ namespace ReactiveUI.Tests
             Assert.NotNull(view.FakeItemsControl.ItemTemplate);
         }
 
-        [Fact]
+        [WpfFact]
         public void ItemsControlWithDisplayMemberPathSetShouldNotGetADataTemplate()
         {
             var vm = new PropertyBindViewModel();
@@ -367,7 +367,7 @@ namespace ReactiveUI.Tests
             Assert.Null(view.FakeItemsControl.ItemTemplate);
         }
 
-        [Fact]
+        [WpfFact]
         public void ItemsControlShouldGetADataTemplateInBindTo()
         {
             var vm = new PropertyBindViewModel();
@@ -383,7 +383,7 @@ namespace ReactiveUI.Tests
                 .BindTo(vm, x => x.Property1);
         }
 
-        [Fact]
+        [WpfFact]
         public void BindingToItemsControl()
         {
             var vm = new PropertyBindViewModel();
@@ -394,7 +394,7 @@ namespace ReactiveUI.Tests
         }
 #endif
 
-        [Fact]
+        [WpfFact]
         public void BindExpectsConverterFuncsToNotBeNull()
         {
             var vm = new PropertyBindViewModel();
@@ -407,7 +407,7 @@ namespace ReactiveUI.Tests
             Assert.Throws<ArgumentNullException>(() => fixture.Bind(vm, view, x => x.Property1, x => x.SomeTextBox.Text, (IObservable<Unit>)null, s => s, nullFunc));
         }
 
-        [Fact]
+        [WpfFact]
         public void BindWithFuncShouldWorkAsExtensionMethodSmokeTest()
         {
             var vm = new PropertyBindViewModel();

--- a/src/ReactiveUI.Tests/ReactiveCollectionTest.cs
+++ b/src/ReactiveUI.Tests/ReactiveCollectionTest.cs
@@ -10,6 +10,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reactive;
+using System.Reactive.Concurrency;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
@@ -1017,7 +1018,7 @@ namespace ReactiveUI.Tests
                 using (resolver.WithResolver()) {
                     resolver.RegisterConstant(new FuncLogManager(t => new WrappingFullLogger(logger, t)), typeof(ILogManager));
 
-                    var incc = new ReactiveList<NoOneHasEverSeenThisClassBefore>();
+                    var incc = new ReactiveList<NoOneHasEverSeenThisClassBefore>(scheduler: CurrentThreadScheduler.Instance);
                     Assert.True(incc is INotifyCollectionChanged);
                     var inccDerived = incc.CreateDerivedCollection(x => x);
 
@@ -1051,7 +1052,7 @@ namespace ReactiveUI.Tests
                 using (resolver.WithResolver()) {
                     resolver.RegisterConstant(new FuncLogManager(t => new WrappingFullLogger(logger, t)), typeof(ILogManager));
 
-                    var incc = new ReactiveList<NoOneHasEverSeenThisClassBeforeEither>();
+                    var incc = new ReactiveList<NoOneHasEverSeenThisClassBeforeEither>(scheduler: CurrentThreadScheduler.Instance);
                     var inccDerived = incc.CreateDerivedCollection(x => x);
 
                     Assert.False(logger.Messages.Any(x => x.Item1.Contains("SuppressChangeNotifications")));

--- a/src/ReactiveUI.Tests/ReactiveCommandTest.cs
+++ b/src/ReactiveUI.Tests/ReactiveCommandTest.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Reactive;
+using System.Reactive.Concurrency;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Threading.Tasks;
@@ -36,7 +37,7 @@ namespace ReactiveUI.Tests
             var fixture = ReactiveCommand.Create(() => Observables.Unit);
             var canExecute = fixture
                 .CanExecute
-                .CreateCollection();
+                .CreateCollection(scheduler: ImmediateScheduler.Instance);
 
             Assert.Equal(1, canExecute.Count);
             Assert.True(canExecute[0]);
@@ -49,7 +50,7 @@ namespace ReactiveUI.Tests
             var fixture = ReactiveCommand.Create(() => Observables.Unit, canExecuteSubject);
             var canExecute = fixture
                 .CanExecute
-                .CreateCollection();
+                .CreateCollection(scheduler: ImmediateScheduler.Instance);
 
             canExecuteSubject.OnNext(false);
             canExecuteSubject.OnNext(false);
@@ -70,7 +71,7 @@ namespace ReactiveUI.Tests
             var fixture = ReactiveCommand.Create(() => Observables.Unit, canExecuteSubject);
             var canExecute = fixture
                 .CanExecute
-                .CreateCollection();
+                .CreateCollection(scheduler: ImmediateScheduler.Instance);
 
             canExecuteSubject.OnNext(true);
             canExecuteSubject.OnNext(false);
@@ -89,7 +90,7 @@ namespace ReactiveUI.Tests
                 var fixture = ReactiveCommand.CreateFromObservable(() => execute, outputScheduler: sched);
                 var canExecute = fixture
                     .CanExecute
-                    .CreateCollection();
+                    .CreateCollection(scheduler: ImmediateScheduler.Instance);
 
                 fixture.Execute().Subscribe();
                 sched.AdvanceByMs(100);
@@ -124,7 +125,7 @@ namespace ReactiveUI.Tests
             var fixture = ReactiveCommand.Create(() => Observables.Unit, canExecuteSubject);
             var thrownExceptions = fixture
                 .ThrownExceptions
-                .CreateCollection();
+                .CreateCollection(scheduler: ImmediateScheduler.Instance);
 
             canExecuteSubject.OnError(new InvalidOperationException("oops"));
 
@@ -169,7 +170,7 @@ namespace ReactiveUI.Tests
             var fixture = ReactiveCommand.Create(() => Observables.Unit);
             var isExecuting = fixture
                 .IsExecuting
-                .CreateCollection();
+                .CreateCollection(scheduler: ImmediateScheduler.Instance);
 
             Assert.Equal(1, isExecuting.Count);
             Assert.False(isExecuting[0]);
@@ -183,7 +184,7 @@ namespace ReactiveUI.Tests
                 var fixture = ReactiveCommand.CreateFromObservable(() => execute, outputScheduler: sched);
                 var isExecuting = fixture
                     .IsExecuting
-                    .CreateCollection();
+                    .CreateCollection(scheduler: ImmediateScheduler.Instance);
 
                 fixture.Execute().Subscribe();
                 sched.AdvanceByMs(100);
@@ -300,9 +301,9 @@ namespace ReactiveUI.Tests
         {
             var parameters = new List<int>();
             var fixture = ReactiveCommand.CreateFromObservable<int, Unit>(param => {
-                    parameters.Add(param);
-                    return Observables.Unit;
-                });
+                parameters.Add(param);
+                return Observables.Unit;
+            });
 
             fixture.Execute(1).Subscribe();
             fixture.Execute(42).Subscribe();
@@ -336,7 +337,7 @@ namespace ReactiveUI.Tests
             var num = 0;
             var fixture = ReactiveCommand.CreateFromObservable(() => Observable.Return(num));
             var results = fixture
-                .CreateCollection();
+                .CreateCollection(scheduler: ImmediateScheduler.Instance);
 
             num = 1;
             fixture.Execute().Subscribe();
@@ -356,7 +357,7 @@ namespace ReactiveUI.Tests
         {
             var fixture = ReactiveCommand.CreateFromObservable(() => new[] { 1, 2, 3 }.ToObservable());
             var results = fixture
-                .CreateCollection();
+                .CreateCollection(scheduler: ImmediateScheduler.Instance);
 
             fixture.Execute().Subscribe();
 
@@ -409,7 +410,7 @@ namespace ReactiveUI.Tests
                 var execute = Observables.Unit.Delay(TimeSpan.FromSeconds(1), sched);
                 var fixture = ReactiveCommand.CreateFromObservable(() => execute, outputScheduler: sched);
                 var executed = fixture
-                    .CreateCollection();
+                    .CreateCollection(scheduler: ImmediateScheduler.Instance);
 
                 var sub1 = fixture.Execute().Subscribe();
                 var sub2 = fixture.Execute().Subscribe();
@@ -451,9 +452,9 @@ namespace ReactiveUI.Tests
         {
             var executed = false;
             ICommand fixture = ReactiveCommand.Create(() => {
-                    executed = true;
-                    return Observables.Unit;
-                });
+                executed = true;
+                return Observables.Unit;
+            });
 
             fixture.Execute(null);
             Assert.True(executed);
@@ -492,7 +493,7 @@ namespace ReactiveUI.Tests
             (new TestScheduler()).With(sched => {
                 var fixture = ReactiveCommand.Create(() => Observables.Unit, outputScheduler: sched);
                 var results = fixture
-                    .CreateCollection();
+                    .CreateCollection(scheduler: ImmediateScheduler.Instance);
 
                 fixture.Execute().Subscribe();
                 Assert.Empty(results);
@@ -508,7 +509,7 @@ namespace ReactiveUI.Tests
             var fixture = ReactiveCommand.CreateFromObservable(() => Observable.Throw<Unit>(new InvalidOperationException("oops")));
             var thrownExceptions = fixture
                 .ThrownExceptions
-                .CreateCollection();
+                .CreateCollection(scheduler: ImmediateScheduler.Instance);
 
             fixture
                 .Execute()
@@ -526,7 +527,7 @@ namespace ReactiveUI.Tests
             var fixture = ReactiveCommand.CreateFromObservable<Unit>(() => { throw new InvalidOperationException("oops"); });
             var thrownExceptions = fixture
                 .ThrownExceptions
-                .CreateCollection();
+                .CreateCollection(scheduler: ImmediateScheduler.Instance);
 
             fixture
                 .Execute()
@@ -544,10 +545,10 @@ namespace ReactiveUI.Tests
             var fixture = ReactiveCommand.CreateFromObservable(() => Observable.Throw<Unit>(new InvalidOperationException("oops")));
             var canExecute = fixture
                 .CanExecute
-                .CreateCollection();
+                .CreateCollection(scheduler: ImmediateScheduler.Instance);
             var thrownExceptions = fixture
                 .ThrownExceptions
-                .CreateCollection();
+                .CreateCollection(scheduler: ImmediateScheduler.Instance);
 
             fixture
                 .Execute()
@@ -569,7 +570,7 @@ namespace ReactiveUI.Tests
         {
             var fixture = ReactiveCommand.CreateFromTask(() => Task.FromResult(13));
             var results = fixture
-                .CreateCollection();
+                .CreateCollection(scheduler: ImmediateScheduler.Instance);
 
             fixture.Execute().Subscribe();
 
@@ -582,7 +583,7 @@ namespace ReactiveUI.Tests
         {
             var fixture = ReactiveCommand.CreateFromTask<int, int>(param => Task.FromResult(param + 1));
             var results = fixture
-                .CreateCollection();
+                .CreateCollection(scheduler: ImmediateScheduler.Instance);
 
             fixture.Execute(3).Subscribe();
             fixture.Execute(41).Subscribe();
@@ -990,7 +991,7 @@ namespace ReactiveUI.Tests
             var fixture = ReactiveCommand.CreateCombined(childCommands);
             var canExecute = fixture
                 .CanExecute
-                .CreateCollection();
+                .CreateCollection(scheduler: ImmediateScheduler.Instance);
 
             Assert.Equal(1, canExecute.Count);
             Assert.False(canExecute[0]);
@@ -1005,7 +1006,7 @@ namespace ReactiveUI.Tests
             var fixture = ReactiveCommand.CreateCombined(childCommands, Observables.False);
             var canExecute = fixture
                 .CanExecute
-                .CreateCollection();
+                .CreateCollection(scheduler: ImmediateScheduler.Instance);
 
             Assert.Equal(1, canExecute.Count);
             Assert.False(canExecute[0]);
@@ -1021,7 +1022,7 @@ namespace ReactiveUI.Tests
             var fixture = ReactiveCommand.CreateCombined(childCommands, canExecuteSubject);
             var thrownExceptions = fixture
                 .ThrownExceptions
-                .CreateCollection();
+                .CreateCollection(scheduler: ImmediateScheduler.Instance);
 
             canExecuteSubject.OnError(new InvalidOperationException("oops"));
 
@@ -1039,7 +1040,7 @@ namespace ReactiveUI.Tests
             var fixture = ReactiveCommand.CreateCombined(childCommands);
             var thrownExceptions = fixture
                 .ThrownExceptions
-                .CreateCollection();
+                .CreateCollection(scheduler: ImmediateScheduler.Instance);
 
             canExecuteSubject.OnError(new InvalidOperationException("oops"));
 
@@ -1058,16 +1059,16 @@ namespace ReactiveUI.Tests
 
             var isExecuting = fixture
                 .IsExecuting
-                .CreateCollection();
+                .CreateCollection(scheduler: ImmediateScheduler.Instance);
             var child1IsExecuting = child1
                 .IsExecuting
-                .CreateCollection();
+                .CreateCollection(scheduler: ImmediateScheduler.Instance);
             var child2IsExecuting = child2
                 .IsExecuting
-                .CreateCollection();
+                .CreateCollection(scheduler: ImmediateScheduler.Instance);
             var child3IsExecuting = child3
                 .IsExecuting
-                .CreateCollection();
+                .CreateCollection(scheduler: ImmediateScheduler.Instance);
 
             fixture.Execute().Subscribe();
 
@@ -1101,7 +1102,7 @@ namespace ReactiveUI.Tests
             var fixture = ReactiveCommand.CreateCombined(childCommands);
 
             var results = fixture
-                .CreateCollection();
+                .CreateCollection(scheduler: ImmediateScheduler.Instance);
 
             fixture.Execute().Subscribe();
 
@@ -1120,7 +1121,7 @@ namespace ReactiveUI.Tests
                 var childCommands = new[] { child1, child2 };
                 var fixture = ReactiveCommand.CreateCombined(childCommands, outputScheduler: sched);
                 var results = fixture
-                    .CreateCollection();
+                    .CreateCollection(scheduler: ImmediateScheduler.Instance);
 
                 fixture.Execute().Subscribe();
                 Assert.Empty(results);
@@ -1139,7 +1140,7 @@ namespace ReactiveUI.Tests
             var fixture = ReactiveCommand.CreateCombined(childCommands);
             var thrownExceptions = fixture
                 .ThrownExceptions
-                .CreateCollection();
+                .CreateCollection(scheduler: ImmediateScheduler.Instance);
 
             fixture
                 .Execute()

--- a/src/ReactiveUI.Tests/ReactiveNotifyPropertyChangedMixinTest.cs
+++ b/src/ReactiveUI.Tests/ReactiveNotifyPropertyChangedMixinTest.cs
@@ -122,7 +122,7 @@ namespace ReactiveUI.Tests
         {
             (new TestScheduler()).With(sched => {
                 var fixture = new TestFixture();
-                var changes = fixture.ObservableForProperty(x => x.IsOnlyOneWord).CreateCollection();
+                var changes = fixture.ObservableForProperty(x => x.IsOnlyOneWord).CreateCollection(scheduler: ImmediateScheduler.Instance);
 
                 fixture.IsOnlyOneWord = "Foo";
                 sched.Start();
@@ -151,7 +151,7 @@ namespace ReactiveUI.Tests
         {
             (new TestScheduler()).With(sched => {
                 var fixture = new HostTestFixture() {Child = new TestFixture()};
-                var changes = fixture.ObservableForProperty(x => x.Child.IsOnlyOneWord).CreateCollection();
+                var changes = fixture.ObservableForProperty(x => x.Child.IsOnlyOneWord).CreateCollection(scheduler: ImmediateScheduler.Instance);
 
                 fixture.Child.IsOnlyOneWord = "Foo";
                 sched.Start();
@@ -180,7 +180,7 @@ namespace ReactiveUI.Tests
         {
             (new TestScheduler()).With(sched => {
                 var fixture = new HostTestFixture() {Child = new TestFixture()};
-                var changes = fixture.ObservableForProperty(x => x.Child.IsOnlyOneWord).CreateCollection();
+                var changes = fixture.ObservableForProperty(x => x.Child.IsOnlyOneWord).CreateCollection(scheduler: ImmediateScheduler.Instance);
 
                 fixture.Child.IsOnlyOneWord = "Foo";
                 sched.Start();
@@ -221,7 +221,7 @@ namespace ReactiveUI.Tests
         {
             (new TestScheduler()).With(sched => {
                 var fixture = new HostTestFixture() {Child = new TestFixture()};
-                var changes = fixture.ObservableForProperty(x => x.Child.IsOnlyOneWord).CreateCollection();
+                var changes = fixture.ObservableForProperty(x => x.Child.IsOnlyOneWord).CreateCollection(scheduler: ImmediateScheduler.Instance);
 
                 fixture.Child.IsOnlyOneWord = "Foo";
                 sched.Start();
@@ -253,7 +253,7 @@ namespace ReactiveUI.Tests
         {
             (new TestScheduler()).With(sched => {
                 var fixture = new HostTestFixture() {Child = new TestFixture()};
-                var changes = fixture.ObservableForProperty(x => x.Child.IsOnlyOneWord).CreateCollection();
+                var changes = fixture.ObservableForProperty(x => x.Child.IsOnlyOneWord).CreateCollection(scheduler: ImmediateScheduler.Instance);
 
                 fixture.Child.IsOnlyOneWord = "Foo";
                 sched.Start();
@@ -275,7 +275,7 @@ namespace ReactiveUI.Tests
             (new TestScheduler()).With(sched => {
                 var fixture = new NonReactiveINPCObject() { InpcProperty = null };
 
-                var changes = fixture.ObservableForProperty(x => x.InpcProperty.IsOnlyOneWord).CreateCollection();
+                var changes = fixture.ObservableForProperty(x => x.InpcProperty.IsOnlyOneWord).CreateCollection(scheduler: ImmediateScheduler.Instance);
 
                 fixture.InpcProperty = new TestFixture();
                 sched.Start();
@@ -509,7 +509,7 @@ namespace ReactiveUI.Tests
         {
             (new TestScheduler()).With(sched => {
                 var fixture = new TestFixture();
-                var changes = fixture.ObservableForProperty<TestFixture, string>(x => x.IsOnlyOneWord).CreateCollection();
+                var changes = fixture.ObservableForProperty<TestFixture, string>(x => x.IsOnlyOneWord).CreateCollection(scheduler: ImmediateScheduler.Instance);
 
                 fixture.IsOnlyOneWord = "Foo";
                 sched.Start();
@@ -538,7 +538,7 @@ namespace ReactiveUI.Tests
         {
             (new TestScheduler()).With(sched => {
                 var fixture = new TestFixture() { IsOnlyOneWord = "Pre" };
-                var changes = fixture.ObservableForProperty<TestFixture, string>(x => x.IsOnlyOneWord, skipInitial: false).CreateCollection();
+                var changes = fixture.ObservableForProperty<TestFixture, string>(x => x.IsOnlyOneWord, skipInitial: false).CreateCollection(scheduler: ImmediateScheduler.Instance);
 
                 sched.Start();
                 Assert.Equal(1, changes.Count);
@@ -558,7 +558,7 @@ namespace ReactiveUI.Tests
         {
             (new TestScheduler()).With(sched => {
                 var fixture = new TestFixture() { IsOnlyOneWord = "Pre" };
-                var changes = fixture.ObservableForProperty<TestFixture, string>(x => x.IsOnlyOneWord, beforeChange: true).CreateCollection();
+                var changes = fixture.ObservableForProperty<TestFixture, string>(x => x.IsOnlyOneWord, beforeChange: true).CreateCollection(scheduler: ImmediateScheduler.Instance);
 
                 sched.Start();
                 Assert.Equal(0, changes.Count);
@@ -582,7 +582,7 @@ namespace ReactiveUI.Tests
         {
             (new TestScheduler()).With(sched => {
                 var fixture = new TestFixture();
-                var changes = fixture.ObservableForProperty<TestFixture, string>(x => x.IsOnlyOneWord).CreateCollection();
+                var changes = fixture.ObservableForProperty<TestFixture, string>(x => x.IsOnlyOneWord).CreateCollection(scheduler: ImmediateScheduler.Instance);
 
                 fixture.IsOnlyOneWord = "Foo";
                 sched.Start();
@@ -664,7 +664,7 @@ namespace ReactiveUI.Tests
         public void WhenAnyObservableWithNullObjectShouldUpdateWhenObjectIsntNullAnymore()
         {
             var fixture = new TestWhenAnyObsViewModel();
-            var output = fixture.WhenAnyObservable(x => x.MyListOfInts.CountChanged).CreateCollection();
+            var output = fixture.WhenAnyObservable(x => x.MyListOfInts.CountChanged).CreateCollection(scheduler: ImmediateScheduler.Instance);
 
             Assert.Equal(0, output.Count);
 

--- a/src/ReactiveUI.Tests/ReactiveNotifyPropertyChangedMixinTest.cs
+++ b/src/ReactiveUI.Tests/ReactiveNotifyPropertyChangedMixinTest.cs
@@ -729,7 +729,7 @@ namespace ReactiveUI.Tests
 
     public class WhenAnyThroughDependencyObjectTests
     {
-        [Fact]
+        [WpfFact]
         public void WhenAnyThroughAViewShouldntGiveNullValues()
         {
             var vm = new HostTestFixture() {

--- a/src/ReactiveUI.Tests/ReactiveObjectTest.cs
+++ b/src/ReactiveUI.Tests/ReactiveObjectTest.cs
@@ -4,8 +4,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Linq;
+using System.Reactive.Concurrency;
 using System.Reactive.Linq;
 using System.Runtime.Serialization;
 using Xunit;
@@ -18,7 +18,8 @@ namespace ReactiveUI.Tests
         [IgnoreDataMember]
         string _IsNotNullString;
         [DataMember]
-        public string IsNotNullString {
+        public string IsNotNullString
+        {
             get { return _IsNotNullString; }
             set { this.RaiseAndSetIfChanged(ref _IsNotNullString, value); }
         }
@@ -26,7 +27,8 @@ namespace ReactiveUI.Tests
         [IgnoreDataMember]
         string _IsOnlyOneWord;
         [DataMember]
-        public string IsOnlyOneWord {
+        public string IsOnlyOneWord
+        {
             get { return _IsOnlyOneWord; }
             set { this.RaiseAndSetIfChanged(ref _IsOnlyOneWord, value); }
         }
@@ -34,7 +36,8 @@ namespace ReactiveUI.Tests
         [IgnoreDataMember]
         List<string> _StackOverflowTrigger;
         [DataMember]
-        public List<string> StackOverflowTrigger {
+        public List<string> StackOverflowTrigger
+        {
             get { return _StackOverflowTrigger; }
             set { this.RaiseAndSetIfChanged(ref _StackOverflowTrigger, value.ToList()); }
         }
@@ -42,7 +45,8 @@ namespace ReactiveUI.Tests
         [IgnoreDataMember]
         string _UsesExprRaiseSet;
         [DataMember]
-        public string UsesExprRaiseSet {
+        public string UsesExprRaiseSet
+        {
             get { return _UsesExprRaiseSet; }
             set { this.RaiseAndSetIfChanged(ref _UsesExprRaiseSet, value); }
         }
@@ -50,7 +54,8 @@ namespace ReactiveUI.Tests
         [IgnoreDataMember]
         string _PocoProperty;
         [DataMember]
-        public string PocoProperty {
+        public string PocoProperty
+        {
             get { return _PocoProperty; }
             set { _PocoProperty = value; }
         }
@@ -59,7 +64,8 @@ namespace ReactiveUI.Tests
         public ReactiveList<int> TestCollection { get; protected set; }
 
         string _NotSerialized;
-        public string NotSerialized {
+        public string NotSerialized
+        {
             get { return _NotSerialized; }
             set { this.RaiseAndSetIfChanged(ref _NotSerialized, value); }
         }
@@ -76,7 +82,7 @@ namespace ReactiveUI.Tests
 
         public TestFixture()
         {
-            TestCollection = new ReactiveList<int>() {ChangeTrackingEnabled = true};
+            TestCollection = new ReactiveList<int>() { ChangeTrackingEnabled = true };
         }
     }
 
@@ -85,7 +91,8 @@ namespace ReactiveUI.Tests
         [IgnoreDataMember]
         ObservableAsPropertyHelper<string> _FirstThreeLettersOfOneWord;
         [IgnoreDataMember]
-        public string FirstThreeLettersOfOneWord {
+        public string FirstThreeLettersOfOneWord
+        {
             get { return _FirstThreeLettersOfOneWord.Value; }
         }
 
@@ -99,7 +106,7 @@ namespace ReactiveUI.Tests
 
     public class ReactiveObjectTest
     {
-        [Fact]        
+        [Fact]
         public void ReactiveObjectSmokeTest()
         {
             var output_changing = new List<string>();
@@ -182,8 +189,8 @@ namespace ReactiveUI.Tests
         public void ChangingShouldAlwaysArriveBeforeChanged()
         {
             string before_set = "Foo";
-            string after_set = "Bar"; 
-            
+            string after_set = "Bar";
+
             var fixture = new TestFixture() { IsOnlyOneWord = before_set };
 
             bool before_fired = false;
@@ -216,7 +223,7 @@ namespace ReactiveUI.Tests
             var fixture = new TestFixture() { IsOnlyOneWord = "Foo" };
 
             fixture.Changed.Subscribe(x => { throw new Exception("Die!"); });
-            var exceptionList = fixture.ThrownExceptions.CreateCollection();
+            var exceptionList = fixture.ThrownExceptions.CreateCollection(scheduler: ImmediateScheduler.Instance);
 
             fixture.IsOnlyOneWord = "Bar";
             Assert.Equal(1, exceptionList.Count);
@@ -226,7 +233,7 @@ namespace ReactiveUI.Tests
         public void DeferringNotificationsDontShowUpUntilUndeferred()
         {
             var fixture = new TestFixture();
-            var output = fixture.Changed.CreateCollection();
+            var output = fixture.Changed.CreateCollection(scheduler: ImmediateScheduler.Instance);
 
             Assert.Equal(0, output.Count);
             fixture.NullableInt = 4;

--- a/src/ReactiveUI.Tests/ReactiveUI.Tests.csproj
+++ b/src/ReactiveUI.Tests/ReactiveUI.Tests.csproj
@@ -9,9 +9,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit" Version="1.9.2" />
+    <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.console" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="Xunit.StaFact" Version="0.2.3-beta" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ReactiveUI.Tests/RoutingState.cs
+++ b/src/ReactiveUI.Tests/RoutingState.cs
@@ -9,17 +9,20 @@ using Xunit;
 
 namespace ReactiveUI.Routing.Tests
 {
+    using System.Reactive.Concurrency;
     using System.Threading.Tasks;
     using Microsoft.Reactive.Testing;
     public class TestViewModel : ReactiveObject, IRoutableViewModel
     {
         string _SomeProp;
-        public string SomeProp {
+        public string SomeProp
+        {
             get { return _SomeProp; }
             set { this.RaiseAndSetIfChanged(ref _SomeProp, value); }
         }
 
-        public string UrlPathSegment {
+        public string UrlPathSegment
+        {
             get { return "Test"; }
         }
 
@@ -32,7 +35,8 @@ namespace ReactiveUI.Routing.Tests
     public class TestScreen : ReactiveObject, IScreen
     {
         RoutingState _Router;
-        public RoutingState Router {
+        public RoutingState Router
+        {
             get { return _Router; }
             set { this.RaiseAndSetIfChanged(ref _Router, value); }
         }
@@ -43,7 +47,7 @@ namespace ReactiveUI.Routing.Tests
         [Fact]
         public async Task NavigationPushPopTest()
         {
-            var input = new TestViewModel() {SomeProp = "Foo"};
+            var input = new TestViewModel() { SomeProp = "Foo" };
             var fixture = new RoutingState();
 
             Assert.False(await fixture.NavigateBack.CanExecute.FirstAsync());
@@ -66,7 +70,7 @@ namespace ReactiveUI.Routing.Tests
         public void CurrentViewModelObservableIsAccurate()
         {
             var fixture = new RoutingState();
-            var output = fixture.CurrentViewModel.CreateCollection();
+            var output = fixture.CurrentViewModel.CreateCollection(scheduler: ImmediateScheduler.Instance);
 
             Assert.Equal(1, output.Count);
 
@@ -86,7 +90,7 @@ namespace ReactiveUI.Routing.Tests
         public void CurrentViewModelObservableIsAccurateViaWhenAnyObservable()
         {
             var fixture = new TestScreen();
-            var output = fixture.WhenAnyObservable(x => x.Router.CurrentViewModel).CreateCollection();
+            var output = fixture.WhenAnyObservable(x => x.Router.CurrentViewModel).CreateCollection(scheduler: ImmediateScheduler.Instance);
             fixture.Router = new RoutingState();
 
             Assert.Equal(1, output.Count);
@@ -128,13 +132,13 @@ namespace ReactiveUI.Routing.Tests
             };
             var navigate = fixture
                 .Navigate
-                .CreateCollection();
+                .CreateCollection(scheduler: ImmediateScheduler.Instance);
             var navigateBack = fixture
                 .NavigateBack
-                .CreateCollection();
+                .CreateCollection(scheduler: ImmediateScheduler.Instance);
             var navigateAndReset = fixture
                 .NavigateAndReset
-                .CreateCollection();
+                .CreateCollection(scheduler: ImmediateScheduler.Instance);
 
             fixture.Navigate.Execute(new TestViewModel()).Subscribe();
             Assert.Empty(navigate);

--- a/src/ReactiveUI.Tests/RxAppTest.cs
+++ b/src/ReactiveUI.Tests/RxAppTest.cs
@@ -16,12 +16,14 @@ namespace ReactiveUI.Tests
         [Fact]
         public void DepPropNotifierShouldBeFound()
         {
+            RxApp.EnsureInitialized();
+
             Assert.True(Locator.Current.GetServices<ICreatesObservableForProperty>()
                 .Any(x => x is DependencyObjectObservableForProperty));
         }
 #endif
 
-        [Fact]
+        [Fact(Skip = "Requires initialize to run on seperate thread")]
         public void SchedulerShouldBeCurrentThreadInTestRunner()
         {
             Debug.WriteLine(RxApp.MainThreadScheduler.GetType().FullName);

--- a/src/ReactiveUI.Tests/TestConfiguration.cs
+++ b/src/ReactiveUI.Tests/TestConfiguration.cs
@@ -1,0 +1,3 @@
+﻿using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true, MaxParallelThreads = 1)]

--- a/src/ReactiveUI.Tests/TestUtilsTest.cs
+++ b/src/ReactiveUI.Tests/TestUtilsTest.cs
@@ -11,10 +11,5 @@ namespace ReactiveUI.Tests
 {
     public class TestUtilsTest
     {
-        [Fact]
-        public async Task WithAsyncScheduler()
-        {
-            await new TestScheduler().WithAsync(_ => Task.Run(() => { }));
-        }
     }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Fixes #1301


**What is the current behavior? (You can also link to an open issue here)**
Uses xunit 1.9.x

**What is the new behavior (if this is a feature change)?**
Use xunit 2.x

**Does this PR introduce a breaking change?**
Unlikely, this shouldn't be being consumed by end users anyway.

**Please check if the PR fulfills these requirements**
- [x] The commit follows our guidelines: https://github.com/reactiveui/reactiveui#contribute
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
The biggest change that impacts this is the threading model for xunit 2 has changed a bit, so some tests are marked as STA or WPF which ensures they're running on the right thread.

I'm a little concerned the tests could be a bit flaky because of the changes, so one thing I'm keen for this PR to do is build it on a different machine.

If tests are flaky, we might need to either rework them a bit, possibly doing one of the following
- explicitly set a thread/Rx dispatcher
- change the way RxApp handles unit test runners
- use async/await (:( I know...) because that makes xunit play nice
