### PR TITLE
housekeeping: upload msbuild binlogs even when the build fails

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,7 +33,7 @@
   - path: src/ReactiveUI.**/Events_*.cs
   test: off
   on_failure:
-  - appveyor PushArtifact '**/*.binlog'
+  - appveyor PushArtifact **/*.binlog
   
 # configuration for "develop" branch
 -
@@ -67,4 +67,4 @@
   - path: src/ReactiveUI.**/Events_*.cs
   test: off
   on_failure:
-  - appveyor PushArtifact '**/*.binlog'
+  - appveyor PushArtifact **/*.binlog

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,6 +30,8 @@
   - path: artifacts/*.nupkg
   - path: '**/bin/*'
   - path: '**/*.binlog'
+    name: binlog
+    type: zip
   - path: src/ReactiveUI.**/Events_*.cs
   test: off
   on_failure:
@@ -64,7 +66,9 @@
   - path: artifacts/*.nupkg
   - path: '**/bin/*'
   - path: '**/*.binlog'
+    name: binlog
+    type: zip
   - path: src/ReactiveUI.**/Events_*.cs
   test: off
   on_failure:
-  - appveyor PushArtifact **/*.binlog
+  - appveyor PushArtifact binlog.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,12 +30,10 @@
   - path: artifacts/*.nupkg
   - path: '**/bin/*'
   - path: '**/*.binlog'
-    name: binlog
-    type: zip
   - path: src/ReactiveUI.**/Events_*.cs
   test: off
   on_failure:
-  - appveyor PushArtifact **/*.binlog
+  - ps: Get-ChildItem **/*.binlog | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
   
 # configuration for "develop" branch
 -
@@ -66,9 +64,7 @@
   - path: artifacts/*.nupkg
   - path: '**/bin/*'
   - path: '**/*.binlog'
-    name: binlog
-    type: zip
   - path: src/ReactiveUI.**/Events_*.cs
   test: off
   on_failure:
-  - appveyor PushArtifact binlog.zip
+  - ps: Get-ChildItem **/*.binlog | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,11 +30,10 @@
   - path: artifacts/*.nupkg
   - path: '**/bin/*'
   - path: '**/*.binlog'
-    name: binlog
   - path: src/ReactiveUI.**/Events_*.cs
   test: off
   on_failure:
-  - appveyor PushArtifact binlog
+  - appveyor PushArtifact '**/*.binlog'
   
 # configuration for "develop" branch
 -
@@ -65,8 +64,7 @@
   - path: artifacts/*.nupkg
   - path: '**/bin/*'
   - path: '**/*.binlog'
-    name: binlog
   - path: src/ReactiveUI.**/Events_*.cs
   test: off
   on_failure:
-  - appveyor PushArtifact binlog
+  - appveyor PushArtifact '**/*.binlog'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,8 +30,11 @@
   - path: artifacts/*.nupkg
   - path: '**/bin/*'
   - path: '**/*.binlog'
+    name: binlog
   - path: src/ReactiveUI.**/Events_*.cs
   test: off
+  on_failure:
+  - appveyor PushArtifact binlog
   
 # configuration for "develop" branch
 -
@@ -62,5 +65,8 @@
   - path: artifacts/*.nupkg
   - path: '**/bin/*'
   - path: '**/*.binlog'
+    name: binlog
   - path: src/ReactiveUI.**/Events_*.cs
   test: off
+  on_failure:
+  - appveyor PushArtifact binlog

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,7 +33,7 @@
   - path: src/ReactiveUI.**/Events_*.cs
   test: off
   on_failure:
-  - ps: Get-ChildItem **/*.binlog | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
+  - ps: Get-ChildItem *.binlog -recurse | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
   
 # configuration for "develop" branch
 -
@@ -67,4 +67,4 @@
   - path: src/ReactiveUI.**/Events_*.cs
   test: off
   on_failure:
-  - ps: Get-ChildItem **/*.binlog | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
+  - ps: Get-ChildItem *.binlog -recurse | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

feature(https://github.com/reactiveui/ReactiveUI/issues/1488)

**What is the current behavior? (You can also link to an open issue here)**

when appveyor fails, binlogs artifact is not being uploaded

**What is the new behavior (if this is a feature change)?**

binlogs artifact is published even if the build failed

**What might this PR break?**

appveyor build :cry: 

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

