### PR TITLE
Fix double registration of ComponentModelTypeConverter

### DIFF
--- a/src/ReactiveUI.Winforms/Registrations.cs
+++ b/src/ReactiveUI.Winforms/Registrations.cs
@@ -15,8 +15,6 @@ namespace ReactiveUI.Winforms
         {
             registerFunction(() => new PlatformOperations(), typeof(IPlatformOperations));
 
-            registerFunction(() => new ComponentModelTypeConverter(), typeof(IBindingTypeConverter));
-
             registerFunction(() => new CreatesWinformsCommandBinding(), typeof(ICreatesCommandBinding));
             registerFunction(() => new WinformsCreatesObservableForProperty(), typeof(ICreatesObservableForProperty));
             registerFunction(() => new ActivationForViewFetcher(), typeof(IActivationForViewFetcher));

--- a/src/ReactiveUI.Wpf/Registrations.cs
+++ b/src/ReactiveUI.Wpf/Registrations.cs
@@ -12,8 +12,7 @@ namespace ReactiveUI.Wpf
         public void Register(Action<Func<object>, Type> registerFunction)
         {
             registerFunction(() => new PlatformOperations(), typeof(IPlatformOperations));
-
-            registerFunction(() => new ComponentModelTypeConverter(), typeof(IBindingTypeConverter));
+            
             registerFunction(() => new ActivationForViewFetcher(), typeof(IActivationForViewFetcher));
             registerFunction(() => new DependencyObjectObservableForProperty(), typeof(ICreatesObservableForProperty));
             registerFunction(() => new BooleanToVisibilityTypeConverter(), typeof(IBindingTypeConverter));


### PR DESCRIPTION
The ComponentModelTypeConverter is already registered by ReactiveUI.PlatformRegistrations (net461)

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Improvement

**What is the current behavior? (You can also link to an open issue here)**
The ComponentModelTypeConverter ist registered by ReactiveUI.PlatformRegistrations (net461) and ReactiveUI.Wpf.Registrations / ReactiveUI.Winforms.Registrations

**What is the new behavior (if this is a feature change)?**
The ComponentModelTypeConverter ist only registered by ReactiveUI.PlatformRegistrations (net461)

**What might this PR break?**
N/A

**Please check if the PR fulfills these requirements**
- [X ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
Found with #1598 
