### PR TITLE
chore: fix build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,7 +33,7 @@
   # also, the sdkmanager in all its glory leaks a bit of output to stderr, and powershell
   # and appveyor interpret that as errors, and blows up. so, when piping in our "Y ENTER"
   # responses, we invoke cmd so we can redirect stderr to stdout, and tell it to --update itself.
-  - ps: for($i=0;$i -lt 30;$i++) { $response += "y`n"}; $response | cmd /c 'C:\android\tools\bin\sdkmanager.bat 2>&1' --update
+  - ps: for($i=0;$i -lt 30;$i++) { $response += "y`n"}; $response | cmd /c 'C:\android-sdk-windows\tools\bin\sdkmanager.bat 2>&1' --update
   build_script:
   - ./build.cmd
   cache:


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Hopefully fixing the build on develop.

**What is the current behavior? (You can also link to an open issue here)**

develop doesn't build on AppVeyor as the android SDK updates are attempting to use files that moved in e086aed792d70c36d6304c2adc687f9ab451c633

**What is the new behavior (if this is a feature change)?**

Use the same line from non-develop builds, with (hopefully) the right android home.

Hopefully the build works, but it's a little hard to tell!

**What might this PR break?**

Possibly the build.

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

Possibly it would be worth using the %ANDROID_HOME% environment variable, but not sure how the powershell wrapping up cmd would behave.
