### PR TITLE
fix: activate iOS views synchronously

### DIFF
--- a/src/ReactiveUI/Platforms/apple-common/ReactiveControl.cs
+++ b/src/ReactiveUI/Platforms/apple-common/ReactiveControl.cs
@@ -93,7 +93,7 @@ namespace ReactiveUI
 #else
             base.ViewWillMoveToSuperview(newsuper);
 #endif
-            RxApp.MainThreadScheduler.Schedule(() => (newsuper != null ? activated : deactivated).OnNext(Unit.Default));
+            (newsuper != null ? activated : deactivated).OnNext(Unit.Default);
         }
 
         void ICanForceManualActivation.Activate(bool activate)

--- a/src/ReactiveUI/Platforms/apple-common/ReactiveImageView.cs
+++ b/src/ReactiveUI/Platforms/apple-common/ReactiveImageView.cs
@@ -95,7 +95,7 @@ namespace ReactiveUI
 #else
             base.ViewWillMoveToSuperview(newsuper);
 #endif
-            RxApp.MainThreadScheduler.Schedule(() => (newsuper != null ? activated : deactivated).OnNext(Unit.Default));
+            (newsuper != null ? activated : deactivated).OnNext(Unit.Default);
         }
 
         void ICanForceManualActivation.Activate(bool activate)

--- a/src/ReactiveUI/Platforms/apple-common/ReactiveNSView.cs
+++ b/src/ReactiveUI/Platforms/apple-common/ReactiveNSView.cs
@@ -100,7 +100,7 @@ namespace ReactiveUI
                 base.ViewWillMoveToSuperview(newsuper);
             }
 #endif
-            RxApp.MainThreadScheduler.Schedule(() => (newsuper != null ? activated : deactivated).OnNext(Unit.Default));
+            (newsuper != null ? activated : deactivated).OnNext(Unit.Default);
         }
 
         void ICanForceManualActivation.Activate(bool activate)

--- a/src/ReactiveUI/Platforms/ios/ReactiveCollectionViewCell.cs
+++ b/src/ReactiveUI/Platforms/ios/ReactiveCollectionViewCell.cs
@@ -83,7 +83,7 @@ namespace ReactiveUI
         public override void WillMoveToSuperview(UIView newsuper)
         {
             base.WillMoveToSuperview(newsuper);
-            RxApp.MainThreadScheduler.Schedule(() => (newsuper != null ? activated : deactivated).OnNext(Unit.Default));
+            (newsuper != null ? activated : deactivated).OnNext(Unit.Default);
         }
     }
 

--- a/src/ReactiveUI/Platforms/ios/ReactiveTableView.cs
+++ b/src/ReactiveUI/Platforms/ios/ReactiveTableView.cs
@@ -73,7 +73,7 @@ namespace ReactiveUI
         public override void WillMoveToSuperview(UIView newsuper)
         {
             base.WillMoveToSuperview(newsuper);
-            RxApp.MainThreadScheduler.Schedule(() => (newsuper != null ? activated : deactivated).OnNext(Unit.Default));
+            (newsuper != null ? activated : deactivated).OnNext(Unit.Default);
         }
 
         void ICanForceManualActivation.Activate(bool activate)

--- a/src/ReactiveUI/Platforms/ios/ReactiveTableViewCell.cs
+++ b/src/ReactiveUI/Platforms/ios/ReactiveTableViewCell.cs
@@ -85,7 +85,7 @@ namespace ReactiveUI
         public override void WillMoveToSuperview(UIView newsuper)
         {
             base.WillMoveToSuperview(newsuper);
-            RxApp.MainThreadScheduler.Schedule(() => (newsuper != null ? activated : deactivated).OnNext(Unit.Default));
+            (newsuper != null ? activated : deactivated).OnNext(Unit.Default);
         }
     }
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

This is either a bug fix or enhancement, depending on how you look at it. It applies the equivalent activation fix for `UIView` subclasses, that #1182 already did for `UIViewController` subclasses.

#1182 changed `UIViewController` subclasses to use `ViewWillAppear` instead of `ViewDidAppear` for activation, such that activation occurs before the view becomes visible.

This PR does the equivalent thing for `UIView` subclasses.

**What is the current behavior? (You can also link to an open issue here)**

`UIView` subclasses (correctly) override `WillMoveToSuperview`, which is called before the view becomes visible. However, within those overrides, they schedule an async callback on the UI thread like this:

``` csharp
public override void WillMoveToSuperview(UIView newsuper)
{
    base.WillMoveToSuperview(newsuper);
    RxApp.MainThreadScheduler.Schedule(() => (newsuper != null ? activated : deactivated).OnNext(Unit.Default));
}
```

Because `Schedule` schedules an async callback on the UI thread, the callback may (and in my testing, will) be called after the view becomes visible. This means that there's a visible flicker where you first see uninitialized views, and then they are populated with data.

**What is the new behavior (if this is a feature change)?**

The activation callbacks are now called synchronously from `UIView` subclasses, such that activation occurs before the view becomes visible. Instead of the code above, the `WillMoveToSuperview` overrides become simpler:

``` csharp
public override void WillMoveToSuperview(UIView newsuper)
{
    base.WillMoveToSuperview(newsuper);
    (newsuper != null ? activated : deactivated).OnNext(Unit.Default);
}
```

This matches the existing behaviour for [ReactiveCollectionReusableView](https://github.com/reactiveui/ReactiveUI/blob/develop/src/ReactiveUI/Platforms/ios/ReactiveCollectionReusableView.cs#L86) and [ReactiveCollectionView](https://github.com/reactiveui/ReactiveUI/blob/develop/src/ReactiveUI/Platforms/ios/ReactiveCollectionView.cs#L86), which already called the activation callback synchronously.

**What might this PR break?**

If anybody relies on the current behaviour of activation occurring after views become visible, this would be a breaking change. But that was almost certainly undesirable behaviour in the first place.

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
