### PR TITLE
fix: implement IHandleObservableErrors on ReactiveCommand

### DIFF
--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.approved.txt
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.approved.txt
@@ -497,7 +497,7 @@ namespace ReactiveUI
         public static ReactiveUI.IReactiveDerivedList<T> CreateCollection<T>(this System.IObservable<T> fromObservable, System.Reactive.Concurrency.IScheduler scheduler) { }
         public static ReactiveUI.IReactiveDerivedList<T> CreateCollection<T>(this System.IObservable<T> fromObservable, System.Nullable<System.TimeSpan> withDelay = null, System.Action<System.Exception> onError = null, System.Reactive.Concurrency.IScheduler scheduler = null) { }
     }
-    public abstract class ReactiveCommand : System.IDisposable, System.Windows.Input.ICommand
+    public abstract class ReactiveCommand : ReactiveUI.IHandleObservableErrors, System.IDisposable, System.Windows.Input.ICommand
     {
         protected ReactiveCommand() { }
         public abstract System.IObservable<bool> CanExecute { get; }

--- a/src/ReactiveUI/ReactiveCommand.cs
+++ b/src/ReactiveUI/ReactiveCommand.cs
@@ -554,7 +554,7 @@ namespace ReactiveUI
     }
 
     // non-generic reactive command functionality
-    public abstract partial class ReactiveCommand : IDisposable, ICommand
+    public abstract partial class ReactiveCommand : IDisposable, ICommand, IHandleObservableErrors
     {
         private EventHandler canExecuteChanged;
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Feature... kind of

**What is the current behavior? (You can also link to an open issue here)**
https://github.com/reactiveui/ReactiveUI/issues/1572

**What is the new behavior (if this is a feature change)?**
ReactiveCommand implements IHandleObservableErrors

**What might this PR break?**
Nothing

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)