### PR TITLE
feature: what if we were licensed under MIT?

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,55 +1,23 @@
-Microsoft Public License (Ms-PL)
+The MIT License (MIT)
 
-This license governs use of the accompanying software. If you use the software,
-you accept this license. If you do not accept the license, do not use the
-software.
+Copyright (c) .NET Foundation and Contributors
 
-1. Definitions
+All rights reserved.
 
-The terms "reproduce," "reproduction," "derivative works," and "distribution"
-have the same meaning here as under U.S. copyright law.  A "contribution" is the
-original software, or any additions or changes to the software.  A "contributor"
-is any person that distributes its contribution under this license.  "Licensed
-patents" are a contributor's patent claims that read directly on its
-contribution.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-2. Grant of Rights
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-  (A) Copyright Grant- Subject to the terms of this license, including the license
-  conditions and limitations in section 3, each contributor grants you a
-  non-exclusive, worldwide, royalty-free copyright license to reproduce its
-  contribution, prepare derivative works of its contribution, and distribute its
-  contribution or any derivative works that you create.
-
-  (B) Patent Grant- Subject
-  to the terms of this license, including the license conditions and limitations
-  in section 3, each contributor grants you a non-exclusive, worldwide,
-  royalty-free license under its licensed patents to make, have made, use, sell,
-  offer for sale, import, and/or otherwise dispose of its contribution in the
-  software or derivative works of the contribution in the software.
-
-3. Conditions and Limitations
-
-  (A) No Trademark License- This license does not grant you rights to use any
-  contributors' name, logo, or trademarks.
-
-  (B) If you bring a patent claim against any contributor over patents that you
-  claim are infringed by the software, your patent license from such contributor
-  to the software ends automatically.
-
-  (C) If you distribute any portion of the software, you must retain all
-  copyright, patent, trademark, and attribution notices that are present in the
-  software.
-
-  (D) If you distribute any portion of the software in source code form, you may
-  do so only under this license by including a complete copy of this license with
-  your distribution. If you distribute any portion of the software in compiled or
-  object code form, you may only do so under a license that complies with this
-  license.
-
-  (E) The software is licensed "as-is." You bear the risk of using it. The
-  contributors give no express warranties, guarantees or conditions. You may have
-  additional consumer rights under your local laws which this license cannot
-  change. To the extent permitted under your local laws, the contributors exclude
-  the implied warranties of merchantability, fitness for a particular purpose and
-  non-infringement.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <Copyright>Copyright (c) .NET Foundation and Contributors</Copyright>
-    <PackageLicenseUrl>http://opensource.org/licenses/ms-pl</PackageLicenseUrl>
+    <PackageLicenseUrl>https://opensource.org/licenses/mit</PackageLicenseUrl>
     <PackageProjectUrl>https://reactiveui.net</PackageProjectUrl>
     <PackageIconUrl>https://i.imgur.com/7WDbqSy.png</PackageIconUrl>
     <Authors>.NET Foundation and Contributors</Authors>


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Fixes #1580 

**What is the current behavior? (You can also link to an open issue here)**

I keep getting reports from folks who want to contribute but their employer has a restrictive list of pre-approved licenses and MSPL isn't on that list. 

**What is the new behavior (if this is a feature change)?**

What if we enabled those to help us? Much easier than making them go through internal corporate bs.

**What might this PR break?**

Feelings (tm). This PR is under review by the .NET Foundation legal team. If no issues, then we merge!
