### PR TITLE
chore: use same vs2017 appveyor image for master and develop

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,8 +2,8 @@
 -
   image: Visual Studio 2017
   branches:
-      only:
-        - master
+    only:
+    - master
   version: 1.0.{build}
   environment:
     ANDROID_HOME: "C:\\android-sdk-windows"
@@ -42,8 +42,8 @@
 -
   image: Visual Studio 2017
   branches:
-      except:
-          - master
+    except:
+    - master
   skip_branch_with_pr: true
   version: 1.0.{build}
   environment:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 # configuration for "master" branch
 -
-  image: Visual Studio 2017 Preview
+  image: Visual Studio 2017
   branches:
       only:
         - master


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

not sure if this is actually hit at the moment, but might make a difference.

**What is the current behavior? (You can also link to an open issue here)**

Use a preview appveyor image

**What is the new behavior (if this is a feature change)?**

Use a non-preview appveyor image (matching the non-master build)

**What might this PR break?**



**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

