### PR TITLE
Made the ReactivePagerAdapter not rely on ReactiveList.

### DIFF
--- a/src/ReactiveUI.AndroidSupport/ControlFetcherMixin.cs
+++ b/src/ReactiveUI.AndroidSupport/ControlFetcherMixin.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -7,8 +7,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Text;
-using Android.App;
 using Android.Views;
 using Java.Interop;
 using Android.Support.V7.App;

--- a/src/ReactiveUI.AndroidSupport/ReactiveAppCompatActivity.cs
+++ b/src/ReactiveUI.AndroidSupport/ReactiveAppCompatActivity.cs
@@ -1,32 +1,18 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Diagnostics.Contracts;
-using System.Linq;
 using System.Reactive;
-using System.Reactive.Concurrency;
-using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Reactive.Threading.Tasks;
-using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Runtime.Serialization;
-using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using Android.App;
 using Android.Content;
-using Android.OS;
 using Android.Runtime;
 using Android.Support.V7.App;
-using Android.Views;
-using Android.Widget;
-using Splat;
 
 namespace ReactiveUI.AndroidSupport
 {
@@ -42,14 +28,14 @@ namespace ReactiveUI.AndroidSupport
         TViewModel _ViewModel;
         public TViewModel ViewModel
         {
-            get { return _ViewModel; }
-            set { this.RaiseAndSetIfChanged(ref _ViewModel, value); }
+            get => _ViewModel;
+            set => this.RaiseAndSetIfChanged(ref _ViewModel, value);
         }
 
         object IViewFor.ViewModel
         {
-            get { return _ViewModel; }
-            set { _ViewModel = (TViewModel)value; }
+            get => _ViewModel;
+            set => _ViewModel = (TViewModel)value;
         }
     }
 
@@ -61,8 +47,8 @@ namespace ReactiveUI.AndroidSupport
     {
         public event PropertyChangingEventHandler PropertyChanging
         {
-            add { PropertyChangingEventManager.AddHandler(this, value); }
-            remove { PropertyChangingEventManager.RemoveHandler(this, value); }
+            add => PropertyChangingEventManager.AddHandler(this, value);
+            remove => PropertyChangingEventManager.RemoveHandler(this, value);
         }
 
         void IReactiveObject.RaisePropertyChanging(PropertyChangingEventArgs args)
@@ -72,8 +58,8 @@ namespace ReactiveUI.AndroidSupport
 
         public event PropertyChangedEventHandler PropertyChanged
         {
-            add { PropertyChangedEventManager.AddHandler(this, value); }
-            remove { PropertyChangedEventManager.RemoveHandler(this, value); }
+            add => PropertyChangedEventManager.AddHandler(this, value);
+            remove => PropertyChangedEventManager.RemoveHandler(this, value);
         }
 
         void IReactiveObject.RaisePropertyChanged(PropertyChangedEventArgs args)
@@ -85,18 +71,12 @@ namespace ReactiveUI.AndroidSupport
         /// Represents an Observable that fires *before* a property is about to
         /// be changed.         
         /// </summary>
-        public IObservable<IReactivePropertyChangedEventArgs<ReactiveAppCompatActivity>> Changing
-        {
-            get { return this.getChangingObservable(); }
-        }
+        public IObservable<IReactivePropertyChangedEventArgs<ReactiveAppCompatActivity>> Changing => this.getChangingObservable();
 
         /// <summary>
         /// Represents an Observable that fires *after* a property has changed.
         /// </summary>
-        public IObservable<IReactivePropertyChangedEventArgs<ReactiveAppCompatActivity>> Changed
-        {
-            get { return this.getChangedObservable(); }
-        }
+        public IObservable<IReactivePropertyChangedEventArgs<ReactiveAppCompatActivity>> Changed => this.getChangedObservable();
 
         protected ReactiveAppCompatActivity() { }
 
@@ -116,13 +96,13 @@ namespace ReactiveUI.AndroidSupport
             return this.suppressChangeNotifications();
         }
 
-        public IObservable<Exception> ThrownExceptions { get { return this.getThrownExceptionsObservable(); } }
+        public IObservable<Exception> ThrownExceptions => this.getThrownExceptionsObservable();
 
         readonly Subject<Unit> activated = new Subject<Unit>();
-        public IObservable<Unit> Activated { get { return activated.AsObservable(); } }
+        public IObservable<Unit> Activated => activated.AsObservable();
 
         readonly Subject<Unit> deactivated = new Subject<Unit>();
-        public IObservable<Unit> Deactivated { get { return deactivated.AsObservable(); } }
+        public IObservable<Unit> Deactivated => deactivated.AsObservable();
 
         protected override void OnPause()
         {
@@ -137,10 +117,7 @@ namespace ReactiveUI.AndroidSupport
         }
 
         readonly Subject<Tuple<int, Result, Intent>> activityResult = new Subject<Tuple<int, Result, Intent>>();
-        public IObservable<Tuple<int, Result, Intent>> ActivityResult
-        {
-            get { return activityResult.AsObservable(); }
-        }
+        public IObservable<Tuple<int, Result, Intent>> ActivityResult => activityResult.AsObservable();
 
         protected override void OnActivityResult(int requestCode, Result resultCode, Intent data)
         {

--- a/src/ReactiveUI.AndroidSupport/ReactiveDialogFragment.cs
+++ b/src/ReactiveUI.AndroidSupport/ReactiveDialogFragment.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -22,14 +22,14 @@ namespace ReactiveUI.AndroidSupport
         TViewModel _ViewModel;
         public TViewModel ViewModel
         {
-            get { return _ViewModel; }
-            set { this.RaiseAndSetIfChanged(ref _ViewModel, value); }
+            get => _ViewModel;
+            set => this.RaiseAndSetIfChanged(ref _ViewModel, value);
         }
 
         object IViewFor.ViewModel
         {
-            get { return _ViewModel; }
-            set { _ViewModel = (TViewModel)value; }
+            get => _ViewModel;
+            set => _ViewModel = (TViewModel)value;
         }
     }
 
@@ -43,8 +43,8 @@ namespace ReactiveUI.AndroidSupport
 
         public event PropertyChangingEventHandler PropertyChanging
         {
-            add { PropertyChangingEventManager.AddHandler(this, value); }
-            remove { PropertyChangingEventManager.RemoveHandler(this, value); }
+            add => PropertyChangingEventManager.AddHandler(this, value);
+            remove => PropertyChangingEventManager.RemoveHandler(this, value);
         }
 
         void IReactiveObject.RaisePropertyChanging(PropertyChangingEventArgs args)
@@ -54,8 +54,8 @@ namespace ReactiveUI.AndroidSupport
 
         public event PropertyChangedEventHandler PropertyChanged
         {
-            add { PropertyChangedEventManager.AddHandler(this, value); }
-            remove { PropertyChangedEventManager.RemoveHandler(this, value); }
+            add => PropertyChangedEventManager.AddHandler(this, value);
+            remove => PropertyChangedEventManager.RemoveHandler(this, value);
         }
 
         void IReactiveObject.RaisePropertyChanged(PropertyChangedEventArgs args)
@@ -67,18 +67,12 @@ namespace ReactiveUI.AndroidSupport
         /// Represents an Observable that fires *before* a property is about to
         /// be changed.         
         /// </summary>
-        public IObservable<IReactivePropertyChangedEventArgs<ReactiveDialogFragment>> Changing
-        {
-            get { return this.getChangingObservable(); }
-        }
+        public IObservable<IReactivePropertyChangedEventArgs<ReactiveDialogFragment>> Changing => this.getChangingObservable();
 
         /// <summary>
         /// Represents an Observable that fires *after* a property has changed.
         /// </summary>
-        public IObservable<IReactivePropertyChangedEventArgs<ReactiveDialogFragment>> Changed
-        {
-            get { return this.getChangedObservable(); }
-        }
+        public IObservable<IReactivePropertyChangedEventArgs<ReactiveDialogFragment>> Changed => this.getChangedObservable();
 
         /// <summary>
         /// When this method is called, an object will not fire change
@@ -92,13 +86,13 @@ namespace ReactiveUI.AndroidSupport
             return this.suppressChangeNotifications();
         }
 
-        public IObservable<Exception> ThrownExceptions { get { return this.getThrownExceptionsObservable(); } }
+        public IObservable<Exception> ThrownExceptions => this.getThrownExceptionsObservable();
 
         readonly Subject<Unit> activated = new Subject<Unit>();
-        public IObservable<Unit> Activated { get { return activated.AsObservable(); } }
+        public IObservable<Unit> Activated => activated.AsObservable();
 
         readonly Subject<Unit> deactivated = new Subject<Unit>();
-        public IObservable<Unit> Deactivated { get { return deactivated.AsObservable(); } }
+        public IObservable<Unit> Deactivated => deactivated.AsObservable();
 
         public override void OnPause()
         {

--- a/src/ReactiveUI.AndroidSupport/ReactiveFragment.cs
+++ b/src/ReactiveUI.AndroidSupport/ReactiveFragment.cs
@@ -1,28 +1,10 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Android.App;
-using Android.Content;
-using Android.OS;
-using Android.Runtime;
-using Android.Util;
-using Android.Views;
-using Android.Widget;
-using System.Runtime.Serialization;
 using System.ComponentModel;
-using System.Reflection;
 using System.Reactive.Subjects;
-using System.Reactive.Concurrency;
-using System.Threading;
-using System.Reactive.Disposables;
-using System.Diagnostics.Contracts;
-using System.Runtime.CompilerServices;
-using Splat;
 using System.Reactive;
 using System.Reactive.Linq;
 
@@ -39,13 +21,13 @@ namespace ReactiveUI.AndroidSupport
 
         TViewModel _ViewModel;
         public TViewModel ViewModel {
-            get { return _ViewModel; }
-            set { this.RaiseAndSetIfChanged(ref _ViewModel, value); }
+            get => _ViewModel;
+            set => this.RaiseAndSetIfChanged(ref _ViewModel, value);
         }
 
         object IViewFor.ViewModel {
-            get { return _ViewModel; }
-            set { _ViewModel = (TViewModel)value; }
+            get => _ViewModel;
+            set => _ViewModel = (TViewModel)value;
         }
     }
 
@@ -58,8 +40,8 @@ namespace ReactiveUI.AndroidSupport
         protected ReactiveFragment() { }
 
         public event PropertyChangingEventHandler PropertyChanging {
-            add { PropertyChangingEventManager.AddHandler(this, value); }
-            remove { PropertyChangingEventManager.RemoveHandler(this, value); }
+            add => PropertyChangingEventManager.AddHandler(this, value);
+            remove => PropertyChangingEventManager.RemoveHandler(this, value);
         }
 
         void IReactiveObject.RaisePropertyChanging(PropertyChangingEventArgs args)
@@ -68,8 +50,8 @@ namespace ReactiveUI.AndroidSupport
         }
 
         public event PropertyChangedEventHandler PropertyChanged {
-            add { PropertyChangedEventManager.AddHandler(this, value); }
-            remove { PropertyChangedEventManager.RemoveHandler(this, value); }
+            add => PropertyChangedEventManager.AddHandler(this, value);
+            remove => PropertyChangedEventManager.RemoveHandler(this, value);
         }
 
         void IReactiveObject.RaisePropertyChanged(PropertyChangedEventArgs args)
@@ -81,36 +63,32 @@ namespace ReactiveUI.AndroidSupport
         /// Represents an Observable that fires *before* a property is about to
         /// be changed.         
         /// </summary>
-        public IObservable<IReactivePropertyChangedEventArgs<ReactiveFragment>> Changing {
-            get { return this.getChangingObservable(); }
-        }
+        public IObservable<IReactivePropertyChangedEventArgs<ReactiveFragment>> Changing => this.getChangingObservable();
 
         /// <summary>
         /// Represents an Observable that fires *after* a property has changed.
         /// </summary>
-        public IObservable<IReactivePropertyChangedEventArgs<ReactiveFragment>> Changed {
-            get { return this.getChangedObservable(); }
-        }
+        public IObservable<IReactivePropertyChangedEventArgs<ReactiveFragment>> Changed => this.getChangedObservable();
 
         /// <summary>
         /// When this method is called, an object will not fire change
         /// notifications (neither traditional nor Observable notifications)
         /// until the return value is disposed.
         /// </summary>
-        /// <returns>An object that, when disposed, reenables change
+        /// <returns>An object that, when disposed, re-enables change
         /// notifications.</returns>
         public IDisposable SuppressChangeNotifications()
         {
             return this.suppressChangeNotifications();
         }
 
-        public IObservable<Exception> ThrownExceptions { get { return this.getThrownExceptionsObservable(); } }
+        public IObservable<Exception> ThrownExceptions => this.getThrownExceptionsObservable();
 
         readonly Subject<Unit> activated = new Subject<Unit>();
-        public IObservable<Unit> Activated { get { return activated.AsObservable(); } }
+        public IObservable<Unit> Activated => activated.AsObservable();
 
         readonly Subject<Unit> deactivated = new Subject<Unit>();
-        public IObservable<Unit> Deactivated { get { return deactivated.AsObservable(); } }
+        public IObservable<Unit> Deactivated => deactivated.AsObservable();
 
         public override void OnPause()
         {

--- a/src/ReactiveUI.AndroidSupport/ReactiveFragmentActivity.cs
+++ b/src/ReactiveUI.AndroidSupport/ReactiveFragmentActivity.cs
@@ -1,34 +1,19 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using Android.App;
 using Android.Content;
-using Android.OS;
-using Android.Runtime;
-using Android.Views;
-using Android.Widget;
-using System.Runtime.Serialization;
 using System.ComponentModel;
-using System.Reflection;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
-using System.Reactive.Concurrency;
 using System.Reactive.Threading.Tasks;
-using System.Threading;
 using System.Threading.Tasks;
-using System.Reactive.Disposables;
-using System.Diagnostics.Contracts;
-using System.Runtime.CompilerServices;
-using Splat;
 using System.Reactive;
 using Android.Support.V4.App;
 
-namespace ReactiveUI
+namespace ReactiveUI.AndroidSupport
 {
     /// <summary>
     /// This is an Activity that is both an Activity and has ReactiveObject powers 
@@ -42,14 +27,14 @@ namespace ReactiveUI
         TViewModel _ViewModel;
         public TViewModel ViewModel
         {
-            get { return _ViewModel; }
-            set { this.RaiseAndSetIfChanged(ref _ViewModel, value); }
+            get => _ViewModel;
+            set => this.RaiseAndSetIfChanged(ref _ViewModel, value);
         }
 
         object IViewFor.ViewModel
         {
-            get { return _ViewModel; }
-            set { _ViewModel = (TViewModel)value; }
+            get => _ViewModel;
+            set => _ViewModel = (TViewModel)value;
         }
     }
 
@@ -61,8 +46,8 @@ namespace ReactiveUI
     {
         public event PropertyChangingEventHandler PropertyChanging
         {
-            add { PropertyChangingEventManager.AddHandler(this, value); }
-            remove { PropertyChangingEventManager.RemoveHandler(this, value); }
+            add => PropertyChangingEventManager.AddHandler(this, value);
+            remove => PropertyChangingEventManager.RemoveHandler(this, value);
         }
 
         void IReactiveObject.RaisePropertyChanging(PropertyChangingEventArgs args)
@@ -72,8 +57,8 @@ namespace ReactiveUI
 
         public event PropertyChangedEventHandler PropertyChanged
         {
-            add { PropertyChangedEventManager.AddHandler(this, value); }
-            remove { PropertyChangedEventManager.RemoveHandler(this, value); }
+            add => PropertyChangedEventManager.AddHandler(this, value);
+            remove => PropertyChangedEventManager.RemoveHandler(this, value);
         }
 
         void IReactiveObject.RaisePropertyChanged(PropertyChangedEventArgs args)
@@ -85,38 +70,32 @@ namespace ReactiveUI
         /// Represents an Observable that fires *before* a property is about to
         /// be changed.         
         /// </summary>
-        public IObservable<IReactivePropertyChangedEventArgs<ReactiveFragmentActivity>> Changing
-        {
-            get { return this.getChangingObservable(); }
-        }
+        public IObservable<IReactivePropertyChangedEventArgs<ReactiveFragmentActivity>> Changing => this.getChangingObservable();
 
         /// <summary>
         /// Represents an Observable that fires *after* a property has changed.
         /// </summary>
-        public IObservable<IReactivePropertyChangedEventArgs<ReactiveFragmentActivity>> Changed
-        {
-            get { return this.getChangedObservable(); }
-        }
+        public IObservable<IReactivePropertyChangedEventArgs<ReactiveFragmentActivity>> Changed => this.getChangedObservable();
 
         /// <summary>
         /// When this method is called, an object will not fire change
         /// notifications (neither traditional nor Observable notifications)
         /// until the return value is disposed.
         /// </summary>
-        /// <returns>An object that, when disposed, reenables change
+        /// <returns>An object that, when disposed, re-enables change
         /// notifications.</returns>
         public IDisposable SuppressChangeNotifications()
         {
             return this.suppressChangeNotifications();
         }
 
-        public IObservable<Exception> ThrownExceptions { get { return this.getThrownExceptionsObservable(); } }
+        public IObservable<Exception> ThrownExceptions => this.getThrownExceptionsObservable();
 
         readonly Subject<Unit> activated = new Subject<Unit>();
-        public IObservable<Unit> Activated { get { return activated.AsObservable(); } }
+        public IObservable<Unit> Activated => activated.AsObservable();
 
         readonly Subject<Unit> deactivated = new Subject<Unit>();
-        public IObservable<Unit> Deactivated { get { return deactivated.AsObservable(); } }
+        public IObservable<Unit> Deactivated => deactivated.AsObservable();
 
         protected override void OnPause()
         {
@@ -131,10 +110,7 @@ namespace ReactiveUI
         }
 
         readonly Subject<Tuple<int, Result, Intent>> activityResult = new Subject<Tuple<int, Result, Intent>>();
-        public IObservable<Tuple<int, Result, Intent>> ActivityResult
-        {
-            get { return activityResult.AsObservable(); }
-        }
+        public IObservable<Tuple<int, Result, Intent>> ActivityResult => activityResult.AsObservable();
 
         protected override void OnActivityResult(int requestCode, Result resultCode, Intent data)
         {

--- a/src/ReactiveUI.AndroidSupport/ReactiveRecyclerViewAdapter.cs
+++ b/src/ReactiveUI.AndroidSupport/ReactiveRecyclerViewAdapter.cs
@@ -17,7 +17,7 @@ using Android.Views;
 using DynamicData;
 using DynamicData.Binding;
 
-namespace ReactiveUI.Android.Support
+namespace ReactiveUI.AndroidSupport
 {
     /// <summary>
     /// An adapter for the Android <see cref="RecyclerView"/>.


### PR DESCRIPTION
Fixed up the namespaces in the Android support.
Some C# 7 support for various things.
Cleaned up using statements.

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Adds DD support to the ReactivePagingAdapter.
Some namespace cleanups.
Some C# 7 stuff. 
Namespace using cleanups.
