### PR TITLE
feature: bumped to xamarin forms 2.4

### DIFF
--- a/src/ReactiveUI.Events.XamForms/ReactiveUI.Events.XamForms.csproj
+++ b/src/ReactiveUI.Events.XamForms/ReactiveUI.Events.XamForms.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="2.3.3.193" />
+    <PackageReference Include="Xamarin.Forms" Version="2.4.0.280" />
     <Compile Include="Events_XAMFORMS.cs" />
   </ItemGroup>  
 

--- a/src/ReactiveUI.XamForms/ReactiveUI.XamForms.csproj
+++ b/src/ReactiveUI.XamForms/ReactiveUI.XamForms.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="2.3.3.193" />
+    <PackageReference Include="Xamarin.Forms" Version="2.4.0.280" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Bug fix the compile.

**What is the current behavior? (You can also link to an open issue here)**
compile fails due to event generator grabbing latest nuget, but the events project referencing older version.

This also fixes #1492 

**What is the new behavior (if this is a feature change)?**
Now referencing Xamarin 2.4


**What might this PR break?**
Clients referencing the old 2.4 release.


**Please check if the PR fulfills these requirements**
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

**Other information**:

