### PR TITLE
feature: pin android sdk version to keep generated events in line in line with build target

### DIFF
--- a/src/EventBuilder/Platforms/Android.cs
+++ b/src/EventBuilder/Platforms/Android.cs
@@ -29,7 +29,8 @@ namespace EventBuilder.Platforms
                    Directory.GetFiles(Path.Combine(referenceAssembliesLocation, "MonoAndroid"),
                        "Mono.Android.dll", SearchOption.AllDirectories);
 
-                var latestVersion = assemblies.Last();
+                // Pin to a particular framework version https://github.com/reactiveui/ReactiveUI/issues/1517
+                var latestVersion = assemblies.Last(x => x.Contains("v7"));
                 Assemblies.Add(latestVersion);
 
                 CecilSearchDirectories.Add(Path.GetDirectoryName(latestVersion));


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

feature

**What is the current behavior? (You can also link to an open issue here)**

Builds don't work if you upgrade VS2017 to latest (#1517)


**What is the new behavior (if this is a feature change)?**

Pin events to MonoAndroid 7


**What might this PR break?**
Upgrading to 8, potentially, but gives us a way to pin in future which I think mitigates

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

Temporarily fixes #1517