### PR TITLE
housekeeping: tidying of build warnings in event builder

### DIFF
--- a/src/EventBuilder/AutoPlatform.cs
+++ b/src/EventBuilder/AutoPlatform.cs
@@ -15,10 +15,12 @@
         /// </summary>
         Android,
 
+#pragma warning disable SA1300 // Element should begin with upper-case letter
         /// <summary>
         /// iOS platform.
         /// </summary>
         iOS,
+#pragma warning restore SA1300 // Element should begin with upper-case letter
 
         /// <summary>
         /// Mac platform.

--- a/src/EventBuilder/Cecil/DelegateTemplateInformation.cs
+++ b/src/EventBuilder/Cecil/DelegateTemplateInformation.cs
@@ -1,8 +1,9 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Globalization;
 using System.Linq;
 using EventBuilder.Entities;
 using Mono.Cecil;
@@ -69,7 +70,11 @@ namespace EventBuilder.Cecil
                                     string.Join(
                                         ", ",
                                         z.Parameters.Select(
-                                            a => string.Format("{0} {1}", a.ParameterType.FullName, a.Name))),
+                                            a => string.Format(
+                                                CultureInfo.InvariantCulture,
+                                                "{0} {1}",
+                                                a.ParameterType.FullName,
+                                                a.Name))),
                                 ParameterTypeList =
                                     string.Join(", ", z.Parameters.Select(a => a.ParameterType.FullName)),
                                 ParameterNameList = string.Join(", ", z.Parameters.Select(a => a.Name))

--- a/src/EventBuilder/Cecil/StaticEventTemplateInformation.cs
+++ b/src/EventBuilder/Cecil/StaticEventTemplateInformation.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using EventBuilder.Entities;
 using Mono.Cecil;
@@ -116,6 +117,7 @@ namespace EventBuilder.Cecil
             }
 
             var ret = string.Format(
+                CultureInfo.InvariantCulture,
                 "{0}<{1}>",
                 t.Namespace + "." + t.Name,
                 string.Join(",", t.GenericParameters.Select(x => GetRealTypeName(x.Resolve()))));
@@ -133,6 +135,7 @@ namespace EventBuilder.Cecil
             }
 
             var ret = string.Format(
+                CultureInfo.InvariantCulture,
                 "{0}<{1}>",
                 generic.Namespace + "." + generic.Name,
                 string.Join(",", generic.GenericArguments.Select(GetRealTypeName)));

--- a/src/EventBuilder/CommandLineOptions.cs
+++ b/src/EventBuilder/CommandLineOptions.cs
@@ -42,7 +42,9 @@ namespace EventBuilder
         /// Manual generation using the specified assemblies. Use with --platform=NONE.
         /// </summary>
         [ValueList(typeof(List<string>))]
+#pragma warning disable CA2227 // Collection properties should be read only
         public List<string> Assemblies { get; set; }
+#pragma warning restore CA2227 // Collection properties should be read only
 
         /// <summary>
         /// Gets the usage.

--- a/src/EventBuilder/Entities/PublicTypeInfo.cs
+++ b/src/EventBuilder/Entities/PublicTypeInfo.cs
@@ -50,6 +50,6 @@ namespace EventBuilder.Entities
         /// <summary>
         /// Gets or sets the multi parameter methods.
         /// </summary>
-        public MultiParameterMethod[] MultiParameterMethods { get; set; }
+        public IEnumerable<MultiParameterMethod> MultiParameterMethods { get; set; }
     }
 }

--- a/src/EventBuilder/ExitCode.cs
+++ b/src/EventBuilder/ExitCode.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace EventBuilder
+{
+    /// <summary>
+    ///     The exit/return code (aka %ERRORLEVEL%) on application exit.
+    /// </summary>
+    public enum ExitCode
+    {
+        /// <summary>
+        /// Success
+        /// </summary>
+        Success = 0,
+
+        /// <summary>
+        /// Error
+        /// </summary>
+        Error = 1,
+    }
+}

--- a/src/EventBuilder/Platforms/Android.cs
+++ b/src/EventBuilder/Platforms/Android.cs
@@ -37,7 +37,6 @@ namespace EventBuilder.Platforms
             }
             else
             {
-
                 var assemblies =
                    Directory.GetFiles(
                        Path.Combine(referenceAssembliesLocation, "MonoAndroid"),

--- a/src/EventBuilder/Platforms/BasePlatform.cs
+++ b/src/EventBuilder/Platforms/BasePlatform.cs
@@ -25,9 +25,9 @@ namespace EventBuilder.Platforms
         public abstract AutoPlatform Platform { get; }
 
         /// <inheritdoc />
-        public List<string> Assemblies { get; set; }
+        public List<string> Assemblies { get; }
 
         /// <inheritdoc />
-        public List<string> CecilSearchDirectories { get; set; }
+        public List<string> CecilSearchDirectories { get; }
     }
 }

--- a/src/EventBuilder/Platforms/IPlatform.cs
+++ b/src/EventBuilder/Platforms/IPlatform.cs
@@ -19,12 +19,12 @@ namespace EventBuilder.Platforms
         /// <summary>
         /// Gets or sets the assemblies.
         /// </summary>
-        List<string> Assemblies { get; set; }
+        List<string> Assemblies { get; }
 
         /// <summary>
         /// Gets or sets the cecil search directories.
         /// Cecil when run on Mono needs some direction as to the location of the platform specific MSCORLIB.
         /// </summary>
-        List<string> CecilSearchDirectories { get; set; }
+        List<string> CecilSearchDirectories { get; }
     }
 }

--- a/src/EventBuilder/Platforms/Mac.cs
+++ b/src/EventBuilder/Platforms/Mac.cs
@@ -7,11 +7,11 @@ using System.Linq;
 
 namespace EventBuilder.Platforms
 {
-    // ReSharper disable once InconsistentNaming
     /// <summary>
     /// Mac platform assemblies and events.
     /// </summary>
     /// <seealso cref="EventBuilder.Platforms.BasePlatform" />
+    // ReSharper disable once InconsistentNaming
     public class Mac : BasePlatform
     {
         /// <summary>

--- a/src/EventBuilder/Platforms/iOS.cs
+++ b/src/EventBuilder/Platforms/iOS.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -13,7 +13,11 @@ namespace EventBuilder.Platforms
     /// </summary>
     /// <seealso cref="BasePlatform" />
     // ReSharper disable once InconsistentNaming
+#pragma warning disable IDE1006 // Naming Styles
+#pragma warning disable SA1300 // Element should begin with upper-case letter
     public class iOS : BasePlatform
+#pragma warning restore SA1300 // Element should begin with upper-case letter
+#pragma warning restore IDE1006 // Naming Styles
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="iOS"/> class.

--- a/src/EventBuilder/Platforms/tvOS.cs
+++ b/src/EventBuilder/Platforms/tvOS.cs
@@ -7,11 +7,11 @@ using System.Linq;
 
 namespace EventBuilder.Platforms
 {
-    // ReSharper disable once InconsistentNaming
     /// <summary>
     /// TV OS platform assemblies and events.
     /// </summary>
     /// <seealso cref="EventBuilder.Platforms.BasePlatform" />
+    // ReSharper disable once InconsistentNaming
     public class TVOS : BasePlatform
     {
         /// <summary>

--- a/src/EventBuilder/Program.cs
+++ b/src/EventBuilder/Program.cs
@@ -16,21 +16,12 @@ using Parser = CommandLine.Parser;
 
 namespace EventBuilder
 {
-    internal class Program
+    internal static class Program
     {
-        /// <summary>
-        ///     The exit/return code (aka %ERRORLEVEL%) on application exit.
-        /// </summary>
-        public enum ExitCode
-        {
-            Success = 0,
-            Error = 1
-        }
-
         private static string _mustacheTemplate = "DefaultTemplate.mustache";
         private static string _referenceAssembliesLocation = @"C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework";
 
-        private static void Main(string[] args)
+        public static void Main(string[] args)
         {
             Log.Logger = new LoggerConfiguration()
                 .ReadFrom.AppSettings()
@@ -79,12 +70,11 @@ namespace EventBuilder
                         }
 
                         platform = new Bespoke();
-                        platform.Assemblies = options.Assemblies;
+                        platform.Assemblies.AddRange(options.Assemblies);
 
                         if (PlatformHelper.IsRunningOnMono())
                         {
-                            platform.CecilSearchDirectories =
-                                platform.Assemblies.Select(Path.GetDirectoryName).Distinct().ToList();
+                            platform.CecilSearchDirectories.AddRange(platform.Assemblies.Select(Path.GetDirectoryName).Distinct().ToList());
                         }
                         else
                         {
@@ -135,7 +125,7 @@ namespace EventBuilder
                         break;
 
                     default:
-                        throw new ArgumentOutOfRangeException();
+                        throw new ArgumentException($"Platform not {options.Platform} supported");
                     }
 
                     ExtractEventsFromAssemblies(platform);


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

housekeeping

**What is the current behavior? (You can also link to an open issue here)**

event builder has a couple of minor warnings

**What is the new behavior (if this is a feature change)?**

fix the warnings

**What might this PR break?**

one of the warnings was for having setters on `Assemblies` and `CecilSearchDirectories`, which I've changed on the interface but this ended up needing a change on the Bespoke path. I don't think this should impact anything, but it's possible it might. Happy to think of alternatives/just ignore this warning though.

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

I've also just ignored the warnings about iOS, because they seemed slightly unreasonable
