### PR TITLE
feature: nameof() overload for ObservableAsPropertyHelper mixin

### DIFF
--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.approved.txt
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.approved.txt
@@ -401,6 +401,10 @@ namespace ReactiveUI
             where TObj : ReactiveUI.IReactiveObject { }
         public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> This, TObj source, System.Linq.Expressions.Expression<System.Func<TObj, TRet>> property, out ReactiveUI.ObservableAsPropertyHelper<> result, TRet initialValue = null, bool deferSubscription = False, System.Reactive.Concurrency.IScheduler scheduler = null)
             where TObj : ReactiveUI.IReactiveObject { }
+        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> This, TObj source, string property, TRet initialValue = null, bool deferSubscription = False, System.Reactive.Concurrency.IScheduler scheduler = null)
+            where TObj : ReactiveUI.IReactiveObject { }
+        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> This, TObj source, string property, out ReactiveUI.ObservableAsPropertyHelper<> result, TRet initialValue = null, bool deferSubscription = False, System.Reactive.Concurrency.IScheduler scheduler = null)
+            where TObj : ReactiveUI.IReactiveObject { }
     }
     public sealed class ObservableAsPropertyHelper<T> : ReactiveUI.IHandleObservableErrors, Splat.IEnableLogger, System.IDisposable
     {

--- a/src/ReactiveUI.Tests/ObservableAsPropertyHelperTest.cs
+++ b/src/ReactiveUI.Tests/ObservableAsPropertyHelperTest.cs
@@ -230,6 +230,27 @@ namespace ReactiveUI.Tests
         {
             var fixture = new OaphNameOfTestFixture();
 
+            var changing = false;
+            var changed = false;
+
+            fixture.PropertyChanging += (sender, e) => changing = true;
+            fixture.PropertyChanged += (sender, e) => changed = true;
+
+            Assert.False(changing);
+            Assert.False(changed);
+
+            fixture.IsOnlyOneWord = "baz";
+
+            Assert.True(changing);
+            Assert.True(changed);
+        }
+
+        [Theory]
+        [InlineData(new string[] { "FooBar", "Bazz" }, new string[] { "Foo", "Baz" }, new string[] { "Bar", "azz" })]
+        public void ToProperty_NameOf_ValidValuesProduced(string[] testWords, string[] first3Letters, string[] last3Letters)
+        {
+            var fixture = new OaphNameOfTestFixture();
+
             var firstThreeChanging = fixture.ObservableForProperty(x => x.FirstThreeLettersOfOneWord, beforeChange: true).CreateCollection(scheduler: ImmediateScheduler.Instance);
             var lastThreeChanging = fixture.ObservableForProperty(x => x.LastThreeLettersOfOneWord, beforeChange: true).CreateCollection(scheduler: ImmediateScheduler.Instance);
 
@@ -239,15 +260,10 @@ namespace ReactiveUI.Tests
             var lastThreeChanged = fixture.ObservableForProperty(x => x.LastThreeLettersOfOneWord, beforeChange: false).CreateCollection(scheduler: ImmediateScheduler.Instance);
             var changed = new[] { firstThreeChanged, lastThreeChanged };
 
-            var testWords = new string[] { "FooBar", "Bazz" };
-            var first3Letters = new string[] { "Foo", "Baz" };
-            var last3Letters = new string[] { "Bar", "azz" };
-
             Assert.True(changed.All(x => x.Count == 0));
             Assert.True(changing.All(x => x.Count == 0));
 
-            for (int i = 0; i < testWords.Length; ++i) 
-            {
+            for (int i = 0; i < testWords.Length; ++i) {
                 fixture.IsOnlyOneWord = testWords[i];
                 Assert.True(changed.All(x => x.Count == i + 1));
                 Assert.True(changing.All(x => x.Count == i + 1));

--- a/src/ReactiveUI.Tests/ObservableAsPropertyHelperTest.cs
+++ b/src/ReactiveUI.Tests/ObservableAsPropertyHelperTest.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Reactive.Concurrency;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
@@ -18,29 +19,6 @@ namespace ReactiveUI.Tests
 {
     public class ObservableAsPropertyHelperTest
     {
-        internal class OAPHTestFixture : ReactiveObject
-        {
-            private string _text;
-
-            public string Text
-            {
-                get { return _text; }
-                set { this.RaiseAndSetIfChanged(ref _text, value); }
-            }
-
-            public string this[string propertyName]
-            {
-                get { return string.Empty; }
-            }
-
-            public OAPHTestFixture()
-            {
-                var temp = this.WhenAnyValue(f => f.Text)
-                       .ToProperty(this, f => f["Whatever"])
-                       .Value;
-            }
-        }
-
         [Fact]
         public void OAPHShouldFireChangeNotifications()
         {
@@ -248,6 +226,47 @@ namespace ReactiveUI.Tests
         }
 
         [Fact]
+        public void ToProperty_NameOf_ShouldFireBothChangingAndChanged()
+        {
+            var fixture = new OaphNameOfTestFixture();
+
+            // NB: This is a hack to connect up the OAPH
+            var dontcare = (fixture.FirstThreeLettersOfOneWord ?? "").Substring(0, 0);
+
+            // NB: This is a hack to connect up the OAPH
+            var dontcare2 = (fixture.LastThreeLettersOfOneWord ?? "").Substring(0, 0);
+
+            var firstThreeChanging = fixture.ObservableForProperty(x => x.FirstThreeLettersOfOneWord, beforeChange: true).CreateCollection(scheduler: ImmediateScheduler.Instance);
+            var lastThreeChanging = fixture.ObservableForProperty(x => x.LastThreeLettersOfOneWord, beforeChange: true).CreateCollection(scheduler: ImmediateScheduler.Instance);
+
+            var changing = new[] { firstThreeChanging, lastThreeChanging };
+
+            var firstThreeChanged = fixture.ObservableForProperty(x => x.FirstThreeLettersOfOneWord, beforeChange: false).CreateCollection(scheduler: ImmediateScheduler.Instance);
+            var lastThreeChanged = fixture.ObservableForProperty(x => x.LastThreeLettersOfOneWord, beforeChange: false).CreateCollection(scheduler: ImmediateScheduler.Instance);
+            var changed = new[] { firstThreeChanged, lastThreeChanged };
+
+            var testWords = new string[] { "FooBar", "Bazz" };
+            var first3Letters = new string[] { "Foo", "Baz" };
+            var last3Letters = new string[] { "Bar", "azz" };
+
+            Assert.True(changed.All(x => x.Count == 0));
+            Assert.True(changing.All(x => x.Count == 0));
+
+            for (int i = 0; i < testWords.Length; ++i) 
+            {
+                fixture.IsOnlyOneWord = testWords[i];
+                Assert.True(changed.All(x => x.Count == i + 1));
+                Assert.True(changing.All(x => x.Count == i + 1));
+                Assert.Equal(first3Letters[i], firstThreeChanged[i].Value);
+                Assert.Equal(last3Letters[i], lastThreeChanged[i].Value);
+                string firstChanging = i - 1 < 0 ? "" : first3Letters[i - 1];
+                string lastChanging = i - 1 < 0 ? "" : last3Letters[i - i];
+                Assert.Equal(firstChanging, firstThreeChanging[i].Value);
+                Assert.Equal(lastChanging, lastThreeChanging[i].Value);
+            }
+        }
+
+        [Fact]
         public void ToPropertyShouldSubscribeOnlyOnce()
         {
             using (ProductionMode.Set()) {
@@ -266,10 +285,28 @@ namespace ReactiveUI.Tests
         }
 
         [Fact]
+        public void ToProperty_NameOf_ShouldSubscribeOnlyOnce()
+        {
+            using (ProductionMode.Set()) {
+                var f = new RaceConditionNameOfFixture();
+                // This line is important because it triggers connect to
+                // be called recursively thus cause the subscription
+                // to be called twice. Not sure if this is a reactive UI
+                // or RX bug.
+                f.PropertyChanged += (e, s) => Debug.WriteLine(f.A);
+
+                // Trigger subscription to the underlying observable.
+                Assert.Equal(true, f.A);
+
+                Assert.Equal(1, f.Count);
+            }
+        }
+
+        [Fact]
         public void ToProperty_GivenIndexer_NotifiesOnExpectedPropertyName()
         {
             (new TestScheduler()).With(sched => {
-                var fixture = new OAPHTestFixture();
+                var fixture = new OAPHIndexerTestFixture();
                 var propertiesChanged = new List<string>();
 
                 fixture.PropertyChanged += (sender, args) => {
@@ -302,6 +339,29 @@ namespace ReactiveUI.Tests
         }
     }
 
+    internal class OAPHIndexerTestFixture : ReactiveObject
+    {
+        private string _text;
+
+        public string Text
+        {
+            get { return _text; }
+            set { this.RaiseAndSetIfChanged(ref _text, value); }
+        }
+
+        public string this[string propertyName]
+        {
+            get { return string.Empty; }
+        }
+
+        public OAPHIndexerTestFixture()
+        {
+            var temp = this.WhenAnyValue(f => f.Text)
+                   .ToProperty(this, f => f["Whatever"])
+                   .Value;
+        }
+    }
+
     public class RaceConditionFixture : ReactiveObject
     {
         public ObservableAsPropertyHelper<bool> _A;
@@ -323,6 +383,30 @@ namespace ReactiveUI.Tests
                 .True
                 .Do(_ => Count++)
                 .ToProperty(this, x => x.A, out _A);
+        }
+    }
+
+    public class RaceConditionNameOfFixture : ReactiveObject
+    {
+        public ObservableAsPropertyHelper<bool> _A;
+        public int Count;
+
+        public bool A
+        {
+            get { return _A.Value; }
+        }
+
+        public RaceConditionNameOfFixture()
+        {
+            // We need to generate a value on subscription
+            // which is different than the default value.
+            // This triggers the property change firing
+            // upon subscription in the ObservableAsPropertyHelper
+            // constructor.
+            Observables
+                .True
+                .Do(_ => Count++)
+                .ToProperty(this, nameof(A), out _A);
         }
     }
 }

--- a/src/ReactiveUI.Tests/ObservableAsPropertyHelperTest.cs
+++ b/src/ReactiveUI.Tests/ObservableAsPropertyHelperTest.cs
@@ -230,12 +230,6 @@ namespace ReactiveUI.Tests
         {
             var fixture = new OaphNameOfTestFixture();
 
-            // NB: This is a hack to connect up the OAPH
-            var dontcare = (fixture.FirstThreeLettersOfOneWord ?? "").Substring(0, 0);
-
-            // NB: This is a hack to connect up the OAPH
-            var dontcare2 = (fixture.LastThreeLettersOfOneWord ?? "").Substring(0, 0);
-
             var firstThreeChanging = fixture.ObservableForProperty(x => x.FirstThreeLettersOfOneWord, beforeChange: true).CreateCollection(scheduler: ImmediateScheduler.Instance);
             var lastThreeChanging = fixture.ObservableForProperty(x => x.LastThreeLettersOfOneWord, beforeChange: true).CreateCollection(scheduler: ImmediateScheduler.Instance);
 

--- a/src/ReactiveUI.Tests/ReactiveObjectTest.cs
+++ b/src/ReactiveUI.Tests/ReactiveObjectTest.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
@@ -101,6 +101,32 @@ namespace ReactiveUI.Tests
             this.WhenAnyValue(x => x.IsOnlyOneWord)
                 .Select(x => (x ?? "")).Select(x => x.Length >= 3 ? x.Substring(0, 3) : x)
                 .ToProperty(this, x => x.FirstThreeLettersOfOneWord, out _FirstThreeLettersOfOneWord);
+        }
+    }
+
+    public class OaphNameOfTestFixture : TestFixture
+    {
+        [IgnoreDataMember]
+        ObservableAsPropertyHelper<string> _FirstThreeLettersOfOneWord;
+
+        [IgnoreDataMember]
+        ObservableAsPropertyHelper<string> _LastThreeLettersOfOneWord;
+
+        [IgnoreDataMember]
+        public string FirstThreeLettersOfOneWord => _FirstThreeLettersOfOneWord.Value;
+
+        [IgnoreDataMember]
+        public string LastThreeLettersOfOneWord => _LastThreeLettersOfOneWord.Value;
+
+        public OaphNameOfTestFixture()
+        {
+            this.WhenAnyValue(x => x.IsOnlyOneWord)
+                .Select(x => (x ?? "")).Select(x => x.Length >= 3 ? x.Substring(0, 3) : x)
+                .ToProperty(this, nameof(FirstThreeLettersOfOneWord), out _FirstThreeLettersOfOneWord);
+
+            this._LastThreeLettersOfOneWord = this.WhenAnyValue(x => x.IsOnlyOneWord)
+                .Select(x => (x ?? "")).Select(x => x.Length >= 3 ? x.Substring(x.Length - 3, 3) : x)
+                .ToProperty(this, nameof(LastThreeLettersOfOneWord));
         }
     }
 

--- a/src/ReactiveUI/ObservableAsPropertyHelper.cs
+++ b/src/ReactiveUI/ObservableAsPropertyHelper.cs
@@ -210,6 +210,27 @@ namespace ReactiveUI
             return ret;
         }
 
+        static ObservableAsPropertyHelper<TRet> observableToProperty<TObj, TRet>(
+        this TObj This,
+        IObservable<TRet> observable,
+        string property,
+        TRet initialValue = default(TRet),
+        bool deferSubscription = false,
+        IScheduler scheduler = null)
+    where TObj : IReactiveObject
+        {
+            Contract.Requires(This != null);
+            Contract.Requires(observable != null);
+            Contract.Requires(property != null);
+
+            var ret = new ObservableAsPropertyHelper<TRet>(observable,
+                _ => This.raisePropertyChanged(property),
+                _ => This.raisePropertyChanging(property),
+                initialValue, deferSubscription, scheduler);
+
+            return ret;
+        }
+
         /// <summary>
         /// Converts an Observable to an ObservableAsPropertyHelper and
         /// automatically provides the onChanged method to raise the property
@@ -291,6 +312,100 @@ namespace ReactiveUI
             this IObservable<TRet> This,
             TObj source,
             Expression<Func<TObj, TRet>> property,
+            out ObservableAsPropertyHelper<TRet> result,
+            TRet initialValue = default(TRet),
+            bool deferSubscription = false,
+            IScheduler scheduler = null)
+            where TObj : IReactiveObject
+        {
+            var ret = source.observableToProperty(This, property, initialValue, deferSubscription, scheduler);
+
+            result = ret;
+            return ret;
+        }
+
+        /// <summary>
+        /// Converts an Observable to an ObservableAsPropertyHelper and
+        /// automatically provides the onChanged method to raise the property
+        /// changed notification.         
+        /// </summary>
+        /// <param name="This">
+        /// The observable to convert to an ObservableAsPropertyHelper
+        /// </param>
+        /// <param name="source">
+        /// The ReactiveObject that has the property
+        /// </param>
+        /// <param name="property">
+        /// The name of the property that has changed. Recommended for use with nameof() or a FODY.
+        /// or a fody.
+        /// </param>
+        /// <param name="initialValue">
+        /// The initial value of the property.
+        /// </param>
+        /// <param name="deferSubscription">
+        /// A value indicating whether the <see cref="ObservableAsPropertyHelper{T}"/> 
+        /// should defer the subscription to the <paramref name="This"/> source 
+        /// until the first call to <see cref="ObservableAsPropertyHelper{T}.Value"/>,
+        /// or if it should immediately subscribe to the the <paramref name="This"/> source.
+        /// </param>
+        /// <param name="scheduler">
+        /// The scheduler that the notifications will be provided on - this should normally 
+        /// be a Dispatcher-based scheduler
+        /// </param>
+        /// <returns>
+        /// An initialized ObservableAsPropertyHelper; use this as the backing field 
+        /// for your property.
+        /// </returns>
+        public static ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(
+            this IObservable<TRet> This,
+            TObj source,
+            string property,
+            TRet initialValue = default(TRet),
+            bool deferSubscription = false,
+            IScheduler scheduler = null)
+            where TObj : IReactiveObject
+        {
+            return source.observableToProperty(This, property, initialValue, deferSubscription, scheduler);
+        }
+
+        /// <summary>
+        /// Converts an Observable to an ObservableAsPropertyHelper and
+        /// automatically provides the onChanged method to raise the property
+        /// changed notification.         
+        /// </summary>
+        /// <param name="This">
+        /// The observable to convert to an ObservableAsPropertyHelper
+        /// </param>
+        /// <param name="source">
+        /// The ReactiveObject that has the property
+        /// </param>
+        /// <param name="property">
+        /// The name of the property that has changed. Recommended for use with nameof() or a FODY.
+        /// </param>
+        /// <param name="result">
+        /// An out param matching the return value, provided for convenience
+        /// </param>
+        /// <param name="initialValue">
+        /// The initial value of the property.
+        /// </param>
+        /// <param name="deferSubscription">
+        /// A value indicating whether the <see cref="ObservableAsPropertyHelper{T}"/> 
+        /// should defer the subscription to the <paramref name="This"/> source 
+        /// until the first call to <see cref="ObservableAsPropertyHelper{T}.Value"/>, 
+        /// or if it should immediately subscribe to the the <paramref name="This"/> source.
+        /// </param>
+        /// <param name="scheduler">
+        /// The scheduler that the notifications will be provided on - this should 
+        /// normally be a Dispatcher-based scheduler
+        /// </param>
+        /// <returns>
+        /// An initialized ObservableAsPropertyHelper; use this as the backing 
+        /// field for your property.
+        /// </returns>
+        public static ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(
+            this IObservable<TRet> This,
+            TObj source,
+            string property,
             out ObservableAsPropertyHelper<TRet> result,
             TRet initialValue = default(TRet),
             bool deferSubscription = false,

--- a/src/ReactiveUI/ObservableAsPropertyHelper.cs
+++ b/src/ReactiveUI/ObservableAsPropertyHelper.cs
@@ -211,24 +211,23 @@ namespace ReactiveUI
         }
 
         static ObservableAsPropertyHelper<TRet> observableToProperty<TObj, TRet>(
-        this TObj This,
-        IObservable<TRet> observable,
-        string property,
-        TRet initialValue = default(TRet),
-        bool deferSubscription = false,
-        IScheduler scheduler = null)
-    where TObj : IReactiveObject
+                this TObj This,
+                IObservable<TRet> observable,
+                string property,
+                TRet initialValue = default(TRet),
+                bool deferSubscription = false,
+                IScheduler scheduler = null)
+            where TObj : IReactiveObject
         {
             Contract.Requires(This != null);
             Contract.Requires(observable != null);
             Contract.Requires(property != null);
 
-            var ret = new ObservableAsPropertyHelper<TRet>(observable,
+            return new ObservableAsPropertyHelper<TRet>(
+                observable,
                 _ => This.raisePropertyChanged(property),
                 _ => This.raisePropertyChanging(property),
                 initialValue, deferSubscription, scheduler);
-
-            return ret;
         }
 
         /// <summary>
@@ -412,10 +411,14 @@ namespace ReactiveUI
             IScheduler scheduler = null)
             where TObj : IReactiveObject
         {
-            var ret = source.observableToProperty(This, property, initialValue, deferSubscription, scheduler);
+            result = source.observableToProperty(
+                This,
+                property,
+                initialValue,
+                deferSubscription,
+                scheduler);
 
-            result = ret;
-            return ret;
+            return result;
         }
     }
 }


### PR DESCRIPTION
…yHelper, which allows use of the nameof() operator for performance based applications

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Address #1505 - It adds a string overload of the ToProperty operator that can be used with the nameof() operator or later a fody. This helps when you have a large number of objects referencing a OAPH object.

**What is the current behavior? (You can also link to an open issue here)**
To use the Expression<Func<>> to interpolate the name of the OAPH.


**What is the new behavior (if this is a feature change)?**
Adds a additional mixin that allows the use of a string. 


**What might this PR break?**
Since it's just adding a new override it shouldn't break existing use of the Expression. If other people have provided similar overrides in their own code could potentially cause issues. Also if the Fody uses these overloads it's probably best to use the string property version for it. 


**Please check if the PR fulfills these requirements**
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

**Other information**:
See also https://github.com/reactiveui/website/pull/54
