### PR TITLE
housekeeping: bumped next version to be v8

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,3 +1,4 @@
+next-version: 8.0.0
 assembly-versioning-scheme: None
 branches:
   master:


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

housekeeping

**What is the current behavior? (You can also link to an open issue here)**

```
C:\dropbox\oss\reactiveui\ReactiveUI [develop ≡ +1 ~1 -0 !]> .\tools\GitVersion.CommandLine\tools\GitVersion.exe
{
  "Major":7,
  "Minor":5,
  "Patch":0,
  "PreReleaseTag":"alpha.32",
  "PreReleaseTagWithDash":"-alpha.32",
  "PreReleaseLabel":"alpha",
  "PreReleaseNumber":32,
  "BuildMetaData":"",
  "BuildMetaDataPadded":"",
  "FullBuildMetaData":"Branch.develop.Sha.7221f582afccc9a10878c99874ef4a0d91871e3d",
  "MajorMinorPatch":"7.5.0",
  "SemVer":"7.5.0-alpha.32",
  "LegacySemVer":"7.5.0-alpha32",
  "LegacySemVerPadded":"7.5.0-alpha0032",
  "AssemblySemVer":"",
  "FullSemVer":"7.5.0-alpha.32",
  "InformationalVersion":"7.5.0-alpha.32+Branch.develop.Sha.7221f582afccc9a10878c99874ef4a0d91871e3d",
  "BranchName":"develop",
  "Sha":"7221f582afccc9a10878c99874ef4a0d91871e3d",
  "NuGetVersionV2":"7.5.0-alpha0032",
  "NuGetVersion":"7.5.0-alpha0032",
  "CommitsSinceVersionSource":32,
  "CommitsSinceVersionSourcePadded":"0032",
  "CommitDate":"2017-07-24"
}
```

**What is the new behavior (if this is a feature change)?**

```
C:\dropbox\oss\reactiveui\ReactiveUI [nextversion-will-be-8 +1 ~1 -0 !]> .\tools\GitVersion.CommandLine\tools\GitVersion.exe
{
  "Major":8,
  "Minor":0,
  "Patch":0,
  "PreReleaseTag":"nextversion-will-be-8.1",
  "PreReleaseTagWithDash":"-nextversion-will-be-8.1",
  "PreReleaseLabel":"nextversion-will-be-8",
  "PreReleaseNumber":1,
  "BuildMetaData":40,
  "BuildMetaDataPadded":"0040",
  "FullBuildMetaData":"40.Branch.nextversion-will-be-8.Sha.2619b6b46a9a532ffef2d561d4b84cefe8b53fc8",
  "MajorMinorPatch":"8.0.0",
  "SemVer":"8.0.0-nextversion-will-be-8.1",
  "LegacySemVer":"8.0.0-nextversion-will-b-1",
  "LegacySemVerPadded":"8.0.0-nextversion-wil-0001",
  "AssemblySemVer":"",
  "FullSemVer":"8.0.0-nextversion-will-be-8.1+40",
  "InformationalVersion":"8.0.0-nextversion-will-be-8.1+40.Branch.nextversion-will-be-8.Sha.2619b6b46a9a532ffef2d561d4b84cefe8b53fc8",
  "BranchName":"nextversion-will-be-8",
  "Sha":"2619b6b46a9a532ffef2d561d4b84cefe8b53fc8",
  "NuGetVersionV2":"8.0.0-nextversion-wil-0001",
  "NuGetVersion":"8.0.0-nextversion-wil-0001",
  "CommitsSinceVersionSource":40,
  "CommitsSinceVersionSourcePadded":"0040",
  "CommitDate":"2017-08-02"
}
```

**Does this PR introduce a breaking change?**

No

**Please check if the PR fulfills these requirements**
- [x] The commit follows our guidelines: https://github.com/reactiveui/reactiveui#contribute
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

Once v8 has been released (i.e. "git tag") then this configuration line will be ignored by GitVersion and should be removed. I'm bumping this version before the release as ReactiveUI needs to enter into a series of public pre-releases as part of building out the Xamarin.Forms sample application.
