### PR TITLE
fix: this.Events() was not available for consumption due to assembly name conflicts

### DIFF
--- a/src/ReactiveUI.Events.WPF/ReactiveUI.Events.WPF.csproj
+++ b/src/ReactiveUI.Events.WPF/ReactiveUI.Events.WPF.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net45</TargetFrameworks>
-    <AssemblyName>ReactiveUI.Events</AssemblyName>
+    <AssemblyName>ReactiveUI.Events.WPF</AssemblyName>
     <RootNamespace>ReactiveUI.Events</RootNamespace>
     <Description>Provides Observable-based events API for WPF UI controls/eventhandlers. The contents of this package is automatically generated, please target pull-requests to the code generator.</Description>
     <PackageId>reactiveui-events-wpf</PackageId>

--- a/src/ReactiveUI.Events.XamForms/ReactiveUI.Events.XamForms.csproj
+++ b/src/ReactiveUI.Events.XamForms/ReactiveUI.Events.XamForms.csproj
@@ -4,7 +4,7 @@
     <PackageTargetFallback Condition="'$(TargetFramework)' == 'netstandard1.3'">
       $(PackageTargetFallback);portable-win+net45+wp8+win81+wpa8
     </PackageTargetFallback>
-    <AssemblyName>ReactiveUI.Events</AssemblyName>
+    <AssemblyName>ReactiveUI.Events.XamForms</AssemblyName>
     <RootNamespace>ReactiveUI.Events</RootNamespace>
     <Description>Provides Observable-based events API for Xamarin Forms UI controls/eventhandlers. The contents of this package is automatically generated, please target pull-requests to the code generator.</Description>
     <PackageId>reactiveui-events-xamforms</PackageId>


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

fix

**What is the current behavior? (You can also link to an open issue here)**

https://github.com/reactiveui/ReactiveUI/issues/1526

**What is the new behavior (if this is a feature change)?**

![image](https://user-images.githubusercontent.com/127353/32427460-a29876e2-c314-11e7-9236-d2e453674396.png)

**What might this PR break?**

Unbreaks people, if an item is missed in the review then potentially a platform might remain broken etc.

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

