### PR TITLE
Fix: Made POCOObservableForProperty include property name in warning

### DIFF
--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.approved.txt
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.approved.txt
@@ -175,7 +175,7 @@ namespace ReactiveUI
     public interface ICreatesObservableForProperty : Splat.IEnableLogger
     {
         int GetAffinityForObject(System.Type type, string propertyName, bool beforeChanged = False);
-        System.IObservable<ReactiveUI.IObservedChange<object, object>> GetNotificationForProperty(object sender, System.Linq.Expressions.Expression expression, bool beforeChanged = False);
+        System.IObservable<ReactiveUI.IObservedChange<object, object>> GetNotificationForProperty(object sender, System.Linq.Expressions.Expression expression, string propertyName, bool beforeChanged = False);
     }
     public interface IHandleObservableErrors
     {
@@ -208,7 +208,7 @@ namespace ReactiveUI
     {
         public INPCObservableForProperty() { }
         public int GetAffinityForObject(System.Type type, string propertyName, bool beforeChanged) { }
-        public System.IObservable<ReactiveUI.IObservedChange<object, object>> GetNotificationForProperty(object sender, System.Linq.Expressions.Expression expression, bool beforeChanged) { }
+        public System.IObservable<ReactiveUI.IObservedChange<object, object>> GetNotificationForProperty(object sender, System.Linq.Expressions.Expression expression, string propertyName, bool beforeChanged) { }
     }
     public class Interaction<TInput, TOutput>
     {
@@ -339,7 +339,7 @@ namespace ReactiveUI
     {
         public IROObservableForProperty() { }
         public int GetAffinityForObject(System.Type type, string propertyName, bool beforeChanged = False) { }
-        public System.IObservable<ReactiveUI.IObservedChange<object, object>> GetNotificationForProperty(object sender, System.Linq.Expressions.Expression expression, bool beforeChanged = False) { }
+        public System.IObservable<ReactiveUI.IObservedChange<object, object>> GetNotificationForProperty(object sender, System.Linq.Expressions.Expression expression, string propertyName, bool beforeChanged = False) { }
     }
     public interface IRoutableViewModel : ReactiveUI.INotifyPropertyChanging, ReactiveUI.IReactiveObject, Splat.IEnableLogger, System.ComponentModel.INotifyPropertyChanged
     {
@@ -467,7 +467,7 @@ namespace ReactiveUI
     {
         public POCOObservableForProperty() { }
         public int GetAffinityForObject(System.Type type, string propertyName, bool beforeChanged = False) { }
-        public System.IObservable<ReactiveUI.IObservedChange<object, object>> GetNotificationForProperty(object sender, System.Linq.Expressions.Expression expression, bool beforeChanged = False) { }
+        public System.IObservable<ReactiveUI.IObservedChange<object, object>> GetNotificationForProperty(object sender, System.Linq.Expressions.Expression expression, string propertyName, bool beforeChanged = False) { }
     }
     public class PropertyBinderImplementation : ReactiveUI.IPropertyBinderImplementation, Splat.IEnableLogger
     {

--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.Winforms.approved.txt
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.Winforms.approved.txt
@@ -109,6 +109,6 @@ namespace ReactiveUI.Winforms
     {
         public WinformsCreatesObservableForProperty() { }
         public int GetAffinityForObject(System.Type type, string propertyName, bool beforeChanged = False) { }
-        public System.IObservable<ReactiveUI.IObservedChange<object, object>> GetNotificationForProperty(object sender, System.Linq.Expressions.Expression expression, bool beforeChanged = False) { }
+        public System.IObservable<ReactiveUI.IObservedChange<object, object>> GetNotificationForProperty(object sender, System.Linq.Expressions.Expression expression, string propertyName, bool beforeChanged = False) { }
     }
 }

--- a/src/ReactiveUI.Tests/INPCObservableForPropertyTests.cs
+++ b/src/ReactiveUI.Tests/INPCObservableForPropertyTests.cs
@@ -40,7 +40,7 @@ namespace ReactiveUI.Tests
             var exp = Reflection.Rewrite(expr.Body);
 
             var changes = new List<IObservedChange<object, object>>();
-            instance.GetNotificationForProperty(testClass, exp, false).Subscribe(c => changes.Add(c));
+            instance.GetNotificationForProperty(testClass, exp, exp.GetMemberInfo().Name, false).Subscribe(c => changes.Add(c));
 
             testClass.Property1 = "test1";
             testClass.Property1 = "test2";
@@ -62,7 +62,7 @@ namespace ReactiveUI.Tests
             var exp = Reflection.Rewrite(expr.Body);
 
             var changes = new List<IObservedChange<object, object>>();
-            instance.GetNotificationForProperty(testClass, exp, true).Subscribe(c => changes.Add(c));
+            instance.GetNotificationForProperty(testClass, exp, exp.GetMemberInfo().Name, true).Subscribe(c => changes.Add(c));
 
             testClass.Property1 = "test1";
             testClass.Property1 = "test2";
@@ -84,7 +84,7 @@ namespace ReactiveUI.Tests
             var exp = Reflection.Rewrite(expr.Body);
 
             var changes = new List<IObservedChange<object, object>>();
-            instance.GetNotificationForProperty(testClass, exp, false).Subscribe(c => changes.Add(c));
+            instance.GetNotificationForProperty(testClass, exp, exp.GetMemberInfo().Name, false).Subscribe(c => changes.Add(c));
 
             testClass.OnPropertyChanged(null);
             testClass.OnPropertyChanged(string.Empty);
@@ -106,7 +106,7 @@ namespace ReactiveUI.Tests
             var exp = Reflection.Rewrite(expr.Body);
 
             var changes = new List<IObservedChange<object, object>>();
-            instance.GetNotificationForProperty(testClass, exp, true).Subscribe(c => changes.Add(c));
+            instance.GetNotificationForProperty(testClass, exp, exp.GetMemberInfo().Name, true).Subscribe(c => changes.Add(c));
 
             testClass.OnPropertyChanging(null);
             testClass.OnPropertyChanging(string.Empty);

--- a/src/ReactiveUI.Tests/Platforms/winforms/DefaultPropertyBindingTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/DefaultPropertyBindingTests.cs
@@ -23,7 +23,8 @@ namespace ReactiveUI.Tests.Winforms
             Assert.NotEqual(0, fixture.GetAffinityForObject(typeof(TextBox), "Text"));
 
             Expression<Func<TextBox, string>> expression = x => x.Text;
-            var output = fixture.GetNotificationForProperty(input, expression.Body).CreateCollection(scheduler: ImmediateScheduler.Instance);
+            var propertyName = expression.Body.GetMemberInfo().Name;
+            var output = fixture.GetNotificationForProperty(input, expression.Body, propertyName).CreateCollection(scheduler: ImmediateScheduler.Instance);
             Assert.Equal(0, output.Count);
 
             input.Text = "Foo";
@@ -46,7 +47,8 @@ namespace ReactiveUI.Tests.Winforms
             Assert.NotEqual(0, fixture.GetAffinityForObject(typeof(ToolStripButton), "Checked"));
 
             Expression<Func<ToolStripButton, bool>> expression = x => x.Checked;
-            var output = fixture.GetNotificationForProperty(input, expression.Body).CreateCollection(scheduler: ImmediateScheduler.Instance);
+            var propertyName = expression.Body.GetMemberInfo().Name;
+            var output = fixture.GetNotificationForProperty(input, expression.Body, propertyName).CreateCollection(scheduler: ImmediateScheduler.Instance);
             Assert.Equal(0, output.Count);
 
             input.Checked = true;
@@ -70,7 +72,8 @@ namespace ReactiveUI.Tests.Winforms
             Assert.NotEqual(0, fixture.GetAffinityForObject(typeof(AThirdPartyNamespace.ThirdPartyControl), "Value"));
 
             Expression<Func<AThirdPartyNamespace.ThirdPartyControl, string>> expression = x => x.Value;
-            var output = fixture.GetNotificationForProperty(input, expression.Body).CreateCollection(scheduler: ImmediateScheduler.Instance);
+            var propertyName = expression.Body.GetMemberInfo().Name;
+            var output = fixture.GetNotificationForProperty(input, expression.Body, propertyName).CreateCollection(scheduler: ImmediateScheduler.Instance);
             Assert.Equal(0, output.Count);
 
             input.Value = "Foo";

--- a/src/ReactiveUI.Tests/Platforms/xaml/DependencyObjectObservableForPropertyTest.cs
+++ b/src/ReactiveUI.Tests/Platforms/xaml/DependencyObjectObservableForPropertyTest.cs
@@ -48,8 +48,9 @@ namespace ReactiveUI.Tests
 
             var results = new List<IObservedChange<object, object>>();
             Expression<Func<DepObjFixture, object>> expression = x => x.TestString;
-            var disp1 = binder.GetNotificationForProperty(fixture, expression.Body).Subscribe(results.Add);
-            var disp2 = binder.GetNotificationForProperty(fixture, expression.Body).Subscribe(results.Add);
+            var propertyName = expression.Body.GetMemberInfo().Name;
+            var disp1 = binder.GetNotificationForProperty(fixture, expression.Body, propertyName).Subscribe(results.Add);
+            var disp2 = binder.GetNotificationForProperty(fixture, expression.Body, propertyName).Subscribe(results.Add);
 
             fixture.TestString = "Foo";
             fixture.TestString = "Bar";
@@ -70,8 +71,9 @@ namespace ReactiveUI.Tests
 
             var results = new List<IObservedChange<object, object>>();
             Expression<Func<DerivedDepObjFixture, object>> expression = x => x.TestString;
-            var disp1 = binder.GetNotificationForProperty(fixture, expression.Body).Subscribe(results.Add);
-            var disp2 = binder.GetNotificationForProperty(fixture, expression.Body).Subscribe(results.Add);
+            var propertyName = expression.Body.GetMemberInfo().Name;
+            var disp1 = binder.GetNotificationForProperty(fixture, expression.Body, propertyName).Subscribe(results.Add);
+            var disp2 = binder.GetNotificationForProperty(fixture, expression.Body, propertyName).Subscribe(results.Add);
 
             fixture.TestString = "Foo";
             fixture.TestString = "Bar";

--- a/src/ReactiveUI.Tests/PocoObservableForPropertyTests.cs
+++ b/src/ReactiveUI.Tests/PocoObservableForPropertyTests.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+using System.Threading.Tasks;
+using Splat;
+using Xunit;
+
+namespace ReactiveUI.Tests
+{
+    public class PocoObservableForPropertyTests
+    {
+        [Fact]
+        public void CheckGetAffinityForObjectValues()
+        {
+            var instance = new POCOObservableForProperty();
+
+            Assert.Equal(1, instance.GetAffinityForObject(typeof(PocoType), null, false));
+            Assert.Equal(1, instance.GetAffinityForObject(typeof(INPCClass), null, false));
+        }
+
+        [Fact]
+        public void NotificationPocoErrorOnBind()
+        {
+            var instance = new POCOObservableForProperty();
+
+            var testLogger = new TestLogger();
+            Locator.CurrentMutable.RegisterConstant<ILogger>(testLogger);
+
+            var testClass = new PocoType();
+
+            Expression<Func<PocoType, string>> expr = x => x.Property1;
+            var exp = Reflection.Rewrite(expr.Body);
+
+            instance.GetNotificationForProperty(testClass, exp, exp.GetMemberInfo().Name, false).Subscribe(_ => { });
+
+            Assert.True(testLogger.LastMessages.Count > 0);
+            Assert.Equal(testLogger.LastMessages[0], $"{nameof(POCOObservableForProperty)}: The class {typeof(PocoType).FullName} property {nameof(PocoType.Property1)} is a POCO type and won't send change notifications, WhenAny will only return a single value!");
+        }
+
+        class PocoType
+        {
+            public string Property1 { get; set; }
+            public string Property2 { get; set; }
+        }
+
+        class INPCClass : INotifyPropertyChanged
+        {
+            public event PropertyChangedEventHandler PropertyChanged;
+        }
+
+        class TestLogger : ILogger
+        {
+            public List<string> LastMessages { get; } = new List<string>();
+            public LogLevel Level { get; set; }
+            public void Write(string message, LogLevel logLevel)
+            {
+                LastMessages.Add(message);
+            }
+        }
+    }
+}

--- a/src/ReactiveUI.Winforms/WinformsCreatesObservableForProperty.cs
+++ b/src/ReactiveUI.Winforms/WinformsCreatesObservableForProperty.cs
@@ -32,12 +32,12 @@ namespace ReactiveUI.Winforms
             }
         }
 
-        public IObservable<IObservedChange<object, object>> GetNotificationForProperty(object sender, Expression expression, bool beforeChanged = false)
+        public IObservable<IObservedChange<object, object>> GetNotificationForProperty(object sender, Expression expression, string propertyName, bool beforeChanged = false)
         {
             var ei = default(EventInfo);
 
             lock (eventInfoCache) {
-                ei = eventInfoCache.Get(Tuple.Create(sender.GetType(), expression.GetMemberInfo().Name));
+                ei = eventInfoCache.Get(Tuple.Create(sender.GetType(), propertyName));
             }
 
             return Observable.Create<IObservedChange<object, object>>(subj => {

--- a/src/ReactiveUI.Wpf/WpfDependencyObjectObservableForProperty.cs
+++ b/src/ReactiveUI.Wpf/WpfDependencyObjectObservableForProperty.cs
@@ -24,10 +24,9 @@ namespace ReactiveUI
             return getDependencyProperty(type, propertyName) != null ? 4 : 0;
         }
 
-        public IObservable<IObservedChange<object, object>> GetNotificationForProperty(object sender, System.Linq.Expressions.Expression expression, bool beforeChanged = false)
+        public IObservable<IObservedChange<object, object>> GetNotificationForProperty(object sender, System.Linq.Expressions.Expression expression, string propertyName, bool beforeChanged = false)
         {
             var type = sender.GetType();
-            var propertyName = expression.GetMemberInfo().Name;
             var dpd = DependencyPropertyDescriptor.FromProperty(getDependencyProperty(type, propertyName), type);
 
             if (dpd == null) {

--- a/src/ReactiveUI/INPCObservableForProperty.cs
+++ b/src/ReactiveUI/INPCObservableForProperty.cs
@@ -21,7 +21,7 @@ namespace ReactiveUI
             return target.GetTypeInfo().IsAssignableFrom(type.GetTypeInfo()) ? 5 : 0;
         }
 
-        public IObservable<IObservedChange<object, object>> GetNotificationForProperty(object sender, Expression expression, bool beforeChanged)
+        public IObservable<IObservedChange<object, object>> GetNotificationForProperty(object sender, Expression expression, string propertyName, bool beforeChanged)
         {
             var before = sender as INotifyPropertyChanging;
             var after = sender as INotifyPropertyChanged;
@@ -30,18 +30,17 @@ namespace ReactiveUI
                 return Observable<IObservedChange<object, object>>.Never;
             }
 
-            var memberInfo = expression.GetMemberInfo();
             if (beforeChanged) {
                 var obs = Observable.FromEventPattern<PropertyChangingEventHandler, PropertyChangingEventArgs>(
                     x => before.PropertyChanging += x, x => before.PropertyChanging -= x);
 
                 if (expression.NodeType == ExpressionType.Index) {
                     return obs.Where(x => string.IsNullOrEmpty(x.EventArgs.PropertyName)
-                        || x.EventArgs.PropertyName.Equals(memberInfo.Name + "[]"))
+                        || x.EventArgs.PropertyName.Equals(propertyName + "[]"))
                         .Select(x => new ObservedChange<object, object>(sender, expression));
                 } else {
                     return obs.Where(x => string.IsNullOrEmpty(x.EventArgs.PropertyName)
-                        || x.EventArgs.PropertyName.Equals(memberInfo.Name))
+                        || x.EventArgs.PropertyName.Equals(propertyName))
                     .Select(x => new ObservedChange<object, object>(sender, expression));
                 }
             } else {
@@ -50,11 +49,11 @@ namespace ReactiveUI
 
                 if (expression.NodeType == ExpressionType.Index) {
                     return obs.Where(x => string.IsNullOrEmpty(x.EventArgs.PropertyName) 
-                        || x.EventArgs.PropertyName.Equals(memberInfo.Name + "[]"))
+                        || x.EventArgs.PropertyName.Equals(propertyName + "[]"))
                     .Select(x => new ObservedChange<object, object>(sender, expression));
                 } else {
                     return obs.Where(x => string.IsNullOrEmpty(x.EventArgs.PropertyName)
-                        || x.EventArgs.PropertyName.Equals(memberInfo.Name))
+                        || x.EventArgs.PropertyName.Equals(propertyName))
                     .Select(x => new ObservedChange<object, object>(sender, expression));
                 }
             }

--- a/src/ReactiveUI/IROObservableForProperty.cs
+++ b/src/ReactiveUI/IROObservableForProperty.cs
@@ -22,7 +22,7 @@ namespace ReactiveUI
             return typeof (IReactiveObject).GetTypeInfo().IsAssignableFrom(type.GetTypeInfo()) ? 10 : 0;
         }
 
-        public IObservable<IObservedChange<object, object>> GetNotificationForProperty(object sender, Expression expression, bool beforeChanged = false)
+        public IObservable<IObservedChange<object, object>> GetNotificationForProperty(object sender, Expression expression, string propertyName, bool beforeChanged = false)
         {
             var iro = sender as IReactiveObject;
             if (iro == null) {
@@ -31,21 +31,20 @@ namespace ReactiveUI
 
             var obs = beforeChanged ? iro.getChangingObservable() : iro.getChangedObservable();
 
-            var memberInfo = expression.GetMemberInfo();
             if (beforeChanged) {
                 if (expression.NodeType == ExpressionType.Index) {
-                    return obs.Where(x => x.PropertyName.Equals(memberInfo.Name + "[]"))
+                    return obs.Where(x => x.PropertyName.Equals(propertyName + "[]"))
                         .Select(x => new ObservedChange<object, object>(sender, expression));
                 } else {
-                    return obs.Where(x => x.PropertyName.Equals(memberInfo.Name))
+                    return obs.Where(x => x.PropertyName.Equals(propertyName))
                         .Select(x => new ObservedChange<object, object>(sender, expression));
                 }
             } else {
                 if (expression.NodeType == ExpressionType.Index) {
-                    return obs.Where(x => x.PropertyName.Equals(memberInfo.Name + "[]"))
+                    return obs.Where(x => x.PropertyName.Equals(propertyName + "[]"))
                         .Select(x => new ObservedChange<object, object>(sender, expression));
                 } else {
-                    return obs.Where(x => x.PropertyName.Equals(memberInfo.Name))
+                    return obs.Where(x => x.PropertyName.Equals(propertyName))
                         .Select(x => new ObservedChange<object, object>(sender, expression));
                 }
             }

--- a/src/ReactiveUI/POCOObservableForProperty.cs
+++ b/src/ReactiveUI/POCOObservableForProperty.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -22,15 +22,13 @@ namespace ReactiveUI
             return 1;
         }
 
-        static readonly Dictionary<Type, bool> hasWarned = new Dictionary<Type, bool>();
-        public IObservable<IObservedChange<object, object>> GetNotificationForProperty(object sender, Expression expression, bool beforeChanged = false)
+        private static readonly Dictionary<(Type, string), bool> hasWarned = new Dictionary<(Type, string), bool>();
+        public IObservable<IObservedChange<object, object>> GetNotificationForProperty(object sender, Expression expression, string propertyName, bool beforeChanged = false)
         {
             var type = sender.GetType();
-            if (!hasWarned.ContainsKey(type)) {
-                this.Log().Warn(
-                    "{0} is a POCO type and won't send change notifications, WhenAny will only return a single value!",
-                    type.FullName);
-                hasWarned[type] = true;
+            if (!hasWarned.ContainsKey((type, propertyName))) {
+                this.Log().Warn($"The class {type.FullName} property {propertyName} is a POCO type and won't send change notifications, WhenAny will only return a single value!");
+                hasWarned[(type, propertyName)] = true;
             }
 
             return Observable.Return(new ObservedChange<object, object>(sender, expression), RxApp.MainThreadScheduler)

--- a/src/ReactiveUI/Platforms/android/AndroidObservableForWidgets.cs
+++ b/src/ReactiveUI/Platforms/android/AndroidObservableForWidgets.cs
@@ -43,10 +43,10 @@ namespace ReactiveUI
             return dispatchTable.Keys.Any(x => x.Item1.IsAssignableFrom(type) && x.Item2 == propertyName) ? 5 : 0;
         }
 
-        public IObservable<IObservedChange<object, object>> GetNotificationForProperty(object sender, Expression expression, bool beforeChanged = false)
+        public IObservable<IObservedChange<object, object>> GetNotificationForProperty(object sender, Expression expression, string propertyName, bool beforeChanged = false)
         {
             var type = sender.GetType();
-            var tableItem = dispatchTable.Keys.First(x => x.Item1.IsAssignableFrom(type) && x.Item2 == expression.GetMemberInfo().Name);
+            var tableItem = dispatchTable.Keys.First(x => x.Item1.IsAssignableFrom(type) && x.Item2 == propertyName);
 
             return dispatchTable[tableItem](sender, expression);
         }

--- a/src/ReactiveUI/Platforms/apple-common/KVOObservableForProperty.cs
+++ b/src/ReactiveUI/Platforms/apple-common/KVOObservableForProperty.cs
@@ -62,13 +62,12 @@ namespace ReactiveUI
             }
         }
 
-        public IObservable<IObservedChange<object, object>> GetNotificationForProperty(object sender, Expression expression, bool beforeChanged = false)
+        public IObservable<IObservedChange<object, object>> GetNotificationForProperty(object sender, Expression expression, string propertyName, bool beforeChanged = false)
         {
             var obj = sender as NSObject;
             if (obj == null) {
                 throw new ArgumentException("Sender isn't an NSObject");
             }
-            var propertyName = expression.GetMemberInfo().Name;
 
             return Observable.Create<IObservedChange<object, object>>(subj => {
                 var bobs = new BlockObserveValueDelegate((key, s, _) => {

--- a/src/ReactiveUI/Platforms/apple-common/ObservableForPropertyBase.cs
+++ b/src/ReactiveUI/Platforms/apple-common/ObservableForPropertyBase.cs
@@ -38,13 +38,12 @@ namespace ReactiveUI
             return match.Affinity;
         }
 
-        public IObservable<IObservedChange<object, object>> GetNotificationForProperty(object sender, Expression expression, bool beforeChanged = false)
+        public IObservable<IObservedChange<object, object>> GetNotificationForProperty(object sender, Expression expression, string propertyName, bool beforeChanged = false)
         {
             if (beforeChanged)
                 return Observable<IObservedChange<object, object>>.Never;
 
             var type = sender.GetType();
-            var propertyName = expression.GetMemberInfo().Name;
 
             var match = config.Keys
                 .Where(x => x.IsAssignableFrom(type) && config[x].Keys.Contains(propertyName))

--- a/src/ReactiveUI/Platforms/uap10.0.16299/DependencyObjectObservableForProperty.cs
+++ b/src/ReactiveUI/Platforms/uap10.0.16299/DependencyObjectObservableForProperty.cs
@@ -22,11 +22,10 @@ namespace ReactiveUI
             return 4;
         }
 
-        public IObservable<IObservedChange<object, object>> GetNotificationForProperty(object sender, System.Linq.Expressions.Expression expression, bool beforeChanged = false)
+        public IObservable<IObservedChange<object, object>> GetNotificationForProperty(object sender, System.Linq.Expressions.Expression expression, string propertyName, bool beforeChanged = false)
         {
             Contract.Requires(sender != null && sender is DependencyObject);
             var type = sender.GetType();
-            var propertyName = expression.GetMemberInfo().Name;
             var depSender = sender as DependencyObject;
 
             if (depSender == null)
@@ -35,7 +34,7 @@ namespace ReactiveUI
                     type.FullName, propertyName);
 
                 var ret = new POCOObservableForProperty();
-                return ret.GetNotificationForProperty(sender, expression, beforeChanged);
+                return ret.GetNotificationForProperty(sender, expression, propertyName, beforeChanged);
             }
 
             if (beforeChanged == true) {
@@ -43,7 +42,7 @@ namespace ReactiveUI
                     type.FullName, propertyName);
 
                 var ret = new POCOObservableForProperty();
-                return ret.GetNotificationForProperty(sender, expression, beforeChanged);
+                return ret.GetNotificationForProperty(sender, expression, propertyName, beforeChanged);
             }
 
             var dpFetcher = getDependencyPropertyFetcher(type, propertyName);
@@ -52,7 +51,7 @@ namespace ReactiveUI
                     type.FullName, propertyName);
 
                 var ret = new POCOObservableForProperty();
-                return ret.GetNotificationForProperty(sender, expression, beforeChanged);
+                return ret.GetNotificationForProperty(sender, expression, propertyName, beforeChanged);
             }
 
             return Observable.Create<IObservedChange<object, object>>(subj => {

--- a/src/ReactiveUI/ReactiveNotifyPropertyChangedMixin.cs
+++ b/src/ReactiveUI/ReactiveNotifyPropertyChangedMixin.cs
@@ -166,18 +166,18 @@ namespace ReactiveUI
 
         static IObservable<IObservedChange<object, object>> notifyForProperty(object sender, Expression expression, bool beforeChange)
         {
+            var propertyName = expression.GetMemberInfo().Name;
             var result = default(ICreatesObservableForProperty);
             lock (notifyFactoryCache) {
-                result = notifyFactoryCache.Get(Tuple.Create(sender.GetType(), expression.GetMemberInfo().Name, beforeChange));
+                result = notifyFactoryCache.Get(Tuple.Create(sender.GetType(), propertyName, beforeChange));
             }
 
             if (result == null) {
                 throw new Exception(
-                    String.Format("Couldn't find a ICreatesObservableForProperty for {0}. This should never happen, your service locator is probably broken.",
-                    sender.GetType()));
+                    String.Format($"Couldn't find a ICreatesObservableForProperty for {sender.GetType()} property {propertyName}. This should never happen, your service locator is probably broken."));
             }
 
-            return result.GetNotificationForProperty(sender, expression, beforeChange);
+            return result.GetNotificationForProperty(sender, expression, propertyName, beforeChange);
         }
     }
 }

--- a/src/ReactiveUI/ReactiveUI.csproj
+++ b/src/ReactiveUI/ReactiveUI.csproj
@@ -24,6 +24,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
     <Compile Include="Platforms\net461\**\*.cs" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'!='netstandard2.0'">

--- a/src/ReactiveUI/RegisterableInterfaces.cs
+++ b/src/ReactiveUI/RegisterableInterfaces.cs
@@ -138,13 +138,14 @@ namespace ReactiveUI
         /// This will be either a MemberExpression or an IndexExpression
         /// dependending on the property.
         /// </param>
+        /// <param name="propertyName">The property of the type to query for.</param>
         /// <param name="beforeChanged">If true, signal just before the
         /// property value actually changes. If false, signal after the
         /// property changes.</param>
         /// <returns>An IObservable which is signalled whenever the specified
         /// property on the object changes. If this cannot be done for a
         /// specified value of beforeChanged, return Observable.Never</returns>
-        IObservable<IObservedChange<object, object>> GetNotificationForProperty(object sender, Expression expression, bool beforeChanged = false);
+        IObservable<IObservedChange<object, object>> GetNotificationForProperty(object sender, Expression expression, string propertyName, bool beforeChanged = false);
     }
 
     /// <summary>


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
bug fix.
Fixes #864

Makes POCOObservableForProperty  error message include the property name.

**What is the current behavior? (You can also link to an open issue here)**
Just lists the full type name.


**What is the new behavior (if this is a feature change)?**
Now includes the property name.


**What might this PR break?**
Could be performance issue but only if the error happens, and only once per instance of the type.


**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
