### PR TITLE
Added git hash to AssemblyInformationVersion

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,5 +1,6 @@
 next-version: 8.0.0
 assembly-versioning-scheme: None
+assembly-informational-format: '{NuGetVersion}-{sha}'
 branches:
   master:
     mode: ContinuousDelivery

--- a/build.cake
+++ b/build.cake
@@ -204,6 +204,7 @@ Task("BuildReactiveUI")
             // Due to https://github.com/NuGet/Home/issues/4790 and https://github.com/NuGet/Home/issues/4337 we
             // have to pass a version explicitly
             .WithProperty("Version", nugetVersion.ToString())
+            .WithProperty("InformationalVersion", informationalVersion)
             .SetVerbosity(Verbosity.Minimal)
             .SetNodeReuse(false));
     };


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Adds the git commit sha to the Product Version on ReactiveUI dll's.


**What is the current behavior? (You can also link to an open issue here)**
fixes #1515 

**What is the new behavior (if this is a feature change)?**
When viewing the Properties -> Details of any ReactiveUI dll you will be able to see the first 8 characters of the git commit hash in the Product Version field.

**What might this PR break?**
Shouldn't break anything, it is an isolated change to the output of the nuget package dll's.

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
@ghuntley was concerned about the legacy dll's being different.  It seems that they are working.  ReactiveUI.WPF and ReactiveUI.Events.WPF both seem to have the new commit hash without the need to do anything different.

  