### PR TITLE
fix: restrict system.reactive to 3.1.1 as min but never 4.x series

### DIFF
--- a/src/ReactiveUI.AndroidSupport/ReactiveUI.AndroidSupport.csproj
+++ b/src/ReactiveUI.AndroidSupport/ReactiveUI.AndroidSupport.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Xamarin.Android.Support.v7.RecyclerView" Version="25.1.1" />
     <PackageReference Include="Xamarin.Android.Support.Vector.Drawable" Version="25.1.1" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
-    <PackageReference Include="System.Reactive" Version="3.1.0" />
+    <PackageReference Include="System.Reactive" Version="[3.1.1,4)" />
     <PackageReference Include="Splat" Version="2.0.0" />
   </ItemGroup>
   

--- a/src/ReactiveUI.Blend/ReactiveUI.Blend.csproj
+++ b/src/ReactiveUI.Blend/ReactiveUI.Blend.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <Compile Remove="Platforms\**\*.cs" />
     <None Include="Platforms\**\*.cs" />
-    <PackageReference Include="System.Reactive" Version="3.1.0" />
+    <PackageReference Include="System.Reactive" Version="[3.1.1,4)" />
     <PackageReference Include="Splat" Version="2.0.0" />
   </ItemGroup>
 

--- a/src/ReactiveUI.Events.WPF/ReactiveUI.Events.WPF.csproj
+++ b/src/ReactiveUI.Events.WPF/ReactiveUI.Events.WPF.csproj
@@ -11,7 +11,7 @@
     <Compile Remove="*.cs" />
     <None Include="*.cs" />
     <Compile Include="../ReactiveUI.Events/SingleAwaitSubject.cs" />
-    <PackageReference Include="System.Reactive" Version="3.1.0" />
+    <PackageReference Include="System.Reactive" Version="[3.1.1,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ReactiveUI.Events.XamForms/ReactiveUI.Events.XamForms.csproj
+++ b/src/ReactiveUI.Events.XamForms/ReactiveUI.Events.XamForms.csproj
@@ -14,7 +14,7 @@
     <Compile Remove="*.cs" />
     <None Include="*.cs" />
     <Compile Include="../ReactiveUI.Events/SingleAwaitSubject.cs" />
-    <PackageReference Include="System.Reactive" Version="3.1.0" />
+    <PackageReference Include="System.Reactive" Version="[3.1.1,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ReactiveUI.Events/ReactiveUI.Events.csproj
+++ b/src/ReactiveUI.Events/ReactiveUI.Events.csproj
@@ -11,7 +11,7 @@
     <Compile Remove="*.cs" />
     <None Include="*.cs" />
     <Compile Include="SingleAwaitSubject.cs" />
-    <PackageReference Include="System.Reactive" Version="3.1.0" />
+    <PackageReference Include="System.Reactive" Version="[3.1.1,4)" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'uap10.0' ">

--- a/src/ReactiveUI.Testing/ReactiveUI.Testing.csproj
+++ b/src/ReactiveUI.Testing/ReactiveUI.Testing.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Reactive.Testing" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Reactive.Testing" Version="[3.1.1,4)" />
     <ProjectReference Include="..\ReactiveUI\ReactiveUI.csproj" />
   </ItemGroup>
 

--- a/src/ReactiveUI/ReactiveUI.csproj
+++ b/src/ReactiveUI/ReactiveUI.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <Compile Remove="Platforms\**\*.cs" />
     <None Include="Platforms\**\*.cs" />
-    <PackageReference Include="System.Reactive" Version="3.1.0" />
+    <PackageReference Include="System.Reactive" Version="[3.1.1,4)" />
     <PackageReference Include="Splat" Version="2.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

bug fix

**What is the current behavior? (You can also link to an open issue here)**

Blocked by https://github.com/NuGet/Home/issues/5751


**What is the new behavior (if this is a feature change)?**

Fixes #1413 by bypassing NuGet issue @ https://github.com/NuGet/Home/issues/5751

**What might this PR break?**

Use https://docs.microsoft.com/en-us/nuget/reference/package-versioning when reviewing

**Please check if the PR fulfills these requirements**
- [ ] The commit follows our guidelines: https://github.com/reactiveui/reactiveui#contribute
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

System.Reactive v4.x and NuGet.exe needs more time to mature. We can remove these restrictions as a point release at a later point in time. Dynamic data is currently using `3.1.1` as min but is not clamped @RolandPheasant I strongly recommend that you do the same changes. Similar changes will be applied to Akavache, Refit, Punchclock, etc.
