### PR TITLE
Remove build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-mono tools/nuget/nuget.exe update -self
-mono tools/nuget/nuget.exe install xunit.runner.console -OutputDirectory tools -ExcludeVersion
-mono tools/nuget/nuget.exe install Cake -OutputDirectory tools -ExcludeVersion
-
-mono tools/Cake/Cake.exe build.cake


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Build fix

**What is the current behavior? (You can also link to an open issue here)**

```build.sh``` is not currently supported (see [#1465](https://github.com/reactiveui/ReactiveUI/pull/1465#issuecomment-327377549)):
> Currently, the only end-to-end way for all platforms to build ReactiveUI is on
Windows via build.cmd.

**Please check if the PR fulfills these requirements**
- [x] The commit follows our guidelines: https://github.com/reactiveui/reactiveui#contribute
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
