### PR TITLE
core: make ViewContractAttribute.Contract public

### DIFF
--- a/src/ReactiveUI/ViewAttributes.cs
+++ b/src/ReactiveUI/ViewAttributes.cs
@@ -24,7 +24,7 @@ namespace ReactiveUI
             Contract = contract;
         }
 
-        internal string Contract { get; }
+        public string Contract { get; }
     }
 
     /// <summary>


### PR DESCRIPTION
The ViewContractAttribute.Contract property is currently internal but to build a custom service locator, which supports view contract attribute, we need access to it.