### PR TITLE
Fix MSBuild.Sdk.Extras support to use the new syntax. 

### DIFF
--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -22,15 +22,6 @@
     <None Include="..\..\LICENSE" Pack="true" PackagePath="LICENSE" />
   </ItemGroup>
   
-  <!-- Use a Choose / When so the legacy project system doesn't get this -->
-  <Choose>
-    <When Condition="'$(IsLegacyProject)' != 'true'">
-      <ItemGroup>
-        <PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.41" PrivateAssets="All" />
-      </ItemGroup>
-    </When>
-  </Choose>
-
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning" Version="2.1.23" PrivateAssets="all" />
   </ItemGroup>

--- a/src/Directory.build.targets
+++ b/src/Directory.build.targets
@@ -22,8 +22,4 @@
   <PropertyGroup Condition="'$(TargetFramework)' == 'tizen40'">
     <DefineConstants>$(DefineConstants);Tizen</DefineConstants>
   </PropertyGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'uap10.0.16299' ">
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.0.8" />
-  </ItemGroup>
 </Project>

--- a/src/EventBuilder/EventBuilder.csproj
+++ b/src/EventBuilder/EventBuilder.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="MSBuild.Sdk.Extras">
 
 <PropertyGroup>
   <OutputType>Exe</OutputType>
-  <TargetFramework>net461</TargetFramework>
+  <TargetFrameworks>net461</TargetFrameworks>
   <AssemblyName>EventBuilder</AssemblyName>
   <RootNamespace>EventBuilder</RootNamespace>
 </PropertyGroup>

--- a/src/ReactiveUI.AndroidSupport/ReactiveUI.AndroidSupport.csproj
+++ b/src/ReactiveUI.AndroidSupport/ReactiveUI.AndroidSupport.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
     <TargetFrameworks>MonoAndroid80</TargetFrameworks>
@@ -23,7 +23,4 @@
   <ItemGroup>
     <ProjectReference Include="..\ReactiveUI\ReactiveUI.csproj" />
   </ItemGroup>
-
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
-
 </Project>

--- a/src/ReactiveUI.Blend/ReactiveUI.Blend.csproj
+++ b/src/ReactiveUI.Blend/ReactiveUI.Blend.csproj
@@ -11,8 +11,8 @@
   <ItemGroup>
     <Compile Remove="Platforms\**\*.cs" />
     <None Include="Platforms\**\*.cs" />
-     <PackageReference Include="System.Reactive" Version="3.1.1" />
-   <PackageReference Include="Splat" Version="4.0.0" />
+    <PackageReference Include="System.Reactive" Version="3.1.1" />
+    <PackageReference Include="Splat" Version="4.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
@@ -22,12 +22,12 @@
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="PresentationFramework.Aero" />
-    <PackageReference Include="Expression.Blend.Sdk" Version="1.0.2" /> 
+    <PackageReference Include="Expression.Blend.Sdk" Version="1.0.2" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'uap10.0.16299' ">
     <Compile Include="Platforms\uap10.0.16299\**\*.cs" />
-    <PackageReference Include="Microsoft.Xaml.Behaviors.Uwp.Managed" Version="1.1.0" />    
+    <PackageReference Include="Microsoft.Xaml.Behaviors.Uwp.Managed" Version="1.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ReactiveUI.Blend/ReactiveUI.Blend.csproj
+++ b/src/ReactiveUI.Blend/ReactiveUI.Blend.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
     <TargetFrameworks>net461;uap10.0.16299</TargetFrameworks>
@@ -11,8 +11,8 @@
   <ItemGroup>
     <Compile Remove="Platforms\**\*.cs" />
     <None Include="Platforms\**\*.cs" />
-    <PackageReference Include="System.Reactive" Version="3.1.1" />
-    <PackageReference Include="Splat" Version="4.0.0" />
+     <PackageReference Include="System.Reactive" Version="3.1.1" />
+   <PackageReference Include="Splat" Version="4.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
@@ -33,6 +33,4 @@
   <ItemGroup>
     <ProjectReference Include="..\ReactiveUI\ReactiveUI.csproj" />
   </ItemGroup>
-
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 </Project>

--- a/src/ReactiveUI.Events.WPF/ReactiveUI.Events.WPF.csproj
+++ b/src/ReactiveUI.Events.WPF/ReactiveUI.Events.WPF.csproj
@@ -1,10 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
     <TargetFrameworks>net461</TargetFrameworks>
     <AssemblyName>ReactiveUI.Events.WPF</AssemblyName>
     <RootNamespace>ReactiveUI.Events</RootNamespace>
     <Description>Provides Observable-based events API for WPF UI controls/eventhandlers. The contents of this package is automatically generated, please target pull-requests to the code generator.</Description>
     <PackageId>ReactiveUI.Events.WPF</PackageId>
+    <ExtrasEnableWpfProjectSetup>true</ExtrasEnableWpfProjectSetup>
   </PropertyGroup>  
 
   <ItemGroup>
@@ -22,6 +23,4 @@
     <Reference Include="PresentationFramework.Aero" />
     <Reference Include="WindowsBase" />
   </ItemGroup>
-
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 </Project>

--- a/src/ReactiveUI.Events.Winforms/ReactiveUI.Events.Winforms.csproj
+++ b/src/ReactiveUI.Events.Winforms/ReactiveUI.Events.Winforms.csproj
@@ -1,10 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
     <TargetFrameworks>net461</TargetFrameworks>
     <AssemblyName>ReactiveUI.Events.Winforms</AssemblyName>
     <RootNamespace>ReactiveUI.Events</RootNamespace>
     <Description>Provides Observable-based events API for Winforms UI controls/eventhandlers. The contents of this package is automatically generated, please target pull-requests to the code generator.</Description>
     <PackageId>ReactiveUI.Events.Winforms</PackageId>
+    <ExtrasEnableWinFormsProjectSetup>true</ExtrasEnableWinFormsProjectSetup >
   </PropertyGroup>  
 
   <ItemGroup>
@@ -25,6 +26,4 @@
     <Reference Include="System.Windows.Forms.DataVisualization" />
     <Reference Include="System.ServiceProcess" />
   </ItemGroup>
-
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 </Project>

--- a/src/ReactiveUI.Events.XamForms/ReactiveUI.Events.XamForms.csproj
+++ b/src/ReactiveUI.Events.XamForms/ReactiveUI.Events.XamForms.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <AssemblyName>ReactiveUI.Events.XamForms</AssemblyName>
@@ -18,6 +18,4 @@
     <PackageReference Include="Xamarin.Forms" Version="2.5.1.444934" />
     <Compile Include="Events_XAMFORMS.cs" />
   </ItemGroup>
-
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 </Project>

--- a/src/ReactiveUI.Events/ReactiveUI.Events.csproj
+++ b/src/ReactiveUI.Events/ReactiveUI.Events.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
     <TargetFrameworks>uap10.0.16299;Xamarin.iOS10;Xamarin.Mac20;MonoAndroid80;tizen40</TargetFrameworks>
     <AssemblyName>ReactiveUI.Events</AssemblyName>
@@ -38,9 +38,5 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'tizen40' ">
     <Compile Include="Events_TIZEN.cs" Condition="Exists('Events_TIZEN.cs')" />
-    <PackageReference Include="Tizen.NET" Version="4.0.0" />
   </ItemGroup>
-  
-
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 </Project>

--- a/src/ReactiveUI.Fody.Helpers/ReactiveUI.Fody.Helpers.csproj
+++ b/src/ReactiveUI.Fody.Helpers/ReactiveUI.Fody.Helpers.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461;uap10.0.16299;Xamarin.iOS10;Xamarin.Mac20;MonoAndroid80;netcoreapp2.0</TargetFrameworks>
     <AssemblyName>ReactiveUI.Fody.Helpers</AssemblyName>
@@ -45,7 +45,5 @@
   
   <ItemGroup>
     <ProjectReference Include="..\ReactiveUI\ReactiveUI.csproj" />
-  </ItemGroup>
- 
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
+  </ItemGroup> 
 </Project>

--- a/src/ReactiveUI.Fody.Tests/ReactiveUI.Fody.Tests.csproj
+++ b/src/ReactiveUI.Fody.Tests/ReactiveUI.Fody.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>    
     <TargetFrameworks>net461</TargetFrameworks>
     <IsPackable>false</IsPackable>
@@ -43,7 +43,4 @@
          until the projects are setup as suggested here: https://github.com/Fody/BasicFodyAddin -->
     <Copy SourceFiles="@(WeaverFiles)" DestinationFolder="..\Tools" />
   </Target>
-
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
-
 </Project>

--- a/src/ReactiveUI.LeakTests/ReactiveUI.LeakTests.csproj
+++ b/src/ReactiveUI.LeakTests/ReactiveUI.LeakTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
     <TargetFramework>net461</TargetFramework>
     <IsPackable>false</IsPackable>

--- a/src/ReactiveUI.Testing/ReactiveUI.Testing.csproj
+++ b/src/ReactiveUI.Testing/ReactiveUI.Testing.csproj
@@ -1,5 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-
+﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netcoreapp2.0;net461;uap10.0.16299;Xamarin.iOS10;Xamarin.Mac20;MonoAndroid80</TargetFrameworks>
     <AssemblyName>ReactiveUI.Testing</AssemblyName>
@@ -12,6 +11,4 @@
     <PackageReference Include="Microsoft.Reactive.Testing" Version="3.1.1" />
     <ProjectReference Include="..\ReactiveUI\ReactiveUI.csproj" />
   </ItemGroup>
-
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 </Project>

--- a/src/ReactiveUI.Tests/ReactiveUI.Tests.csproj
+++ b/src/ReactiveUI.Tests/ReactiveUI.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>    
     <TargetFrameworks>net461</TargetFrameworks>
@@ -49,7 +49,4 @@
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
-
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
-
 </Project>

--- a/src/ReactiveUI.Winforms/ReactiveUI.Winforms.csproj
+++ b/src/ReactiveUI.Winforms/ReactiveUI.Winforms.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
     <TargetFrameworks>net461</TargetFrameworks>
@@ -6,6 +6,7 @@
     <RootNamespace>ReactiveUI.Winforms</RootNamespace>
     <Description>Windows Forms specific extensions to ReactiveUI</Description>
     <PackageId>ReactiveUI.WinForms</PackageId>
+    <ExtrasEnableWinFormsProjectSetup>true</ExtrasEnableWinFormsProjectSetup >
   </PropertyGroup>
 
   <ItemGroup>
@@ -30,6 +31,4 @@
       <SubType>UserControl</SubType>
     </Compile>
   </ItemGroup>
-
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 </Project>

--- a/src/ReactiveUI.Wpf/ReactiveUI.Wpf.csproj
+++ b/src/ReactiveUI.Wpf/ReactiveUI.Wpf.csproj
@@ -1,10 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="MSBuild.Sdk.Extras">
   <!-- workaround for https://github.com/NuGet/Home/issues/5894 -->
   <PropertyGroup>
     <_SdkLanguageName>CSharp</_SdkLanguageName>
+    <ExtrasEnableWpfProjectSetup>true</ExtrasEnableWpfProjectSetup>
   </PropertyGroup>
-  <Import Project="obj\*.props" Condition=" '$(MSBuildProjectExtension)' == '.tmp_proj'" />
-  
   <PropertyGroup>
     <TargetFramework>net461</TargetFramework>        
     <Description>WPF specific extensions to ReactiveUI</Description>
@@ -15,8 +14,4 @@
     <ProjectReference Include="..\ReactiveUI\ReactiveUI.csproj" />    
     <Compile Include="..\ReactiveUI\Platforms\windows-common\**\*.cs" />
   </ItemGroup>
-
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
-  <!-- workaround for https://github.com/NuGet/Home/issues/5894 -->
-  <Import Project="obj\*.targets" Condition=" '$(MSBuildProjectExtension)' == '.tmp_proj'" />  
 </Project>

--- a/src/ReactiveUI.XamForms/ReactiveUI.XamForms.csproj
+++ b/src/ReactiveUI.XamForms/ReactiveUI.XamForms.csproj
@@ -1,5 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-
+﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <Description>Xamarin Forms specific extensions to ReactiveUI</Description>
@@ -13,6 +12,4 @@
   <ItemGroup>
     <ProjectReference Include="..\ReactiveUI\ReactiveUI.csproj" />
   </ItemGroup>
-
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 </Project>

--- a/src/ReactiveUI/Platforms/netcoreapp2.1/PlatformRegistrations.cs
+++ b/src/ReactiveUI/Platforms/netcoreapp2.1/PlatformRegistrations.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MS-PL license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Reactive.Concurrency;
+
+namespace ReactiveUI
+{
+    public class PlatformRegistrations : IWantsToRegisterStuff
+    {
+        public void Register(Action<Func<object>, Type> registerFunction)
+        {
+            RxApp.TaskpoolScheduler = TaskPoolScheduler.Default;
+            RxApp.MainThreadScheduler = DefaultScheduler.Instance;
+        }
+    }
+}

--- a/src/ReactiveUI/ReactiveUI.csproj
+++ b/src/ReactiveUI/ReactiveUI.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461;uap10.0.16299;Xamarin.iOS10;Xamarin.Mac20;MonoAndroid80;netcoreapp2.0;tizen40</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461;uap10.0.16299;Xamarin.iOS10;Xamarin.Mac20;MonoAndroid80;netcoreapp2.0;netcoreapp2.1;tizen40</TargetFrameworks>
     <AssemblyName>ReactiveUI</AssemblyName>
     <RootNamespace>ReactiveUI</RootNamespace>
     <Description>A MVVM framework that integrates with the Reactive Extensions for .NET to create elegant, testable User Interfaces that run on any mobile or desktop platform. Supports Xamarin.iOS, Xamarin.Android, Xamarin.Mac, Xamarin Forms, WPF, Windows Forms, Windows Phone 8.1, Windows Store and Universal Windows Platform (UWP).</Description>
@@ -21,13 +21,13 @@
     <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
   </ItemGroup>
-  
+
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
     <Compile Include="Platforms\net461\**\*.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'!='netstandard2.0'">
-    <Compile Include="Platforms\shared\**\*.cs" />    
+    <Compile Include="Platforms\shared\**\*.cs" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'uap10.0.16299' ">
@@ -39,33 +39,47 @@
     <Compile Include="Platforms\apple-common\**\*.cs" />
     <Compile Include="Platforms\ios\**\*.cs" />
     <Compile Include="Platforms\xamarin-common\**\*.cs" />
-    <Reference Include="System.Runtime.Serialization" />    
+    <Reference Include="System.Runtime.Serialization" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'Xamarin.Mac20' ">
     <Compile Include="Platforms\apple-common\**\*.cs" />
     <Compile Include="Platforms\mac\**\*.cs" />
     <Compile Include="Platforms\xamarin-common\**\*.cs" />
-    <Reference Include="System.Runtime.Serialization" />    
+    <Reference Include="System.Runtime.Serialization" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'MonoAndroid80' ">
     <Compile Include="Platforms\android\**\*.cs" />
     <Compile Include="Platforms\xamarin-common\**\*.cs" />
-    <Reference Include="System.Runtime.Serialization" />    
+    <Reference Include="System.Runtime.Serialization" />
   </ItemGroup>
-  
+
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
     <Compile Include="Platforms\netcoreapp2.0\**\*.cs" />
+    <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
+    <Compile Include="Platforms\netcoreapp2.1\**\*.cs" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'tizen40' ">
     <Compile Include="Platforms\tizen\**\*.cs" />
     <Compile Include="Platforms\xamarin-common\**\*.cs" />
-    <PackageReference Include="Tizen.NET" Version="4.0.0" />
+    <PackageReference Include="System.Collections" Version="4.3.0" />
+    <PackageReference Include="System.Diagnostics.Debug" Version="4.3.0" />
+    <PackageReference Include="System.Diagnostics.Tracing" Version="4.3.0" />
+    <PackageReference Include="System.IO.FileSystem" Version="4.3.0" />
+    <PackageReference Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
+    <PackageReference Include="System.Net.Primitives" Version="4.3.0" />
+    <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
+    <PackageReference Include="System.Text.Encoding.Extensions" Version="4.3.0" />
+    <PackageReference Include="System.Threading" Version="4.3.0" />
+    <PackageReference Include="Microsoft.Win32.Primitives" Version="4.3.0" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <None Update="VariadicTemplates.tt" Generator="TextTemplatingFileGenerator" LastGenOutput="VariadicTemplates.cs" />
     <Compile Update="VariadicTemplates.cs" DesignTime="true" AutoGen="true" DependentUpon="VariadicTemplates.tt" />
@@ -74,6 +88,4 @@
   <ItemGroup>
     <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
   </ItemGroup>
-  
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 </Project>

--- a/src/global.json
+++ b/src/global.json
@@ -1,0 +1,5 @@
+{
+    "msbuild-sdks": {
+        "MSBuild.Sdk.Extras": "1.6.41"
+    }
+}


### PR DESCRIPTION
…Core 2.1 target

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Fixes the fact that RxUI was broken with MSBuild.SdkExtras 1.6.41. Not uses the SDK method and a global.json file. Also removed references that msbuild.sdk.extras provide. 



**What is the current behavior? (You can also link to an open issue here)**
For the build system to fail and not build anything.


**What is the new behavior (if this is a feature change)?**
That everything will build and will pretty.


**What might this PR break?**
Don't think anything?
