### PR TITLE
housekeeping: header incorrectly said MS-PL instead of MIT

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 //////////////////////////////////////////////////////////////////////

--- a/samples/stylecop.json
+++ b/samples/stylecop.json
@@ -6,7 +6,7 @@
       "documentationCulture": "en-US",
       "documentInterfaces": true,
       "documentInternalElements": false,
-      "copyrightText": "Licensed to the .NET Foundation under one or more agreements.\nThe .NET Foundation licenses this file to you under the MS-PL license.\nSee the LICENSE file in the project root for more information.",
+      "copyrightText": "Licensed to the .NET Foundation under one or more agreements.\nThe .NET Foundation licenses this file to you under the MIT license.\nSee the LICENSE file in the project root for more information.",
       "xmlHeader": true
     },
     "orderingRules": {

--- a/samples/xamarin-forms/Cinephile.Core/Cinephile.Core.licenseheader
+++ b/samples/xamarin-forms/Cinephile.Core/Cinephile.Core.licenseheader
@@ -1,12 +1,12 @@
 ﻿extensions: designer.cs generated.cs
 extensions: .cs .cpp .h
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 extensions:  .xml .config .xsd
 <!--
 Licensed to the .NET Foundation under one or more agreements.
-The .NET Foundation licenses this file to you under the MS-PL license.
+The .NET Foundation licenses this file to you under the MIT license.
 See the LICENSE file in the project root for more information.
 -->

--- a/samples/xamarin-forms/Cinephile.Core/Infrastructure/HttpTools/HttpLoggingHandler.cs
+++ b/samples/xamarin-forms/Cinephile.Core/Infrastructure/HttpTools/HttpLoggingHandler.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/samples/xamarin-forms/Cinephile.Core/Models/IMovieService.cs
+++ b/samples/xamarin-forms/Cinephile.Core/Models/IMovieService.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/samples/xamarin-forms/Cinephile.Core/Models/Movie.cs
+++ b/samples/xamarin-forms/Cinephile.Core/Models/Movie.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/samples/xamarin-forms/Cinephile.Core/Models/MovieService.cs
+++ b/samples/xamarin-forms/Cinephile.Core/Models/MovieService.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/samples/xamarin-forms/Cinephile.Core/Properties/AssemblyInfo.cs
+++ b/samples/xamarin-forms/Cinephile.Core/Properties/AssemblyInfo.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System.Reflection;

--- a/samples/xamarin-forms/Cinephile.Core/Rest/ApiService.cs
+++ b/samples/xamarin-forms/Cinephile.Core/Rest/ApiService.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/samples/xamarin-forms/Cinephile.Core/Rest/Cache.cs
+++ b/samples/xamarin-forms/Cinephile.Core/Rest/Cache.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/samples/xamarin-forms/Cinephile.Core/Rest/Dtos/ImageConfigurations/ImageConfigurationDto.cs
+++ b/samples/xamarin-forms/Cinephile.Core/Rest/Dtos/ImageConfigurations/ImageConfigurationDto.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/samples/xamarin-forms/Cinephile.Core/Rest/Dtos/ImageConfigurations/ImagesDto.cs
+++ b/samples/xamarin-forms/Cinephile.Core/Rest/Dtos/ImageConfigurations/ImagesDto.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/samples/xamarin-forms/Cinephile.Core/Rest/Dtos/Movies/GenreDto.cs
+++ b/samples/xamarin-forms/Cinephile.Core/Rest/Dtos/Movies/GenreDto.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/samples/xamarin-forms/Cinephile.Core/Rest/Dtos/Movies/GenresDto.cs
+++ b/samples/xamarin-forms/Cinephile.Core/Rest/Dtos/Movies/GenresDto.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/samples/xamarin-forms/Cinephile.Core/Rest/Dtos/Movies/MovieDates.cs
+++ b/samples/xamarin-forms/Cinephile.Core/Rest/Dtos/Movies/MovieDates.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/samples/xamarin-forms/Cinephile.Core/Rest/Dtos/Movies/MovieDto.cs
+++ b/samples/xamarin-forms/Cinephile.Core/Rest/Dtos/Movies/MovieDto.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/samples/xamarin-forms/Cinephile.Core/Rest/Dtos/Movies/MovieResult.cs
+++ b/samples/xamarin-forms/Cinephile.Core/Rest/Dtos/Movies/MovieResult.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/samples/xamarin-forms/Cinephile.Core/Rest/IApiService.cs
+++ b/samples/xamarin-forms/Cinephile.Core/Rest/IApiService.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/samples/xamarin-forms/Cinephile.Core/Rest/ICache.cs
+++ b/samples/xamarin-forms/Cinephile.Core/Rest/ICache.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/samples/xamarin-forms/Cinephile.Core/Rest/IRestApiClient.cs
+++ b/samples/xamarin-forms/Cinephile.Core/Rest/IRestApiClient.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/samples/xamarin-forms/Cinephile.Core/app.config
+++ b/samples/xamarin-forms/Cinephile.Core/app.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!--
 Licensed to the .NET Foundation under one or more agreements.
-The .NET Foundation licenses this file to you under the MS-PL license.
+The .NET Foundation licenses this file to you under the MIT license.
 See the LICENSE file in the project root for more information.
 -->
 

--- a/samples/xamarin-forms/Cinephile.Core/packages.config
+++ b/samples/xamarin-forms/Cinephile.Core/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!--
 Licensed to the .NET Foundation under one or more agreements.
-The .NET Foundation licenses this file to you under the MS-PL license.
+The .NET Foundation licenses this file to you under the MIT license.
 See the LICENSE file in the project root for more information.
 -->
 

--- a/samples/xamarin-forms/Cinephile.UnitTests/Cinephile.UnitTests.licenseheader
+++ b/samples/xamarin-forms/Cinephile.UnitTests/Cinephile.UnitTests.licenseheader
@@ -1,12 +1,12 @@
 ﻿extensions: designer.cs generated.cs
 extensions: .cs .cpp .h
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 extensions:  .xml .config .xsd
 <!--
 Licensed to the .NET Foundation under one or more agreements.
-The .NET Foundation licenses this file to you under the MS-PL license.
+The .NET Foundation licenses this file to you under the MIT license.
 See the LICENSE file in the project root for more information.
 -->

--- a/samples/xamarin-forms/Cinephile.UnitTests/Model/MovieServiceTest.cs
+++ b/samples/xamarin-forms/Cinephile.UnitTests/Model/MovieServiceTest.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/samples/xamarin-forms/Cinephile.UnitTests/app.config
+++ b/samples/xamarin-forms/Cinephile.UnitTests/app.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!--
 Licensed to the .NET Foundation under one or more agreements.
-The .NET Foundation licenses this file to you under the MS-PL license.
+The .NET Foundation licenses this file to you under the MIT license.
 See the LICENSE file in the project root for more information.
 -->
 

--- a/samples/xamarin-forms/Cinephile.UnitTests/packages.config
+++ b/samples/xamarin-forms/Cinephile.UnitTests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!--
 Licensed to the .NET Foundation under one or more agreements.
-The .NET Foundation licenses this file to you under the MS-PL license.
+The .NET Foundation licenses this file to you under the MIT license.
 See the LICENSE file in the project root for more information.
 -->
 

--- a/samples/xamarin-forms/Cinephile/App.xaml.cs
+++ b/samples/xamarin-forms/Cinephile/App.xaml.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using Xamarin.Forms;

--- a/samples/xamarin-forms/Cinephile/AppBootstrapper.cs
+++ b/samples/xamarin-forms/Cinephile/AppBootstrapper.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/samples/xamarin-forms/Cinephile/Cinephile.licenseheader
+++ b/samples/xamarin-forms/Cinephile/Cinephile.licenseheader
@@ -1,12 +1,12 @@
 ﻿extensions: designer.cs generated.cs
 extensions: .cs .cpp .h
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 extensions:  .xml .config .xsd
 <!--
 Licensed to the .NET Foundation under one or more agreements.
-The .NET Foundation licenses this file to you under the MS-PL license.
+The .NET Foundation licenses this file to you under the MIT license.
 See the LICENSE file in the project root for more information.
 -->

--- a/samples/xamarin-forms/Cinephile/Properties/AssemblyInfo.cs
+++ b/samples/xamarin-forms/Cinephile/Properties/AssemblyInfo.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System.Reflection;

--- a/samples/xamarin-forms/Cinephile/ViewModels/MovieDetailViewModel.cs
+++ b/samples/xamarin-forms/Cinephile/ViewModels/MovieDetailViewModel.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/samples/xamarin-forms/Cinephile/ViewModels/UpcomingMoviesCellViewModel.cs
+++ b/samples/xamarin-forms/Cinephile/ViewModels/UpcomingMoviesCellViewModel.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/samples/xamarin-forms/Cinephile/ViewModels/UpcomingMoviesListViewModel.cs
+++ b/samples/xamarin-forms/Cinephile/ViewModels/UpcomingMoviesListViewModel.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/samples/xamarin-forms/Cinephile/ViewModels/ViewModelBase.cs
+++ b/samples/xamarin-forms/Cinephile/ViewModels/ViewModelBase.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/samples/xamarin-forms/Cinephile/Views/ContentPageBase.cs
+++ b/samples/xamarin-forms/Cinephile/Views/ContentPageBase.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/samples/xamarin-forms/Cinephile/Views/MovieDetailView.xaml.cs
+++ b/samples/xamarin-forms/Cinephile/Views/MovieDetailView.xaml.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System.Reactive.Disposables;

--- a/samples/xamarin-forms/Cinephile/Views/UpcomingMoviesCellView.xaml.cs
+++ b/samples/xamarin-forms/Cinephile/Views/UpcomingMoviesCellView.xaml.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/samples/xamarin-forms/Cinephile/Views/UpcomingMoviesListView.xaml.cs
+++ b/samples/xamarin-forms/Cinephile/Views/UpcomingMoviesListView.xaml.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;

--- a/samples/xamarin-forms/Cinephile/app.config
+++ b/samples/xamarin-forms/Cinephile/app.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!--
 Licensed to the .NET Foundation under one or more agreements.
-The .NET Foundation licenses this file to you under the MS-PL license.
+The .NET Foundation licenses this file to you under the MIT license.
 See the LICENSE file in the project root for more information.
 -->
 

--- a/samples/xamarin-forms/Cinephile/packages.config
+++ b/samples/xamarin-forms/Cinephile/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!--
 Licensed to the .NET Foundation under one or more agreements.
-The .NET Foundation licenses this file to you under the MS-PL license.
+The .NET Foundation licenses this file to you under the MIT license.
 See the LICENSE file in the project root for more information.
 -->
 <packages>

--- a/samples/xamarin-forms/Droid/AkavacheSqliteLinkerOverride.cs
+++ b/samples/xamarin-forms/Droid/AkavacheSqliteLinkerOverride.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/samples/xamarin-forms/Droid/Droid.licenseheader
+++ b/samples/xamarin-forms/Droid/Droid.licenseheader
@@ -1,12 +1,12 @@
 ﻿extensions: designer.cs generated.cs
 extensions: .cs .cpp .h
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 extensions:  .xml .config .xsd
 <!--
 Licensed to the .NET Foundation under one or more agreements.
-The .NET Foundation licenses this file to you under the MS-PL license.
+The .NET Foundation licenses this file to you under the MIT license.
 See the LICENSE file in the project root for more information.
 -->

--- a/samples/xamarin-forms/Droid/MainActivity.cs
+++ b/samples/xamarin-forms/Droid/MainActivity.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/samples/xamarin-forms/Droid/Properties/AndroidManifest.xml
+++ b/samples/xamarin-forms/Droid/Properties/AndroidManifest.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!--
 Licensed to the .NET Foundation under one or more agreements.
-The .NET Foundation licenses this file to you under the MS-PL license.
+The .NET Foundation licenses this file to you under the MIT license.
 See the LICENSE file in the project root for more information.
 -->
 

--- a/samples/xamarin-forms/Droid/Properties/AssemblyInfo.cs
+++ b/samples/xamarin-forms/Droid/Properties/AssemblyInfo.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System.Reflection;

--- a/samples/xamarin-forms/Droid/Resources/values/styles.xml
+++ b/samples/xamarin-forms/Droid/Resources/values/styles.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <!--
 Licensed to the .NET Foundation under one or more agreements.
-The .NET Foundation licenses this file to you under the MS-PL license.
+The .NET Foundation licenses this file to you under the MIT license.
 See the LICENSE file in the project root for more information.
 -->
 

--- a/samples/xamarin-forms/Droid/app.config
+++ b/samples/xamarin-forms/Droid/app.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!--
 Licensed to the .NET Foundation under one or more agreements.
-The .NET Foundation licenses this file to you under the MS-PL license.
+The .NET Foundation licenses this file to you under the MIT license.
 See the LICENSE file in the project root for more information.
 -->
 

--- a/samples/xamarin-forms/Droid/packages.config
+++ b/samples/xamarin-forms/Droid/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!--
 Licensed to the .NET Foundation under one or more agreements.
-The .NET Foundation licenses this file to you under the MS-PL license.
+The .NET Foundation licenses this file to you under the MIT license.
 See the LICENSE file in the project root for more information.
 -->
 <packages>

--- a/samples/xamarin-forms/iOS/AkavacheSqliteLinkerOverride.cs
+++ b/samples/xamarin-forms/iOS/AkavacheSqliteLinkerOverride.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/samples/xamarin-forms/iOS/AppDelegate.cs
+++ b/samples/xamarin-forms/iOS/AppDelegate.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/samples/xamarin-forms/iOS/Main.cs
+++ b/samples/xamarin-forms/iOS/Main.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/samples/xamarin-forms/iOS/app.config
+++ b/samples/xamarin-forms/iOS/app.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!--
 Licensed to the .NET Foundation under one or more agreements.
-The .NET Foundation licenses this file to you under the MS-PL license.
+The .NET Foundation licenses this file to you under the MIT license.
 See the LICENSE file in the project root for more information.
 -->
 

--- a/samples/xamarin-forms/iOS/iOS.licenseheader
+++ b/samples/xamarin-forms/iOS/iOS.licenseheader
@@ -1,12 +1,12 @@
 ﻿extensions: designer.cs generated.cs
 extensions: .cs .cpp .h
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 extensions:  .xml .config .xsd
 <!--
 Licensed to the .NET Foundation under one or more agreements.
-The .NET Foundation licenses this file to you under the MS-PL license.
+The .NET Foundation licenses this file to you under the MIT license.
 See the LICENSE file in the project root for more information.
 -->

--- a/samples/xamarin-forms/iOS/packages.config
+++ b/samples/xamarin-forms/iOS/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!--
 Licensed to the .NET Foundation under one or more agreements.
-The .NET Foundation licenses this file to you under the MS-PL license.
+The .NET Foundation licenses this file to you under the MIT license.
 See the LICENSE file in the project root for more information.
 -->
 <packages>

--- a/src/EventBuilder/App.config
+++ b/src/EventBuilder/App.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
 Licensed to the .NET Foundation under one or more agreements.
-The .NET Foundation licenses this file to you under the MS-PL license.
+The .NET Foundation licenses this file to you under the MIT license.
 See the LICENSE file in the project root for more information.
 -->
 

--- a/src/EventBuilder/Cecil/DelegateTemplateInformation.cs
+++ b/src/EventBuilder/Cecil/DelegateTemplateInformation.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using EventBuilder.Entities;

--- a/src/EventBuilder/Cecil/EventTemplateInformation.cs
+++ b/src/EventBuilder/Cecil/EventTemplateInformation.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using EventBuilder.Entities;

--- a/src/EventBuilder/Cecil/PathSearchAssemblyResolver.cs
+++ b/src/EventBuilder/Cecil/PathSearchAssemblyResolver.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/EventBuilder/Cecil/SafeTypes.cs
+++ b/src/EventBuilder/Cecil/SafeTypes.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using Mono.Cecil;

--- a/src/EventBuilder/CommandLineOptions.cs
+++ b/src/EventBuilder/CommandLineOptions.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;

--- a/src/EventBuilder/DefaultTemplate.mustache
+++ b/src/EventBuilder/DefaultTemplate.mustache
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 #pragma warning disable 1591,0618,0105,0672,0108

--- a/src/EventBuilder/Entities/MultiParameterMethod.cs
+++ b/src/EventBuilder/Entities/MultiParameterMethod.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 namespace EventBuilder.Entities

--- a/src/EventBuilder/Entities/NamespaceInfo.cs
+++ b/src/EventBuilder/Entities/NamespaceInfo.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;

--- a/src/EventBuilder/Entities/ParentInfo.cs
+++ b/src/EventBuilder/Entities/ParentInfo.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 namespace EventBuilder.Entities

--- a/src/EventBuilder/Entities/PublicEventInfo.cs
+++ b/src/EventBuilder/Entities/PublicEventInfo.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 namespace EventBuilder.Entities

--- a/src/EventBuilder/Entities/PublicTypeInfo.cs
+++ b/src/EventBuilder/Entities/PublicTypeInfo.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using Mono.Cecil;

--- a/src/EventBuilder/Entities/SingleParameterMethod.cs
+++ b/src/EventBuilder/Entities/SingleParameterMethod.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 namespace EventBuilder.Entities

--- a/src/EventBuilder/EventBuilder.licenseheader
+++ b/src/EventBuilder/EventBuilder.licenseheader
@@ -1,12 +1,12 @@
 ﻿extensions: designer.cs generated.cs
 extensions: .cs .cpp .h
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 extensions:  .xml .config .xsd
 <!--
 Licensed to the .NET Foundation under one or more agreements.
-The .NET Foundation licenses this file to you under the MS-PL license.
+The .NET Foundation licenses this file to you under the MIT license.
 See the LICENSE file in the project root for more information.
 -->

--- a/src/EventBuilder/PlatformHelper.cs
+++ b/src/EventBuilder/PlatformHelper.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/EventBuilder/Platforms/Android.cs
+++ b/src/EventBuilder/Platforms/Android.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System.IO;

--- a/src/EventBuilder/Platforms/BasePlatform.cs
+++ b/src/EventBuilder/Platforms/BasePlatform.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;

--- a/src/EventBuilder/Platforms/Bespoke.cs
+++ b/src/EventBuilder/Platforms/Bespoke.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 namespace EventBuilder.Platforms

--- a/src/EventBuilder/Platforms/IPlatform.cs
+++ b/src/EventBuilder/Platforms/IPlatform.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;

--- a/src/EventBuilder/Platforms/Mac.cs
+++ b/src/EventBuilder/Platforms/Mac.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System.IO;

--- a/src/EventBuilder/Platforms/Tizen.cs
+++ b/src/EventBuilder/Platforms/Tizen.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using NuGet;

--- a/src/EventBuilder/Platforms/UWP.cs
+++ b/src/EventBuilder/Platforms/UWP.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/EventBuilder/Platforms/WPF.cs
+++ b/src/EventBuilder/Platforms/WPF.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/EventBuilder/Platforms/Winforms.cs
+++ b/src/EventBuilder/Platforms/Winforms.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/EventBuilder/Platforms/XamForms.cs
+++ b/src/EventBuilder/Platforms/XamForms.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using NuGet;

--- a/src/EventBuilder/Platforms/iOS.cs
+++ b/src/EventBuilder/Platforms/iOS.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System.IO;

--- a/src/EventBuilder/Program.cs
+++ b/src/EventBuilder/Program.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.AndroidSupport/ControlFetcherMixin.cs
+++ b/src/ReactiveUI.AndroidSupport/ControlFetcherMixin.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.AndroidSupport/ReactiveAppCompatActivity.cs
+++ b/src/ReactiveUI.AndroidSupport/ReactiveAppCompatActivity.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.AndroidSupport/ReactiveDialogFragment.cs
+++ b/src/ReactiveUI.AndroidSupport/ReactiveDialogFragment.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.AndroidSupport/ReactiveFragment.cs
+++ b/src/ReactiveUI.AndroidSupport/ReactiveFragment.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.AndroidSupport/ReactiveFragmentActivity.cs
+++ b/src/ReactiveUI.AndroidSupport/ReactiveFragmentActivity.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.AndroidSupport/ReactivePagerAdapter.cs
+++ b/src/ReactiveUI.AndroidSupport/ReactivePagerAdapter.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.AndroidSupport/ReactiveRecyclerViewAdapter.cs
+++ b/src/ReactiveUI.AndroidSupport/ReactiveRecyclerViewAdapter.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.AndroidSupport/ReactiveUI.AndroidSupport.licenseheader
+++ b/src/ReactiveUI.AndroidSupport/ReactiveUI.AndroidSupport.licenseheader
@@ -1,12 +1,12 @@
 ﻿extensions: designer.cs generated.cs
 extensions: .cs .cpp .h
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 extensions:  .xml .config .xsd
 <!--
 Licensed to the .NET Foundation under one or more agreements.
-The .NET Foundation licenses this file to you under the MS-PL license.
+The .NET Foundation licenses this file to you under the MIT license.
 See the LICENSE file in the project root for more information.
 -->

--- a/src/ReactiveUI.Blend/FollowObservableStateBehavior.cs
+++ b/src/ReactiveUI.Blend/FollowObservableStateBehavior.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.Blend/Platforms/net461/ObservableTrigger.cs
+++ b/src/ReactiveUI.Blend/Platforms/net461/ObservableTrigger.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.Blend/Platforms/uap10.0.16299/Behavior.cs
+++ b/src/ReactiveUI.Blend/Platforms/uap10.0.16299/Behavior.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using Windows.UI.Xaml;

--- a/src/ReactiveUI.Blend/Platforms/uap10.0.16299/ObservableTriggerBehavior.cs
+++ b/src/ReactiveUI.Blend/Platforms/uap10.0.16299/ObservableTriggerBehavior.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.Blend/Properties/ReactiveUI.Blend_UWP.rd.xml
+++ b/src/ReactiveUI.Blend/Properties/ReactiveUI.Blend_UWP.rd.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
 Licensed to the .NET Foundation under one or more agreements.
-The .NET Foundation licenses this file to you under the MS-PL license.
+The .NET Foundation licenses this file to you under the MIT license.
 See the LICENSE file in the project root for more information.
 -->
 

--- a/src/ReactiveUI.Blend/ReactiveUI.Blend.licenseheader
+++ b/src/ReactiveUI.Blend/ReactiveUI.Blend.licenseheader
@@ -1,12 +1,12 @@
 ﻿extensions: designer.cs generated.cs
 extensions: .cs .cpp .h
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 extensions:  .xml .config .xsd
 <!--
 Licensed to the .NET Foundation under one or more agreements.
-The .NET Foundation licenses this file to you under the MS-PL license.
+The .NET Foundation licenses this file to you under the MIT license.
 See the LICENSE file in the project root for more information.
 -->

--- a/src/ReactiveUI.Events.WPF/ReactiveUI.Events.WPF.licenseheader
+++ b/src/ReactiveUI.Events.WPF/ReactiveUI.Events.WPF.licenseheader
@@ -1,12 +1,12 @@
 ﻿extensions: designer.cs generated.cs
 extensions: .cs .cpp .h
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 extensions:  .xml .config .xsd
 <!--
 Licensed to the .NET Foundation under one or more agreements.
-The .NET Foundation licenses this file to you under the MS-PL license.
+The .NET Foundation licenses this file to you under the MIT license.
 See the LICENSE file in the project root for more information.
 -->

--- a/src/ReactiveUI.Events.Winforms/ReactiveUI.Events.Winforms.licenseheader
+++ b/src/ReactiveUI.Events.Winforms/ReactiveUI.Events.Winforms.licenseheader
@@ -1,12 +1,12 @@
 ﻿extensions: designer.cs generated.cs
 extensions: .cs .cpp .h
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 extensions:  .xml .config .xsd
 <!--
 Licensed to the .NET Foundation under one or more agreements.
-The .NET Foundation licenses this file to you under the MS-PL license.
+The .NET Foundation licenses this file to you under the MIT license.
 See the LICENSE file in the project root for more information.
 -->

--- a/src/ReactiveUI.Events.XamForms/ReactiveUI.Events.XamForms.licenseheader
+++ b/src/ReactiveUI.Events.XamForms/ReactiveUI.Events.XamForms.licenseheader
@@ -1,12 +1,12 @@
 ﻿extensions: designer.cs generated.cs
 extensions: .cs .cpp .h
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 extensions:  .xml .config .xsd
 <!--
 Licensed to the .NET Foundation under one or more agreements.
-The .NET Foundation licenses this file to you under the MS-PL license.
+The .NET Foundation licenses this file to you under the MIT license.
 See the LICENSE file in the project root for more information.
 -->

--- a/src/ReactiveUI.Events/ReactiveUI.Events.licenseheader
+++ b/src/ReactiveUI.Events/ReactiveUI.Events.licenseheader
@@ -1,12 +1,12 @@
 ﻿extensions: designer.cs generated.cs
 extensions: .cs .cpp .h
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 extensions:  .xml .config .xsd
 <!--
 Licensed to the .NET Foundation under one or more agreements.
-The .NET Foundation licenses this file to you under the MS-PL license.
+The .NET Foundation licenses this file to you under the MIT license.
 See the LICENSE file in the project root for more information.
 -->

--- a/src/ReactiveUI.Events/SingleAwaitSubject.cs
+++ b/src/ReactiveUI.Events/SingleAwaitSubject.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.Fody.Helpers/ObservableAsPropertyAttribute.cs
+++ b/src/ReactiveUI.Fody.Helpers/ObservableAsPropertyAttribute.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.Fody.Helpers/ObservableAsPropertyExtensions.cs
+++ b/src/ReactiveUI.Fody.Helpers/ObservableAsPropertyExtensions.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.Fody.Helpers/Properties/AssemblyInfo.cs
+++ b/src/ReactiveUI.Fody.Helpers/Properties/AssemblyInfo.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System.Runtime.CompilerServices;

--- a/src/ReactiveUI.Fody.Helpers/ReactiveAttribute.cs
+++ b/src/ReactiveUI.Fody.Helpers/ReactiveAttribute.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.Fody.Helpers/ReactiveDependencyAttribute.cs
+++ b/src/ReactiveUI.Fody.Helpers/ReactiveDependencyAttribute.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.Fody.Helpers/ReactiveUI.Fody.Helpers.licenseheader
+++ b/src/ReactiveUI.Fody.Helpers/ReactiveUI.Fody.Helpers.licenseheader
@@ -1,12 +1,12 @@
 ﻿extensions: designer.cs generated.cs
 extensions: .cs 
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 extensions:  .xml .config .xsd
 <!--
 Licensed to the .NET Foundation under one or more agreements.
-The .NET Foundation licenses this file to you under the MS-PL license.
+The .NET Foundation licenses this file to you under the MIT license.
 See the LICENSE file in the project root for more information.
 -->

--- a/src/ReactiveUI.Fody.Tests/API/ApiApprovalTests.cs
+++ b/src/ReactiveUI.Fody.Tests/API/ApiApprovalTests.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.Fody.Tests/FodyWeavers.xml
+++ b/src/ReactiveUI.Fody.Tests/FodyWeavers.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!--
 Licensed to the .NET Foundation under one or more agreements.
-The .NET Foundation licenses this file to you under the MS-PL license.
+The .NET Foundation licenses this file to you under the MIT license.
 See the LICENSE file in the project root for more information.
 -->
 

--- a/src/ReactiveUI.Fody.Tests/Issues/Issue10Tests.cs
+++ b/src/ReactiveUI.Fody.Tests/Issues/Issue10Tests.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.Fody.Tests/Issues/Issue11Tests.cs
+++ b/src/ReactiveUI.Fody.Tests/Issues/Issue11Tests.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System.Reactive.Linq;

--- a/src/ReactiveUI.Fody.Tests/Issues/Issue13Tests.cs
+++ b/src/ReactiveUI.Fody.Tests/Issues/Issue13Tests.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using ReactiveUI.Fody.Helpers;

--- a/src/ReactiveUI.Fody.Tests/ObservableAsPropertyTests.cs
+++ b/src/ReactiveUI.Fody.Tests/ObservableAsPropertyTests.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System.Reactive.Linq;

--- a/src/ReactiveUI.Fody.Tests/ReactiveDependencyTests.cs
+++ b/src/ReactiveUI.Fody.Tests/ReactiveDependencyTests.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System.ComponentModel;

--- a/src/ReactiveUI.Fody.Tests/ReactiveUI.Fody.Tests.licenseheader
+++ b/src/ReactiveUI.Fody.Tests/ReactiveUI.Fody.Tests.licenseheader
@@ -1,12 +1,12 @@
 ﻿extensions: designer.cs generated.cs
 extensions: .cs 
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 extensions:  .xml .config .xsd
 <!--
 Licensed to the .NET Foundation under one or more agreements.
-The .NET Foundation licenses this file to you under the MS-PL license.
+The .NET Foundation licenses this file to you under the MIT license.
 See the LICENSE file in the project root for more information.
 -->

--- a/src/ReactiveUI.Fody/CecilExtensions.cs
+++ b/src/ReactiveUI.Fody/CecilExtensions.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.Fody/ModuleWeaver.cs
+++ b/src/ReactiveUI.Fody/ModuleWeaver.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;

--- a/src/ReactiveUI.Fody/ObservableAsPropertyWeaver.cs
+++ b/src/ReactiveUI.Fody/ObservableAsPropertyWeaver.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.Fody/Properties/AssemblyInfo.cs
+++ b/src/ReactiveUI.Fody/Properties/AssemblyInfo.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System.Runtime.CompilerServices;

--- a/src/ReactiveUI.Fody/ReactiveDependencyPropertyWeaver.cs
+++ b/src/ReactiveUI.Fody/ReactiveDependencyPropertyWeaver.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.Fody/ReactiveUI.Fody.licenseheader
+++ b/src/ReactiveUI.Fody/ReactiveUI.Fody.licenseheader
@@ -1,12 +1,12 @@
 ﻿extensions: designer.cs generated.cs
 extensions: .cs 
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 extensions:  .xml .config .xsd
 <!--
 Licensed to the .NET Foundation under one or more agreements.
-The .NET Foundation licenses this file to you under the MS-PL license.
+The .NET Foundation licenses this file to you under the MIT license.
 See the LICENSE file in the project root for more information.
 -->

--- a/src/ReactiveUI.Fody/ReactiveUIPropertyWeaver.cs
+++ b/src/ReactiveUI.Fody/ReactiveUIPropertyWeaver.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.Testing/Properties/ReactiveUI.Testing.rd.xml
+++ b/src/ReactiveUI.Testing/Properties/ReactiveUI.Testing.rd.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
 Licensed to the .NET Foundation under one or more agreements.
-The .NET Foundation licenses this file to you under the MS-PL license.
+The .NET Foundation licenses this file to you under the MIT license.
 See the LICENSE file in the project root for more information.
 -->
 

--- a/src/ReactiveUI.Testing/ReactiveUI.Testing.licenseheader
+++ b/src/ReactiveUI.Testing/ReactiveUI.Testing.licenseheader
@@ -1,12 +1,12 @@
 ﻿extensions: designer.cs generated.cs
 extensions: .cs .cpp .h
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 extensions:  .xml .config .xsd
 <!--
 Licensed to the .NET Foundation under one or more agreements.
-The .NET Foundation licenses this file to you under the MS-PL license.
+The .NET Foundation licenses this file to you under the MIT license.
 See the LICENSE file in the project root for more information.
 -->

--- a/src/ReactiveUI.Testing/TestUtils.cs
+++ b/src/ReactiveUI.Testing/TestUtils.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.cs
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.Tests/Activation/ActivatingView.cs
+++ b/src/ReactiveUI.Tests/Activation/ActivatingView.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System.Reactive;

--- a/src/ReactiveUI.Tests/Activation/ActivatingViewFetcher.cs
+++ b/src/ReactiveUI.Tests/Activation/ActivatingViewFetcher.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.Tests/Activation/ActivatingViewModel.cs
+++ b/src/ReactiveUI.Tests/Activation/ActivatingViewModel.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System.Reactive.Disposables;

--- a/src/ReactiveUI.Tests/Activation/ActivatingViewModelTests.cs
+++ b/src/ReactiveUI.Tests/Activation/ActivatingViewModelTests.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using Xunit;

--- a/src/ReactiveUI.Tests/Activation/ActivatingViewTests.cs
+++ b/src/ReactiveUI.Tests/Activation/ActivatingViewTests.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System.Reactive;

--- a/src/ReactiveUI.Tests/Activation/CanActivateViewFetcherTests.cs
+++ b/src/ReactiveUI.Tests/Activation/CanActivateViewFetcherTests.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.Tests/Activation/DerivedActivatingViewModel.cs
+++ b/src/ReactiveUI.Tests/Activation/DerivedActivatingViewModel.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System.Reactive.Disposables;

--- a/src/ReactiveUI.Tests/Activation/ViewModelActivatorTests.cs
+++ b/src/ReactiveUI.Tests/Activation/ViewModelActivatorTests.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System.Reactive.Concurrency;

--- a/src/ReactiveUI.Tests/AutoPersistHelperTest.cs
+++ b/src/ReactiveUI.Tests/AutoPersistHelperTest.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.Tests/AwaiterTest.cs
+++ b/src/ReactiveUI.Tests/AwaiterTest.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.Tests/BindingTypeConvertersTest.cs
+++ b/src/ReactiveUI.Tests/BindingTypeConvertersTest.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using Xunit;

--- a/src/ReactiveUI.Tests/CommandBindingTests.cs
+++ b/src/ReactiveUI.Tests/CommandBindingTests.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.Tests/DependencyResolverTests.cs
+++ b/src/ReactiveUI.Tests/DependencyResolverTests.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 namespace ReactiveUI.Tests

--- a/src/ReactiveUI.Tests/INPCObservableForPropertyTests.cs
+++ b/src/ReactiveUI.Tests/INPCObservableForPropertyTests.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.Tests/InteractionsTest.cs
+++ b/src/ReactiveUI.Tests/InteractionsTest.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.Tests/MessageBusTest.cs
+++ b/src/ReactiveUI.Tests/MessageBusTest.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.Tests/ObservableAsPropertyHelperTest.cs
+++ b/src/ReactiveUI.Tests/ObservableAsPropertyHelperTest.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.Tests/ObservedChangedMixinTest.cs
+++ b/src/ReactiveUI.Tests/ObservedChangedMixinTest.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.Tests/OrderedComparerTests.cs
+++ b/src/ReactiveUI.Tests/OrderedComparerTests.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.Tests/Platforms/android/MainActivity.cs
+++ b/src/ReactiveUI.Tests/Platforms/android/MainActivity.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.Tests/Platforms/android/PropertyBindingTestViews.cs
+++ b/src/ReactiveUI.Tests/Platforms/android/PropertyBindingTestViews.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.Tests/Platforms/cocoa/AppDelegate.cs
+++ b/src/ReactiveUI.Tests/Platforms/cocoa/AppDelegate.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.Tests/Platforms/cocoa/IndexNormalizerTest.cs
+++ b/src/ReactiveUI.Tests/Platforms/cocoa/IndexNormalizerTest.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 namespace ReactiveUI.Tests

--- a/src/ReactiveUI.Tests/Platforms/cocoa/KVOBindingTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/cocoa/KVOBindingTests.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.Tests/Platforms/cocoa/Main.cs
+++ b/src/ReactiveUI.Tests/Platforms/cocoa/Main.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.Tests/Platforms/cocoa/PropertyBindingTestViews.cs
+++ b/src/ReactiveUI.Tests/Platforms/cocoa/PropertyBindingTestViews.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.Tests/Platforms/cocoa/UnitTestAppDelegate.cs
+++ b/src/ReactiveUI.Tests/Platforms/cocoa/UnitTestAppDelegate.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.Tests/Platforms/winforms/ActivationTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/ActivationTests.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.Tests/Platforms/winforms/CommandBindingTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/CommandBindingTests.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.Tests/Platforms/winforms/DefaultPropertyBindingTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/DefaultPropertyBindingTests.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.Tests/Platforms/winforms/ReactiveBindingListTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/ReactiveBindingListTests.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.Tests/Platforms/winforms/RoutedViewHostTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/RoutedViewHostTests.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System.Linq;

--- a/src/ReactiveUI.Tests/Platforms/winforms/ViewModelViewHostTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/ViewModelViewHostTests.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.Tests/Platforms/xaml/ActivationForViewFetcherTest.cs
+++ b/src/ReactiveUI.Tests/Platforms/xaml/ActivationForViewFetcherTest.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.Reactive.Testing;

--- a/src/ReactiveUI.Tests/Platforms/xaml/DependencyObjectObservableForPropertyTest.cs
+++ b/src/ReactiveUI.Tests/Platforms/xaml/DependencyObjectObservableForPropertyTest.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.Tests/Platforms/xaml/PropertyBindingTestViews.cs
+++ b/src/ReactiveUI.Tests/Platforms/xaml/PropertyBindingTestViews.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.Tests/PropertyBindingTest.cs
+++ b/src/ReactiveUI.Tests/PropertyBindingTest.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.Tests/ReactiveCollectionTest.cs
+++ b/src/ReactiveUI.Tests/ReactiveCollectionTest.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.Reactive.Testing;

--- a/src/ReactiveUI.Tests/ReactiveCommandTest.cs
+++ b/src/ReactiveUI.Tests/ReactiveCommandTest.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.Tests/ReactiveNotifyPropertyChangedMixinTest.cs
+++ b/src/ReactiveUI.Tests/ReactiveNotifyPropertyChangedMixinTest.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.Tests/ReactiveObjectTest.cs
+++ b/src/ReactiveUI.Tests/ReactiveObjectTest.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.Tests/ReactiveUI.Tests.licenseheader
+++ b/src/ReactiveUI.Tests/ReactiveUI.Tests.licenseheader
@@ -1,12 +1,12 @@
 ﻿extensions: designer.cs generated.cs
 extensions: .cs .cpp .h
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 extensions:  .xml .config .xsd
 <!--
 Licensed to the .NET Foundation under one or more agreements.
-The .NET Foundation licenses this file to you under the MS-PL license.
+The .NET Foundation licenses this file to you under the MIT license.
 See the LICENSE file in the project root for more information.
 -->

--- a/src/ReactiveUI.Tests/RoutableViewModelMixinTests.cs
+++ b/src/ReactiveUI.Tests/RoutableViewModelMixinTests.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.Tests/RoutingState.cs
+++ b/src/ReactiveUI.Tests/RoutingState.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.Tests/RxAppTest.cs
+++ b/src/ReactiveUI.Tests/RxAppTest.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;

--- a/src/ReactiveUI.Tests/TestLogger.cs
+++ b/src/ReactiveUI.Tests/TestLogger.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.Tests/TestUtilsTest.cs
+++ b/src/ReactiveUI.Tests/TestUtilsTest.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System.Threading.Tasks;

--- a/src/ReactiveUI.Tests/Utility.cs
+++ b/src/ReactiveUI.Tests/Utility.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.Tests/ViewLocatorTests.cs
+++ b/src/ReactiveUI.Tests/ViewLocatorTests.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.Tests/WaitForDispatcherSchedulerTests.cs
+++ b/src/ReactiveUI.Tests/WaitForDispatcherSchedulerTests.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.Tests/WeakEventManagerTest.cs
+++ b/src/ReactiveUI.Tests/WeakEventManagerTest.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.Winforms/ActivationForViewFetcher.cs
+++ b/src/ReactiveUI.Winforms/ActivationForViewFetcher.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.Winforms/CreatesCommandBinding.cs
+++ b/src/ReactiveUI.Winforms/CreatesCommandBinding.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.Winforms/ObservableCollectionChangedToListChangedTransformer.cs
+++ b/src/ReactiveUI.Winforms/ObservableCollectionChangedToListChangedTransformer.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;

--- a/src/ReactiveUI.Winforms/PlatformOperations.cs
+++ b/src/ReactiveUI.Winforms/PlatformOperations.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.Winforms/ReactiveBindingList.cs
+++ b/src/ReactiveUI.Winforms/ReactiveBindingList.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.Winforms/ReactiveDerivedBindingListMixins.cs
+++ b/src/ReactiveUI.Winforms/ReactiveDerivedBindingListMixins.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.Winforms/ReactiveUI.Winforms.licenseheader
+++ b/src/ReactiveUI.Winforms/ReactiveUI.Winforms.licenseheader
@@ -1,12 +1,12 @@
 ﻿extensions: designer.cs generated.cs
 extensions: .cs .cpp .h
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 extensions:  .xml .config .xsd
 <!--
 Licensed to the .NET Foundation under one or more agreements.
-The .NET Foundation licenses this file to you under the MS-PL license.
+The .NET Foundation licenses this file to you under the MIT license.
 See the LICENSE file in the project root for more information.
 -->

--- a/src/ReactiveUI.Winforms/Registrations.cs
+++ b/src/ReactiveUI.Winforms/Registrations.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using Splat;

--- a/src/ReactiveUI.Winforms/RoutedViewHost.cs
+++ b/src/ReactiveUI.Winforms/RoutedViewHost.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.Winforms/ViewModelViewHost.cs
+++ b/src/ReactiveUI.Winforms/ViewModelViewHost.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.Winforms/WeakEventManagerShims.cs
+++ b/src/ReactiveUI.Winforms/WeakEventManagerShims.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.Winforms/WinformsCreatesObservableForProperty.cs
+++ b/src/ReactiveUI.Winforms/WinformsCreatesObservableForProperty.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.Wpf/Attributes.cs
+++ b/src/ReactiveUI.Wpf/Attributes.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System.Windows;

--- a/src/ReactiveUI.Wpf/ReactiveUI.Wpf.licenseheader
+++ b/src/ReactiveUI.Wpf/ReactiveUI.Wpf.licenseheader
@@ -1,12 +1,12 @@
 ﻿extensions: designer.cs generated.cs
 extensions: .cs .cpp .h
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 extensions:  .xml .config .xsd
 <!--
 Licensed to the .NET Foundation under one or more agreements.
-The .NET Foundation licenses this file to you under the MS-PL license.
+The .NET Foundation licenses this file to you under the MIT license.
 See the LICENSE file in the project root for more information.
 -->

--- a/src/ReactiveUI.Wpf/Registrations.cs
+++ b/src/ReactiveUI.Wpf/Registrations.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.Wpf/TransitioningContentControl.cs
+++ b/src/ReactiveUI.Wpf/TransitioningContentControl.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.Wpf/WpfAutoSuspendHelper.cs
+++ b/src/ReactiveUI.Wpf/WpfAutoSuspendHelper.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.Wpf/WpfDependencyObjectObservableForProperty.cs
+++ b/src/ReactiveUI.Wpf/WpfDependencyObjectObservableForProperty.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.XamForms/ActivationForViewFetcher.cs
+++ b/src/ReactiveUI.XamForms/ActivationForViewFetcher.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.XamForms/ReactiveCarouselPage.cs
+++ b/src/ReactiveUI.XamForms/ReactiveCarouselPage.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.XamForms/ReactiveContentPage.cs
+++ b/src/ReactiveUI.XamForms/ReactiveContentPage.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.XamForms/ReactiveContentView.cs
+++ b/src/ReactiveUI.XamForms/ReactiveContentView.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.XamForms/ReactiveEntryCell.cs
+++ b/src/ReactiveUI.XamForms/ReactiveEntryCell.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using ReactiveUI;

--- a/src/ReactiveUI.XamForms/ReactiveImageCell.cs
+++ b/src/ReactiveUI.XamForms/ReactiveImageCell.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using ReactiveUI;

--- a/src/ReactiveUI.XamForms/ReactiveMasterDetailPage.cs
+++ b/src/ReactiveUI.XamForms/ReactiveMasterDetailPage.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.XamForms/ReactiveMultiPage.cs
+++ b/src/ReactiveUI.XamForms/ReactiveMultiPage.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.XamForms/ReactiveNavigationPage.cs
+++ b/src/ReactiveUI.XamForms/ReactiveNavigationPage.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.XamForms/ReactiveSwitchCell.cs
+++ b/src/ReactiveUI.XamForms/ReactiveSwitchCell.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using ReactiveUI;

--- a/src/ReactiveUI.XamForms/ReactiveTabbedPage.cs
+++ b/src/ReactiveUI.XamForms/ReactiveTabbedPage.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.XamForms/ReactiveTextCell.cs
+++ b/src/ReactiveUI.XamForms/ReactiveTextCell.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using ReactiveUI;

--- a/src/ReactiveUI.XamForms/ReactiveUI.XamForms.licenseheader
+++ b/src/ReactiveUI.XamForms/ReactiveUI.XamForms.licenseheader
@@ -1,12 +1,12 @@
 ﻿extensions: designer.cs generated.cs
 extensions: .cs .cpp .h
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 extensions:  .xml .config .xsd
 <!--
 Licensed to the .NET Foundation under one or more agreements.
-The .NET Foundation licenses this file to you under the MS-PL license.
+The .NET Foundation licenses this file to you under the MIT license.
 See the LICENSE file in the project root for more information.
 -->

--- a/src/ReactiveUI.XamForms/ReactiveViewCell.cs
+++ b/src/ReactiveUI.XamForms/ReactiveViewCell.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using ReactiveUI;

--- a/src/ReactiveUI.XamForms/Registrations.cs
+++ b/src/ReactiveUI.XamForms/Registrations.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.XamForms/RoutedViewHost.cs
+++ b/src/ReactiveUI.XamForms/RoutedViewHost.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI.XamForms/ViewModelViewHost.cs
+++ b/src/ReactiveUI.XamForms/ViewModelViewHost.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Activation/CanActivateViewFetcher.cs
+++ b/src/ReactiveUI/Activation/CanActivateViewFetcher.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Activation/IActivationForViewFetcher.cs
+++ b/src/ReactiveUI/Activation/IActivationForViewFetcher.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Activation/ViewForMixins.cs
+++ b/src/ReactiveUI/Activation/ViewForMixins.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Activation/ViewModelActivator.cs
+++ b/src/ReactiveUI/Activation/ViewModelActivator.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/AutoPersistHelper.cs
+++ b/src/ReactiveUI/AutoPersistHelper.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/BindingTypeConverters.cs
+++ b/src/ReactiveUI/BindingTypeConverters.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/CollectionDebugView.cs
+++ b/src/ReactiveUI/CollectionDebugView.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/CommandBinding.cs
+++ b/src/ReactiveUI/CommandBinding.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/CompatMixins.cs
+++ b/src/ReactiveUI/CompatMixins.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/ContractStubs.cs
+++ b/src/ReactiveUI/ContractStubs.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/CreatesCommandBinding.cs
+++ b/src/ReactiveUI/CreatesCommandBinding.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/DisposableMixins.cs
+++ b/src/ReactiveUI/DisposableMixins.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 namespace System.Reactive.Disposables

--- a/src/ReactiveUI/ExpressionMixins.cs
+++ b/src/ReactiveUI/ExpressionMixins.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/ExpressionRewriter.cs
+++ b/src/ReactiveUI/ExpressionRewriter.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/IDependencyResolver.cs
+++ b/src/ReactiveUI/IDependencyResolver.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/INPCObservableForProperty.cs
+++ b/src/ReactiveUI/INPCObservableForProperty.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/IROObservableForProperty.cs
+++ b/src/ReactiveUI/IROObservableForProperty.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/IReactiveObject.cs
+++ b/src/ReactiveUI/IReactiveObject.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Interactions.cs
+++ b/src/ReactiveUI/Interactions.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Interfaces.cs
+++ b/src/ReactiveUI/Interfaces.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/LoggingMixins.cs
+++ b/src/ReactiveUI/LoggingMixins.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/MessageBus.cs
+++ b/src/ReactiveUI/MessageBus.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/ObservableAsPropertyHelper.cs
+++ b/src/ReactiveUI/ObservableAsPropertyHelper.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Observables.cs
+++ b/src/ReactiveUI/Observables.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 namespace System.Reactive.Linq

--- a/src/ReactiveUI/ObservedChangedMixin.cs
+++ b/src/ReactiveUI/ObservedChangedMixin.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/OrderedComparer.cs
+++ b/src/ReactiveUI/OrderedComparer.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/POCOObservableForProperty.cs
+++ b/src/ReactiveUI/POCOObservableForProperty.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/android/AndroidCommandBinders.cs
+++ b/src/ReactiveUI/Platforms/android/AndroidCommandBinders.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/android/AndroidObservableForWidgets.cs
+++ b/src/ReactiveUI/Platforms/android/AndroidObservableForWidgets.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/android/AndroidUIScheduler.cs
+++ b/src/ReactiveUI/Platforms/android/AndroidUIScheduler.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/android/AutoSuspendHelper.cs
+++ b/src/ReactiveUI/Platforms/android/AutoSuspendHelper.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/android/BundleSuspensionDriver.cs
+++ b/src/ReactiveUI/Platforms/android/BundleSuspensionDriver.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/android/ContextExtensions.cs
+++ b/src/ReactiveUI/Platforms/android/ContextExtensions.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/android/ControlFetcherMixin.cs
+++ b/src/ReactiveUI/Platforms/android/ControlFetcherMixin.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/android/FlexibleCommandBinder.cs
+++ b/src/ReactiveUI/Platforms/android/FlexibleCommandBinder.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/android/LayoutViewHost.cs
+++ b/src/ReactiveUI/Platforms/android/LayoutViewHost.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/android/LinkerOverrides.cs
+++ b/src/ReactiveUI/Platforms/android/LinkerOverrides.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/android/ObjectExtension.cs
+++ b/src/ReactiveUI/Platforms/android/ObjectExtension.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/android/PlatformOperations.cs
+++ b/src/ReactiveUI/Platforms/android/PlatformOperations.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/android/PlatformRegistrations.cs
+++ b/src/ReactiveUI/Platforms/android/PlatformRegistrations.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements. 
-// The .NET Foundation licenses this file to you under the MS-PL license. 
+// The .NET Foundation licenses this file to you under the MIT license. 
 // See the LICENSE file in the project root for more information. 
 
 using System;

--- a/src/ReactiveUI/Platforms/android/ReactiveActivity.cs
+++ b/src/ReactiveUI/Platforms/android/ReactiveActivity.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/android/ReactiveFragment.cs
+++ b/src/ReactiveUI/Platforms/android/ReactiveFragment.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/android/ReactiveListAdapter.cs
+++ b/src/ReactiveUI/Platforms/android/ReactiveListAdapter.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/android/ReactivePreferenceActivity.cs
+++ b/src/ReactiveUI/Platforms/android/ReactivePreferenceActivity.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/android/ReactivePreferenceFragment.cs
+++ b/src/ReactiveUI/Platforms/android/ReactivePreferenceFragment.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/android/SharedPreferencesExtensions.cs
+++ b/src/ReactiveUI/Platforms/android/SharedPreferencesExtensions.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/android/UsbManagerExtensions.cs
+++ b/src/ReactiveUI/Platforms/android/UsbManagerExtensions.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/android/ViewCommandExtensions.cs
+++ b/src/ReactiveUI/Platforms/android/ViewCommandExtensions.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/apple-common/AutoLayoutViewModelViewHost.cs
+++ b/src/ReactiveUI/Platforms/apple-common/AutoLayoutViewModelViewHost.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/apple-common/Buildsupport/Linker.xml
+++ b/src/ReactiveUI/Platforms/apple-common/Buildsupport/Linker.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
 Licensed to the .NET Foundation under one or more agreements.
-The .NET Foundation licenses this file to you under the MS-PL license.
+The .NET Foundation licenses this file to you under the MIT license.
 See the LICENSE file in the project root for more information.
 -->
 

--- a/src/ReactiveUI/Platforms/apple-common/Converters/DateTimeToNSDateConverter.cs
+++ b/src/ReactiveUI/Platforms/apple-common/Converters/DateTimeToNSDateConverter.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/apple-common/IndexNormalizer.cs
+++ b/src/ReactiveUI/Platforms/apple-common/IndexNormalizer.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 namespace ReactiveUI

--- a/src/ReactiveUI/Platforms/apple-common/JsonSuspensionDriver.cs
+++ b/src/ReactiveUI/Platforms/apple-common/JsonSuspensionDriver.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/apple-common/KVOObservableForProperty.cs
+++ b/src/ReactiveUI/Platforms/apple-common/KVOObservableForProperty.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/apple-common/NSRunloopScheduler.cs
+++ b/src/ReactiveUI/Platforms/apple-common/NSRunloopScheduler.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/apple-common/ObservableForPropertyBase.cs
+++ b/src/ReactiveUI/Platforms/apple-common/ObservableForPropertyBase.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/apple-common/PlatformOperations.cs
+++ b/src/ReactiveUI/Platforms/apple-common/PlatformOperations.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 namespace ReactiveUI

--- a/src/ReactiveUI/Platforms/apple-common/ReactiveControl.cs
+++ b/src/ReactiveUI/Platforms/apple-common/ReactiveControl.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/apple-common/ReactiveImageView.cs
+++ b/src/ReactiveUI/Platforms/apple-common/ReactiveImageView.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/apple-common/ReactiveNSView.cs
+++ b/src/ReactiveUI/Platforms/apple-common/ReactiveNSView.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/apple-common/ReactiveNSViewController.cs
+++ b/src/ReactiveUI/Platforms/apple-common/ReactiveNSViewController.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/apple-common/ReactiveSplitViewController.cs
+++ b/src/ReactiveUI/Platforms/apple-common/ReactiveSplitViewController.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/apple-common/TargetActionCommandBinder.cs
+++ b/src/ReactiveUI/Platforms/apple-common/TargetActionCommandBinder.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/apple-common/ViewModelViewHost.cs
+++ b/src/ReactiveUI/Platforms/apple-common/ViewModelViewHost.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/ios/AutoSuspendHelper.cs
+++ b/src/ReactiveUI/Platforms/ios/AutoSuspendHelper.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/ios/CommonReactiveSource.cs
+++ b/src/ReactiveUI/Platforms/ios/CommonReactiveSource.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/ios/FlexibleCommandBinder.cs
+++ b/src/ReactiveUI/Platforms/ios/FlexibleCommandBinder.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/ios/LinkerOverrides.cs
+++ b/src/ReactiveUI/Platforms/ios/LinkerOverrides.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/ios/PlatformRegistrations.cs
+++ b/src/ReactiveUI/Platforms/ios/PlatformRegistrations.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements. 
-// The .NET Foundation licenses this file to you under the MS-PL license. 
+// The .NET Foundation licenses this file to you under the MIT license. 
 // See the LICENSE file in the project root for more information. 
 
 using System;

--- a/src/ReactiveUI/Platforms/ios/ReactiveCollectionReusableView.cs
+++ b/src/ReactiveUI/Platforms/ios/ReactiveCollectionReusableView.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/ios/ReactiveCollectionView.cs
+++ b/src/ReactiveUI/Platforms/ios/ReactiveCollectionView.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/ios/ReactiveCollectionViewCell.cs
+++ b/src/ReactiveUI/Platforms/ios/ReactiveCollectionViewCell.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/ios/ReactiveCollectionViewController.cs
+++ b/src/ReactiveUI/Platforms/ios/ReactiveCollectionViewController.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/ios/ReactiveCollectionViewSource.cs
+++ b/src/ReactiveUI/Platforms/ios/ReactiveCollectionViewSource.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/ios/ReactiveNavigationController.cs
+++ b/src/ReactiveUI/Platforms/ios/ReactiveNavigationController.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/ios/ReactivePageViewController.cs
+++ b/src/ReactiveUI/Platforms/ios/ReactivePageViewController.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/ios/ReactiveTabBarController.cs
+++ b/src/ReactiveUI/Platforms/ios/ReactiveTabBarController.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/ios/ReactiveTableView.cs
+++ b/src/ReactiveUI/Platforms/ios/ReactiveTableView.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/ios/ReactiveTableViewCell.cs
+++ b/src/ReactiveUI/Platforms/ios/ReactiveTableViewCell.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/ios/ReactiveTableViewController.cs
+++ b/src/ReactiveUI/Platforms/ios/ReactiveTableViewController.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/ios/ReactiveTableViewSource.cs
+++ b/src/ReactiveUI/Platforms/ios/ReactiveTableViewSource.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/ios/RoutedViewHost.cs
+++ b/src/ReactiveUI/Platforms/ios/RoutedViewHost.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/ios/UIControlCommandExtensions.cs
+++ b/src/ReactiveUI/Platforms/ios/UIControlCommandExtensions.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/ios/UIKitCommandBinders.cs
+++ b/src/ReactiveUI/Platforms/ios/UIKitCommandBinders.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/ios/UIKitObservableForProperty.cs
+++ b/src/ReactiveUI/Platforms/ios/UIKitObservableForProperty.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/mac/AppKitAutoSuspendHelper.cs
+++ b/src/ReactiveUI/Platforms/mac/AppKitAutoSuspendHelper.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/mac/AppKitObservableForProperty.cs
+++ b/src/ReactiveUI/Platforms/mac/AppKitObservableForProperty.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/mac/PlatformRegistrations.cs
+++ b/src/ReactiveUI/Platforms/mac/PlatformRegistrations.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements. 
-// The .NET Foundation licenses this file to you under the MS-PL license. 
+// The .NET Foundation licenses this file to you under the MIT license. 
 // See the LICENSE file in the project root for more information. 
 
 using System;

--- a/src/ReactiveUI/Platforms/mac/ReactiveNSWindowController.cs
+++ b/src/ReactiveUI/Platforms/mac/ReactiveNSWindowController.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/net461/ComponentModelTypeConverter.cs
+++ b/src/ReactiveUI/Platforms/net461/ComponentModelTypeConverter.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/net461/PlatformRegistrations.cs
+++ b/src/ReactiveUI/Platforms/net461/PlatformRegistrations.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. 
-// The .NET Foundation licenses this file to you under the MS-PL license. 
+// The .NET Foundation licenses this file to you under the MIT license. 
 // See the LICENSE file in the project root for more information. 
 
 using System;

--- a/src/ReactiveUI/Platforms/netcoreapp2.0/PlatformRegistrations.cs
+++ b/src/ReactiveUI/Platforms/netcoreapp2.0/PlatformRegistrations.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/netstandard2.0/PlatformRegistrations.cs
+++ b/src/ReactiveUI/Platforms/netstandard2.0/PlatformRegistrations.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/tizen/EcoreMainloopScheduler.cs
+++ b/src/ReactiveUI/Platforms/tizen/EcoreMainloopScheduler.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/tizen/PlatformOperations.cs
+++ b/src/ReactiveUI/Platforms/tizen/PlatformOperations.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 namespace ReactiveUI

--- a/src/ReactiveUI/Platforms/tizen/PlatformRegistrations.cs
+++ b/src/ReactiveUI/Platforms/tizen/PlatformRegistrations.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/uap10.0.16299/DependencyObjectObservableForProperty.cs
+++ b/src/ReactiveUI/Platforms/uap10.0.16299/DependencyObjectObservableForProperty.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using Splat;

--- a/src/ReactiveUI/Platforms/uap10.0.16299/PlatformRegistrations.cs
+++ b/src/ReactiveUI/Platforms/uap10.0.16299/PlatformRegistrations.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements. 
-// The .NET Foundation licenses this file to you under the MS-PL license. 
+// The .NET Foundation licenses this file to you under the MIT license. 
 // See the LICENSE file in the project root for more information. 
 
 using System;

--- a/src/ReactiveUI/Platforms/uap10.0.16299/TransitioningContentControl.Empty.cs
+++ b/src/ReactiveUI/Platforms/uap10.0.16299/TransitioningContentControl.Empty.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using Windows.UI.Xaml.Controls;

--- a/src/ReactiveUI/Platforms/uap10.0.16299/WinRTAppDataDriver.cs
+++ b/src/ReactiveUI/Platforms/uap10.0.16299/WinRTAppDataDriver.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/uap10.0.16299/WinRTAutoSuspendApplication.cs
+++ b/src/ReactiveUI/Platforms/uap10.0.16299/WinRTAutoSuspendApplication.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/windows-common/ActivationForViewFetcher.cs
+++ b/src/ReactiveUI/Platforms/windows-common/ActivationForViewFetcher.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/windows-common/AutoDataTemplateBindingHook.cs
+++ b/src/ReactiveUI/Platforms/windows-common/AutoDataTemplateBindingHook.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/windows-common/BindingTypeConverters.cs
+++ b/src/ReactiveUI/Platforms/windows-common/BindingTypeConverters.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/windows-common/PlatformOperations.cs
+++ b/src/ReactiveUI/Platforms/windows-common/PlatformOperations.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/windows-common/ReactiveUserControl.cs
+++ b/src/ReactiveUI/Platforms/windows-common/ReactiveUserControl.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 namespace ReactiveUI

--- a/src/ReactiveUI/Platforms/windows-common/RoutedViewHost.cs
+++ b/src/ReactiveUI/Platforms/windows-common/RoutedViewHost.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/windows-common/ViewModelViewHost.cs
+++ b/src/ReactiveUI/Platforms/windows-common/ViewModelViewHost.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Platforms/xamarin-common/ComponentModelTypeConverter.cs
+++ b/src/ReactiveUI/Platforms/xamarin-common/ComponentModelTypeConverter.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Properties/AssemblyInfo.cs
+++ b/src/ReactiveUI/Properties/AssemblyInfo.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System.Runtime.CompilerServices;

--- a/src/ReactiveUI/PropertyBinding.cs
+++ b/src/ReactiveUI/PropertyBinding.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/ReactiveBinding.cs
+++ b/src/ReactiveUI/ReactiveBinding.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/ReactiveCollectionMixins.cs
+++ b/src/ReactiveUI/ReactiveCollectionMixins.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using Splat;

--- a/src/ReactiveUI/ReactiveCommand.cs
+++ b/src/ReactiveUI/ReactiveCommand.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/ReactiveList.cs
+++ b/src/ReactiveUI/ReactiveList.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using Splat;

--- a/src/ReactiveUI/ReactiveNotifyPropertyChangedMixin.cs
+++ b/src/ReactiveUI/ReactiveNotifyPropertyChangedMixin.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/ReactiveObject.cs
+++ b/src/ReactiveUI/ReactiveObject.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/ReactiveUI.licenseheader
+++ b/src/ReactiveUI/ReactiveUI.licenseheader
@@ -1,12 +1,12 @@
 ﻿extensions: designer.cs generated.cs
 extensions: .cs 
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 extensions:  .xml .config .xsd
 <!--
 Licensed to the .NET Foundation under one or more agreements.
-The .NET Foundation licenses this file to you under the MS-PL license.
+The .NET Foundation licenses this file to you under the MIT license.
 See the LICENSE file in the project root for more information.
 -->

--- a/src/ReactiveUI/RefcountDisposeWrapper.cs
+++ b/src/ReactiveUI/RefcountDisposeWrapper.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Reflection.cs
+++ b/src/ReactiveUI/Reflection.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/RegisterableInterfaces.cs
+++ b/src/ReactiveUI/RegisterableInterfaces.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/Registrations.cs
+++ b/src/ReactiveUI/Registrations.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/RoutableViewModelMixin.cs
+++ b/src/ReactiveUI/RoutableViewModelMixin.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/RoutingState.cs
+++ b/src/ReactiveUI/RoutingState.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/RxApp.cs
+++ b/src/ReactiveUI/RxApp.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using Splat;

--- a/src/ReactiveUI/ScheduledSubject.cs
+++ b/src/ReactiveUI/ScheduledSubject.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/SuspensionHost.cs
+++ b/src/ReactiveUI/SuspensionHost.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/UnhandledErrorException.cs
+++ b/src/ReactiveUI/UnhandledErrorException.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/VariadicTemplates.cs
+++ b/src/ReactiveUI/VariadicTemplates.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/ViewAttributes.cs
+++ b/src/ReactiveUI/ViewAttributes.cs
@@ -1,5 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 namespace ReactiveUI

--- a/src/ReactiveUI/ViewLocator.cs
+++ b/src/ReactiveUI/ViewLocator.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/WaitForDispatcherScheduler.cs
+++ b/src/ReactiveUI/WaitForDispatcherScheduler.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;

--- a/src/ReactiveUI/WeakEventManager.cs
+++ b/src/ReactiveUI/WeakEventManager.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MS-PL license.
+// The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

house keeping

**What is the current behavior? (You can also link to an open issue here)**

Headers incorrectly say MS-PL

**What is the new behavior (if this is a feature change)?**

Headers state the correct license (MIT)

**What might this PR break?**

It was a programmatic find and replace

![image](https://user-images.githubusercontent.com/127353/43068314-71840ea8-8ead-11e8-8d43-b758e4c41ad6.png)


**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

