### PR TITLE
Fix WPF users not having themes set correctly.

### DIFF
--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -36,4 +36,8 @@
   <ItemGroup Condition="'$(IsTestProject)' != 'true' and '$(SourceLinkEnabled)' != 'false'">
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" /> 
   </ItemGroup>
+  
+   <PropertyGroup>
+    <SolutionDir Condition="'$(SolutionDir)' == ''">$(MSBuildThisFileDirectory)</SolutionDir>
+  </PropertyGroup>
 </Project>

--- a/src/ReactiveUI.Wpf/ReactiveUI.Wpf.csproj
+++ b/src/ReactiveUI.Wpf/ReactiveUI.Wpf.csproj
@@ -1,13 +1,9 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
-  <!-- workaround for https://github.com/NuGet/Home/issues/5894 -->
-  <PropertyGroup>
-    <_SdkLanguageName>CSharp</_SdkLanguageName>
-    <ExtrasEnableWpfProjectSetup>true</ExtrasEnableWpfProjectSetup>
-  </PropertyGroup>
   <PropertyGroup>
     <TargetFrameworks>net461</TargetFrameworks>        
     <Description>WPF specific extensions to ReactiveUI</Description>
     <PackageId>ReactiveUI.WPF</PackageId>
+    <ExtrasEnableWpfProjectSetup>true</ExtrasEnableWpfProjectSetup>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ReactiveUI.sln
+++ b/src/ReactiveUI.sln
@@ -8,6 +8,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		..\.vsts-ci.yml = ..\.vsts-ci.yml
 		Directory.build.props = Directory.build.props
 		Directory.build.targets = Directory.build.targets
+		global.json = global.json
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ReactiveUI", "ReactiveUI\ReactiveUI.csproj", "{464CB812-F99F-401B-BE4C-E8F0515CD19D}"

--- a/src/global.json
+++ b/src/global.json
@@ -1,5 +1,5 @@
 {
     "msbuild-sdks": {
-        "MSBuild.Sdk.Extras": "1.6.41"
+        "MSBuild.Sdk.Extras": "1.6.46"
     }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Increments the MsBuildSdkExtras version so it doesn't break WPF.

The old version wasn't producing baml files in the resources, instead was just injecting XAML.

**What is the current behavior? (You can also link to an open issue here)**
Xaml files which breaks WPF users by having the transitioncontrol not work.

This bumps the MSBuildSdkExtras to 1.6.46


**What is the new behavior (if this is a feature change)?**
Will allow the transition control to work.


**Other information**:
Some other minor changes. 
- Removed unneeded stuff inside the wpf project csproj.
- set a constant for the solution directory if one doesn't exist. Can be useful if you are using VS code or something
- Added the global.json to the solution so we can easily edit it.

