### PR TITLE
fix: disable WeakEventManager for net461 build (#1617)

### DIFF
--- a/src/ReactiveUI/ReactiveList.cs
+++ b/src/ReactiveUI/ReactiveList.cs
@@ -24,7 +24,7 @@ namespace ReactiveUI
     [DebuggerTypeProxy(typeof(CollectionDebugView<>))]
     public class ReactiveList<T> : IReactiveList<T>, IReadOnlyReactiveList<T>, IList
     {
-#if NET_45
+#if NET_461
         public event NotifyCollectionChangedEventHandler CollectionChanging;
 
         protected virtual void raiseCollectionChanging(NotifyCollectionChangedEventArgs args)

--- a/src/ReactiveUI/ReactiveObject.cs
+++ b/src/ReactiveUI/ReactiveObject.cs
@@ -28,7 +28,7 @@ namespace ReactiveUI
     [DataContract]
     public class ReactiveObject : IReactiveNotifyPropertyChanged<IReactiveObject>, IHandleObservableErrors, IReactiveObject
     {
-#if NET_45        
+#if NET_461        
         public event PropertyChangingEventHandler PropertyChanging;
 
         void IReactiveObject.RaisePropertyChanging(PropertyChangingEventArgs args)

--- a/src/ReactiveUI/WeakEventManager.cs
+++ b/src/ReactiveUI/WeakEventManager.cs
@@ -17,7 +17,7 @@ using System.Windows.Input;
 
 namespace ReactiveUI
 {
-#if !NET_45
+#if !NET_461
     internal class CanExecuteChangedEventManager : WeakEventManager<ICommand, EventHandler, EventArgs>
     {
     }


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Fix 

**What is the current behavior? (You can also link to an open issue here)**
https://github.com/reactiveui/ReactiveUI/issues/1617

**What is the new behavior (if this is a feature change)?**
Use NET_461 instead of NET_45 pre-processor directive to disable WeakEventManager for WPF platform


**What might this PR break?**
Nothing.

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)