### PR TITLE
housekeeping: automatically close stale github issues in a friendly way

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,25 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 60
+
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - up-for-grabs
+  - starters
+  - bug
+  - cla-signed
+  - cla-already-signed
+
+# Label to use when marking an issue as stale
+staleLabel: waiting-for-response-or-contribution
+
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. We do this because it helps reduce the workload of our extremely busy maintainers. If you want this issue progressed faster please start talks with a maintainer with how you can help out. 
+  
+  There are so many ways to contribute to open-source and the most valued are often not code related. We are always looking for more help and look after those who stick around. Say howdy to one of the maintainers or browse https://reactiveui.net/contribute/ for ideas on where to start your journey.
+
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

housekeeping feature

**What is the current behavior? (You can also link to an open issue here)**

GitHub issues (inc pull-requests) linger causing maintainer and user frustration.

**What is the new behavior (if this is a feature change)?**

A friendly robot automatically closes out issues which have no activity and reminds people that if they want the issue progressed then the best way to progress it is to ask a maintainer how. 

```
# Number of days of inactivity before an issue becomes stale
daysUntilStale: 60

# Number of days of inactivity before a stale issue is closed
daysUntilClose: 7

# Issues with these labels will never be considered stale
exemptLabels:
  - up-for-grabs
  - starters
  - bug
  - cla-signed
  - cla-already-signed
```

**What might this PR break?**

All GitHub issues (inc PR) that are older than 60 days of inactivity will need a bump of human activity within seven days of the notification otherwise the GitHub issue will be closed automatically. We have a quite a few open GitHub issues which match this criteria so there will be a little bit of noise initially but in doing so the maintainers will learn more about the needs of contributors/users of ReactiveUI. For those that have open-pull requests that have yet to be attended to - we are sorry; the guilt is real. Let us know if your contribution is still applicable and we will try to do better by you. Thank-you for your contributions.

