### PR TITLE
Fix Xamarin.Forms RoutedViewHost exception

### DIFF
--- a/src/ReactiveUI.XamForms/RoutedViewHost.cs
+++ b/src/ReactiveUI.XamForms/RoutedViewHost.cs
@@ -46,7 +46,7 @@ namespace ReactiveUI.XamForms
                     })
                     .Subscribe ());
 
-                var previousCount = this.WhenAnyObservable(x => x.Router.NavigationChanged.CountChanged().Select(_ => x.Router.NavigationStack.Count)).StartWith(this.Router.NavigationStack.Count);
+                var previousCount = this.WhenAnyObservable(x => x.Router.NavigationChanged).CountChanged().Select(_ => this.Router.NavigationStack.Count).StartWith(this.Router.NavigationStack.Count);
                 var currentCount = previousCount.Skip(1);
 
                 d (Observable.Zip(previousCount, currentCount, (previous, current) => new { Delta = previous - current, Current = current })


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix (introduced in the migration from ReactiveList to DynamicData)


**What is the current behavior? (You can also link to an open issue here)**
Null reference exception when creating a Xamarin.Forms RoutedViewHost. Internally, the following exception was thrown by the line changed in this PR:

> Index expressions are only supported with constants.


**What is the new behavior (if this is a feature change)?**
No more exception


**What might this PR break?**
Nothing


**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

