### PR TITLE
fix: allow ANDROID_HOME to contain spaces when building

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -116,7 +116,7 @@ Task("BuildEventBuilder")
             ArgumentCustomization = args => args.Append("/bl:eventbuilder.binlog /m")
         }
         .SetConfiguration("Release")
-		.WithProperty("AndroidSdkDirectory", androidHome)
+		.WithProperty("AndroidSdkDirectory", androidHome.Quote())
         .WithProperty("TreatWarningsAsErrors", treatWarningsAsErrors.ToString())
         .SetVerbosity(Verbosity.Minimal)
         .SetNodeReuse(false));
@@ -197,7 +197,7 @@ Task("BuildReactiveUI")
                 ArgumentCustomization = args => args.Append("/bl:reactiveui-build.binlog /m")
             }
             .WithTarget("build;pack") 
-            .WithProperty("AndroidSdkDirectory", androidHome)
+            .WithProperty("AndroidSdkDirectory", androidHome.Quote())
             .WithProperty("PackageOutputPath",  MakeAbsolute(Directory(artifactDirectory)).ToString().Quote())
             .WithProperty("TreatWarningsAsErrors", treatWarningsAsErrors.ToString())
             .SetConfiguration("Release")
@@ -215,7 +215,7 @@ Task("BuildReactiveUI")
             ArgumentCustomization = args => args.Append("/bl:reactiveui-restore.binlog /m")
         }
         .WithTarget("restore")
-		.WithProperty("AndroidSdkDirectory", androidHome)
+		.WithProperty("AndroidSdkDirectory", androidHome.Quote())
         .WithProperty("Version", nugetVersion.ToString())
         .SetVerbosity(Verbosity.Minimal));
     


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix in build process.

**What is the current behavior? (You can also link to an open issue here)**
MSBuild aborts if `/p:AndroidSdkDirectory` contains spaces (e.g. with `/p:AndroidSdkDirectory=C:\Program Files (x86)\Android\android-sdk`, which is where Xamarin installs it by default).

**What is the new behavior (if this is a feature change)?**
Added quotes to the Android SDK path passed to MSBuild.
