### PR TITLE
fix: set UWP min version to 10.0.10586.0

### DIFF
--- a/src/Directory.build.targets
+++ b/src/Directory.build.targets
@@ -8,6 +8,7 @@
   <PropertyGroup Condition="'$(TargetFramework)' == 'uap10.0'">
     <DefineConstants>$(DefineConstants);NETFX_CORE;XAML;WINDOWS_UWP</DefineConstants>
     <TargetPlatformVersion>10.0.14393.0</TargetPlatformVersion>
+    <TargetPlatformMinVersion>10.0.10586.0</TargetPlatformMinVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'Xamarin.iOS10'">
     <DefineConstants>$(DefineConstants);MONO;UIKIT;COCOA</DefineConstants>


### PR DESCRIPTION
**Do you want to request a *feature* or report a *bug*?**

Bug

**What is the current behavior?**

> In this you have the TargetPlatformVersion, but you also probably want to specify the TargetPlatformMinVersion. It defaults to 10.0.10240.0...and that version isn't even in support anymore :)

https://github.com/reactiveui/ReactiveUI/blob/ece4833e2712048851ac01e7b6285fd33681ebeb/src/Directory.build.targets#L10

**If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem**

See https://github.com/akavache/Akavache/issues/370

**What is the expected behavior?**

See https://github.com/akavache/Akavache/issues/370

**What is the motivation / use case for changing the behavior?**

See https://github.com/akavache/Akavache/issues/370