### PR TITLE
fix: added netstandard 1.1 build and added system.reactive references

### DIFF
--- a/src/ReactiveUI.Testing/ReactiveUI.Testing.csproj
+++ b/src/ReactiveUI.Testing/ReactiveUI.Testing.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;uap10.0;Xamarin.iOS10;Xamarin.Mac20;MonoAndroid70</TargetFrameworks>
+    <TargetFrameworks>netstandard1.1;net45;uap10.0;Xamarin.iOS10;Xamarin.Mac20;MonoAndroid70</TargetFrameworks>
     <AssemblyName>ReactiveUI.Testing</AssemblyName>
     <RootNamespace>ReactiveUI.Testing</RootNamespace>
     <Description>A library to aid in writing unit tests for ReactiveUI projects</Description>

--- a/src/ReactiveUI.Tests/ReactiveUI.Tests.csproj
+++ b/src/ReactiveUI.Tests/ReactiveUI.Tests.csproj
@@ -13,6 +13,8 @@
     <PackageReference Include="xunit.runner.console" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <PackageReference Include="Xunit.StaFact" Version="0.2.3-beta" />
+    <PackageReference Include="System.Reactive" Version="[3.1.1,4)" />
+    <PackageReference Include="Microsoft.Reactive.Testing" Version="[3.1.1,4)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Fixes #1340 
Fixes #1370 (this PR supersedes that one)

**What is the current behavior? (You can also link to an open issue here)**

`reactiveui-testing` does not have a netstandard build.

**What is the new behavior (if this is a feature change)?**

We now have a `netstandard1.1` build (as well as all the other existing builds)

**Does this PR introduce a breaking change?**

No.

**Please check if the PR fulfills these requirements**
- [X] The commit follows our guidelines: https://github.com/reactiveui/reactiveui#contribute
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

In #1370 Kent attempted to replace all platforms a single netstandard target but we couldn't get it working. I had to keep keep all the other platforms otherwise system.reactive.interfaces blows up when installed into net45. NuGet resolved 3.0.0 when I specifically have 3.1.1 listed. Ugh.
