### PR TITLE
Add warning about disposing command-to-event bindings when deactiving…

### DIFF
--- a/src/ReactiveUI/CommandBinding.cs
+++ b/src/ReactiveUI/CommandBinding.cs
@@ -41,7 +41,9 @@ namespace ReactiveUI
         /// <param name="withParameter">The ViewModel property to pass as the
         /// param of the ICommand</param>
         /// <param name="toEvent">If specified, bind to the specific event
-        /// instead of the default.</param>
+        /// instead of the default.
+        /// NOTE: If this parameter is used inside WhenActivated, it's 
+        /// important to dispose the binding when the view is deactivated.</param>
         public static IReactiveBinding<TView, TViewModel, TProp> BindCommand<TView, TViewModel, TProp, TControl, TParam>(
                 this TView view,
                 TViewModel viewModel,
@@ -67,7 +69,9 @@ namespace ReactiveUI
         /// <param name="propertyName">The ViewModel command to bind</param>
         /// <param name="controlName">The name of the control on the view</param>
         /// <param name="toEvent">If specified, bind to the specific event
-        /// instead of the default.</param>
+        /// instead of the default.
+        /// NOTE: If this parameter is used inside WhenActivated, it's 
+        /// important to dispose the binding when the view is deactivated.</param>
         public static IReactiveBinding<TView, TViewModel, TProp> BindCommand<TView, TViewModel, TProp, TControl>(
                 this TView view,
                 TViewModel viewModel,
@@ -94,7 +98,9 @@ namespace ReactiveUI
         /// <param name="withParameter">The ViewModel property to pass as the
         /// param of the ICommand</param>
         /// <param name="toEvent">If specified, bind to the specific event
-        /// instead of the default.</param>
+        /// instead of the default.
+        /// NOTE: If this parameter is used inside WhenActivated, it's 
+        /// important to dispose the binding when the view is deactivated.</param>
         public static IReactiveBinding<TView, TViewModel, TProp> BindCommand<TView, TViewModel, TProp, TControl, TParam>(
                 this TView view,
                 TViewModel viewModel,
@@ -153,7 +159,9 @@ namespace ReactiveUI
         /// <param name="withParameter">The ViewModel property to pass as the
         /// param of the ICommand</param>
         /// <param name="toEvent">If specified, bind to the specific event
-        /// instead of the default.</param>
+        /// instead of the default.
+        /// NOTE: If this parameter is used inside WhenActivated, it's 
+        /// important to dispose the binding when the view is deactivated.</param>
         public IReactiveBinding<TView, TViewModel, TProp> BindCommand<TView, TViewModel, TProp, TControl, TParam>(
                 TViewModel viewModel,
                 TView view,
@@ -196,7 +204,9 @@ namespace ReactiveUI
         /// <param name="withParameter">The ViewModel property to pass as the
         /// param of the ICommand</param>
         /// <param name="toEvent">If specified, bind to the specific event
-        /// instead of the default.</param>
+        /// instead of the default.
+        /// NOTE: If this parameter is used inside WhenActivated, it's 
+        /// important to dispose the binding when the view is deactivated.</param>
         public IReactiveBinding<TView, TViewModel, TProp> BindCommand<TView, TViewModel, TProp, TControl, TParam>(
                 TViewModel viewModel,
                 TView view,


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
XML docs update


**What is the current behavior? (You can also link to an open issue here)**
The XML docs for the `toEvent` parameter of `BindCommand()` states

> If specified, bind to the specific event instead of the default.


**What is the new behavior (if this is a feature change)?**
The XML docs now states

> If specified, bind to the specific event instead of the default.
> NOTE: If this parameter is used inside WhenActivated, it's important to dispose the binding when the view is deactivated.

The additional notice is to make it clear that if the `toEvent` parameter is used it's important to dispose the subscription. If this is not done, it will lead to multiple subscriptions to the event, which will (most likely) lead to unwanted behavior.

Feedback on the added text is very welcome.

I'm also making a PR to the docs to mention this behavior.


**What might this PR break?**
Shouldn't break anything


**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

