### PR TITLE
chore: use pre-release visual studio 2017 sdk to work around tooling issues

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 # configuration for "master" branch
 -
-  image: Visual Studio 2017
+  image: Visual Studio 2017 Preview
   branches:
       only:
         - master


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

chore

**What is the current behavior? (You can also link to an open issue here)**

Uses -stable virtual machine on AppVeyor

**What is the new behavior (if this is a feature change)?**

Uses -preview virtual machine on AppVeyor

**What might this PR break?**

No end user breaking changes, this affects where we compile from. @onovotny recommends going up to 2017 preview to obtain fixes for compiling project SDK packages. For a maintainer - I'd recommend creating a virtual machine for ReactiveUI development running VS2017 preview if you are going to get heavily involved with msbuild stuff. For simple PR's then you are a-okay staying with -stable.

**Please check if the PR fulfills these requirements**
- [ ] The commit follows our guidelines: https://github.com/reactiveui/reactiveui#contribute
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

