### PR TITLE
chore: cull Splat methods that were never removed

### DIFF
--- a/src/ReactiveUI/IDependencyResolver.cs
+++ b/src/ReactiveUI/IDependencyResolver.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
@@ -13,8 +13,8 @@ namespace ReactiveUI
     public static class DependencyResolverMixins
     {
         /// <summary>
-        /// This method allows you to initialize resolvers with the default 
-        /// ReactiveUI types. All resolvers used as the default 
+        /// This method allows you to initialize resolvers with the default
+        /// ReactiveUI types. All resolvers used as the default
         /// Locator.Current
         /// </summary>
         /// <param name="resolver">The resolver to initialize.</param>
@@ -57,16 +57,6 @@ namespace ReactiveUI
                     registerType(resolver, ti, ivf, contract);
                 }
             }
-        }
-
-        public static void Register<TService>(this IMutableDependencyResolver resolver, Func<object> factory, string contract = null)
-        {
-            resolver.Register(factory, typeof(TService), contract);
-        }
-
-        public static void RegisterConstant<TService>(this IMutableDependencyResolver resolver, TService value, string contract = null)
-        {
-            resolver.RegisterConstant(value, typeof(TService), contract);
         }
 
         static void registerType(IMutableDependencyResolver resolver, TypeInfo ti, Type serviceType, string contract)


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

chore

**What is the current behavior? (You can also link to an open issue here)**

Registration methods were duplicated in ReactiveUI and Splat.

**What is the new behavior (if this is a feature change)?**

Remove the duplicate methods from ReactiveUI.

**What might this PR break?**

People who explicitly used the RxUI methods. They should just use the Splat ones instead.

**Please check if the PR fulfills these requirements**
- [ ] The commit follows our guidelines: https://github.com/reactiveui/reactiveui#contribute
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

