### PR TITLE
housekeeping: pin xamarin.forms version used by eventbuilder

### DIFF
--- a/src/EventBuilder/Platforms/XamForms.cs
+++ b/src/EventBuilder/Platforms/XamForms.cs
@@ -39,7 +39,7 @@ namespace EventBuilder.Platforms
 
                 var packageManager = new PackageManager(repo, packageUnzipPath);
 
-                var package = repo.FindPackagesById(_packageName).Single(x => x.IsLatestVersion);
+                var package = repo.FindPackagesById(_packageName).Single(x => x.Version.ToString() == "2.5.1.444934");
 
                 Log.Debug("Using Xamarin Forms {Version} released on {Published}", package.Version, package.Published);
                 Log.Debug("{ReleaseNotes}", package.ReleaseNotes);


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

dodgy workaround that has been documented in the maintainer guide

**What is the current behavior? (You can also link to an open issue here)**

unpinned builds

**What is the new behavior (if this is a feature change)?**

pinned builds

**What might this PR break?**

If we forget to bump this when bumping reactiveui.xamforms and then the correct version of events won't be code generatoed.

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

