### PR TITLE
Housekeeping: Allow explicit specification of VS and MSBuild path

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -33,6 +33,8 @@ if (string.IsNullOrWhiteSpace(target))
 }
 
 var includePrerelease = Argument("includePrerelease", false);
+var vsLocationString = Argument("vsLocation", string.Empty);
+var msBuildPathString = Argument("msBuildPath", string.Empty);
 
 //////////////////////////////////////////////////////////////////////
 // PREPARATION
@@ -47,7 +49,8 @@ var isPullRequest = !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariabl
 var isRepository = StringComparer.OrdinalIgnoreCase.Equals("reactiveui/reactiveui", TFBuild.Environment.Repository.RepoName);
 
 var vsWhereSettings = new VSWhereLatestSettings() { IncludePrerelease = includePrerelease };
-var msBuildPath = VSWhereLatest(vsWhereSettings).CombineWithFilePath("./MSBuild/15.0/Bin/MSBuild.exe");
+var vsLocation = string.IsNullOrWhiteSpace(vsLocationString) ? VSWhereLatest(vsWhereSettings) : new DirectoryPath(vsLocationString);
+var msBuildPath = string.IsNullOrWhiteSpace(msBuildPathString) ? vsLocation.CombineWithFilePath("./MSBuild/15.0/Bin/MSBuild.exe") : new FilePath(msBuildPathString);
 
 var informationalVersion = EnvironmentVariable("GitAssemblyInformationalVersion");
 
@@ -119,7 +122,7 @@ Task("GenerateEvents")
 {
     var eventBuilder = "./src/EventBuilder/bin/Release/net461/EventBuilder.exe";
     var workingDirectory = "./src/EventBuilder/bin/Release/Net461";
-    var referenceAssembliesPath = VSWhereLatest(vsWhereSettings).CombineWithFilePath("./Common7/IDE/ReferenceAssemblies/Microsoft/Framework");
+    var referenceAssembliesPath = vsLocation.CombineWithFilePath("./Common7/IDE/ReferenceAssemblies/Microsoft/Framework");
 
     Information(referenceAssembliesPath.ToString());
 


### PR DESCRIPTION
Some test scenarios cannot depend on cake locating VS/MSBuild correctly.

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Allows explicitly specifying VS and MSBuild to your cake script.

**What is the current behavior? (You can also link to an open issue here)**

Relies on cake to locate VS.

**What is the new behavior (if this is a feature change)?**

VS/MSbuild can be specified to cake, if not falls back to cake locator.

**What might this PR break?**

I suppose it could break the cake script..

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

Required for https://github.com/reactiveui/ReactiveUI/issues/1615