### PR TITLE
[XamForms] Allow navigation transition animations to be disabled

### DIFF
--- a/src/ReactiveUI.XamForms/DisableAnimationAttribute.cs
+++ b/src/ReactiveUI.XamForms/DisableAnimationAttribute.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace ReactiveUI.XamForms
+{
+    public class DisableAnimationAttribute : Attribute
+    {
+    }
+}

--- a/src/ReactiveUI.XamForms/RoutedViewHost.cs
+++ b/src/ReactiveUI.XamForms/RoutedViewHost.cs
@@ -3,13 +3,14 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using Xamarin.Forms;
-using Splat;
-using ReactiveUI;
+using System.Reactive;
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
-using System.Diagnostics;
-using System.Reactive;
+using System.Reflection;
+
+using Xamarin.Forms;
+
+using Splat;
 
 namespace ReactiveUI.XamForms
 {

--- a/src/ReactiveUI.XamForms/RoutedViewHost.cs
+++ b/src/ReactiveUI.XamForms/RoutedViewHost.cs
@@ -94,7 +94,16 @@ namespace ReactiveUI.XamForms
                         }
                         else
                         {
-                            await this.PushAsync(x);
+                            bool animated = true;
+                            var type = x.GetType();
+                            Attribute[] attrs = Attribute.GetCustomAttributes(type);
+
+                            foreach (var a in attrs) {
+                                    if (a is DisableAnimationAttribute)
+                                        animated = false;
+                            }
+
+                            await this.PushAsync(x, animated);
                         }
 
                         popToRootPending = false;

--- a/src/ReactiveUI.XamForms/RoutedViewHost.cs
+++ b/src/ReactiveUI.XamForms/RoutedViewHost.cs
@@ -86,28 +86,26 @@ namespace ReactiveUI.XamForms
 
                 d(this.WhenAnyObservable(x => x.Router.Navigate)
                     .SelectMany(_ => PageForViewModel(Router.GetCurrentViewModel()))
-                    .SelectMany(async x => {
+                    .SelectMany(async page => {
                         if (popToRootPending && this.Navigation.NavigationStack.Count > 0)
                         {
-                            this.Navigation.InsertPageBefore(x, this.Navigation.NavigationStack[0]);
+                            this.Navigation.InsertPageBefore(page, this.Navigation.NavigationStack[0]);
                             await this.PopToRootAsync();
                         }
                         else
                         {
                             bool animated = true;
-                            var type = x.GetType();
-                            Attribute[] attrs = Attribute.GetCustomAttributes(type);
-
-                            foreach (var a in attrs) {
-                                    if (a is DisableAnimationAttribute)
-                                        animated = false;
+                            var attribute = page.GetType().GetCustomAttribute<DisableAnimationAttribute>();
+                            if (attribute != null)
+                            {
+                                animated = false;
                             }
 
-                            await this.PushAsync(x, animated);
+                            await this.PushAsync(page, animated);
                         }
 
                         popToRootPending = false;
-                        return x;
+                        return page;
                     })
                     .Subscribe());
 


### PR DESCRIPTION
Xamarin.Forms navigation animations transitions by default, and apps
must explicitly opt out of the animation. RoutedViewHost hides these
APIs from the user.

This allows apps to apply DisableAnimation attribute to views in order
to instruct RoutedViewHost to not animate the transition.

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Feature - right now the ReactiveUI.XamForms RoutedViewHost hides the Xamarin.Forms navigation API so that there's no way for apps to disable animation transitions. This change allows developers to mark views so that when they are pushed into the navigation stack there is no transition animation.


**What is the current behavior? (You can also link to an open issue here)**

The current behavior is to call `PushAsync(x)`, which is the same as calling `PushAsync(x, true)`. There is currently no way to call `PushAsync(x, false)`.


**What is the new behavior (if this is a feature change)?**

This change would allow apps to apply a `[DisableAnimation]` attribute to their view, and when RoutedViewHost sees this attribute it will pass `false` to `PushAsync()`.

**What might this PR break?**

I don't think this is likely to break anything.

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

I'd like some feedback from devs/maintainers if this seems like a decent approach. Originally I thought to have a new property on `IRoutableViewModel` but that was a little trickier to do and it would have the major downside of breaking backwards compatibility since everyone would have to add that property to their viewmodels.