### PR TITLE
refactor: remove unused UIKIT ifdefs

### DIFF
--- a/src/ReactiveUI/Platforms/android/FlexibleCommandBinder.cs
+++ b/src/ReactiveUI/Platforms/android/FlexibleCommandBinder.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
@@ -9,9 +9,6 @@ using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reflection;
 using System.Windows.Input;
-#if UIKIT
-using UIKit;
-#endif
 
 namespace ReactiveUI
 {
@@ -117,45 +114,6 @@ namespace ReactiveUI
 
             return compDisp;
         }
-
-#if UIKIT
-        /// <summary>
-        /// Creates a commands binding from event and a property
-        /// </summary>
-        protected static IDisposable ForTargetAction(ICommand command, object target, IObservable<object> commandParameter, PropertyInfo enabledProperty)
-        {
-            commandParameter = commandParameter ?? Observable.Return(target);
-
-            object latestParam = null;
-
-            IDisposable actionDisp = null;
-
-            var ctl = target as UIControl;
-            if (ctl != null) {
-                var eh = new EventHandler((o, e) => {
-                    if (command.CanExecute(latestParam)) command.Execute(latestParam);
-                });
-
-                ctl.AddTarget(eh, UIControlEvent.TouchUpInside);
-                actionDisp = Disposable.Create(() => ctl.RemoveTarget(eh, UIControlEvent.TouchUpInside));
-            }
-
-            var enabledSetter = Reflection.GetValueSetterForProperty(enabledProperty);
-            if (enabledSetter == null) return actionDisp;
-
-            // Initial enabled state
-            enabledSetter(target, command.CanExecute(latestParam), null);
-
-            var compDisp = new CompositeDisposable(
-                actionDisp,
-                commandParameter.Subscribe(x => latestParam = x),
-                Observable.FromEventPattern<EventHandler, EventArgs>(x => command.CanExecuteChanged += x, x => command.CanExecuteChanged -= x)
-                    .Select(_ => command.CanExecute(latestParam))
-                    .Subscribe(x => enabledSetter(target, x, null)));
-
-            return compDisp;
-        }
-#endif
     }
 }
 

--- a/src/ReactiveUI/Platforms/ios/FlexibleCommandBinder.cs
+++ b/src/ReactiveUI/Platforms/ios/FlexibleCommandBinder.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
@@ -9,10 +9,7 @@ using System.Linq;
 using System.Reactive.Linq;
 using System.Reflection;
 using System.Windows.Input;
-
-#if UIKIT
 using UIKit;
-#endif
 
 namespace ReactiveUI
 {
@@ -52,9 +49,7 @@ namespace ReactiveUI
         }
 
         public IDisposable BindCommandToObject<TEventArgs>(ICommand command, object target, IObservable<object> commandParameter, string eventName)
-#if MONO
             where TEventArgs : EventArgs
-#endif
         {
             throw new NotImplementedException();
         }
@@ -119,7 +114,6 @@ namespace ReactiveUI
             return compDisp;
         }
 
-#if UIKIT
         /// <summary>
         /// Creates a commands binding from event and a property
         /// </summary>
@@ -156,6 +150,5 @@ namespace ReactiveUI
 
             return compDisp;
         }
-#endif
     }
 }

--- a/src/ReactiveUI/Platforms/ios/LinkerOverrides.cs
+++ b/src/ReactiveUI/Platforms/ios/LinkerOverrides.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
@@ -7,7 +7,6 @@ using UIKit;
 
 namespace ReactiveUI.Cocoa
 {
-#if UIKIT
     /// <summary>
     /// This class exists to force the MT linker to include properties called by RxUI via reflection
     /// </summary>
@@ -65,5 +64,4 @@ namespace ReactiveUI.Cocoa
             eh.Invoke(null, null);
         }
     }
-#endif
 }

--- a/src/ReactiveUI/Platforms/ios/RoutedViewHost.cs
+++ b/src/ReactiveUI/Platforms/ios/RoutedViewHost.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MS-PL license.
 // See the LICENSE file in the project root for more information.
 
@@ -6,14 +6,9 @@ using System;
 using System.Reactive.Linq;
 using System.Collections.Specialized;
 using System.Reactive.Disposables;
-
-#if UIKIT
 using UIKit;
 using NSView = UIKit.UIView;
 using NSViewController = UIKit.UIViewController;
-#else
-using AppKit;
-#endif
 
 namespace ReactiveUI
 {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Housekeeping.

**What is the current behavior? (You can also link to an open issue here)**

There are some UIKit ifdefs that don't make a whole host of sense (e.g. iOS always defines UIKIT  and Android never defines it)

**What is the new behavior (if this is a feature change)?**

Remove the extra ifdefs to try and tidy up.

**What might this PR break?**

Hopefully nothing.

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

