### PR TITLE
chore: fix build

### DIFF
--- a/src/EventBuilder/Platforms/XamForms.cs
+++ b/src/EventBuilder/Platforms/XamForms.cs
@@ -19,6 +19,8 @@ namespace EventBuilder.Platforms
         {
             var packageUnzipPath = Environment.CurrentDirectory;
 
+            Log.Debug("Package unzip path is {PackageUnzipPath}", packageUnzipPath);
+
             var retryPolicy = Policy
                 .Handle<Exception>()
                 .WaitAndRetry(
@@ -42,7 +44,7 @@ namespace EventBuilder.Platforms
                 Log.Debug("Using Xamarin Forms {Version} released on {Published}", package.Version, package.Published);
                 Log.Debug("{ReleaseNotes}", package.ReleaseNotes);
 
-                packageManager.InstallPackage(package.Id);
+                packageManager.InstallPackage(package, ignoreDependencies: true, allowPrereleaseVersions: false);
             });
 
             var xamarinForms =

--- a/src/EventBuilder/Platforms/XamForms.cs
+++ b/src/EventBuilder/Platforms/XamForms.cs
@@ -39,10 +39,10 @@ namespace EventBuilder.Platforms
 
                 var package = repo.FindPackagesById(_packageName).Single(x => x.IsLatestVersion);
 
-                packageManager.InstallPackage(package.Id);
-
                 Log.Debug("Using Xamarin Forms {Version} released on {Published}", package.Version, package.Published);
                 Log.Debug("{ReleaseNotes}", package.ReleaseNotes);
+
+                packageManager.InstallPackage(package.Id);
             });
 
             var xamarinForms =

--- a/src/ReactiveUI.Events.XamForms/ReactiveUI.Events.XamForms.csproj
+++ b/src/ReactiveUI.Events.XamForms/ReactiveUI.Events.XamForms.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ReactiveUI.Events</RootNamespace>
     <Description>Provides Observable-based events API for Xamarin Forms UI controls/eventhandlers. The contents of this package is automatically generated, please target pull-requests to the code generator.</Description>
     <PackageId>ReactiveUI.Events.XamForms</PackageId>
-  </PropertyGroup>  
+  </PropertyGroup>
 
   <ItemGroup>
     <Compile Remove="*.cs" />
@@ -18,9 +18,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="2.4.0.280" />
+    <PackageReference Include="Xamarin.Forms" Version="2.5.0.91635" />
     <Compile Include="Events_XAMFORMS.cs" />
-  </ItemGroup>  
+  </ItemGroup>
 
   <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 </Project>

--- a/src/ReactiveUI.XamForms/ReactiveUI.XamForms.csproj
+++ b/src/ReactiveUI.XamForms/ReactiveUI.XamForms.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="2.4.0.280" />
+    <PackageReference Include="Xamarin.Forms" Version="2.5.0.91635" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Bug fix (build).

**What is the current behavior? (You can also link to an open issue here)**

The release of Xamarin.Forms 2.5 broke the build. Here's what happened, to the best of my understanding...

Xamarin.Forms 2.5 is the first version to have different platforms depend on different versions of the Android support libraries:

![image](https://user-images.githubusercontent.com/1901832/33204780-89496e28-d154-11e7-8fca-b921fde581c6.png)

For reasons I don't fully understand, this was causing the NuGet package install in the XamForms event generation step to fail with:
```
2017-11-24 19:46:34.242 +10:30 [Warning] An exception was thrown whilst retrieving or installing "Xamarin.Forms": "System.InvalidOperationException: Updating 'Xamarin.Android.Support.v4 23.3.0' to 'Xamarin.Android.Support.v4 25.4.0.2' failed. Unable to find versions of 'Xamarin.Forms, Xamarin.Android.Support.v7.AppCompat, Xamarin.Android.Support.Vector.Drawable, Xamarin.Android.Support.Animated.Vector.Drawable, Xamarin.Android.Support.v7.RecyclerView, Xamarin.Android.Support.Design, Xamarin.Android.Support.v7.MediaRouter' that are compatible with 'Xamarin.Android.Support.v4 25.4.0.2'.
   at NuGet.InstallWalker.OnBeforePackageWalk(IPackage package)
   at NuGet.PackageWalker.Walk(IPackage package)
   at NuGet.PackageWalker.Walk(IPackage package)
   at NuGet.InstallWalker.ResolveOperations(IPackage package)
   at NuGet.PackageManager.Execute(IPackage package, IPackageOperationResolver resolver)
   at NuGet.PackageManager.InstallPackage(IPackage package, Boolean ignoreDependencies, Boolean allowPrereleaseVersions)
   at EventBuilder.Platforms.XamForms.<>c__DisplayClass1_0.<.ctor>b__2() in C:\Users\Kent\Repository\ReactiveUI\src\EventBuilder\Platforms\XamForms.cs:line 48
   at Polly.Retry.RetryPolicy.Implementation(Action action, IEnumerable`1 shouldRetryPredicates, Func`1 policyStateFactory)"
```

But I don't see why we even need to install dependencies when installing the Xamarin.Forms package for the purposes of generating events. Therefore, I disabled the installation of dependencies to get past this problem.

However, the second problem was that XF 2.5 includes events that depend on types that are not in 2.4. Therefore, in order to build the generated events, the ReactiveUI.XamForms.Events library had to also depend on 2.5. And I figured it makes sense for the ReactiveUI.XamForms library to follow suit.

**What might this PR break?**

Anyone who isn't on XF 2.5 yet won't be able to upgrade.

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

