### PR TITLE
ReactiveAppCompatActivity was missing ctors for JNI ownership transfer

### DIFF
--- a/src/ReactiveUI.AndroidSupport/ReactiveAppCompatActivity.cs
+++ b/src/ReactiveUI.AndroidSupport/ReactiveAppCompatActivity.cs
@@ -98,6 +98,12 @@ namespace ReactiveUI.AndroidSupport
             get { return this.getChangedObservable(); }
         }
 
+        protected ReactiveAppCompatActivity() { }
+
+        protected ReactiveAppCompatActivity(IntPtr handle, JniHandleOwnership ownership) : base(handle, ownership)
+        {
+        }
+
         /// <summary>
         /// When this method is called, an object will not fire change
         /// notifications (neither traditional nor Observable notifications)


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

feature

**What is the current behavior? (You can also link to an open issue here)**

https://github.com/reactiveui/ReactiveUI/issues/1329

**What is the new behavior (if this is a feature change)?**

More details were mentioned [here](https://github.com/reactiveui/ReactiveUI/pull/841).

**What might this PR break?**



**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
* Couldn't find any tests for a similar use case, but if you can think of anything I can cover here, please let me know.
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

