### PR TITLE
housekeeping: ¯\_(ツ)_/¯ and proposal labels won't be autoclosed

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -11,6 +11,8 @@ exemptLabels:
   - bug
   - cla-signed
   - cla-already-signed
+  - proposal
+  - ¯\_(ツ)_/¯
 
 # Label to use when marking an issue as stale
 staleLabel: waiting-for-response-or-contribution


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

More options when triaging

**What is the current behavior? (You can also link to an open issue here)**

See `.github/stale.yml` for current.

**What is the new behavior (if this is a feature change)?**

- Often I find myself doing triage and I just don't know (`¯\_(ツ)_/¯`) what to do with it but think the issue should be addressed. If you come across a `¯\_(ツ)_/¯` then that's an opportunity to help me and the other maintainers out. 

- `bug` now means an actual verified bug with an attached test case w/implicit understanding for maintainers (or community - yes please) should PR it. 

- There's sometimes long running discussions the maintainers want to have with a community - an proposal. 

**What might this PR break?**

If `¯\_(ツ)_/¯` is invalid for probot then it might not run. Easy to backout change if it stumbles.

**Please check if the PR fulfills these requirements**
- [ ] The commit follows our guidelines: https://github.com/reactiveui/reactiveui#contribute
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

