### PR TITLE
 Add ResolveStrategy parameter to WireUpControls in ReactiveUI.AndroidSupport

### DIFF
--- a/src/ReactiveUI.AndroidSupport/ControlFetcherMixin.cs
+++ b/src/ReactiveUI.AndroidSupport/ControlFetcherMixin.cs
@@ -12,6 +12,7 @@ using Android.App;
 using Android.Views;
 using Java.Interop;
 using Android.Support.V7.App;
+using static ReactiveUI.ControlFetcherMixin;
 
 namespace ReactiveUI.AndroidSupport
 {
@@ -67,20 +68,21 @@ namespace ReactiveUI.AndroidSupport
                 () => This.FindViewById(controlIds[propertyName.ToLowerInvariant()]).JavaCast<T>());
         }
 
-        /// <summary>
-        /// This should be called in the Fragement's OnCreateView, with the newly inflated layout
-        /// </summary>
-        /// <param name="This"></param>
-        /// <param name="inflatedView"></param>
-        public static void WireUpControls(this global::Android.Support.V4.App.Fragment This, View inflatedView)
+		/// <summary>
+		/// A helper method to automatically resolve properties in an <see cref="Android.Support.V4.App.Fragment"/> to their respective elements in the layout.
+		/// This should be called in the Fragement's OnCreateView, with the newly inflated layout
+		/// </summary>
+		/// <param name="This"></param>
+		/// <param name="inflatedView">The newly inflated <see cref="View"/> returned from <see cref="LayoutInflater.Inflate"/>.</param>
+		/// <param name="resolveMembers">The strategy used to resolve properties that either subclass <see cref="View"/>, have a <see cref="WireUpResourceAttribute"/> or have a <see cref="IgnoreResourceAttribute"/></param>
+		public static void WireUpControls(this global::Android.Support.V4.App.Fragment This, View inflatedView, ResolveStrategy resolveMembers = ResolveStrategy.Implicit)
 		{
-			var members = This.GetType().GetRuntimeProperties()
-				.Where(m => m.PropertyType.IsSubclassOf(typeof(View)));
+			var members = This.getWireUpMembers(ResolveStrategy.Implicit);
 
 			members.ToList().ForEach(m => {
 				try {
 					// Find the android control with the same name from the view
-					var view = inflatedView.getControlInternal(m.PropertyType, m.Name);
+					var view = inflatedView.getControlInternal(m.PropertyType, m.getResourceName());
 
 					// Set the activity field's value to the view with that identifier
 					m.SetValue(This, view);
@@ -92,17 +94,18 @@ namespace ReactiveUI.AndroidSupport
 		}
 
 		/// <summary>
-		///
+		/// A helper method to automatically resolve properties in an <see cref="AppCompatActivity"/> to their respective elements in the layout.
 		/// </summary>
-		public static void WireUpControls(this AppCompatActivity This)
+		/// <param name="This"></param>
+		/// <param name="resolveMembers">The strategy used to resolve properties that either subclass <see cref="View"/>, have a <see cref="WireUpResourceAttribute"/> or have a <see cref="IgnoreResourceAttribute"/></param>
+		public static void WireUpControls(this AppCompatActivity This, ResolveStrategy resolveMembers = ResolveStrategy.Implicit)
 		{
-			var members = This.GetType().GetRuntimeProperties()
-				.Where(m => m.PropertyType.IsSubclassOf(typeof(View)));
+			var members = This.getWireUpMembers(resolveMembers);
 
 			members.ToList().ForEach(m => {
 				try {
 					// Find the android control with the same name
-					var view = This.getControlInternal(m.PropertyType, m.Name);
+					var view = This.getControlInternal(m.PropertyType, m.getResourceName());
 
 					// Set the activity field's value to the view with that identifier
 					m.SetValue(This, view);
@@ -111,6 +114,33 @@ namespace ReactiveUI.AndroidSupport
 						+ m.Name + " to a View in your layout with a corresponding identifier", ex);
 				}
 			});
+		}
+
+		// Copied from ReactiveUI/Platforms/android/ControlFetcherMixins.cs
+		static IEnumerable<PropertyInfo> getWireUpMembers(this object This, ResolveStrategy resolveStrategy)
+		{
+			var members = This.GetType().GetRuntimeProperties();
+
+			switch (resolveStrategy) {
+				default:
+				case ResolveStrategy.Implicit:
+					return members.Where(m => m.PropertyType.IsSubclassOf(typeof(View))
+										 || m.GetCustomAttribute<WireUpResourceAttribute>(true) != null);
+
+				case ResolveStrategy.ExplicitOptIn:
+					return members.Where(m => m.GetCustomAttribute<WireUpResourceAttribute>(true) != null);
+
+				case ResolveStrategy.ExplicitOptOut:
+					return members.Where(m => typeof(View).IsAssignableFrom(m.PropertyType)
+										 && m.GetCustomAttribute<IgnoreResourceAttribute>(true) == null);
+			}
+		}
+
+		// Also copied from ReactiveUI/Platforms/android/ControlFetcherMixins.cs
+		static string getResourceName(this PropertyInfo member)
+		{
+			var resourceNameOverride = member.GetCustomAttribute<WireUpResourceAttribute>()?.ResourceNameOverride;
+			return resourceNameOverride ?? member.Name;
 		}
 
 		static View getControlInternal(this View parent, Type viewType, string name)

--- a/src/ReactiveUI.AndroidSupport/ControlFetcherMixin.cs
+++ b/src/ReactiveUI.AndroidSupport/ControlFetcherMixin.cs
@@ -93,29 +93,6 @@ namespace ReactiveUI.AndroidSupport
 			});
 		}
 
-		/// <summary>
-		/// A helper method to automatically resolve properties in an <see cref="AppCompatActivity"/> to their respective elements in the layout.
-		/// </summary>
-		/// <param name="This"></param>
-		/// <param name="resolveMembers">The strategy used to resolve properties that either subclass <see cref="View"/>, have a <see cref="WireUpResourceAttribute"/> or have a <see cref="IgnoreResourceAttribute"/></param>
-		public static void WireUpControls(this AppCompatActivity This, ResolveStrategy resolveMembers = ResolveStrategy.Implicit)
-		{
-			var members = This.getWireUpMembers(resolveMembers);
-
-			members.ToList().ForEach(m => {
-				try {
-					// Find the android control with the same name
-					var view = This.getControlInternal(m.PropertyType, m.getResourceName());
-
-					// Set the activity field's value to the view with that identifier
-					m.SetValue(This, view);
-				} catch (Exception ex) {
-					throw new MissingFieldException("Failed to wire up the Property "
-						+ m.Name + " to a View in your layout with a corresponding identifier", ex);
-				}
-			});
-		}
-
 		// Copied from ReactiveUI/Platforms/android/ControlFetcherMixins.cs
 		static IEnumerable<PropertyInfo> getWireUpMembers(this object This, ResolveStrategy resolveStrategy)
 		{


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Fixes #1679

**What is the current behavior? (You can also link to an open issue here)**

See https://github.com/reactiveui/ReactiveUI/issues/1679

**What is the new behavior (if this is a feature change)?**

Adds a `ResolveStrategy` parameter to `WireUpControls` for AppCompatActivity and Fragment in `Android.Support.V{4,7}...` 

**What might this PR break?**

`ReactiveUI.AndroidSupport.ControlFetcherMixins.WireUpControls(AppCompatActivity)` is removed in favour of a more capable `ReactiveUI.ControlFetcherMixins.WireUpControls(Activity, ResolveStrategy)`

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

**Other information**:

