### PR TITLE
fody: use FindType for Exception

### DIFF
--- a/src/ReactiveUI.Fody/ModuleWeaver.cs
+++ b/src/ReactiveUI.Fody/ModuleWeaver.cs
@@ -27,7 +27,8 @@ namespace ReactiveUI.Fody
             var observableAsPropertyWeaver = new ObservableAsPropertyWeaver
             {
                 ModuleDefinition = ModuleDefinition,
-                LogInfo = LogInfo
+                LogInfo = LogInfo,
+                FindType = FindType
             };
             observableAsPropertyWeaver.Execute();
 

--- a/src/ReactiveUI.Fody/ObservableAsPropertyWeaver.cs
+++ b/src/ReactiveUI.Fody/ObservableAsPropertyWeaver.cs
@@ -32,6 +32,11 @@ namespace ReactiveUI.Fody
         public Action<string> LogInfo { get; set; }
 
         /// <summary>
+        /// Locates a type from referenced assemblies by name.
+        /// </summary>
+        public Func<string, TypeDefinition> FindType { get; internal set; }
+
+        /// <summary>
         /// Executes this property weaver.
         /// </summary>
         public void Execute()
@@ -61,10 +66,7 @@ namespace ReactiveUI.Fody
             var observableAsPropertyHelper = ModuleDefinition.FindType("ReactiveUI", "ObservableAsPropertyHelper`1", reactiveUI, "T");
             var observableAsPropertyAttribute = ModuleDefinition.FindType("ReactiveUI.Fody.Helpers", "ObservableAsPropertyAttribute", helpers);
             var observableAsPropertyHelperGetValue = ModuleDefinition.ImportReference(observableAsPropertyHelper.Resolve().Properties.Single(x => x.Name == "Value").GetMethod);
-            var systemRuntimeName = ModuleDefinition.AssemblyReferences.FirstOrDefault(x => x.Name == "System.Runtime");
-            var exceptionDefinition = systemRuntimeName == null
-                ? ModuleDefinition.ImportReference(typeof(Exception)).Resolve() // Referenced from .NET Framework
-                : ModuleDefinition.AssemblyResolver.Resolve(systemRuntimeName).MainModule.Types.First(x => x.Name == "Exception"); // Referenced from .NET Standard
+            var exceptionDefinition = FindType(typeof(Exception).FullName);
             var constructorDefinition = exceptionDefinition.GetConstructors().Single(x => x.Parameters.Count == 1);
             var exceptionConstructor = ModuleDefinition.ImportReference(constructorDefinition);
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Bug fix

**What is the current behavior? (You can also link to an open issue here)**

#1746

When building using dotnet.exe, the Fody weaver executes in .Net Core instead of .Net Framework. Cecil does not correctly resolve the System.Exception type when running on .Net Core probably because code targeting .Net Core does not copy all dependencies into the build directory, and Cecil on .Net Core does not fallback to locating assemblies from the GAC? It doesn't make a lot of sense for that to be the problem but I know Cecil's assembly resolution is different on .Net Core. I'm not sure if there was a more subtle problem here where you could potentially get multiple System.Exceptions referenced in some cases.

**What is the new behavior (if this is a feature change)?**

The type lookup is now done using Fody's FindType functionality to search through referenced assemblies of the target code.

**What might this PR break?**

Probably this change is safe, but I don't know too much about what I've changed.

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

I'm not sure how to handle the testing.

The test code is already sufficient, but the problem is not detected because build.cake only builds ReactiveUI.Fody.Tests using MSBuild and building the code is actually part of the test. If code is added to build also using DotNetCoreMSBuild then the build will fail on the original code and pass on the new code.

However, copying and pasting the existing MSBuild and changing it to a DotNetCoreMSBuild isn't very nice, and ideally I think when building using MSBuild it should still target net461 but when building using DotNetCoreMSBuild it should target netcoreapp2.0. Also, the .Net Core build of the tests should probably be executed, but XUnit2 doesn't seem to work for netcoreapp2.0 tests so it needs to be replaced with DotNetCoreTest or DotNetCoreTool, and then the test report output should probably be similar to how it was before.

I haven't used Cake or xUnit like this before so I don't know if these are the right things to be doing or if there are good shortcuts.