### PR TITLE
housekeeping: ignore cla github labels otherwise release will break

### DIFF
--- a/GitReleaseManager.yaml
+++ b/GitReleaseManager.yaml
@@ -25,6 +25,10 @@ issue-labels-include:
 - documentation
 issue-labels-exclude:
 - Build
+- cla-already-signed
+- cla-not-required
+- cla-required
+- cla-signed
 issue-labels-alias:
     - name:    reactiveui-core
       header:  All Platforms


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

housekeeping

**What is the current behavior? (You can also link to an open issue here)**

DNF labels would cause GRM to fail/we would not be able to release.

**What is the new behavior (if this is a feature change)?**

Ignore all DNF labels 

**What might this PR break?**

This will unbreak the release of v8.0.0; haven't discovered this yet because no releases have been done since joining the .NET foundation. GRM has a limitation (https://github.com/GitTools/GitReleaseManager/issues/90) where an issue can only belong to one label.

**Please check if the PR fulfills these requirements**
- [x] The commit follows our guidelines: https://github.com/reactiveui/reactiveui#contribute
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

