### PR TITLE
housekeeping: Fix typos and broken links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,48 +1,36 @@
 [![NuGet Stats](https://img.shields.io/nuget/v/reactiveui.svg)](https://www.nuget.org/packages/reactiveui) [![Build status](https://dotnetfoundation.visualstudio.com/_apis/public/build/definitions/a5852744-a77d-4d76-a9d2-81ac1fdd5744/11/badge)](https://dotnetfoundation.visualstudio.com/ReactiveUI/ReactiveUI%20Team/_build/index?definitionId=11)
- [![Coverage Status](https://coveralls.io/repos/github/reactiveui/ReactiveUI/badge.svg?branch=develop)](https://coveralls.io/github/reactiveui/ReactiveUI?branch=develop) [![#yourfirstpr](https://img.shields.io/badge/first--timers--only-friendly-blue.svg)](https://reactiveui.net/contribute) [![Pull Request Stats](http://www.issuestats.com/github/reactiveui/reactiveui/badge/pr?style=flat)](http://www.issuestats.com/github/reactiveui/reactiveui) [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Freactiveui%2FReactiveUI.svg?type=shield)](https://app.fossa.io/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Freactiveui%2FReactiveUI?ref=badge_shield)
+ [![Coverage Status](https://coveralls.io/repos/github/reactiveui/ReactiveUI/badge.svg?branch=develop)](https://coveralls.io/github/reactiveui/ReactiveUI?branch=develop) [![#yourfirstpr](https://img.shields.io/badge/first--timers--only-friendly-blue.svg)](https://reactiveui.net/contribute) <!--[![Pull Request Stats](http://www.issuestats.com/github/reactiveui/reactiveui/badge/pr?style=flat)](http://www.issuestats.com/github/reactiveui/reactiveui)--> [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Freactiveui%2FReactiveUI.svg?type=shield)](https://app.fossa.io/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Freactiveui%2FReactiveUI?ref=badge_shield)
+<br>
+<a href="https://www.nuget.org/packages/reactiveui">
+        <img src="https://img.shields.io/nuget/dt/reactiveui-core.svg">
+</a>
+<a href="#backers">
+        <img src="https://opencollective.com/reactiveui/backers/badge.svg">
+</a>
+<a href="#sponsors">
+        <img src="https://opencollective.com/reactiveui/sponsors/badge.svg">
+</a>
+<a href="https://reactiveui.net/slack">
+        <img src="https://img.shields.io/badge/chat-slack-blue.svg">
+</a>
+<br>
+<a href="https://github.com/reactiveui/reactiveui">
+  <img width="160" heigth="160" src="https://i.imgur.com/23kfbS9.png">
+</a>
+<br>
+<h1>What is ReactiveUI?</h1>
 
+<a href="https://reactiveui.net/">ReactiveUI</a> is a composable, cross-platform model-view-viewmodel framework for all .NET platforms that is inspired by functional reactive programming which is a paradigm that allows you to <a href="https://www.youtube.com/watch?v=3HwEytvngXk">abstract mutable state away from your user interfaces and express the idea around a feature in one readable place</a> and improve the testability of your application. 
 
-<div align="center">
-  <a href="https://github.com/reactiveui/reactiveui">
-    <img width="200" heigth="200" src="https://i.imgur.com/23kfbS9.png">
-  </a>
-  <br>
-  <br>
-	<a href="https://www.nuget.org/packages/reactiveui">
-		<img src="https://img.shields.io/nuget/dt/reactiveui-core.svg">
-	</a>
-	<a href="#backers">
-		<img src="https://opencollective.com/reactiveui/backers/badge.svg">
-	</a>
-	<a href="#sponsors">
-		<img src="https://opencollective.com/reactiveui/sponsors/badge.svg">
-	</a>
-	<a href="https://reactiveui.net/slack">
-		<img src="https://img.shields.io/badge/chat-slack-blue.svg">
-	</a>
-  <h1>ReactiveUI</h1>
-  <p>
-    ReactiveUI is a composable, cross-platform model-view-viewmodel framework for all .NET platforms that is inspired by functional reactive programming which is a paradigm that allows you to <a href="https://www.youtube.com/watch?v=3HwEytvngXk">abstract mutable state away from your user interfaces and express the idea around a feature in one readable place</a> and improve the testability of your application.
-  <p>
-</div>
+<a href="https://reactiveui.net/docs/getting-started/">Get Started</a> | <a href="https://reactiveui.net/docs/getting-started/installation/nuget-packages/">Install Packages</a> | <a href="https://reactiveui.net/docs/resources/videos">Watch Videos</a> | <a href="https://reactiveui.net/docs/samples/">View Samples</a> | <a href="https://reactiveui.net/slack">Discuss</a>
 
-<h2 align="center">Table of Contents</h2>
-
-* [Introduction](#introduction)
-* [A Compelling Example](#a-compelling-example)
-* [Support](#support)
-* [Contribute](#contribute)
-* [Showcase](#showcase)
-* [Sponsorship](#sponsorship)
-
-<h2 align="center">Introduction</h2>
+<h2>Introduction to Reactive Programming</h2>
 
 Long ago, when computer programming first came to be, machines had to be programmed quite manually. If the technician entered the correct sequence of machine codes in the correct order, then the resulting program behavior would satisfy the business requirements. Instead of telling a computer how to do its job, which error-prone and relies too heavily on the infallibility of the programmer, why don't we just tell it what it's job is and let it figure the rest out?
 
 ReactiveUI is inspired by the paradigm of Functional Reactive Programming, which allows you to model user input as a function that changes over time. This is super cool because it allows you to abstract mutable state away from your user interfaces and express the idea around a feature in one readable place whilst improving application testability. Reactive programming can look scary and complex at first glance, but the best way to describe reactive programming is to think of a spreadsheet:
 
-![](https://reactiveui.net/images/frp-excel.gif)
-
+![](https://reactiveui.net/docs/frp-excel.gif)
 
 * Three cells, A, B, and C.
 * C is defined as the sum of A and B.
@@ -50,71 +38,69 @@ ReactiveUI is inspired by the paradigm of Functional Reactive Programming, which
 
 That's reactive programming: changes propagate throughout a system automatically. Welcome to the peanut butter and jelly of programming paradigms. For further information please watch the this video from the Xamarin Evolve conference - [Why You Should Be Building Better Mobile Apps with Reactive Programming](http://www.youtube.com/watch?v=DYEbUF4xs1Q) by Michael Stonis.
 
-<h2 align="center">A Compelling Example</h2>
+<h2>A Compelling Example</h2>
 
 Let’s say you have a text field, and whenever the user types something into it, you want to make a network request which searches for that query.
-
 
 ![](http://i.giphy.com/xTka02wR2HiFOFACoE.gif)
 
 ```csharp
 public interface ISearchViewModel
 {
-    ReactiveList<SearchResults> SearchResults { get; }
-    string SearchQuery { get; }	 
-    ReactiveCommand<string, List<SearchResults>> Search { get; }
-    ISearchService SearchService { get; }
+    string SearchQuery { get; set; }	 
+    ReactiveCommand<string, List<SearchResult>> Search { get; }
+    ReactiveList<SearchResult> SearchResults { get; }
 }
 ```
 
-<h3 align="center">Define under what conditions a network request will be made</h3>
+<h3>Define under what conditions a network request will be made</h3>
 
 ```csharp
 // Here we're describing here, in a *declarative way*, the conditions in
 // which the Search command is enabled.  Now our Command IsEnabled is
 // perfectly efficient, because we're only updating the UI in the scenario
 // when it should change.
-var canSearch = this.WhenAny(x => x.SearchQuery, x => !String.IsNullOrWhiteSpace(x.Value));
+var canSearch = this.WhenAnyValue(x => x.SearchQuery, query => !string.IsNullOrWhiteSpace(query));
 ```
 
-<h3 align="center">Make the network connection</h3>
+<h3>Make the network connection</h3>
 
 ```csharp
 // ReactiveCommand has built-in support for background operations and
 // guarantees that this block will only run exactly once at a time, and
 // that the CanExecute will auto-disable and that property IsExecuting will
 // be set accordingly whilst it is running.
-Search = ReactiveCommand.CreateFromTask<string, List<SearchResults>>(_ => 
-        searchService.Search(this.SearchQuery), canSearch);
+Search = ReactiveCommand.CreateFromTask(_ => searchService.Search(this.SearchQuery), canSearch);
 ```
 
-<h3 align="center">Update the user interface</h3>
+<h3>Update the user interface</h3>
 
 ```csharp
 // ReactiveCommands are themselves IObservables, whose value are the results
 // from the async method, guaranteed to arrive on the UI thread. We're going
 // to take the list of search results that the background operation loaded, 
 // and them into our SearchResults.
-Search.Subscribe(results => {
+Search.Subscribe(results => 
+{
     SearchResults.Clear();
     SearchResults.AddRange(results);
 });
 
 ```
 
-<h3 align="center">Handling failures</h3>
+<h3>Handling failures</h3>
 
 ```csharp
 // ThrownExceptions is any exception thrown from the CreateAsyncTask piped
 // to this Observable. Subscribing to this allows you to handle errors on
 // the UI thread. 
-Search.ThrownExceptions
-    .Subscribe(ex => {
-        UserError.Throw("Potential Network Connectivity Error", ex);
-    });
+Search.ThrownExceptions.Subscribe(error => 
+{
+    UserError.Throw("Potential Network Connectivity Error", error);
+});
 ```
 
-<h3 align="center">Throttling network requests and automatic search execution behaviour</h3>
+<h3>Throttling network requests and automatic search execution behaviour</h3>
 
 ```csharp
 // Whenever the Search query changes, we're going to wait for one second
@@ -124,7 +110,7 @@ this.WhenAnyValue(x => x.SearchQuery)
     .InvokeCommand(Search);
 ```
 
-<h2 align="center">Support</h2>
+<h2>Support</h2>
 
 If you have a question, please see if any discussions in our [GitHub issues](github.com/reactiveui/ReactiveUI/issues) or [Stack Overflow](https://stackoverflow.com/questions/tagged/reactiveui) have already answered it.
 
@@ -134,9 +120,7 @@ If you are twitter savvy you can tweet #reactiveui with your question and someon
 
 If you have discovered a 🐜 or have a feature suggestion, feel free to create an issue on GitHub.
 
-
-<h2 align="center">Contribute</h2>
-
+<h2>Contribute</h2>
 
 ReactiveUI is developed under an OSI-approved open source license, making it freely usable and distributable, even for commercial use. Because of our Open Collective model for funding and transparency, we are able to funnel support and funds through to our contributors and community. We ❤ the people who are involved in this project, and we’d love to have you on board, especially if you are just getting started or have never contributed to open-source before.
 
@@ -165,14 +149,11 @@ We're also looking for people to assist with code reviews of ReactiveUI contribu
  - [Tizen](https://github.com/orgs/reactiveui/teams/tizen-team)
  - [Web Assembly](https://github.com/orgs/reactiveui/teams/webassembly-team)
 
-<img src="https://opencollective.com/reactiveui/contributors.png?avatarHeight=64&button=true&width=1400&margin=3"/>
-
-
-<h2 align="center">.NET Foundation</h2>
+<h2>.NET Foundation</h2>
 
 ReactiveUI is part of the [.NET Foundation](https://www.dotnetfoundation.org/). Other projects that are associated with the foundation include the Microsoft .NET Compiler Platform ("Roslyn") as well as the Microsoft ASP.NET family of projects, Microsoft .NET Core & Xamarin Forms.
 
-<h2 align="center">Core Team</h2>
+<h2>Core Team</h2>
 
 <table>
   <tbody>
@@ -217,7 +198,7 @@ ReactiveUI is part of the [.NET Foundation](https://www.dotnetfoundation.org/). 
   </tbody>
 </table>
 
-<h2 align="center">Sponsorship</h2>
+<h2>Sponsorship</h2>
 
 The core team members, ReactiveUI contributors and contributors in the ecosystem do this open source work in their free time. If you use ReactiveUI a serious task, and you'd like us to invest more time on it, please donate. This project increases your income/productivity too. It makes development and applications faster and it reduces the required bandwidth.
 
@@ -230,7 +211,7 @@ This is how we use the donations:
 * Infrastructure cost
 * Fees for money handling
 
-<h2 align="center">Backers</h2>
+<h2>Backers</h2>
 
 [Become a backer](https://opencollective.com/reactiveui#backer) and get your image on our README on Github with a link to your site.
 
@@ -265,7 +246,7 @@ This is how we use the donations:
 <a href="https://opencollective.com/reactiveui/backer/28/website" target="_blank"><img src="https://opencollective.com/reactiveui/backer/28/avatar.svg"></a>
 <a href="https://opencollective.com/reactiveui/backer/29/website" target="_blank"><img src="https://opencollective.com/reactiveui/backer/29/avatar.svg"></a>
 
-<h2 align="center">Sponsors</h2>
+<h2>Sponsors</h2>
 
 [Become a sponsor](https://opencollective.com/reactiveui#sponsor) and get your logo on our README on Github with a link to your site.
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
         <img src="https://img.shields.io/badge/chat-slack-blue.svg">
 </a>
 <br>
+<br>
 <a href="https://github.com/reactiveui/reactiveui">
   <img width="160" heigth="160" src="https://i.imgur.com/23kfbS9.png">
 </a>
@@ -22,7 +23,7 @@
 
 <a href="https://reactiveui.net/">ReactiveUI</a> is a composable, cross-platform model-view-viewmodel framework for all .NET platforms that is inspired by functional reactive programming which is a paradigm that allows you to <a href="https://www.youtube.com/watch?v=3HwEytvngXk">abstract mutable state away from your user interfaces and express the idea around a feature in one readable place</a> and improve the testability of your application. 
 
-<a href="https://reactiveui.net/docs/getting-started/">Get Started</a> | <a href="https://reactiveui.net/docs/getting-started/installation/nuget-packages/">Install Packages</a> | <a href="https://reactiveui.net/docs/resources/videos">Watch Videos</a> | <a href="https://reactiveui.net/docs/samples/">View Samples</a> | <a href="https://reactiveui.net/slack">Discuss</a>
+<a href="https://reactiveui.net/docs/getting-started/">🔨 Get Started</a>, <a href="https://reactiveui.net/docs/getting-started/installation/nuget-packages/">🛍 Install Packages</a>, <a href="https://reactiveui.net/docs/resources/videos">🎞 Watch Videos</a>, <a href="https://reactiveui.net/docs/samples/">🎓 View Samples</a>, <a href="https://reactiveui.net/slack">🎤 Discuss ReactiveUI</a>
 
 <h2>Introduction to Reactive Programming</h2>
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Changes in README.md to make it more friendly to new users.

**What is the current behavior? (You can also link to an open issue here)**
There are some images not displaying due to broken urls, there are no links to documentation or to "Getting Started" page in old README.md file.

**What is the new behavior (if this is a feature change)?**
Images are back in town, links to docs, packages and samples are also added. "A Compelling Example" now uses `WhenAnyValue` instead of `WhenAny` and `x.Value`, curly brackets are formatted using .NET Core code of conduct. 

**What might this PR break?**
Nothing, really.

**Other information**:
Personally I don't like centered text and huge empty space caused by "Table of Contents", so I removed these things.