### PR TITLE
if a popToRootPending is true then don't run the code that looks for incremental Stack changes

### DIFF
--- a/src/ReactiveUI.XamForms/RoutedViewHost.cs
+++ b/src/ReactiveUI.XamForms/RoutedViewHost.cs
@@ -45,7 +45,7 @@ namespace ReactiveUI.XamForms
                 var currentCount = previousCount.Skip(1);
 
                 d (Observable.Zip(previousCount, currentCount, (previous, current) => new { Delta = previous - current, Current = current })
-                    .Where(_ => !userInstigated)
+                    .Where(_ => !userInstigated && !popToRootPending)
                     .Where(x => x.Delta > 0)
                     .SelectMany(
                         async x =>


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug Fix


**What is the current behavior? (You can also link to an open issue here)**
If you issue a "NavigateAndReset" command this block of code runs which shouldn't really run when doing a NavigateAndReset operation

https://github.com/reactiveui/ReactiveUI/blob/020a59b96dfe68889e6ff687825f6c9dcfec0e5d/src/ReactiveUI.XamForms/RoutedViewHost.cs#L76

The issue I found from this comes up because NavigateAndReset does a clear and then it inserts a VM on the stack.  I've seen this surface in two ways

When this runs
```
  ((IViewFor)this.CurrentPage).ViewModel = Router.GetCurrentViewModel();
```
It will throw an invalid cast Exception or it will just return a NULL record depending on if the event runs after the Clear or After the Insert

The CurrentPage is still set to the page that will eventually be popped off by this code 

https://github.com/reactiveui/ReactiveUI/blob/020a59b96dfe68889e6ff687825f6c9dcfec0e5d/src/ReactiveUI.XamForms/RoutedViewHost.cs#L88

Another result of this change is that instead of popping the pages one by one this code will just take care of it with a PopToRootAsync
```
  this.Navigation.InsertPageBefore(x, this.Navigation.NavigationStack[0]);
                            await this.PopToRootAsync();
```

**What is the new behavior (if this is a feature change)?**

Ignore the incremental popping when a NavigateAndReset is issued

**Does this PR introduce a breaking change?**
It shouldn't... I ran a few different scenarios and I have this change in my local code and it seems to work fine.


**Please check if the PR fulfills these requirements**
- [X ] The commit follows our guidelines: https://github.com/reactiveui/reactiveui#contribute
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

