### PR TITLE
fix: remove ViewModel="{Binding .}" from Cinephile

### DIFF
--- a/samples/xamarin-forms/Cinephile/Views/UpcomingMoviesListView.xaml
+++ b/samples/xamarin-forms/Cinephile/Views/UpcomingMoviesListView.xaml
@@ -13,7 +13,7 @@
               CachingStrategy="RecycleElement">
         <ListView.ItemTemplate>
             <DataTemplate>
-                <ui:UpcomingMoviesCellView ViewModel="{Binding .}" />
+                <ui:UpcomingMoviesCellView />
             </DataTemplate>
         </ListView.ItemTemplate>
     </ListView>


### PR DESCRIPTION
Since this was fixed https://github.com/reactiveui/ReactiveUI/pull/1270 we don't need to rely on a ViewModel="{Binding .}" anymore.

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
samples update


**What is the current behavior? (You can also link to an open issue here)**
The list binding on Cinephile was done as `ViewModel="{Binding .}"`


**What is the new behavior (if this is a feature change)?**
Removed the XAML binding since after RxUI 7.2 this is not necessary anymore


**What might this PR break?**
nothing


**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
