### PR TITLE
Allow building against prerelease versions of VS

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -32,6 +32,8 @@ if (string.IsNullOrWhiteSpace(target))
     target = "Default";
 }
 
+var includePrerelease = Argument("includePrerelease", false);
+
 //////////////////////////////////////////////////////////////////////
 // PREPARATION
 //////////////////////////////////////////////////////////////////////
@@ -44,7 +46,8 @@ var local = BuildSystem.IsLocalBuild;
 var isPullRequest = !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("SYSTEM_PULLREQUEST_PULLREQUESTNUMBER"));
 var isRepository = StringComparer.OrdinalIgnoreCase.Equals("reactiveui/reactiveui", TFBuild.Environment.Repository.RepoName);
 
-var msBuildPath = VSWhereLatest().CombineWithFilePath("./MSBuild/15.0/Bin/MSBuild.exe");
+var vsWhereSettings = new VSWhereLatestSettings() { IncludePrerelease = includePrerelease };
+var msBuildPath = VSWhereLatest(vsWhereSettings).CombineWithFilePath("./MSBuild/15.0/Bin/MSBuild.exe");
 
 var informationalVersion = EnvironmentVariable("GitAssemblyInformationalVersion");
 
@@ -116,7 +119,7 @@ Task("GenerateEvents")
 {
     var eventBuilder = "./src/EventBuilder/bin/Release/net461/EventBuilder.exe";
     var workingDirectory = "./src/EventBuilder/bin/Release/Net461";
-    var referenceAssembliesPath = VSWhereLatest().CombineWithFilePath("./Common7/IDE/ReferenceAssemblies/Microsoft/Framework");
+    var referenceAssembliesPath = VSWhereLatest(vsWhereSettings).CombineWithFilePath("./Common7/IDE/ReferenceAssemblies/Microsoft/Framework");
 
     Information(referenceAssembliesPath.ToString());
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

feature

**What is the current behavior? (You can also link to an open issue here)**

build only targets stable VS instances

**What is the new behavior (if this is a feature change)?**

include prerelease instances of VS when using vswhere.exe

**What might this PR break?**

There is no way, with this implementation, to prefer Stable VS if Preview is also installed.

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
 
Needed to address https://github.com/reactiveui/ReactiveUI/issues/1615 
