### PR TITLE
feature: enable reactiveui with system.reactive v4

### DIFF
--- a/src/ReactiveUI.AndroidSupport/ReactiveUI.AndroidSupport.csproj
+++ b/src/ReactiveUI.AndroidSupport/ReactiveUI.AndroidSupport.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Xamarin.Android.Support.v7.RecyclerView" Version="26.1.0.1" />
     <PackageReference Include="Xamarin.Android.Support.Vector.Drawable" Version="26.1.0.1" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
-    <PackageReference Include="System.Reactive" Version="[3.1.1,4)" />
+    <PackageReference Include="System.Reactive" Version="3.1.1" />
     <PackageReference Include="Splat" Version="4.0.0" />
     <Reference Include="System.Runtime.Serialization" />
   </ItemGroup>

--- a/src/ReactiveUI.Blend/ReactiveUI.Blend.csproj
+++ b/src/ReactiveUI.Blend/ReactiveUI.Blend.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <Compile Remove="Platforms\**\*.cs" />
     <None Include="Platforms\**\*.cs" />
-    <PackageReference Include="System.Reactive" Version="[3.1.1,4)" />
+    <PackageReference Include="System.Reactive" Version="3.1.1" />
     <PackageReference Include="Splat" Version="4.0.0" />
   </ItemGroup>
 

--- a/src/ReactiveUI.Events.WPF/ReactiveUI.Events.WPF.csproj
+++ b/src/ReactiveUI.Events.WPF/ReactiveUI.Events.WPF.csproj
@@ -11,7 +11,7 @@
     <Compile Remove="*.cs" />
     <None Include="*.cs" />
     <Compile Include="../ReactiveUI.Events/SingleAwaitSubject.cs" />
-    <PackageReference Include="System.Reactive" Version="[3.1.1,4)" />
+    <PackageReference Include="System.Reactive" Version="3.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ReactiveUI.Events.Winforms/ReactiveUI.Events.Winforms.csproj
+++ b/src/ReactiveUI.Events.Winforms/ReactiveUI.Events.Winforms.csproj
@@ -11,7 +11,7 @@
     <Compile Remove="*.cs" />
     <None Include="*.cs" />
     <Compile Include="../ReactiveUI.Events/SingleAwaitSubject.cs" />
-    <PackageReference Include="System.Reactive" Version="[3.1.1,4)" />
+    <PackageReference Include="System.Reactive" Version="3.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ReactiveUI.Events.XamForms/ReactiveUI.Events.XamForms.csproj
+++ b/src/ReactiveUI.Events.XamForms/ReactiveUI.Events.XamForms.csproj
@@ -11,7 +11,7 @@
     <Compile Remove="*.cs" />
     <None Include="*.cs" />
     <Compile Include="../ReactiveUI.Events/SingleAwaitSubject.cs" />
-    <PackageReference Include="System.Reactive" Version="[3.1.1,4)" />
+    <PackageReference Include="System.Reactive" Version="3.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ReactiveUI.Events/ReactiveUI.Events.csproj
+++ b/src/ReactiveUI.Events/ReactiveUI.Events.csproj
@@ -11,7 +11,7 @@
     <Compile Remove="*.cs" />
     <None Include="*.cs" />
     <Compile Include="SingleAwaitSubject.cs" />
-    <PackageReference Include="System.Reactive" Version="[3.1.1,4)" />
+    <PackageReference Include="System.Reactive" Version="3.1.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'uap10.0.16299' ">

--- a/src/ReactiveUI.Fody.Helpers/ReactiveUI.Fody.Helpers.csproj
+++ b/src/ReactiveUI.Fody.Helpers/ReactiveUI.Fody.Helpers.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Fody" Version="3.0.3" PrivateAssets="None" />
     <PackageReference Include="FodyPackaging" Version="3.0.3" PrivateAssets="All" />
-    <PackageReference Include="System.Reactive" Version="[3.1.1,4)" />
+    <PackageReference Include="System.Reactive" Version="3.1.1" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('netstandard'))">

--- a/src/ReactiveUI.Fody.Tests/ReactiveUI.Fody.Tests.csproj
+++ b/src/ReactiveUI.Fody.Tests/ReactiveUI.Fody.Tests.csproj
@@ -11,8 +11,8 @@
 
   <ItemGroup>
     <PackageReference Include="ApprovalTests" Version=" 3.0.13" />
-    <PackageReference Include="System.Reactive" Version="[3.1.1,4)" />
-    <PackageReference Include="Microsoft.Reactive.Testing" Version="[3.1.1,4)" />
+    <PackageReference Include="System.Reactive" Version="3.1.1" />
+    <PackageReference Include="Microsoft.Reactive.Testing" Version="3.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ReactiveUI.Testing/ReactiveUI.Testing.csproj
+++ b/src/ReactiveUI.Testing/ReactiveUI.Testing.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Reactive.Testing" Version="[3.1.1,4)" />
+    <PackageReference Include="Microsoft.Reactive.Testing" Version="3.1.1" />
     <ProjectReference Include="..\ReactiveUI\ReactiveUI.csproj" />
   </ItemGroup>
 

--- a/src/ReactiveUI.Tests/ReactiveUI.Tests.csproj
+++ b/src/ReactiveUI.Tests/ReactiveUI.Tests.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0-beta.2.build3984" />
     <PackageReference Include="Xunit.StaFact" Version="0.2.9" />
     <PackageReference Include="ApprovalTests" Version=" 3.0.13" />
-    <PackageReference Include="Microsoft.Reactive.Testing" Version="[3.1.1,4)" />
+    <PackageReference Include="Microsoft.Reactive.Testing" Version="3.1.1" />
     <PackageReference Include="PublicApiGenerator" Version="6.0.0" />
   </ItemGroup>
 

--- a/src/ReactiveUI/ReactiveUI.csproj
+++ b/src/ReactiveUI/ReactiveUI.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <Compile Remove="Platforms\**\*.cs" />
     <None Include="Platforms\**\*.cs" />
-    <PackageReference Include="System.Reactive" Version="[3.1.1,4)" />
+    <PackageReference Include="System.Reactive" Version="3.1.1" />
     <PackageReference Include="Splat" Version="4.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Feature

**What is the current behavior? (You can also link to an open issue here)**

`System.Reactive` is pinned to v3.x, preventing installation of v4.x

**What is the new behavior (if this is a feature change)?**

`System.Reactive` is unpinned.

**What might this PR break?**

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

I have not tested this change; it's a pure find and replace.