### PR TITLE
resolve red builds on the develop branch after VS2017 15.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ artifacts/
 *.pidb
 *.svclog
 *.scc
+*.binlog
 
 # Chutzpah Test files
 _Chutzpah*

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 # configuration for "master" branch
 -
-  image: Visual Studio 2017 Preview
+  image: Visual Studio 2017
   branches:
       only:
         - master
@@ -33,7 +33,7 @@
   
 # configuration for "develop" branch
 -
-  image: Visual Studio 2017 Preview
+  image: Visual Studio 2017
   branches:
       except:
           - master

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,6 +37,7 @@
   artifacts:
   - path: artifacts/*.nupkg
   - path: '**/bin/*'
+  - path: '**/*.binlog'
   - path: src/ReactiveUI.**/Events_*.cs
   test: off
   
@@ -77,6 +78,7 @@
   artifacts:
   - path: artifacts/*.nupkg
   - path: '**/bin/*'
+  - path: '**/*.binlog'
   - path: src/ReactiveUI.**/Events_*.cs
   test: off
   on_finish:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,18 +16,18 @@
     NUGET_APIKEY:
       secure: cANUegIQhgeZ7Yg4sosXNGmFF33i77nTriEjaeniQ4S26btcwYsopOO3qXKlbrvf
   init:
-  - mkdir %ANDROID_HOME%"
-  - cd "%ANDROID_HOME%"
-  - appveyor DownloadFile "https://dl.google.com/android/repository/tools_r25.2.3-windows.zip"
-  - 7z x "tools_r25.2.3-windows.zip" > nul
+  #- mkdir %ANDROID_HOME%"
+  #- cd "%ANDROID_HOME%"
+  #- appveyor DownloadFile "https://dl.google.com/android/repository/tools_r25.2.3-windows.zip"
+  #- 7z x "tools_r25.2.3-windows.zip" > nul
   - cd "C:\projects\reactiveui"
   install: 
-  - echo y | "%ANDROID_HOME%\tools\android.bat" update sdk -u -a -t tools
-  - echo y | "%ANDROID_HOME%\tools\android.bat" update sdk -u -a -t platform-tools
-  - echo y | "%ANDROID_HOME%\tools\android.bat" update sdk -u -a -t build-tools-25.0.2
-  - echo y | "%ANDROID_HOME%\tools\android.bat" update sdk -u -a -t android-25
-  - echo y | "%ANDROID_HOME%\tools\android.bat" update sdk -u -a -t extra-google-m2repository
-  - echo y | "%ANDROID_HOME%\tools\android.bat" update sdk -u -a -t extra-android-m2repository
+  #- echo y | "%ANDROID_HOME%\tools\android.bat" update sdk -u -a -t tools
+  #- echo y | "%ANDROID_HOME%\tools\android.bat" update sdk -u -a -t platform-tools
+  #- echo y | "%ANDROID_HOME%\tools\android.bat" update sdk -u -a -t build-tools-25.0.2
+  #- echo y | "%ANDROID_HOME%\tools\android.bat" update sdk -u -a -t android-25
+  #- echo y | "%ANDROID_HOME%\tools\android.bat" update sdk -u -a -t extra-google-m2repository
+  #- echo y | "%ANDROID_HOME%\tools\android.bat" update sdk -u -a -t extra-android-m2repository
   build_script:
   - ./build.cmd
   cache:
@@ -35,9 +35,9 @@
   - src\packages -> **\packages.config
   - '%USERPROFILE%\.nuget\packages -> **\project.json'
   artifacts:
-  - path: artifacts/*
+  - path: artifacts/*.nupkg
   - path: '**/bin/*'
-  - path: src/ReactiveUI.Events/Events_*.cs
+  - path: src/ReactiveUI.**/Events_*.cs
   test: off
   
 # configuration for "develop" branch
@@ -55,19 +55,19 @@
     NUGET_APIKEY:
       secure: KTszzEEs33kbeqkpGGMvM58elvNLeTJhytpv7s9fPHoY4ZZmk5fMwofKDtK2lhno
   init:
-  - mkdir %ANDROID_HOME%"
-  - cd "%ANDROID_HOME%"
-  - appveyor DownloadFile "https://dl.google.com/android/repository/tools_r25.2.3-windows.zip"
-  - 7z x "tools_r25.2.3-windows.zip" > nul
+  #- mkdir %ANDROID_HOME%"
+  #- cd "%ANDROID_HOME%"
+  #- appveyor DownloadFile "https://dl.google.com/android/repository/tools_r25.2.3-windows.zip"
+  #- 7z x "tools_r25.2.3-windows.zip" > nul
   - cd "C:\projects\reactiveui"
   - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
   install: 
-  - echo y | "%ANDROID_HOME%\tools\android.bat" update sdk -u -a -t tools
-  - echo y | "%ANDROID_HOME%\tools\android.bat" update sdk -u -a -t platform-tools
-  - echo y | "%ANDROID_HOME%\tools\android.bat" update sdk -u -a -t build-tools-25.0.2
-  - echo y | "%ANDROID_HOME%\tools\android.bat" update sdk -u -a -t android-25
-  - echo y | "%ANDROID_HOME%\tools\android.bat" update sdk -u -a -t extra-google-m2repository
-  - echo y | "%ANDROID_HOME%\tools\android.bat" update sdk -u -a -t extra-android-m2repository
+  #- echo y | "%ANDROID_HOME%\tools\android.bat" update sdk -u -a -t tools
+  #- echo y | "%ANDROID_HOME%\tools\android.bat" update sdk -u -a -t platform-tools
+  #- echo y | "%ANDROID_HOME%\tools\android.bat" update sdk -u -a -t build-tools-25.0.2
+  #- echo y | "%ANDROID_HOME%\tools\android.bat" update sdk -u -a -t android-25
+  #- echo y | "%ANDROID_HOME%\tools\android.bat" update sdk -u -a -t extra-google-m2repository
+  #- echo y | "%ANDROID_HOME%\tools\android.bat" update sdk -u -a -t extra-android-m2repository
   build_script:
   - ./build.cmd
   cache:
@@ -75,9 +75,9 @@
   - src\packages -> **\packages.config
   - '%USERPROFILE%\.nuget\packages -> **\project.json'
   artifacts:
-  - path: artifacts/*
+  - path: artifacts/*.nupkg
   - path: '**/bin/*'
-  - path: src/ReactiveUI.Events/Events_*.cs
+  - path: src/ReactiveUI.**/Events_*.cs
   test: off
   on_finish:
   - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -60,6 +60,7 @@
   - appveyor DownloadFile "https://dl.google.com/android/repository/tools_r25.2.3-windows.zip"
   - 7z x "tools_r25.2.3-windows.zip" > nul
   - cd "C:\projects\reactiveui"
+  - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
   install: 
   - echo y | "%ANDROID_HOME%\tools\android.bat" update sdk -u -a -t tools
   - echo y | "%ANDROID_HOME%\tools\android.bat" update sdk -u -a -t platform-tools
@@ -78,3 +79,5 @@
   - path: '**/bin/*'
   - path: src/ReactiveUI.Events/Events_*.cs
   test: off
+  on_finish:
+  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -60,7 +60,6 @@
   - appveyor DownloadFile "https://dl.google.com/android/repository/tools_r25.2.3-windows.zip"
   - 7z x "tools_r25.2.3-windows.zip" > nul
   - cd "C:\projects\reactiveui"
-  - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
   install: 
   - echo y | "%ANDROID_HOME%\tools\android.bat" update sdk -u -a -t tools
   - echo y | "%ANDROID_HOME%\tools\android.bat" update sdk -u -a -t platform-tools
@@ -79,5 +78,3 @@
   - path: '**/bin/*'
   - path: src/ReactiveUI.Events/Events_*.cs
   test: off
-  on_finish:
-  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,18 +16,8 @@
     NUGET_APIKEY:
       secure: cANUegIQhgeZ7Yg4sosXNGmFF33i77nTriEjaeniQ4S26btcwYsopOO3qXKlbrvf
   init:
-  #- mkdir %ANDROID_HOME%"
-  #- cd "%ANDROID_HOME%"
-  #- appveyor DownloadFile "https://dl.google.com/android/repository/tools_r25.2.3-windows.zip"
-  #- 7z x "tools_r25.2.3-windows.zip" > nul
   - cd "C:\projects\reactiveui"
   install: 
-  #- echo y | "%ANDROID_HOME%\tools\android.bat" update sdk -u -a -t tools
-  #- echo y | "%ANDROID_HOME%\tools\android.bat" update sdk -u -a -t platform-tools
-  #- echo y | "%ANDROID_HOME%\tools\android.bat" update sdk -u -a -t build-tools-25.0.2
-  #- echo y | "%ANDROID_HOME%\tools\android.bat" update sdk -u -a -t android-25
-  #- echo y | "%ANDROID_HOME%\tools\android.bat" update sdk -u -a -t extra-google-m2repository
-  #- echo y | "%ANDROID_HOME%\tools\android.bat" update sdk -u -a -t extra-android-m2repository
   build_script:
   - ./build.cmd
   cache:
@@ -56,19 +46,8 @@
     NUGET_APIKEY:
       secure: KTszzEEs33kbeqkpGGMvM58elvNLeTJhytpv7s9fPHoY4ZZmk5fMwofKDtK2lhno
   init:
-  #- mkdir %ANDROID_HOME%"
-  #- cd "%ANDROID_HOME%"
-  #- appveyor DownloadFile "https://dl.google.com/android/repository/tools_r25.2.3-windows.zip"
-  #- 7z x "tools_r25.2.3-windows.zip" > nul
   - cd "C:\projects\reactiveui"
-  - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
   install: 
-  #- echo y | "%ANDROID_HOME%\tools\android.bat" update sdk -u -a -t tools
-  #- echo y | "%ANDROID_HOME%\tools\android.bat" update sdk -u -a -t platform-tools
-  #- echo y | "%ANDROID_HOME%\tools\android.bat" update sdk -u -a -t build-tools-25.0.2
-  #- echo y | "%ANDROID_HOME%\tools\android.bat" update sdk -u -a -t android-25
-  #- echo y | "%ANDROID_HOME%\tools\android.bat" update sdk -u -a -t extra-google-m2repository
-  #- echo y | "%ANDROID_HOME%\tools\android.bat" update sdk -u -a -t extra-android-m2repository
   build_script:
   - ./build.cmd
   cache:
@@ -81,5 +60,3 @@
   - path: '**/*.binlog'
   - path: src/ReactiveUI.**/Events_*.cs
   test: off
-  on_finish:
-  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 # configuration for "master" branch
 -
-  image: Visual Studio 2017
+  image: Visual Studio 2017 Preview
   branches:
       only:
         - master
@@ -42,7 +42,7 @@
   
 # configuration for "develop" branch
 -
-  image: Visual Studio 2017
+  image: Visual Studio 2017 Preview
   branches:
       except:
           - master

--- a/build.cake
+++ b/build.cake
@@ -212,7 +212,7 @@ Task("BuildReactiveUI")
                 ToolPath = msBuildPath,
                 ArgumentCustomization = args => args.Append("/bl:reactiveui.binlog")
             }
-            .WithTarget("restore;pack")
+            .WithTarget("restore;build;pack")
             .WithProperty("PackageOutputPath",  MakeAbsolute(Directory(artifactDirectory)).ToString())
             .WithProperty("TreatWarningsAsErrors", treatWarningsAsErrors.ToString())
             .SetConfiguration("Release")

--- a/build.cake
+++ b/build.cake
@@ -125,7 +125,11 @@ Task("BuildEventBuilder")
 
     NuGetRestore(solution, new NuGetRestoreSettings() { ConfigFile = "./src/.nuget/NuGet.config" });
 
-    MSBuild(solution, new MSBuildSettings()
+    FilePath msBuildPath = VSWhereLatest().CombineWithFilePath("./MSBuild/15.0/Bin/MSBuild.exe");
+
+    MSBuild(solution, new MSBuildSettings() {
+            ToolPath = msBuildPath
+        }
         .SetConfiguration("Release")
         .WithProperty("TreatWarningsAsErrors", treatWarningsAsErrors.ToString())
         .SetVerbosity(Verbosity.Minimal)
@@ -201,11 +205,11 @@ Task("BuildReactiveUI")
     Action<string> build = (solution) =>
     {
         Information("Building {0}", solution);
-
+    
         FilePath msBuildPath = VSWhereLatest().CombineWithFilePath("./MSBuild/15.0/Bin/MSBuild.exe");
 
         MSBuild(solution, new MSBuildSettings() {
-                ToolPath= msBuildPath
+                ToolPath = msBuildPath
             }
             .WithTarget("restore;pack")
             .WithProperty("PackageOutputPath",  MakeAbsolute(Directory(artifactDirectory)).ToString())

--- a/build.cake
+++ b/build.cake
@@ -51,6 +51,8 @@ var githubOwner = "reactiveui";
 var githubRepository = "reactiveui";
 var githubUrl = string.Format("https://github.com/{0}/{1}", githubOwner, githubRepository);
 
+var msBuildPath = VSWhereLatest().CombineWithFilePath("./MSBuild/15.0/Bin/MSBuild.exe");
+
 // Version
 var gitVersion = GitVersion();
 var majorMinorPatch = gitVersion.MajorMinorPatch;
@@ -122,10 +124,10 @@ Task("BuildEventBuilder")
     .Does (() =>
 {
     var solution = "./src/EventBuilder.sln";
+    Information("Building {0} using {1}", solution, msBuildPath);
 
     NuGetRestore(solution, new NuGetRestoreSettings() { ConfigFile = "./src/.nuget/NuGet.config" });
 
-    FilePath msBuildPath = VSWhereLatest().CombineWithFilePath("./MSBuild/15.0/Bin/MSBuild.exe");
 
     MSBuild(solution, new MSBuildSettings() {
             ToolPath = msBuildPath
@@ -204,9 +206,7 @@ Task("BuildReactiveUI")
 {
     Action<string> build = (solution) =>
     {
-        Information("Building {0}", solution);
-    
-        FilePath msBuildPath = VSWhereLatest().CombineWithFilePath("./MSBuild/15.0/Bin/MSBuild.exe");
+        Information("Building {0} using {1}", solution, msBuildPath);
 
         MSBuild(solution, new MSBuildSettings() {
                 ToolPath = msBuildPath

--- a/build.cake
+++ b/build.cake
@@ -128,9 +128,9 @@ Task("BuildEventBuilder")
 
     NuGetRestore(solution, new NuGetRestoreSettings() { ConfigFile = "./src/.nuget/NuGet.config" });
 
-
     MSBuild(solution, new MSBuildSettings() {
-            ToolPath = msBuildPath
+            ToolPath = msBuildPath,
+            ArgumentCustomization = args => args.Append("/bl:eventbuilder.binlog")
         }
         .SetConfiguration("Release")
         .WithProperty("TreatWarningsAsErrors", treatWarningsAsErrors.ToString())
@@ -209,7 +209,8 @@ Task("BuildReactiveUI")
         Information("Building {0} using {1}", solution, msBuildPath);
 
         MSBuild(solution, new MSBuildSettings() {
-                ToolPath = msBuildPath
+                ToolPath = msBuildPath,
+                ArgumentCustomization = args => args.Append("/bl:reactiveui.binlog")
             }
             .WithTarget("restore;pack")
             .WithProperty("PackageOutputPath",  MakeAbsolute(Directory(artifactDirectory)).ToString())

--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -18,7 +18,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.0.1" PrivateAssets="All" />
+    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.0.6" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(IsTestProject)' != 'true' and '$(SourceLinkEnabled)' != 'false'">


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Fix for #1420

**What is the current behavior? (You can also link to an open issue here)**
Appveyor is old version


**What is the new behavior (if this is a feature change)?**
Appveyor is preview builds


**What might this PR break?**
Hopefully nothing


**Please check if the PR fulfills these requirements**
- [ ] The commit follows our guidelines: https://github.com/reactiveui/reactiveui#contribute
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
Have raised a ticket on Cake, as the VSWhere tool we're using doesn't currently include pre-release builds, so VS can't find what it's doing. The build is falling back to MSBuild 14, which doesn't support new csprojs, hence breaking the build.

Cake ticket https://github.com/cake-build/cake/issues/1754, notes on vswhere prerelease flag https://blogs.msdn.microsoft.com/heaths/2017/06/24/vswhere-version-2-0-released/
