### PR TITLE
housekeeping:  use new nuget package names to enable nuget namespace reservation

### DIFF
--- a/src/ReactiveUI.AndroidSupport/ReactiveUI.AndroidSupport.csproj
+++ b/src/ReactiveUI.AndroidSupport/ReactiveUI.AndroidSupport.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>ReactiveUI.AndroidSupport</AssemblyName>
     <RootNamespace>ReactiveUI.AndroidSupport</RootNamespace>
     <Description>ReactiveUI extensions for the Android Support Library</Description>
-    <PackageId>reactiveui-androidsupport</PackageId>
+    <PackageId>ReactiveUI.AndroidSupport</PackageId>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/ReactiveUI.Events.WPF/ReactiveUI.Events.WPF.csproj
+++ b/src/ReactiveUI.Events.WPF/ReactiveUI.Events.WPF.csproj
@@ -4,7 +4,7 @@
     <AssemblyName>ReactiveUI.Events.WPF</AssemblyName>
     <RootNamespace>ReactiveUI.Events</RootNamespace>
     <Description>Provides Observable-based events API for WPF UI controls/eventhandlers. The contents of this package is automatically generated, please target pull-requests to the code generator.</Description>
-    <PackageId>reactiveui-events-wpf</PackageId>
+    <PackageId>ReactiveUI.Events.WPF</PackageId>
   </PropertyGroup>  
 
   <ItemGroup>

--- a/src/ReactiveUI.Events.XamForms/ReactiveUI.Events.XamForms.csproj
+++ b/src/ReactiveUI.Events.XamForms/ReactiveUI.Events.XamForms.csproj
@@ -7,7 +7,7 @@
     <AssemblyName>ReactiveUI.Events.XamForms</AssemblyName>
     <RootNamespace>ReactiveUI.Events</RootNamespace>
     <Description>Provides Observable-based events API for Xamarin Forms UI controls/eventhandlers. The contents of this package is automatically generated, please target pull-requests to the code generator.</Description>
-    <PackageId>reactiveui-events-xamforms</PackageId>
+    <PackageId>ReactiveUI.Events.XamForms</PackageId>
   </PropertyGroup>  
 
   <ItemGroup>

--- a/src/ReactiveUI.Events/ReactiveUI.Events.csproj
+++ b/src/ReactiveUI.Events/ReactiveUI.Events.csproj
@@ -4,7 +4,7 @@
     <AssemblyName>ReactiveUI.Events</AssemblyName>
     <RootNamespace>ReactiveUI.Events</RootNamespace>
     <Description>Provides Observable-based events API for common UI controls/eventhandlers. The contents of this package is automatically generated, please target pull-requests to the code generator.</Description>
-    <PackageId>reactiveui-events</PackageId>
+    <PackageId>ReactiveUI.Events</PackageId>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ReactiveUI.Testing/ReactiveUI.Testing.csproj
+++ b/src/ReactiveUI.Testing/ReactiveUI.Testing.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>ReactiveUI.Testing</AssemblyName>
     <RootNamespace>ReactiveUI.Testing</RootNamespace>
     <Description>A library to aid in writing unit tests for ReactiveUI projects</Description>
-    <PackageId>reactiveui-testing</PackageId>
+    <PackageId>ReactiveUI.Testing</PackageId>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/ReactiveUI.Winforms/ReactiveUI.Winforms.csproj
+++ b/src/ReactiveUI.Winforms/ReactiveUI.Winforms.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>ReactiveUI.Winforms</AssemblyName>
     <RootNamespace>ReactiveUI.Winforms</RootNamespace>
     <Description>Windows Forms specific extensions to ReactiveUI</Description>
-    <PackageId>reactiveui-winforms</PackageId>
+    <PackageId>ReactiveUI.WinForms</PackageId>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ReactiveUI.Wpf/ReactiveUI.Wpf.csproj
+++ b/src/ReactiveUI.Wpf/ReactiveUI.Wpf.csproj
@@ -14,7 +14,7 @@
     <WarningLevel>4</WarningLevel>
     <TargetFrameworkProfile />
     <TargetFrameworkIdentifier>.NETFramework</TargetFrameworkIdentifier>
-    <PackageId>reactiveui-wpf</PackageId>    
+    <PackageId>ReactiveUI.WPF</PackageId>    
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/ReactiveUI.XamForms/ReactiveUI.XamForms.csproj
+++ b/src/ReactiveUI.XamForms/ReactiveUI.XamForms.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard1.3</TargetFrameworks>
     <PackageTargetFallback>$(PackageTargetFallback);portable-win+net45+wp8+win81+wpa8</PackageTargetFallback>
     <Description>Xamarin Forms specific extensions to ReactiveUI</Description>
-    <PackageId>reactiveui-xamforms</PackageId>
+    <PackageId>ReactiveUI.XamarinForms</PackageId>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ReactiveUI/ReactiveUI.csproj
+++ b/src/ReactiveUI/ReactiveUI.csproj
@@ -4,7 +4,7 @@
     <AssemblyName>ReactiveUI</AssemblyName>
     <RootNamespace>ReactiveUI</RootNamespace>
     <Description>A MVVM framework that integrates with the Reactive Extensions for .NET to create elegant, testable User Interfaces that run on any mobile or desktop platform. Supports Xamarin.iOS, Xamarin.Android, Xamarin.Mac, Xamarin Forms, WPF, Windows Forms, Windows Phone 8.1, Windows Store and Universal Windows Platform (UWP).</Description>
-    <PackageId>reactiveui</PackageId>
+    <PackageId>ReactiveUI</PackageId>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

breaking, disruptive change which is required to be able to implement NuGet package verification

**What is the current behavior? (You can also link to an open issue here)**

```
reactiveui                  -> ReactiveUI (if $platform == WPF use ReactiveUI.WPF instead)
reactiveui-androidsupport   -> ReactiveUI.AndroidSupport
reactiveui-blend            -> ReactiveUI.Blend
reactiveui-events           -> ReactiveUI.Events
reactiveui-events-wpf       -> ReactiveUI.Events.WPF
reactiveui-events-xamforms  -> ReactiveUI.Events.XamForms
reactiveui-testing          -> ReactiveUI.Testinggi
reactiveui-winforms         -> ReactiveUI.WindowsForms
reactiveui-wpf              -> ReactiveUI.WPF
reactiveui-xamforms         -> ReactiveUI.XamForms
```

**What might this PR break?**

The community. They will need to update their package references to use the new package names; I wish there was another way. 

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

https://github.com/NuGet/Home/wiki/NuGet-Package-Identity-Verification#application-process-for-package-id-prefix-reservation