### PR TITLE
feature: add the tizen30 platform to reactiveui

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="MSBuildSDKExtras CI" value="https://www.myget.org/F/msbuildsdkextras/api/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="MSBuildSDKExtras CI" value="https://www.myget.org/F/msbuildsdkextras/api/v3/index.json" />
-  </packageSources>
-</configuration>

--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -18,7 +18,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.0.1" PrivateAssets="All" />
+    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.0.5-beta.52" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(IsTestProject)' != 'true' and '$(SourceLinkEnabled)' != 'false'">

--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -18,7 +18,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.0.5-beta.52" PrivateAssets="All" />
+    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.0.5" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(IsTestProject)' != 'true' and '$(SourceLinkEnabled)' != 'false'">

--- a/src/ReactiveUI/ReactiveUI.csproj
+++ b/src/ReactiveUI/ReactiveUI.csproj
@@ -6,12 +6,7 @@
     <Description>A MVVM framework that integrates with the Reactive Extensions for .NET to create elegant, testable User Interfaces that run on any mobile or desktop platform. Supports Xamarin.iOS, Xamarin.Android, Xamarin.Mac, Xamarin Forms, WPF, Windows Forms, Windows Phone 8.1, Windows Store and Universal Windows Platform (UWP).</Description>
     <PackageId>reactiveui</PackageId>
   </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'tizen30' ">
-    <TargetFrameworkIdentifier>Tizen</TargetFrameworkIdentifier>
-    <TargetFrameworkVersion>v3.0</TargetFrameworkVersion>
-  </PropertyGroup>
-
+  
   <ItemGroup>
     <Compile Remove="Platforms\**\*.cs" />
     <None Include="Platforms\**\*.cs" />

--- a/src/ReactiveUI/ReactiveUI.csproj
+++ b/src/ReactiveUI/ReactiveUI.csproj
@@ -7,6 +7,11 @@
     <PackageId>reactiveui</PackageId>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'tizen30' ">
+    <TargetFrameworkIdentifier>Tizen</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>v3.0</TargetFrameworkVersion>
+  </PropertyGroup>
+
   <ItemGroup>
     <Compile Remove="Platforms\**\*.cs" />
     <None Include="Platforms\**\*.cs" />

--- a/src/ReactiveUI/ReactiveUI.csproj
+++ b/src/ReactiveUI/ReactiveUI.csproj
@@ -61,9 +61,7 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'tizen30' ">
     <Compile Include="Platforms\tizen\**\*.cs" />
-    <PackageReference Include="Tizen.Library" Version="1.0.0-pre3" />
-    <!-- Need this as it brings in NETStandard.Library Tizen.Library 1.0.0-pre3 chains in 1.0.3, which does not -->
-    <PackageReference Include="Tizen" Version="1.0.5" />
+    <PackageReference Include="Tizen.NET" Version="3.0.0" />
   </ItemGroup>    
   
   <ItemGroup>

--- a/src/ReactiveUI/ReactiveUI.csproj
+++ b/src/ReactiveUI/ReactiveUI.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.1;net45;uap10.0;Xamarin.iOS10;Xamarin.Mac20;MonoAndroid70</TargetFrameworks>
+    <TargetFrameworks>netstandard1.1;net45;uap10.0;Xamarin.iOS10;Xamarin.Mac20;MonoAndroid70;tizen30</TargetFrameworks>
     <AssemblyName>ReactiveUI</AssemblyName>
     <RootNamespace>ReactiveUI</RootNamespace>
     <Description>A MVVM framework that integrates with the Reactive Extensions for .NET to create elegant, testable User Interfaces that run on any mobile or desktop platform. Supports Xamarin.iOS, Xamarin.Android, Xamarin.Mac, Xamarin Forms, WPF, Windows Forms, Windows Phone 8.1, Windows Store and Universal Windows Platform (UWP).</Description>
@@ -57,6 +57,10 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'MonoAndroid70' ">
     <Compile Include="Platforms\android\**\*.cs" />
     <Compile Include="Platforms\xamarin-common\**\*.cs" />
+  </ItemGroup>  
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'tizen30' ">
+    <Compile Include="Platforms\tizen\**\*.cs" />
   </ItemGroup>  
   
   <ItemGroup>

--- a/src/ReactiveUI/ReactiveUI.csproj
+++ b/src/ReactiveUI/ReactiveUI.csproj
@@ -61,7 +61,10 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'tizen30' ">
     <Compile Include="Platforms\tizen\**\*.cs" />
-  </ItemGroup>  
+    <PackageReference Include="Tizen.Library" Version="1.0.0-pre3" />
+    <!-- Need this as it brings in NETStandard.Library Tizen.Library 1.0.0-pre3 chains in 1.0.3, which does not -->
+    <PackageReference Include="Tizen" Version="1.0.5" />
+  </ItemGroup>    
   
   <ItemGroup>
     <None Update="VariadicTemplates.tt" Generator="TextTemplatingFileGenerator" LastGenOutput="VariadicTemplates.cs" />


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

feature

**The Plan**
- [ ] Get a clean msbuild without referencing any Tizen platform specifics. (**we are here; current attempts blocked at this stage**)
- [ ] Generate and package `reactiveui-events` for `tizen30` via downloading packages from NuGet.
- [ ] Start adding platform specific/public API surface to `reactiveui`


**Other information**:

* The TFM is `tizen30` as per https://github.com/NuGet/Home/issues/4175 which was implemented in over at https://github.com/NuGet/NuGet.Client/pull/1083/files
* NuGet v4.1 (now released) has support for this TFM.
* We are super-early adopters - expect 🐉's - based on some googling only other person who has tried this yet is @maltegoetz  https://github.com/jamesmontemagno/SettingsPlugin/pull/72/files

Blocked until figure out how to multi-target the platform correctly:

Error message after https://github.com/reactiveui/ReactiveUI/pull/1387/commits/7e9535a191b91ed94dfd42ffe4f235e5a78a1ba1

![image](https://user-images.githubusercontent.com/127353/27615220-0763f0e8-5bea-11e7-965b-77ca3c5f34ec.png)

Error message after https://github.com/reactiveui/ReactiveUI/pull/1387/commits/2fb2ba45d2d25a0df55cee215069980f7f81030f

![image](https://user-images.githubusercontent.com/127353/27615524-207f724e-5bec-11e7-8893-d2b819e7b019.png)

AppVeyor does not have the tizen SDK's installed but I do on my local machine (obtained yesterday from https://developer.tizen.org/development/tizen-.net-preview/getting-started/installing-visual-studio-tools-tizen). All screenshots/logs are from my local machine.

/cc @WonyoungChoi 