### PR TITLE
Add netcoreapp build

### DIFF
--- a/src/Directory.build.targets
+++ b/src/Directory.build.targets
@@ -18,6 +18,8 @@
   <PropertyGroup Condition="'$(TargetFramework)' == 'MonoAndroid70'">
     <DefineConstants>$(DefineConstants);MONO;ANDROID</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp1.0'">
+  </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'uap10.0' ">
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform " Version="5.2.2" />

--- a/src/ReactiveUI/Platforms/net45/PlatformRegistrations.cs
+++ b/src/ReactiveUI/Platforms/net45/PlatformRegistrations.cs
@@ -13,7 +13,7 @@ namespace ReactiveUI
         {
             registerFunction(() => new ComponentModelTypeConverter(), typeof(IBindingTypeConverter));
             RxApp.TaskpoolScheduler = TaskPoolScheduler.Default;
-            RxApp.MainThreadScheduler = new WaitForDispatcherScheduler(() => DispatcherScheduler.Current);
+            RxApp.MainThreadScheduler = DefaultScheduler.Instance;
         }
     }
 }

--- a/src/ReactiveUI/Platforms/netcoreapp1.0/PlatformRegistrations.cs
+++ b/src/ReactiveUI/Platforms/netcoreapp1.0/PlatformRegistrations.cs
@@ -12,6 +12,7 @@ namespace ReactiveUI
         public void Register(Action<Func<object>, Type> registerFunction)
         {
             RxApp.TaskpoolScheduler = TaskPoolScheduler.Default;
+            RxApp.MainThreadScheduler = DefaultScheduler.Instance;
         }
     }
 }

--- a/src/ReactiveUI/Platforms/netcoreapp1.0/PlatformRegistrations.cs
+++ b/src/ReactiveUI/Platforms/netcoreapp1.0/PlatformRegistrations.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Reactive.Concurrency;
+
+namespace ReactiveUI
+{
+    public class PlatformRegistrations : IWantsToRegisterStuff
+    {
+        public void Register(Action<Func<object>, Type> registerFunction)
+        {
+            RxApp.TaskpoolScheduler = TaskPoolScheduler.Default;
+        }
+    }
+}

--- a/src/ReactiveUI/ReactiveUI.csproj
+++ b/src/ReactiveUI/ReactiveUI.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.1;net45;uap10.0;Xamarin.iOS10;Xamarin.Mac20;MonoAndroid70</TargetFrameworks>
+    <TargetFrameworks>netstandard1.1;net45;uap10.0;Xamarin.iOS10;Xamarin.Mac20;MonoAndroid70;netcoreapp1.0</TargetFrameworks>
     <AssemblyName>ReactiveUI</AssemblyName>
     <RootNamespace>ReactiveUI</RootNamespace>
     <Description>A MVVM framework that integrates with the Reactive Extensions for .NET to create elegant, testable User Interfaces that run on any mobile or desktop platform. Supports Xamarin.iOS, Xamarin.Android, Xamarin.Mac, Xamarin Forms, WPF, Windows Forms, Windows Phone 8.1, Windows Store and Universal Windows Platform (UWP).</Description>
@@ -51,7 +51,11 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'MonoAndroid70' ">
     <Compile Include="Platforms\android\**\*.cs" />
     <Compile Include="Platforms\xamarin-common\**\*.cs" />
-  </ItemGroup>  
+  </ItemGroup>
+  
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
+    <Compile Include="Platforms\netcoreapp1.0\**\*.cs" />
+  </ItemGroup>
   
   <ItemGroup>
     <None Update="VariadicTemplates.tt" Generator="TextTemplatingFileGenerator" LastGenOutput="VariadicTemplates.cs" />


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Support for a .NET Core non-crashing build.


**What is the current behavior? (You can also link to an open issue here)**
Any .NET Core usage of ReactiveUI will crash.


**What is the new behavior (if this is a feature change)?**
A .NET Core build will not crash upon load. The user must supply a scheduler for the `RxApp.MainThreadScheduler` depending on their platform.


**What might this PR break?**
Nothing.


**Please check if the PR fulfills these requirements**
- [x] The commit follows our guidelines: https://github.com/reactiveui/reactiveui#contribute
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

Fixes #1417 
