### PR TITLE
possibility to wrap exception

### DIFF
--- a/src/ReactiveUI/ReactiveCommand.cs
+++ b/src/ReactiveUI/ReactiveCommand.cs
@@ -854,7 +854,7 @@ namespace ReactiveUI
                     .Do(result => this.synchronizedExecutionInfo.OnNext(ExecutionInfo.CreateResult(result)))
                     .Catch<TResult, Exception>(
                         ex => {
-                            exceptions.OnNext(ex);
+                            exceptions.OnNext(GetExecuteException(ex, parameter));
                             return Observable.Throw<TResult>(ex);
                         })
                     .Finally(() => this.synchronizedExecutionInfo.OnNext(ExecutionInfo.CreateEnd()))
@@ -862,9 +862,20 @@ namespace ReactiveUI
                     .RefCount()
                     .ObserveOn(this.outputScheduler);
             } catch (Exception ex) {
-                this.exceptions.OnNext(ex);
+                this.exceptions.OnNext(GetExecuteException(ex, parameter));
                 return Observable.Throw<TResult>(ex);
             }
+        }
+
+        /// <summary>
+        /// Allows to preprocess exceptions pushed to <see cref="ThrownExceptions"/> from <see cref="Execute(TParam)"/>
+        /// </summary>
+        /// <param name="ex">original exception</param>
+        /// <param name="parameter">parameter passed to <see cref="Execute(TParam)"</param>
+        /// <returns>Converted exception</returns>
+        protected virtual Exception GetExecuteException(Exception ex, object parameter)
+        {
+            return ex;
         }
 
         protected override void Dispose(bool disposing)


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Feature


**What is the current behavior? (You can also link to an open issue here)**
Unable to reexecute the command


**What is the new behavior (if this is a feature change)?**
I want to make universal exception handler for commands. It should show exception message to user and ask if he wants to try again.
In general to do it I should know:
* exception
* command
* command parameter 

For now I can wrap `ThrownExceptions` and add command information, but there are no way to store command parameter.

So the idea is - I would override `GetExecuteException`:
```cs
protected override Exception GetExecuteException(Exception ex, object parameter)
    => new MyСommandException(ex, this, parameter)
```

So in `ThrownExceptions` listener I would be able to reinvoke the command


**What might this PR break?**
No


**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:

