### PR TITLE
housekeeping: added .net foundation license headers

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 //////////////////////////////////////////////////////////////////////
 // ADDINS
 //////////////////////////////////////////////////////////////////////

--- a/src/EventBuilder/App.config
+++ b/src/EventBuilder/App.config
@@ -1,4 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+Licensed to the .NET Foundation under one or more agreements.
+The .NET Foundation licenses this file to you under the MS-PL license.
+See the LICENSE file in the project root for more information.
+-->
+
 <configuration>
   <startup>
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/>

--- a/src/EventBuilder/Cecil/DelegateTemplateInformation.cs
+++ b/src/EventBuilder/Cecil/DelegateTemplateInformation.cs
@@ -1,4 +1,8 @@
-﻿using EventBuilder.Entities;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using EventBuilder.Entities;
 using Mono.Cecil;
 using System;
 using System.Linq;

--- a/src/EventBuilder/Cecil/EventTemplateInformation.cs
+++ b/src/EventBuilder/Cecil/EventTemplateInformation.cs
@@ -1,4 +1,8 @@
-﻿using EventBuilder.Entities;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using EventBuilder.Entities;
 using Mono.Cecil;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/EventBuilder/Cecil/PathSearchAssemblyResolver.cs
+++ b/src/EventBuilder/Cecil/PathSearchAssemblyResolver.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.IO;
 using System.Linq;

--- a/src/EventBuilder/Cecil/SafeTypes.cs
+++ b/src/EventBuilder/Cecil/SafeTypes.cs
@@ -1,4 +1,8 @@
-﻿using Mono.Cecil;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using Mono.Cecil;
 using System.Linq;
 
 namespace EventBuilder.Cecil

--- a/src/EventBuilder/CommandLineOptions.cs
+++ b/src/EventBuilder/CommandLineOptions.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System.Collections.Generic;
 using CommandLine;
 using CommandLine.Text;

--- a/src/EventBuilder/DefaultTemplate.mustache
+++ b/src/EventBuilder/DefaultTemplate.mustache
@@ -1,4 +1,8 @@
-﻿#pragma warning disable 1591,0618,0105,0672
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+#pragma warning disable 1591,0618,0105,0672
 
 using System;
 using System.Reactive;

--- a/src/EventBuilder/Entities/MultiParameterMethod.cs
+++ b/src/EventBuilder/Entities/MultiParameterMethod.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 namespace EventBuilder.Entities
 {
     public class MultiParameterMethod

--- a/src/EventBuilder/Entities/NamespaceInfo.cs
+++ b/src/EventBuilder/Entities/NamespaceInfo.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System.Collections.Generic;
 
 namespace EventBuilder.Entities

--- a/src/EventBuilder/Entities/ParentInfo.cs
+++ b/src/EventBuilder/Entities/ParentInfo.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 namespace EventBuilder.Entities
 {
     public class ParentInfo

--- a/src/EventBuilder/Entities/PublicEventInfo.cs
+++ b/src/EventBuilder/Entities/PublicEventInfo.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 namespace EventBuilder.Entities
 {
     public class PublicEventInfo

--- a/src/EventBuilder/Entities/PublicTypeInfo.cs
+++ b/src/EventBuilder/Entities/PublicTypeInfo.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using Mono.Cecil;
 using System.Collections.Generic;
 

--- a/src/EventBuilder/Entities/SingleParameterMethod.cs
+++ b/src/EventBuilder/Entities/SingleParameterMethod.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 namespace EventBuilder.Entities
 {
     public class SingleParameterMethod

--- a/src/EventBuilder/EventBuilder.licenseheader
+++ b/src/EventBuilder/EventBuilder.licenseheader
@@ -1,0 +1,12 @@
+﻿extensions: designer.cs generated.cs
+extensions: .cs .cpp .h
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+extensions:  .xml .config .xsd
+<!--
+Licensed to the .NET Foundation under one or more agreements.
+The .NET Foundation licenses this file to you under the MS-PL license.
+See the LICENSE file in the project root for more information.
+-->

--- a/src/EventBuilder/PlatformHelper.cs
+++ b/src/EventBuilder/PlatformHelper.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 
 namespace EventBuilder
 {

--- a/src/EventBuilder/Platforms/Android.cs
+++ b/src/EventBuilder/Platforms/Android.cs
@@ -1,4 +1,8 @@
-﻿using System.IO;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
 using System.Linq;
 
 namespace EventBuilder.Platforms

--- a/src/EventBuilder/Platforms/BasePlatform.cs
+++ b/src/EventBuilder/Platforms/BasePlatform.cs
@@ -1,4 +1,8 @@
-﻿using System.Collections.Generic;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
 
 namespace EventBuilder.Platforms
 {

--- a/src/EventBuilder/Platforms/Bespoke.cs
+++ b/src/EventBuilder/Platforms/Bespoke.cs
@@ -1,4 +1,8 @@
-﻿namespace EventBuilder.Platforms
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+namespace EventBuilder.Platforms
 {
     public class Bespoke : BasePlatform
     {

--- a/src/EventBuilder/Platforms/IPlatform.cs
+++ b/src/EventBuilder/Platforms/IPlatform.cs
@@ -1,4 +1,8 @@
-﻿using System.Collections.Generic;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
 
 namespace EventBuilder.Platforms
 {

--- a/src/EventBuilder/Platforms/Mac.cs
+++ b/src/EventBuilder/Platforms/Mac.cs
@@ -1,4 +1,8 @@
-﻿using System.IO;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
 using System.Linq;
 
 namespace EventBuilder.Platforms

--- a/src/EventBuilder/Platforms/UWP.cs
+++ b/src/EventBuilder/Platforms/UWP.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 
 namespace EventBuilder.Platforms
 {

--- a/src/EventBuilder/Platforms/WPF.cs
+++ b/src/EventBuilder/Platforms/WPF.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 
 namespace EventBuilder.Platforms
 {

--- a/src/EventBuilder/Platforms/XamForms.cs
+++ b/src/EventBuilder/Platforms/XamForms.cs
@@ -1,4 +1,8 @@
-﻿using NuGet;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using NuGet;
 using Polly;
 using Serilog;
 using System;

--- a/src/EventBuilder/Platforms/iOS.cs
+++ b/src/EventBuilder/Platforms/iOS.cs
@@ -1,4 +1,8 @@
-﻿using System.IO;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
 using System.Linq;
 
 namespace EventBuilder.Platforms

--- a/src/EventBuilder/Program.cs
+++ b/src/EventBuilder/Program.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;

--- a/src/EventBuilder/Properties/AssemblyInfo.cs
+++ b/src/EventBuilder/Properties/AssemblyInfo.cs
@@ -1,4 +1,8 @@
-﻿using System.Reflection;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following

--- a/src/ReactiveUI.AndroidSupport/ControlFetcherMixin.cs
+++ b/src/ReactiveUI.AndroidSupport/ControlFetcherMixin.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/ReactiveUI.AndroidSupport/ReactiveActionBarActivity.cs
+++ b/src/ReactiveUI.AndroidSupport/ReactiveActionBarActivity.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;

--- a/src/ReactiveUI.AndroidSupport/ReactiveAppCompatActivity.cs
+++ b/src/ReactiveUI.AndroidSupport/ReactiveAppCompatActivity.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;

--- a/src/ReactiveUI.AndroidSupport/ReactiveDialogFragment.cs
+++ b/src/ReactiveUI.AndroidSupport/ReactiveDialogFragment.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.ComponentModel;
 using System.Reactive.Subjects;

--- a/src/ReactiveUI.AndroidSupport/ReactiveFragment.cs
+++ b/src/ReactiveUI.AndroidSupport/ReactiveFragment.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/ReactiveUI.AndroidSupport/ReactiveFragmentActivity.cs
+++ b/src/ReactiveUI.AndroidSupport/ReactiveFragmentActivity.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/ReactiveUI.AndroidSupport/ReactivePagerAdapter.cs
+++ b/src/ReactiveUI.AndroidSupport/ReactivePagerAdapter.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reactive.Disposables;

--- a/src/ReactiveUI.AndroidSupport/ReactiveRecyclerViewAdapter.cs
+++ b/src/ReactiveUI.AndroidSupport/ReactiveRecyclerViewAdapter.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Specialized;
 using System.ComponentModel;

--- a/src/ReactiveUI.AndroidSupport/ReactiveUI.AndroidSupport.licenseheader
+++ b/src/ReactiveUI.AndroidSupport/ReactiveUI.AndroidSupport.licenseheader
@@ -1,0 +1,12 @@
+﻿extensions: designer.cs generated.cs
+extensions: .cs .cpp .h
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+extensions:  .xml .config .xsd
+<!--
+Licensed to the .NET Foundation under one or more agreements.
+The .NET Foundation licenses this file to you under the MS-PL license.
+See the LICENSE file in the project root for more information.
+-->

--- a/src/ReactiveUI.Blend/FollowObservableStateBehavior.cs
+++ b/src/ReactiveUI.Blend/FollowObservableStateBehavior.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Reactive.Linq;
 
 #if !NETFX_CORE

--- a/src/ReactiveUI.Blend/Platforms/net45/ObservableTrigger.cs
+++ b/src/ReactiveUI.Blend/Platforms/net45/ObservableTrigger.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reactive.Linq;

--- a/src/ReactiveUI.Blend/Platforms/uap10.0/Behavior.cs
+++ b/src/ReactiveUI.Blend/Platforms/uap10.0/Behavior.cs
@@ -1,4 +1,8 @@
-﻿using Windows.UI.Xaml;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using Windows.UI.Xaml;
 using Microsoft.Xaml.Interactivity;
 using Windows.ApplicationModel;
 using System;

--- a/src/ReactiveUI.Blend/Platforms/uap10.0/ObservableTriggerBehavior.cs
+++ b/src/ReactiveUI.Blend/Platforms/uap10.0/ObservableTriggerBehavior.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reactive.Disposables;

--- a/src/ReactiveUI.Blend/Properties/ReactiveUI.Blend_UWP.rd.xml
+++ b/src/ReactiveUI.Blend/Properties/ReactiveUI.Blend_UWP.rd.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
+Licensed to the .NET Foundation under one or more agreements.
+The .NET Foundation licenses this file to you under the MS-PL license.
+See the LICENSE file in the project root for more information.
+-->
+
+<!--
     This file contains Runtime Directives, specifications about types your application accesses
     through reflection and other dynamic code patterns. Runtime Directives are used to control the
     .NET Native optimizer and ensure that it does not remove code accessed by your library. If your

--- a/src/ReactiveUI.Blend/ReactiveUI.Blend.licenseheader
+++ b/src/ReactiveUI.Blend/ReactiveUI.Blend.licenseheader
@@ -1,0 +1,12 @@
+﻿extensions: designer.cs generated.cs
+extensions: .cs .cpp .h
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+extensions:  .xml .config .xsd
+<!--
+Licensed to the .NET Foundation under one or more agreements.
+The .NET Foundation licenses this file to you under the MS-PL license.
+See the LICENSE file in the project root for more information.
+-->

--- a/src/ReactiveUI.Events.WPF/ReactiveUI.Events.WPF.licenseheader
+++ b/src/ReactiveUI.Events.WPF/ReactiveUI.Events.WPF.licenseheader
@@ -1,0 +1,12 @@
+﻿extensions: designer.cs generated.cs
+extensions: .cs .cpp .h
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+extensions:  .xml .config .xsd
+<!--
+Licensed to the .NET Foundation under one or more agreements.
+The .NET Foundation licenses this file to you under the MS-PL license.
+See the LICENSE file in the project root for more information.
+-->

--- a/src/ReactiveUI.Events.XamForms/ReactiveUI.Events.XamForms.licenseheader
+++ b/src/ReactiveUI.Events.XamForms/ReactiveUI.Events.XamForms.licenseheader
@@ -1,0 +1,12 @@
+﻿extensions: designer.cs generated.cs
+extensions: .cs .cpp .h
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+extensions:  .xml .config .xsd
+<!--
+Licensed to the .NET Foundation under one or more agreements.
+The .NET Foundation licenses this file to you under the MS-PL license.
+See the LICENSE file in the project root for more information.
+-->

--- a/src/ReactiveUI.Events/ReactiveUI.Events.licenseheader
+++ b/src/ReactiveUI.Events/ReactiveUI.Events.licenseheader
@@ -1,0 +1,12 @@
+﻿extensions: designer.cs generated.cs
+extensions: .cs .cpp .h
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+extensions:  .xml .config .xsd
+<!--
+Licensed to the .NET Foundation under one or more agreements.
+The .NET Foundation licenses this file to you under the MS-PL license.
+See the LICENSE file in the project root for more information.
+-->

--- a/src/ReactiveUI.Events/SingleAwaitSubject.cs
+++ b/src/ReactiveUI.Events/SingleAwaitSubject.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 

--- a/src/ReactiveUI.Testing/Properties/ReactiveUI.Testing.rd.xml
+++ b/src/ReactiveUI.Testing/Properties/ReactiveUI.Testing.rd.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
+Licensed to the .NET Foundation under one or more agreements.
+The .NET Foundation licenses this file to you under the MS-PL license.
+See the LICENSE file in the project root for more information.
+-->
+
+<!--
     This file contains Runtime Directives, specifications about types your application accesses
     through reflection and other dynamic code patterns. Runtime Directives are used to control the
     .NET Native optimizer and ensure that it does not remove code accessed by your library. If your

--- a/src/ReactiveUI.Testing/ReactiveUI.Testing.licenseheader
+++ b/src/ReactiveUI.Testing/ReactiveUI.Testing.licenseheader
@@ -1,0 +1,12 @@
+﻿extensions: designer.cs generated.cs
+extensions: .cs .cpp .h
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+extensions:  .xml .config .xsd
+<!--
+Licensed to the .NET Foundation under one or more agreements.
+The .NET Foundation licenses this file to you under the MS-PL license.
+See the LICENSE file in the project root for more information.
+-->

--- a/src/ReactiveUI.Testing/TestUtils.cs
+++ b/src/ReactiveUI.Testing/TestUtils.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Reactive;
 using System.Reactive.Disposables;
 using System.Threading;

--- a/src/ReactiveUI.Tests/ActivationTests.cs
+++ b/src/ReactiveUI.Tests/ActivationTests.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Linq;
 using System.Reactive;

--- a/src/ReactiveUI.Tests/AutoPersistHelperTest.cs
+++ b/src/ReactiveUI.Tests/AutoPersistHelperTest.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/ReactiveUI.Tests/AwaiterTest.cs
+++ b/src/ReactiveUI.Tests/AwaiterTest.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/ReactiveUI.Tests/BindingTypeConvertersTest.cs
+++ b/src/ReactiveUI.Tests/BindingTypeConvertersTest.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using Xunit;
 
 namespace ReactiveUI.Tests

--- a/src/ReactiveUI.Tests/CommandBindingTests.cs
+++ b/src/ReactiveUI.Tests/CommandBindingTests.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.ComponentModel;
 using System.Reactive;
 using System.Reactive.Linq;

--- a/src/ReactiveUI.Tests/DependencyResolverTests.cs
+++ b/src/ReactiveUI.Tests/DependencyResolverTests.cs
@@ -1,4 +1,8 @@
-﻿namespace ReactiveUI.Tests
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+namespace ReactiveUI.Tests
 {
     using Splat;
     using TestViewModels;

--- a/src/ReactiveUI.Tests/INPCObservableForPropertyTests.cs
+++ b/src/ReactiveUI.Tests/INPCObservableForPropertyTests.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;

--- a/src/ReactiveUI.Tests/InteractionsTest.cs
+++ b/src/ReactiveUI.Tests/InteractionsTest.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Reactive;
 using System.Reactive.Concurrency;

--- a/src/ReactiveUI.Tests/MessageBusTest.cs
+++ b/src/ReactiveUI.Tests/MessageBusTest.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using Xunit;

--- a/src/ReactiveUI.Tests/ObservableAsPropertyHelperTest.cs
+++ b/src/ReactiveUI.Tests/ObservableAsPropertyHelperTest.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/ReactiveUI.Tests/ObservedChangedMixinTest.cs
+++ b/src/ReactiveUI.Tests/ObservedChangedMixinTest.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/ReactiveUI.Tests/OrderedComparerTests.cs
+++ b/src/ReactiveUI.Tests/OrderedComparerTests.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/ReactiveUI.Tests/Platforms/android/MainActivity.cs
+++ b/src/ReactiveUI.Tests/Platforms/android/MainActivity.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using Android.App;
 using Android.Content;
 using Android.Runtime;

--- a/src/ReactiveUI.Tests/Platforms/android/PropertyBindingTestViews.cs
+++ b/src/ReactiveUI.Tests/Platforms/android/PropertyBindingTestViews.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;

--- a/src/ReactiveUI.Tests/Platforms/cocoa/AppDelegate.cs
+++ b/src/ReactiveUI.Tests/Platforms/cocoa/AppDelegate.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/ReactiveUI.Tests/Platforms/cocoa/IndexNormalizerTest.cs
+++ b/src/ReactiveUI.Tests/Platforms/cocoa/IndexNormalizerTest.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 namespace ReactiveUI.Tests
 {
     using System;

--- a/src/ReactiveUI.Tests/Platforms/cocoa/KVOBindingTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/cocoa/KVOBindingTests.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using Xunit;
 using ReactiveUI.Cocoa;

--- a/src/ReactiveUI.Tests/Platforms/cocoa/Main.cs
+++ b/src/ReactiveUI.Tests/Platforms/cocoa/Main.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/ReactiveUI.Tests/Platforms/cocoa/PropertyBindingTestViews.cs
+++ b/src/ReactiveUI.Tests/Platforms/cocoa/PropertyBindingTestViews.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;

--- a/src/ReactiveUI.Tests/Platforms/cocoa/UnitTestAppDelegate.cs
+++ b/src/ReactiveUI.Tests/Platforms/cocoa/UnitTestAppDelegate.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/ReactiveUI.Tests/Platforms/winforms/ActivationTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/ActivationTests.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
 using Xunit;

--- a/src/ReactiveUI.Tests/Platforms/winforms/CommandBindingTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/CommandBindingTests.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.ComponentModel;
 using System.Reactive;
 using System.Reactive.Linq;

--- a/src/ReactiveUI.Tests/Platforms/winforms/DefaultPropertyBindingTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/DefaultPropertyBindingTests.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Linq.Expressions;
 using System.Reactive.Disposables;
 using System.Windows.Forms;

--- a/src/ReactiveUI.Tests/Platforms/winforms/ReactiveBindingListTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/ReactiveBindingListTests.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;

--- a/src/ReactiveUI.Tests/Platforms/winforms/RoutedViewHostTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/RoutedViewHostTests.cs
@@ -1,4 +1,8 @@
-﻿using System.Linq;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System.Linq;
 using System.Windows.Forms;
 using ReactiveUI;
 using ReactiveUI.Winforms;

--- a/src/ReactiveUI.Tests/Platforms/winforms/ViewModelViewHostTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/ViewModelViewHostTests.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Linq;
 using System.Windows.Forms;
 using ReactiveUI.Winforms;

--- a/src/ReactiveUI.Tests/Platforms/xaml/ActivationForViewFetcherTest.cs
+++ b/src/ReactiveUI.Tests/Platforms/xaml/ActivationForViewFetcherTest.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/ReactiveUI.Tests/Platforms/xaml/DependencyObjectObservableForPropertyTest.cs
+++ b/src/ReactiveUI.Tests/Platforms/xaml/DependencyObjectObservableForPropertyTest.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;

--- a/src/ReactiveUI.Tests/Platforms/xaml/PropertyBindingTestViews.cs
+++ b/src/ReactiveUI.Tests/Platforms/xaml/PropertyBindingTestViews.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;

--- a/src/ReactiveUI.Tests/PropertyBindingTest.cs
+++ b/src/ReactiveUI.Tests/PropertyBindingTest.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Linq;
 using System.Reactive;

--- a/src/ReactiveUI.Tests/ReactiveCollectionTest.cs
+++ b/src/ReactiveUI.Tests/ReactiveCollectionTest.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/ReactiveUI.Tests/ReactiveCommandTest.cs
+++ b/src/ReactiveUI.Tests/ReactiveCommandTest.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.Reactive;

--- a/src/ReactiveUI.Tests/ReactiveNotifyPropertyChangedMixinTest.cs
+++ b/src/ReactiveUI.Tests/ReactiveNotifyPropertyChangedMixinTest.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;

--- a/src/ReactiveUI.Tests/ReactiveObjectTest.cs
+++ b/src/ReactiveUI.Tests/ReactiveObjectTest.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;

--- a/src/ReactiveUI.Tests/ReactiveUI.Tests.licenseheader
+++ b/src/ReactiveUI.Tests/ReactiveUI.Tests.licenseheader
@@ -1,0 +1,12 @@
+﻿extensions: designer.cs generated.cs
+extensions: .cs .cpp .h
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+extensions:  .xml .config .xsd
+<!--
+Licensed to the .NET Foundation under one or more agreements.
+The .NET Foundation licenses this file to you under the MS-PL license.
+See the LICENSE file in the project root for more information.
+-->

--- a/src/ReactiveUI.Tests/RoutableViewModelMixinTests.cs
+++ b/src/ReactiveUI.Tests/RoutableViewModelMixinTests.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Reactive.Disposables;
 using ReactiveUI.Tests.RoutableViewMixinTests;

--- a/src/ReactiveUI.Tests/RoutingState.cs
+++ b/src/ReactiveUI.Tests/RoutingState.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Linq;
 using System.Reactive.Linq;

--- a/src/ReactiveUI.Tests/RxAppTest.cs
+++ b/src/ReactiveUI.Tests/RxAppTest.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System.Diagnostics;
 using System.Linq;
 using System.Reactive.Concurrency;

--- a/src/ReactiveUI.Tests/TestLogger.cs
+++ b/src/ReactiveUI.Tests/TestLogger.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/ReactiveUI.Tests/TestUtilsTest.cs
+++ b/src/ReactiveUI.Tests/TestUtilsTest.cs
@@ -1,4 +1,8 @@
-﻿using System.Threading.Tasks;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
 using Microsoft.Reactive.Testing;
 using ReactiveUI.Testing;
 using Xunit;

--- a/src/ReactiveUI.Tests/Utility.cs
+++ b/src/ReactiveUI.Tests/Utility.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.Reactive.Concurrency;

--- a/src/ReactiveUI.Tests/ViewLocatorTests.cs
+++ b/src/ReactiveUI.Tests/ViewLocatorTests.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using Splat;
 using Xunit;

--- a/src/ReactiveUI.Tests/WeakEventManagerTest.cs
+++ b/src/ReactiveUI.Tests/WeakEventManagerTest.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Reactive;
 using System.Windows.Controls;
 using Xunit;

--- a/src/ReactiveUI.Winforms/ActivationForViewFetcher.cs
+++ b/src/ReactiveUI.Winforms/ActivationForViewFetcher.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Reactive;
 using System.Reactive.Linq;
 using System.Reflection;

--- a/src/ReactiveUI.Winforms/CreatesCommandBinding.cs
+++ b/src/ReactiveUI.Winforms/CreatesCommandBinding.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;

--- a/src/ReactiveUI.Winforms/ObservableCollectionChangedToListChangedTransformer.cs
+++ b/src/ReactiveUI.Winforms/ObservableCollectionChangedToListChangedTransformer.cs
@@ -1,4 +1,8 @@
-﻿using System.Collections.Generic;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Linq;

--- a/src/ReactiveUI.Winforms/PlatformOperations.cs
+++ b/src/ReactiveUI.Winforms/PlatformOperations.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/ReactiveUI.Winforms/Properties/AssemblyInfo.cs
+++ b/src/ReactiveUI.Winforms/Properties/AssemblyInfo.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;

--- a/src/ReactiveUI.Winforms/ReactiveBindingList.cs
+++ b/src/ReactiveUI.Winforms/ReactiveBindingList.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.Collections;
 using System.Collections.Specialized;

--- a/src/ReactiveUI.Winforms/ReactiveDerivedBindingListMixins.cs
+++ b/src/ReactiveUI.Winforms/ReactiveDerivedBindingListMixins.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;

--- a/src/ReactiveUI.Winforms/ReactiveUI.Winforms.licenseheader
+++ b/src/ReactiveUI.Winforms/ReactiveUI.Winforms.licenseheader
@@ -1,0 +1,12 @@
+﻿extensions: designer.cs generated.cs
+extensions: .cs .cpp .h
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+extensions:  .xml .config .xsd
+<!--
+Licensed to the .NET Foundation under one or more agreements.
+The .NET Foundation licenses this file to you under the MS-PL license.
+See the LICENSE file in the project root for more information.
+-->

--- a/src/ReactiveUI.Winforms/Registrations.cs
+++ b/src/ReactiveUI.Winforms/Registrations.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;

--- a/src/ReactiveUI.Winforms/RoutedViewHost.cs
+++ b/src/ReactiveUI.Winforms/RoutedViewHost.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Reactive.Disposables;

--- a/src/ReactiveUI.Winforms/ViewModelViewHost.cs
+++ b/src/ReactiveUI.Winforms/ViewModelViewHost.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Reactive.Disposables;

--- a/src/ReactiveUI.Winforms/WeakEventManagerShims.cs
+++ b/src/ReactiveUI.Winforms/WeakEventManagerShims.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;

--- a/src/ReactiveUI.Winforms/WinformsCreatesObservableForProperty.cs
+++ b/src/ReactiveUI.Winforms/WinformsCreatesObservableForProperty.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.ComponentModel;
 using System.Linq;
 using System.Linq.Expressions;

--- a/src/ReactiveUI.Wpf/Attributes.cs
+++ b/src/ReactiveUI.Wpf/Attributes.cs
@@ -1,4 +1,8 @@
-﻿using System.Windows;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System.Windows;
 using System.Windows.Markup;
 
 [assembly:XmlnsDefinition("http://reactiveui.net", "ReactiveUI")]

--- a/src/ReactiveUI.Wpf/ComponentModelTypeConverter.cs
+++ b/src/ReactiveUI.Wpf/ComponentModelTypeConverter.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.ComponentModel;
 using Splat;

--- a/src/ReactiveUI.Wpf/ReactiveUI.Wpf.licenseheader
+++ b/src/ReactiveUI.Wpf/ReactiveUI.Wpf.licenseheader
@@ -1,0 +1,12 @@
+﻿extensions: designer.cs generated.cs
+extensions: .cs .cpp .h
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+extensions:  .xml .config .xsd
+<!--
+Licensed to the .NET Foundation under one or more agreements.
+The .NET Foundation licenses this file to you under the MS-PL license.
+See the LICENSE file in the project root for more information.
+-->

--- a/src/ReactiveUI.Wpf/Registrations.cs
+++ b/src/ReactiveUI.Wpf/Registrations.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Reactive.Concurrency;
 
 namespace ReactiveUI.Wpf

--- a/src/ReactiveUI.Wpf/TransitioningContentControl.cs
+++ b/src/ReactiveUI.Wpf/TransitioningContentControl.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows;

--- a/src/ReactiveUI.Wpf/WpfAutoSuspendHelper.cs
+++ b/src/ReactiveUI.Wpf/WpfAutoSuspendHelper.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reactive;

--- a/src/ReactiveUI.Wpf/WpfDependencyObjectObservableForProperty.cs
+++ b/src/ReactiveUI.Wpf/WpfDependencyObjectObservableForProperty.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/ReactiveUI.XamForms/ActivationForViewFetcher.cs
+++ b/src/ReactiveUI.XamForms/ActivationForViewFetcher.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.ComponentModel;
 using System.Reactive.Linq;
 using System.Reflection;

--- a/src/ReactiveUI.XamForms/ReactiveCarouselPage.cs
+++ b/src/ReactiveUI.XamForms/ReactiveCarouselPage.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using ReactiveUI;
 using Xamarin.Forms;
 

--- a/src/ReactiveUI.XamForms/ReactiveContentPage.cs
+++ b/src/ReactiveUI.XamForms/ReactiveContentPage.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using ReactiveUI;
 using Xamarin.Forms;
 

--- a/src/ReactiveUI.XamForms/ReactiveContentView.cs
+++ b/src/ReactiveUI.XamForms/ReactiveContentView.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using ReactiveUI;
 using Xamarin.Forms;
 

--- a/src/ReactiveUI.XamForms/ReactiveEntryCell.cs
+++ b/src/ReactiveUI.XamForms/ReactiveEntryCell.cs
@@ -1,4 +1,8 @@
-﻿using ReactiveUI;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using ReactiveUI;
 using Xamarin.Forms;
 
 namespace ReactiveUI.XamForms

--- a/src/ReactiveUI.XamForms/ReactiveImageCell.cs
+++ b/src/ReactiveUI.XamForms/ReactiveImageCell.cs
@@ -1,4 +1,8 @@
-﻿using ReactiveUI;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using ReactiveUI;
 using Xamarin.Forms;
 
 namespace ReactiveUI.XamForms

--- a/src/ReactiveUI.XamForms/ReactiveMasterDetailPage.cs
+++ b/src/ReactiveUI.XamForms/ReactiveMasterDetailPage.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using ReactiveUI;
 using Xamarin.Forms;
 

--- a/src/ReactiveUI.XamForms/ReactiveMultiPage.cs
+++ b/src/ReactiveUI.XamForms/ReactiveMultiPage.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using ReactiveUI;
 using Xamarin.Forms;
 

--- a/src/ReactiveUI.XamForms/ReactiveNavigationPage.cs
+++ b/src/ReactiveUI.XamForms/ReactiveNavigationPage.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using ReactiveUI;
 using Xamarin.Forms;
 

--- a/src/ReactiveUI.XamForms/ReactiveSwitchCell.cs
+++ b/src/ReactiveUI.XamForms/ReactiveSwitchCell.cs
@@ -1,4 +1,8 @@
-﻿using ReactiveUI;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using ReactiveUI;
 using Xamarin.Forms;
 
 namespace ReactiveUI.XamForms

--- a/src/ReactiveUI.XamForms/ReactiveTabbedPage.cs
+++ b/src/ReactiveUI.XamForms/ReactiveTabbedPage.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using ReactiveUI;
 using Xamarin.Forms;
 

--- a/src/ReactiveUI.XamForms/ReactiveTextCell.cs
+++ b/src/ReactiveUI.XamForms/ReactiveTextCell.cs
@@ -1,4 +1,8 @@
-﻿using ReactiveUI;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using ReactiveUI;
 using Xamarin.Forms;
 
 namespace ReactiveUI.XamForms

--- a/src/ReactiveUI.XamForms/ReactiveUI.XamForms.licenseheader
+++ b/src/ReactiveUI.XamForms/ReactiveUI.XamForms.licenseheader
@@ -1,0 +1,12 @@
+﻿extensions: designer.cs generated.cs
+extensions: .cs .cpp .h
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+extensions:  .xml .config .xsd
+<!--
+Licensed to the .NET Foundation under one or more agreements.
+The .NET Foundation licenses this file to you under the MS-PL license.
+See the LICENSE file in the project root for more information.
+-->

--- a/src/ReactiveUI.XamForms/ReactiveViewCell.cs
+++ b/src/ReactiveUI.XamForms/ReactiveViewCell.cs
@@ -1,4 +1,8 @@
-﻿using ReactiveUI;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using ReactiveUI;
 using Xamarin.Forms;
 
 namespace ReactiveUI.XamForms

--- a/src/ReactiveUI.XamForms/Registrations.cs
+++ b/src/ReactiveUI.XamForms/Registrations.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;

--- a/src/ReactiveUI.XamForms/RoutedViewHost.cs
+++ b/src/ReactiveUI.XamForms/RoutedViewHost.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using Xamarin.Forms;
 using Splat;
 using ReactiveUI;

--- a/src/ReactiveUI.XamForms/ViewModelViewHost.cs
+++ b/src/ReactiveUI.XamForms/ViewModelViewHost.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Reactive.Linq;
 using Splat;

--- a/src/ReactiveUI/Activation.cs
+++ b/src/ReactiveUI/Activation.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reactive;

--- a/src/ReactiveUI/AutoPersistHelper.cs
+++ b/src/ReactiveUI/AutoPersistHelper.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;

--- a/src/ReactiveUI/BindingTypeConverters.cs
+++ b/src/ReactiveUI/BindingTypeConverters.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Diagnostics.Contracts;
 using System.Linq;

--- a/src/ReactiveUI/CollectionDebugView.cs
+++ b/src/ReactiveUI/CollectionDebugView.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/ReactiveUI/CommandBinding.cs
+++ b/src/ReactiveUI/CommandBinding.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reactive.Disposables;

--- a/src/ReactiveUI/CompatMixins.cs
+++ b/src/ReactiveUI/CompatMixins.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/ReactiveUI/ContractStubs.cs
+++ b/src/ReactiveUI/ContractStubs.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Specialized;
 

--- a/src/ReactiveUI/CreatesCommandBinding.cs
+++ b/src/ReactiveUI/CreatesCommandBinding.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/ReactiveUI/DisposableMixins.cs
+++ b/src/ReactiveUI/DisposableMixins.cs
@@ -1,4 +1,8 @@
-﻿namespace System.Reactive.Disposables
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Reactive.Disposables
 {
     public static class DisposableMixins
     {

--- a/src/ReactiveUI/ExpressionMixins.cs
+++ b/src/ReactiveUI/ExpressionMixins.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/ReactiveUI/ExpressionRewriter.cs
+++ b/src/ReactiveUI/ExpressionRewriter.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/ReactiveUI/IDependencyResolver.cs
+++ b/src/ReactiveUI/IDependencyResolver.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Linq;
 using System.Linq.Expressions;

--- a/src/ReactiveUI/INPCObservableForProperty.cs
+++ b/src/ReactiveUI/INPCObservableForProperty.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.ComponentModel;
 using System.Linq.Expressions;

--- a/src/ReactiveUI/IROObservableForProperty.cs
+++ b/src/ReactiveUI/IROObservableForProperty.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Linq.Expressions;
 using System.Reactive.Linq;

--- a/src/ReactiveUI/IReactiveObject.cs
+++ b/src/ReactiveUI/IReactiveObject.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;

--- a/src/ReactiveUI/Interactions.cs
+++ b/src/ReactiveUI/Interactions.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reactive;

--- a/src/ReactiveUI/Interfaces.cs
+++ b/src/ReactiveUI/Interfaces.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;

--- a/src/ReactiveUI/Legacy/Errors.cs
+++ b/src/ReactiveUI/Legacy/Errors.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/ReactiveUI/Legacy/ReactiveCommand.cs
+++ b/src/ReactiveUI/Legacy/ReactiveCommand.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Diagnostics.Contracts;
 using System.Linq;

--- a/src/ReactiveUI/LoggingMixins.cs
+++ b/src/ReactiveUI/LoggingMixins.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Reactive.Linq;
 using Splat;

--- a/src/ReactiveUI/MessageBus.cs
+++ b/src/ReactiveUI/MessageBus.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.Reactive.Concurrency;

--- a/src/ReactiveUI/ObservableAsPropertyHelper.cs
+++ b/src/ReactiveUI/ObservableAsPropertyHelper.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Diagnostics.Contracts;
 using System.Linq.Expressions;
 using System.Reactive.Concurrency;

--- a/src/ReactiveUI/Observables.cs
+++ b/src/ReactiveUI/Observables.cs
@@ -1,4 +1,8 @@
-﻿namespace System.Reactive.Linq
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Reactive.Linq
 {
     /// <summary>
     /// Provides commonly required, statically-allocated, pre-canned observables.

--- a/src/ReactiveUI/ObservedChangedMixin.cs
+++ b/src/ReactiveUI/ObservedChangedMixin.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Linq;
 using System.Linq.Expressions;

--- a/src/ReactiveUI/OrderedComparer.cs
+++ b/src/ReactiveUI/OrderedComparer.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 

--- a/src/ReactiveUI/POCOObservableForProperty.cs
+++ b/src/ReactiveUI/POCOObservableForProperty.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;

--- a/src/ReactiveUI/Platforms/android/AndroidCommandBinders.cs
+++ b/src/ReactiveUI/Platforms/android/AndroidCommandBinders.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Linq.Expressions;
 using System.Reflection;

--- a/src/ReactiveUI/Platforms/android/AndroidObservableForWidgets.cs
+++ b/src/ReactiveUI/Platforms/android/AndroidObservableForWidgets.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Linq;
 using System.Linq.Expressions;

--- a/src/ReactiveUI/Platforms/android/AndroidUIScheduler.cs
+++ b/src/ReactiveUI/Platforms/android/AndroidUIScheduler.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Linq;
 using System.Collections.Generic;

--- a/src/ReactiveUI/Platforms/android/AutoSuspendHelper.cs
+++ b/src/ReactiveUI/Platforms/android/AutoSuspendHelper.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Linq;
 using System.Reactive;

--- a/src/ReactiveUI/Platforms/android/BundleSuspensionDriver.cs
+++ b/src/ReactiveUI/Platforms/android/BundleSuspensionDriver.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Reactive;
 using System.Reactive.Linq;

--- a/src/ReactiveUI/Platforms/android/ContextExtensions.cs
+++ b/src/ReactiveUI/Platforms/android/ContextExtensions.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Reactive.Linq;
 using Android.Content;
 using Android.OS;

--- a/src/ReactiveUI/Platforms/android/ControlFetcherMixin.cs
+++ b/src/ReactiveUI/Platforms/android/ControlFetcherMixin.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/ReactiveUI/Platforms/android/FlexibleCommandBinder.cs
+++ b/src/ReactiveUI/Platforms/android/FlexibleCommandBinder.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/ReactiveUI/Platforms/android/LayoutViewHost.cs
+++ b/src/ReactiveUI/Platforms/android/LayoutViewHost.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Runtime.Serialization;
 using System.Reactive.Subjects;
 using System.Reactive.Concurrency;

--- a/src/ReactiveUI/Platforms/android/LinkerOverrides.cs
+++ b/src/ReactiveUI/Platforms/android/LinkerOverrides.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/ReactiveUI/Platforms/android/ObjectExtension.cs
+++ b/src/ReactiveUI/Platforms/android/ObjectExtension.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/ReactiveUI/Platforms/android/PlatformOperations.cs
+++ b/src/ReactiveUI/Platforms/android/PlatformOperations.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using Android.App;
 using Android.Content;

--- a/src/ReactiveUI/Platforms/android/ReactiveActivity.cs
+++ b/src/ReactiveUI/Platforms/android/ReactiveActivity.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/ReactiveUI/Platforms/android/ReactiveFragment.cs
+++ b/src/ReactiveUI/Platforms/android/ReactiveFragment.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/ReactiveUI/Platforms/android/ReactiveListAdapter.cs
+++ b/src/ReactiveUI/Platforms/android/ReactiveListAdapter.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.Reactive.Disposables;

--- a/src/ReactiveUI/Platforms/android/ReactivePreferenceActivity.cs
+++ b/src/ReactiveUI/Platforms/android/ReactivePreferenceActivity.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using Android.App;
 using Android.Content;
 using Android.Runtime;

--- a/src/ReactiveUI/Platforms/android/ReactivePreferenceFragment.cs
+++ b/src/ReactiveUI/Platforms/android/ReactivePreferenceFragment.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using Android.Runtime;
 using System.ComponentModel;
 using System.Reactive.Subjects;

--- a/src/ReactiveUI/Platforms/android/SharedPreferencesExtensions.cs
+++ b/src/ReactiveUI/Platforms/android/SharedPreferencesExtensions.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using Android.Content;

--- a/src/ReactiveUI/Platforms/android/UsbManagerExtensions.cs
+++ b/src/ReactiveUI/Platforms/android/UsbManagerExtensions.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using Android.App;

--- a/src/ReactiveUI/Platforms/android/ViewCommandExtensions.cs
+++ b/src/ReactiveUI/Platforms/android/ViewCommandExtensions.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/ReactiveUI/Platforms/apple-common/AutoLayoutViewModelViewHost.cs
+++ b/src/ReactiveUI/Platforms/apple-common/AutoLayoutViewModelViewHost.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 #if UIKIT
 using NSView = UIKit.UIView;

--- a/src/ReactiveUI/Platforms/apple-common/Buildsupport/Linker.xml
+++ b/src/ReactiveUI/Platforms/apple-common/Buildsupport/Linker.xml
@@ -1,4 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!--
+Licensed to the .NET Foundation under one or more agreements.
+The .NET Foundation licenses this file to you under the MS-PL license.
+See the LICENSE file in the project root for more information.
+-->
+
 <linker>
   <assembly fullname="System">
     <type fullname="System.ComponentModel.NullableConverter"></type>

--- a/src/ReactiveUI/Platforms/apple-common/Converters/DateTimeToNSDateConverter.cs
+++ b/src/ReactiveUI/Platforms/apple-common/Converters/DateTimeToNSDateConverter.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using Foundation;
 
 namespace ReactiveUI

--- a/src/ReactiveUI/Platforms/apple-common/IndexNormalizer.cs
+++ b/src/ReactiveUI/Platforms/apple-common/IndexNormalizer.cs
@@ -1,4 +1,8 @@
-﻿namespace ReactiveUI
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+namespace ReactiveUI
 {
     using System;
     using System.Collections.Generic;

--- a/src/ReactiveUI/Platforms/apple-common/JsonSuspensionDriver.cs
+++ b/src/ReactiveUI/Platforms/apple-common/JsonSuspensionDriver.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.IO;
 using System.Reactive;

--- a/src/ReactiveUI/Platforms/apple-common/KVOObservableForProperty.cs
+++ b/src/ReactiveUI/Platforms/apple-common/KVOObservableForProperty.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Linq;
 using System.Linq.Expressions;

--- a/src/ReactiveUI/Platforms/apple-common/NSRunloopScheduler.cs
+++ b/src/ReactiveUI/Platforms/apple-common/NSRunloopScheduler.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Reactive.Concurrency;
 using System.Reactive.Disposables;

--- a/src/ReactiveUI/Platforms/apple-common/PlatformOperations.cs
+++ b/src/ReactiveUI/Platforms/apple-common/PlatformOperations.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 namespace ReactiveUI
 {
     /// <summary>

--- a/src/ReactiveUI/Platforms/apple-common/ReactiveControl.cs
+++ b/src/ReactiveUI/Platforms/apple-common/ReactiveControl.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.ComponentModel;
 using System.Reactive;

--- a/src/ReactiveUI/Platforms/apple-common/ReactiveImageView.cs
+++ b/src/ReactiveUI/Platforms/apple-common/ReactiveImageView.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.ComponentModel;
 using System.Reactive;

--- a/src/ReactiveUI/Platforms/apple-common/ReactiveNSView.cs
+++ b/src/ReactiveUI/Platforms/apple-common/ReactiveNSView.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.ComponentModel;
 using System.Reactive;

--- a/src/ReactiveUI/Platforms/apple-common/ReactiveNSViewController.cs
+++ b/src/ReactiveUI/Platforms/apple-common/ReactiveNSViewController.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.ComponentModel;
 using System.Reactive;

--- a/src/ReactiveUI/Platforms/apple-common/ReactiveSplitViewController.cs
+++ b/src/ReactiveUI/Platforms/apple-common/ReactiveSplitViewController.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.ComponentModel;
 using System.Reactive;
 using System.Reactive.Subjects;

--- a/src/ReactiveUI/Platforms/apple-common/TargetActionCommandBinder.cs
+++ b/src/ReactiveUI/Platforms/apple-common/TargetActionCommandBinder.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Linq;
 using System.Reactive.Disposables;

--- a/src/ReactiveUI/Platforms/apple-common/ViewModelViewHost.cs
+++ b/src/ReactiveUI/Platforms/apple-common/ViewModelViewHost.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Reactive.Linq;
 using System.Reactive.Disposables;

--- a/src/ReactiveUI/Platforms/ios/AutoSuspendHelper.cs
+++ b/src/ReactiveUI/Platforms/ios/AutoSuspendHelper.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/ReactiveUI/Platforms/ios/CommonReactiveSource.cs
+++ b/src/ReactiveUI/Platforms/ios/CommonReactiveSource.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/ReactiveUI/Platforms/ios/FlexibleCommandBinder.cs
+++ b/src/ReactiveUI/Platforms/ios/FlexibleCommandBinder.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Reactive.Disposables;
 using System.Collections.Generic;

--- a/src/ReactiveUI/Platforms/ios/LinkerOverrides.cs
+++ b/src/ReactiveUI/Platforms/ios/LinkerOverrides.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using UIKit;
 

--- a/src/ReactiveUI/Platforms/ios/ReactiveCollectionReusableView.cs
+++ b/src/ReactiveUI/Platforms/ios/ReactiveCollectionReusableView.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.ComponentModel;
 using System.Reactive;
 using System.Reactive.Linq;

--- a/src/ReactiveUI/Platforms/ios/ReactiveCollectionView.cs
+++ b/src/ReactiveUI/Platforms/ios/ReactiveCollectionView.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.ComponentModel;
 using System.Reactive;
 using System.Reactive.Concurrency;

--- a/src/ReactiveUI/Platforms/ios/ReactiveCollectionViewCell.cs
+++ b/src/ReactiveUI/Platforms/ios/ReactiveCollectionViewCell.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.ComponentModel;
 using System.Reactive;

--- a/src/ReactiveUI/Platforms/ios/ReactiveCollectionViewController.cs
+++ b/src/ReactiveUI/Platforms/ios/ReactiveCollectionViewController.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.ComponentModel;
 using System.Reactive;

--- a/src/ReactiveUI/Platforms/ios/ReactiveCollectionViewSource.cs
+++ b/src/ReactiveUI/Platforms/ios/ReactiveCollectionViewSource.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;

--- a/src/ReactiveUI/Platforms/ios/ReactiveNavigationController.cs
+++ b/src/ReactiveUI/Platforms/ios/ReactiveNavigationController.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.ComponentModel;
 using System.Reactive;
 using System.Reactive.Subjects;

--- a/src/ReactiveUI/Platforms/ios/ReactivePageViewController.cs
+++ b/src/ReactiveUI/Platforms/ios/ReactivePageViewController.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.ComponentModel;
 using System.Reactive;
 using System.Reactive.Subjects;

--- a/src/ReactiveUI/Platforms/ios/ReactiveTabBarController.cs
+++ b/src/ReactiveUI/Platforms/ios/ReactiveTabBarController.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.ComponentModel;
 using System.Reactive;
 using System.Reactive.Subjects;

--- a/src/ReactiveUI/Platforms/ios/ReactiveTableView.cs
+++ b/src/ReactiveUI/Platforms/ios/ReactiveTableView.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.ComponentModel;
 using System.Reactive;
 using System.Reactive.Concurrency;

--- a/src/ReactiveUI/Platforms/ios/ReactiveTableViewCell.cs
+++ b/src/ReactiveUI/Platforms/ios/ReactiveTableViewCell.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.ComponentModel;
 using System.Reactive;

--- a/src/ReactiveUI/Platforms/ios/ReactiveTableViewController.cs
+++ b/src/ReactiveUI/Platforms/ios/ReactiveTableViewController.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.ComponentModel;
 using System.Reactive;

--- a/src/ReactiveUI/Platforms/ios/ReactiveTableViewSource.cs
+++ b/src/ReactiveUI/Platforms/ios/ReactiveTableViewSource.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;

--- a/src/ReactiveUI/Platforms/ios/RoutedViewHost.cs
+++ b/src/ReactiveUI/Platforms/ios/RoutedViewHost.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Reactive.Linq;
 using System.Collections.Specialized;

--- a/src/ReactiveUI/Platforms/ios/UIControlCommandExtensions.cs
+++ b/src/ReactiveUI/Platforms/ios/UIControlCommandExtensions.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Windows.Input;
 using System.Reactive.Disposables;

--- a/src/ReactiveUI/Platforms/ios/UIKitCommandBinders.cs
+++ b/src/ReactiveUI/Platforms/ios/UIKitCommandBinders.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Reflection;
 using UIKit;

--- a/src/ReactiveUI/Platforms/ios/UIKitObservableForProperty.cs
+++ b/src/ReactiveUI/Platforms/ios/UIKitObservableForProperty.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using UIKit;
 

--- a/src/ReactiveUI/Platforms/ios/UIKitObservableForPropertyBase.cs
+++ b/src/ReactiveUI/Platforms/ios/UIKitObservableForPropertyBase.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/ReactiveUI/Platforms/mac/AppKitAutoSuspendHelper.cs
+++ b/src/ReactiveUI/Platforms/mac/AppKitAutoSuspendHelper.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Reactive;
 using System.Reactive.Concurrency;

--- a/src/ReactiveUI/Platforms/mac/ReactiveNSWindowController.cs
+++ b/src/ReactiveUI/Platforms/mac/ReactiveNSWindowController.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.ComponentModel;
 using System.Reactive.Subjects;

--- a/src/ReactiveUI/Platforms/net45/ComponentModelTypeConverter.cs
+++ b/src/ReactiveUI/Platforms/net45/ComponentModelTypeConverter.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.ComponentModel;
 using Splat;

--- a/src/ReactiveUI/Platforms/netstandard1.1/PortableLibraryStubs.cs
+++ b/src/ReactiveUI/Platforms/netstandard1.1/PortableLibraryStubs.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/ReactiveUI/Platforms/shared/Registrations.cs
+++ b/src/ReactiveUI/Platforms/shared/Registrations.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Reactive.Concurrency;
 

--- a/src/ReactiveUI/Platforms/uap10.0/DependencyObjectObservableForProperty.cs
+++ b/src/ReactiveUI/Platforms/uap10.0/DependencyObjectObservableForProperty.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Linq;

--- a/src/ReactiveUI/Platforms/uap10.0/TransitioningContentControl.Empty.cs
+++ b/src/ReactiveUI/Platforms/uap10.0/TransitioningContentControl.Empty.cs
@@ -1,4 +1,8 @@
-﻿using Windows.UI.Xaml.Controls;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using Windows.UI.Xaml.Controls;
 
 namespace ReactiveUI
 {

--- a/src/ReactiveUI/Platforms/uap10.0/WinRTAppDataDriver.cs
+++ b/src/ReactiveUI/Platforms/uap10.0/WinRTAppDataDriver.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/ReactiveUI/Platforms/uap10.0/WinRTAutoSuspendApplication.cs
+++ b/src/ReactiveUI/Platforms/uap10.0/WinRTAutoSuspendApplication.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Linq;
 using System.Reactive;
 using System.Reactive.Disposables;

--- a/src/ReactiveUI/Platforms/windows-common/ActivationForViewFetcher.cs
+++ b/src/ReactiveUI/Platforms/windows-common/ActivationForViewFetcher.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Linq;
 using System.Reactive.Linq;
 using System.Windows;

--- a/src/ReactiveUI/Platforms/windows-common/AutoDataTemplateBindingHook.cs
+++ b/src/ReactiveUI/Platforms/windows-common/AutoDataTemplateBindingHook.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/ReactiveUI/Platforms/windows-common/BindingTypeConverters.cs
+++ b/src/ReactiveUI/Platforms/windows-common/BindingTypeConverters.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 #if NETFX_CORE
 using Windows.UI.Xaml;
 #else

--- a/src/ReactiveUI/Platforms/windows-common/PlatformOperations.cs
+++ b/src/ReactiveUI/Platforms/windows-common/PlatformOperations.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/ReactiveUI/Platforms/windows-common/ReactiveUserControl.cs
+++ b/src/ReactiveUI/Platforms/windows-common/ReactiveUserControl.cs
@@ -1,4 +1,8 @@
-﻿namespace ReactiveUI
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+namespace ReactiveUI
 {
 #if NETFX_CORE
     using Windows.UI.Xaml;

--- a/src/ReactiveUI/Platforms/windows-common/RoutedViewHost.cs
+++ b/src/ReactiveUI/Platforms/windows-common/RoutedViewHost.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.Reactive.Linq;
 using System.Linq;

--- a/src/ReactiveUI/Platforms/windows-common/ViewModelViewHost.cs
+++ b/src/ReactiveUI/Platforms/windows-common/ViewModelViewHost.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Reactive;
 using System.Reactive.Linq;

--- a/src/ReactiveUI/Platforms/xamarin-common/ComponentModelTypeConverter.cs
+++ b/src/ReactiveUI/Platforms/xamarin-common/ComponentModelTypeConverter.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.ComponentModel;
 using Splat;

--- a/src/ReactiveUI/Properties/AssemblyInfo.cs
+++ b/src/ReactiveUI/Properties/AssemblyInfo.cs
@@ -1,4 +1,8 @@
-﻿using System.Runtime.CompilerServices;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("ReactiveUI.Tests")]
 [assembly: InternalsVisibleTo("ReactiveUI.Winforms")]

--- a/src/ReactiveUI/PropertyBinding.cs
+++ b/src/ReactiveUI/PropertyBinding.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;

--- a/src/ReactiveUI/ReactiveBinding.cs
+++ b/src/ReactiveUI/ReactiveBinding.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/ReactiveUI/ReactiveCollectionMixins.cs
+++ b/src/ReactiveUI/ReactiveCollectionMixins.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;

--- a/src/ReactiveUI/ReactiveCommand.cs
+++ b/src/ReactiveUI/ReactiveCommand.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;

--- a/src/ReactiveUI/ReactiveList.cs
+++ b/src/ReactiveUI/ReactiveList.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections;
 using System.Reactive;

--- a/src/ReactiveUI/ReactiveNotifyPropertyChangedMixin.cs
+++ b/src/ReactiveUI/ReactiveNotifyPropertyChangedMixin.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;

--- a/src/ReactiveUI/ReactiveObject.cs
+++ b/src/ReactiveUI/ReactiveObject.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;

--- a/src/ReactiveUI/ReactiveUI.licenseheader
+++ b/src/ReactiveUI/ReactiveUI.licenseheader
@@ -1,0 +1,12 @@
+﻿extensions: designer.cs generated.cs
+extensions: .cs 
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+extensions:  .xml .config .xsd
+<!--
+Licensed to the .NET Foundation under one or more agreements.
+The .NET Foundation licenses this file to you under the MS-PL license.
+See the LICENSE file in the project root for more information.
+-->

--- a/src/ReactiveUI/RefcountDisposeWrapper.cs
+++ b/src/ReactiveUI/RefcountDisposeWrapper.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Threading;
 

--- a/src/ReactiveUI/Reflection.cs
+++ b/src/ReactiveUI/Reflection.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Linq;

--- a/src/ReactiveUI/RegisterableInterfaces.cs
+++ b/src/ReactiveUI/RegisterableInterfaces.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/ReactiveUI/Registrations.cs
+++ b/src/ReactiveUI/Registrations.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/ReactiveUI/RoutableViewModelMixin.cs
+++ b/src/ReactiveUI/RoutableViewModelMixin.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Reactive;
 using System.Reactive.Linq;

--- a/src/ReactiveUI/RoutingState.cs
+++ b/src/ReactiveUI/RoutingState.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Linq;
 using System.Reactive;

--- a/src/ReactiveUI/RxApp.cs
+++ b/src/ReactiveUI/RxApp.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Diagnostics;
 using System.Reactive;

--- a/src/ReactiveUI/ScheduledSubject.cs
+++ b/src/ReactiveUI/ScheduledSubject.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Reactive.Concurrency;
 using System.Reactive.Disposables;

--- a/src/ReactiveUI/SuspensionHost.cs
+++ b/src/ReactiveUI/SuspensionHost.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Reactive;
 using System.Reactive.Disposables;

--- a/src/ReactiveUI/UnhandledErrorException.cs
+++ b/src/ReactiveUI/UnhandledErrorException.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 
 namespace ReactiveUI
 {

--- a/src/ReactiveUI/VariadicTemplates.cs
+++ b/src/ReactiveUI/VariadicTemplates.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;

--- a/src/ReactiveUI/ViewAttributes.cs
+++ b/src/ReactiveUI/ViewAttributes.cs
@@ -1,4 +1,8 @@
-﻿namespace ReactiveUI
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+namespace ReactiveUI
 {
     using System;
 

--- a/src/ReactiveUI/ViewLocator.cs
+++ b/src/ReactiveUI/ViewLocator.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Reflection;
 using ReactiveUI;

--- a/src/ReactiveUI/WaitForDispatcherScheduler.cs
+++ b/src/ReactiveUI/WaitForDispatcherScheduler.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/ReactiveUI/WeakEventManager.cs
+++ b/src/ReactiveUI/WeakEventManager.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

housekeeping

**What is the current behavior? (You can also link to an open issue here)**

- No license headers

**What is the new behavior (if this is a feature change)?**

- Appropriate license headers added
- Each project has a `.licenseheader` file within the directory and if https://marketplace.visualstudio.com/items?itemName=StefanWenig.LicenseHeaderManager is installed all new files will automatically have the license added to the top.


**Does this PR introduce a breaking change?**

No

**Please check if the PR fulfills these requirements**
- [x] The commit follows our guidelines: https://github.com/reactiveui/reactiveui#contribute
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

