### PR TITLE
bug: Fix the project to use TargetFrameworks

### DIFF
--- a/src/ReactiveUI.Wpf/ReactiveUI.Wpf.csproj
+++ b/src/ReactiveUI.Wpf/ReactiveUI.Wpf.csproj
@@ -5,7 +5,7 @@
     <ExtrasEnableWpfProjectSetup>true</ExtrasEnableWpfProjectSetup>
   </PropertyGroup>
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>        
+    <TargetFrameworks>net461</TargetFrameworks>        
     <Description>WPF specific extensions to ReactiveUI</Description>
     <PackageId>ReactiveUI.WPF</PackageId>
   </PropertyGroup>


### PR DESCRIPTION
MSBuild.Sdk.Extras prefers TargetFrameworks and makes it consistent with other projects.

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Makes it consistent with other projects, and MSBuild.Sdk.Extras prefers the TargetFrameworks

As mentioned on the MSBuild.Sdk.Extras readme:

```
Make sure to use TargetFrameworks instead of TargetFramework, even if you're only building a single target framework. I am piggy-backing off of its looping capabilities.
```
**What is the current behavior? (You can also link to an open issue here)**
To use TargetFramework instead of TargetFrameworks.


**What is the new behavior (if this is a feature change)?**
To use TargetFrameworks


**What might this PR break?**
It shouldn't TargetFramework is an alias for TargetFrameworks that takes one platform.
