### PR TITLE
feat: propagate obsolete attributes to generated observables

### DIFF
--- a/src/EventBuilder/Cecil/EventTemplateInformation.cs
+++ b/src/EventBuilder/Cecil/EventTemplateInformation.cs
@@ -88,8 +88,8 @@ namespace EventBuilder.Cecil
 
             return new ObsoleteEventInfo
             {
-                Message = obsoleteAttribute?.ConstructorArguments?.ElementAtOrDefault(0).Value?.ToString() ?? string.Empty,
-                IsError = bool.Parse(obsoleteAttribute?.ConstructorArguments?.ElementAtOrDefault(1).Value?.ToString() ?? bool.FalseString)
+                Message = obsoleteAttribute.ConstructorArguments?.ElementAtOrDefault(0).Value?.ToString() ?? string.Empty,
+                IsError = bool.Parse(obsoleteAttribute.ConstructorArguments?.ElementAtOrDefault(1).Value?.ToString() ?? bool.FalseString)
             };
         }
 

--- a/src/EventBuilder/Cecil/EventTemplateInformation.cs
+++ b/src/EventBuilder/Cecil/EventTemplateInformation.cs
@@ -40,12 +40,10 @@ namespace EventBuilder.Cecil
             var ret = RenameBogusWinRTTypes(param.ParameterType.FullName);
 
             var generic = ei.EventType as GenericInstanceType;
-            if (generic != null)
-            {
+            if (generic != null) {
                 foreach (
                     var kvp in
-                        type.GenericParameters.Zip(generic.GenericArguments, (name, actual) => new {name, actual}))
-                {
+                        type.GenericParameters.Zip(generic.GenericArguments, (name, actual) => new { name, actual })) {
                     var realType = GetRealTypeName(kvp.actual);
 
                     ret = ret.Replace(kvp.name.FullName, realType);
@@ -81,6 +79,20 @@ namespace EventBuilder.Cecil
             return ret.Replace('/', '.');
         }
 
+        private static ObsoleteEventInfo GetObsoleteInfo(EventDefinition ei)
+        {
+            var obsoleteAttribute = ei.CustomAttributes.FirstOrDefault(attr => attr.AttributeType.FullName.Equals("System.ObsoleteAttribute"));
+
+            if (obsoleteAttribute == null) 
+                return null;
+
+            return new ObsoleteEventInfo
+            {
+                Message = obsoleteAttribute?.ConstructorArguments?.ElementAtOrDefault(0).Value?.ToString() ?? string.Empty,
+                IsError = bool.Parse(obsoleteAttribute?.ConstructorArguments?.ElementAtOrDefault(1).Value?.ToString() ?? bool.FalseString)
+            };
+        }
+
         private static EventDefinition[] GetPublicEvents(TypeDefinition t)
         {
             return
@@ -93,7 +105,7 @@ namespace EventBuilder.Cecil
             var publicTypesWithEvents = targetAssemblies
                 .SelectMany(x => SafeTypes.GetSafeTypes(x))
                 .Where(x => x.IsPublic && !x.HasGenericParameters)
-                .Select(x => new {Type = x, Events = GetPublicEvents(x)})
+                .Select(x => new { Type = x, Events = GetPublicEvents(x) })
                 .Where(x => x.Events.Length > 0)
                 .ToArray();
 
@@ -121,17 +133,17 @@ namespace EventBuilder.Cecil
                         {
                             Name = z.Name,
                             EventHandlerType = GetRealTypeName(z.EventType),
-                            EventArgsType = GetEventArgsTypeForEvent(z)
+                            EventArgsType = GetEventArgsTypeForEvent(z),
+                            ObsoleteEventInfo = GetObsoleteInfo(z)
                         }).ToArray()
                     }).ToArray()
                 }).ToArray();
 
-            foreach (var type in namespaceData.SelectMany(x => x.Types))
-            {
+            foreach (var type in namespaceData.SelectMany(x => x.Types)) {
                 var parentWithEvents = GetParents(type.Type).FirstOrDefault(x => GetPublicEvents(x).Any());
                 if (parentWithEvents == null) continue;
 
-                type.Parent = new ParentInfo {Name = parentWithEvents.FullName};
+                type.Parent = new ParentInfo { Name = parentWithEvents.FullName };
             }
 
             return namespaceData;
@@ -143,8 +155,7 @@ namespace EventBuilder.Cecil
                 ? type.BaseType.Resolve()
                 : null;
 
-            while (current != null)
-            {
+            while (current != null) {
                 yield return current.Resolve();
 
                 current = current.BaseType != null

--- a/src/EventBuilder/DefaultTemplate.mustache
+++ b/src/EventBuilder/DefaultTemplate.mustache
@@ -47,9 +47,10 @@ namespace {{Name}}
         }
 
 {{#Events}}
-        {{#ObsoleteAttrInfo}}
-        [Obsolete{{#ObsoleteAttrInfo.Message}}("{{ObsoleteAttrInfo.Message}}"{{#ObsoleteAttrInfo.IsError}}, true{{/ObsoleteAttrInfo.IsError}}){{/ObsoleteAttrInfo.Message}}]
-        {{/ObsoleteAttrInfo}}
+
+        {{#ObsoleteEventInfo}}
+        [Obsolete{{#ObsoleteEventInfo.Message}}("{{ObsoleteEventInfo.Message}}"{{#ObsoleteEventInfo.IsError}}, true{{/ObsoleteEventInfo.IsError}}){{/ObsoleteEventInfo.Message}}]
+        {{/ObsoleteEventInfo}}
         public IObservable<{{EventArgsType}}> {{Name}} {
             get { return Observable.FromEventPattern<{{EventHandlerType}}, {{EventArgsType}}>(x => This.{{Name}} += x, x => This.{{Name}} -= x).Select(x => x.EventArgs); }
         }

--- a/src/EventBuilder/DefaultTemplate.mustache
+++ b/src/EventBuilder/DefaultTemplate.mustache
@@ -47,6 +47,9 @@ namespace {{Name}}
         }
 
 {{#Events}}
+        {{#ObsoleteAttrInfo}}
+        [Obsolete{{#ObsoleteAttrInfo.Message}}("{{ObsoleteAttrInfo.Message}}"{{#ObsoleteAttrInfo.IsError}}, true{{/ObsoleteAttrInfo.IsError}}){{/ObsoleteAttrInfo.Message}}]
+        {{/ObsoleteAttrInfo}}
         public IObservable<{{EventArgsType}}> {{Name}} {
             get { return Observable.FromEventPattern<{{EventHandlerType}}, {{EventArgsType}}>(x => This.{{Name}} += x, x => This.{{Name}} -= x).Select(x => x.EventArgs); }
         }

--- a/src/EventBuilder/Entities/ObsoleteEventInfo.cs
+++ b/src/EventBuilder/Entities/ObsoleteEventInfo.cs
@@ -1,0 +1,8 @@
+﻿namespace EventBuilder.Entities
+{
+    public class ObsoleteEventInfo
+    {
+        public string Message { get; set; }
+        public bool IsError { get; set; }
+    }
+}

--- a/src/EventBuilder/Entities/PublicEventInfo.cs
+++ b/src/EventBuilder/Entities/PublicEventInfo.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
@@ -9,5 +9,6 @@ namespace EventBuilder.Entities
         public string Name { get; set; }
         public string EventHandlerType { get; set; }
         public string EventArgsType { get; set; }
+        public ObsoleteEventInfo ObsoleteEventInfo { get; set; }
     }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

feature

**What is the current behavior? (You can also link to an open issue here)**

#1508 

**What is the new behavior (if this is a feature change)?**

If source event has [Obsolete] attribute generated event also will has it. Additional properties like Message, IsError are also passed.

**What might this PR break?**

nothing

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
btw Visual Studio automatically format some code in `EventTemplateInformation.cs`. Some discussion already started about that at slack.
