### PR TITLE
housekeeping: remove fully qualified test names in test explorer (#1328)

### DIFF
--- a/src/ReactiveUI.Tests/app.config
+++ b/src/ReactiveUI.Tests/app.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <appSettings>
+    <add key="xunit.methodDisplay" value="method"/>
+  </appSettings>
+</configuration>


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Remove fully qualified test names in test explorer.

**What is the current behavior? (You can also link to an open issue here)**

#1328 

**What is the new behavior (if this is a feature change)?**

-

**What might this PR break?**

-

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

I'm having serious problems getting solution building in Visual Studio (do you have pre-requisities listed anywhere?). So I've not been able to verify this fix in VS. However, output from build scripts seems to remove fully qualified name from tests.