### PR TITLE
housekeeping: Make debug type use portable format and embedded.

### DIFF
--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -16,7 +16,7 @@
     <NoWarn>$(NoWarn);1591;1701;1702;1705</NoWarn>
     <GenerateDocumentationFile Condition=" '$(Configuration)' == 'Release' ">true</GenerateDocumentationFile>
     <Platform>AnyCPU</Platform>
-    <DebugType>full</DebugType>
+    <DebugType>embedded</DebugType>
     <IsTestProject>$(MSBuildProjectName.Contains('Tests'))</IsTestProject>
   </PropertyGroup>
 


### PR DESCRIPTION
Required for sourcelink to function on non-netstandard platforms.

This will embed the PDB inside the file.

See https://github.com/dotnet/core/blob/master/Documentation/diagnostics/portable_pdb.md

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Fixes sourcelink functionality. It isn't compatible with the old non-documented "full" debug method. .NET Standard by default uses the new portable, and this will make the .net framework use it as well.


**What is the current behavior? (You can also link to an open issue here)**
Use full where it can which is the older legacy PDB version.


**What is the new behavior (if this is a feature change)?**
Use embedded which will simplify debugging on RxUI. This matches Rx.NET which also embeds.


**What might this PR break?**
This will increase our executable size by about 20% but will make it easier for consumers to use our code base. This matches a lot of Microsoft and Rx.NET frameworks. 