### PR TITLE
Fix Modal WPF dialog from Interaction handler

### DIFF
--- a/src/ReactiveUI/Interactions.cs
+++ b/src/ReactiveUI/Interactions.cs
@@ -169,8 +169,7 @@ namespace ReactiveUI
             }
 
             return RegisterHandler(interaction => {
-                handler(interaction);
-                return Observables.Unit;
+                return Observable.Start(() => handler(interaction), RxApp.MainThreadScheduler);
             });
         }
 


### PR DESCRIPTION
Closes #1396

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug

**What is the current behavior? (You can also link to an open issue here)**
Opening a dialog (using OpenDialog()) from an interaction handler breaks ReactiveUI in the opened dialog.

**What is the new behavior (if this is a feature change)?**
Now the demo SSCCE.zip works.

**What might this PR break?**
I hope nothing...

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
For this kind of bugs, I don't know how to create a unit test.
