### PR TITLE
housekeeping: removed dead code that references WINRT80

### DIFF
--- a/src/ReactiveUI/Platforms/windows-common/PlatformOperations.cs
+++ b/src/ReactiveUI/Platforms/windows-common/PlatformOperations.cs
@@ -10,9 +10,7 @@ namespace ReactiveUI
     {
         public string GetOrientation()
         {
-#if WINRT80
-            return Windows.Graphics.Display.DisplayProperties.CurrentOrientation.ToString();
-#elif NETFX_CORE
+#if NETFX_CORE
             return Windows.Graphics.Display.DisplayInformation.GetForCurrentView().CurrentOrientation.ToString(); 
 #elif SILVERLIGHT
             var app = System.Windows.Application.Current;


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

housekeeping

**What is the current behavior? (You can also link to an open issue here)**

```
#if WINRT80
            return Windows.Graphics.Display.DisplayProperties.CurrentOrientation.ToString();
#elif NETFX_CORE
```

**What is the new behavior (if this is a feature change)?**

```
-#if WINRT80
-            return Windows.Graphics.Display.DisplayProperties.CurrentOrientation.ToString();
-#elif NETFX_CORE
```

**Does this PR introduce a breaking change?**

no

**Please check if the PR fulfills these requirements**
- [x] The commit follows our guidelines: https://github.com/reactiveui/reactiveui#contribute
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

This is the last trace of WINRT80

```shell
reactiveui\ReactiveUI$ ack WINRT80

<nothing>
```
