### PR TITLE
housekeeping: the f in wpf is foundation, not framework

### DIFF
--- a/GitReleaseManager.yaml
+++ b/GitReleaseManager.yaml
@@ -15,7 +15,7 @@ issue-labels-include:
 - reactiveui-events
 - windows-forms
 - universal-windows-platform
-- windows-presentation-framework
+- windows-presentation-foundation
 - tizen
 - xamarin-android
 - xamarin-forms
@@ -42,9 +42,9 @@ issue-labels-alias:
     - name:    universal-windows-platform
       header:  Universal Windows Platform
       plural:  Universal Windows Platform
-    - name:    windows-presentation-framework
-      header:  Windows Presentation Framework
-      plural:  Windows Presentation Framework
+    - name:    windows-presentation-foundation
+      header:  Windows Presentation Foundation
+      plural:  Windows Presentation Foundation
     - tizen:   tizen
       header:  Tizen
       plural:  Tizen


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

housekeeping

**What is the current behavior? (You can also link to an open issue here)**

product named incorrectly

**What is the new behavior (if this is a feature change)?**

product named correctly

**What might this PR break?**

must rename github label as well otherwise gitreleasenotes will break.
