### PR TITLE
(GH-1474) Pinned Cake 0.21.0. Pinned tools and addins to current vers…

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -6,21 +6,21 @@
 // ADDINS
 //////////////////////////////////////////////////////////////////////
 
-#addin "Cake.FileHelpers"
-#addin "Cake.Coveralls"
-#addin "Cake.PinNuGetDependency"
-#addin "Cake.Powershell"
+#addin "nuget:?package=Cake.FileHelpers&version=1.0.4"
+#addin "nuget:?package=Cake.Coveralls&version=0.4.0"
+#addin "nuget:?package=Cake.PinNuGetDependency&version=0.1.0.1495792899"
+#addin "nuget:?package=Cake.Powershell&version=0.3.5"
 
 //////////////////////////////////////////////////////////////////////
 // TOOLS
 //////////////////////////////////////////////////////////////////////
 
-#tool "GitReleaseManager"
-#tool "GitVersion.CommandLine"
-#tool "coveralls.io"
-#tool "OpenCover"
-#tool "ReportGenerator"
-#tool "nuget:?package=vswhere"
+#tool "nuget:?package=GitReleaseManager&version=0.6.0"
+#tool "nuget:?package=GitVersion.CommandLine&version=3.6.5"
+#tool "nuget:?package=coveralls.io&version=1.3.4"
+#tool "nuget:?package=OpenCover&version=4.6.519"
+#tool "nuget:?package=ReportGenerator&version=2.5.11"
+#tool "nuget:?package=vswhere&version=2.1.4"
 
 //////////////////////////////////////////////////////////////////////
 // ARGUMENTS

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+	<package id="Cake" version="0.21.1" />
+</packages>


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Fixes #1474 by pinning cake, addins and tools to their current versions.

**What is the current behavior? (You can also link to an open issue here)**
Currently the build will download the latest tool.

**What is the new behavior (if this is a feature change)?**
Now the build will depend on the pinned version of cake, addins and tools

**What might this PR break?**
The build.


**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
