### PR TITLE
Add .idea to gitignore to simplify use of JetBrains Rider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -244,3 +244,4 @@ src/ReactiveUI.Events*/Events_*.cs
 .DS_Store
 
 src/*.Tests/API/*.received.txt
+.idea/


### PR DESCRIPTION
Rider creates a *.idea* folder to store editor specific project properties, the equivalent of Visual Studio's *.vs* folder. Adding *.idea* to gitignore makes it easier to use Rider for contributors.