### PR TITLE
housekeeping: Use ReactiveWindow in the Getting Started app

### DIFF
--- a/samples/getting-started/ReactiveDemo/AppViewModel.cs
+++ b/samples/getting-started/ReactiveDemo/AppViewModel.cs
@@ -113,8 +113,8 @@ namespace ReactiveDemo
 
             var filter = new SearchFilter(false);
             var resource = await source.GetResourceAsync<PackageSearchResource>().ConfigureAwait(false);
-            var meta = await resource.SearchAsync(term, filter, 0, 10, null, token).ConfigureAwait(false);
-            return meta.Select(x => new NugetDetailsViewModel(x));
+            var metadata = await resource.SearchAsync(term, filter, 0, 10, null, token).ConfigureAwait(false);
+            return metadata.Select(x => new NugetDetailsViewModel(x));
         }
     }
 }

--- a/samples/getting-started/ReactiveDemo/AppViewModel.cs
+++ b/samples/getting-started/ReactiveDemo/AppViewModel.cs
@@ -1,13 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
+using System.Linq;
 using System.Reactive.Linq;
 using System.Threading;
-using System.Linq;
-using ReactiveUI;
-using NuGet.Protocol.Core.Types;
-using NuGet.Protocol;
+using System.Threading.Tasks;
 using NuGet.Configuration;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
+using ReactiveUI;
 
 namespace ReactiveDemo
 {
@@ -108,13 +108,13 @@ namespace ReactiveDemo
         {
             var providers = new List<Lazy<INuGetResourceProvider>>();
             providers.AddRange(Repository.Provider.GetCoreV3()); // Add v3 API support
-            var packageSource = new PackageSource("https://api.nuget.org/v3/index.json");
-            var sourceRepository = new SourceRepository(packageSource, providers);
+            var package = new PackageSource("https://api.nuget.org/v3/index.json");
+            var source = new SourceRepository(package, providers);
 
             var filter = new SearchFilter(false);
-            var searchResource = await sourceRepository.GetResourceAsync<PackageSearchResource>();
-            var searchMetadata = await searchResource.SearchAsync(term, filter, 0, 10, null, token);
-            return searchMetadata.Select(x => new NugetDetailsViewModel(x));
+            var resource = await source.GetResourceAsync<PackageSearchResource>().ConfigureAwait(false);
+            var meta = await resource.SearchAsync(term, filter, 0, 10, null, token).ConfigureAwait(false);
+            return meta.Select(x => new NugetDetailsViewModel(x));
         }
     }
 }

--- a/samples/getting-started/ReactiveDemo/MainWindow.xaml
+++ b/samples/getting-started/ReactiveDemo/MainWindow.xaml
@@ -1,10 +1,14 @@
-﻿<Window x:Class="ReactiveDemo.MainWindow"
-        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        Title="NuGet Browser"
-        mc:Ignorable="d" Height="450" Width="800">
+﻿<reactiveui:ReactiveWindow 
+    x:Class="ReactiveDemo.MainWindow"
+    x:TypeArguments="reactivedemo:AppViewModel"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:reactivedemo="clr-namespace:ReactiveDemo"
+    xmlns:reactiveui="http://reactiveui.net"
+    Title="NuGet Browser" Height="450" Width="800"
+    mc:Ignorable="d">
     <Grid Margin="12">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="Auto" />
@@ -21,4 +25,4 @@
                  Grid.Row="1" Margin="0,6,0,0" HorizontalContentAlignment="Stretch"
                  ScrollViewer.HorizontalScrollBarVisibility="Disabled" />
     </Grid>
-</Window>
+</reactiveui:ReactiveWindow>

--- a/samples/getting-started/ReactiveDemo/MainWindow.xaml.cs
+++ b/samples/getting-started/ReactiveDemo/MainWindow.xaml.cs
@@ -1,29 +1,24 @@
 ﻿using System.Reactive.Disposables;
-using System.Windows;
 using ReactiveUI;
 
 namespace ReactiveDemo
 {
-    public partial class MainWindow : IViewFor<AppViewModel>
+    // MainWindow class derives off ReactiveWindow which implements the IViewFor<TViewModel>
+    // interface using a WPF DependencyProperty. We need this to use WhenActivated extension
+    // method that helps us handling View and ViewModel activation and deactivation.
+    public partial class MainWindow : ReactiveWindow<AppViewModel>
     {
-        // Using a DependencyProperty as the backing store for ViewModel.  
-        // This enables animation, styling, binding, etc.
-        public static readonly DependencyProperty ViewModelProperty =
-            DependencyProperty.Register("ViewModel",
-                typeof(AppViewModel), typeof(MainWindow),
-                new PropertyMetadata(null));
-
         public MainWindow()
         {
             InitializeComponent();
             ViewModel = new AppViewModel();
 
-            // We create our bindings here. These are the code behind bindings which allow 
+            // We create our bindings here. These are the code behind bindings which allow
             // type safety. The bindings will only become active when the Window is being shown.
-            // We register our subscription in our disposableRegistration, this will cause 
+            // We register our subscription in our disposableRegistration, this will cause
             // the binding subscription to become inactive when the Window is closed.
-            // The disposableRegistration is a CompositeDisposable which is a container of 
-            // other Disposables. We use the DisposeWith() extension method which simply adds 
+            // The disposableRegistration is a CompositeDisposable which is a container of
+            // other Disposables. We use the DisposeWith() extension method which simply adds
             // the subscription disposable to the CompositeDisposable.
             this.WhenActivated(disposableRegistration =>
             {
@@ -44,22 +39,6 @@ namespace ReactiveDemo
                     view => view.searchTextBox.Text)
                     .DisposeWith(disposableRegistration);
             });
-        }
-
-        // Our main view model instance.
-        public AppViewModel ViewModel
-        {
-            get => (AppViewModel)GetValue(ViewModelProperty);
-            set => SetValue(ViewModelProperty, value);
-        }
-
-        // This is required by the interface IViewFor, you always just set it to use the 
-        // main ViewModel property. Note on XAML based platforms we have a control called
-        // ReactiveUserControl that abstracts this.
-        object IViewFor.ViewModel
-        {
-            get => ViewModel;
-            set => ViewModel = (AppViewModel)value;
         }
     }
 }

--- a/samples/getting-started/ReactiveDemo/ReactiveDemo.csproj
+++ b/samples/getting-started/ReactiveDemo/ReactiveDemo.csproj
@@ -73,7 +73,7 @@
   <ItemGroup>
     <PackageReference Include="NuGet.Client" Version="4.2.0" />
     <PackageReference Include="NuGet.Protocol.Core.v3" Version="4.2.0" />
-    <PackageReference Include="ReactiveUI.WPF" Version="9.1.1" />
+    <PackageReference Include="ReactiveUI.WPF" Version="*" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/samples/getting-started/ReactiveDemo/ReactiveDemo.csproj
+++ b/samples/getting-started/ReactiveDemo/ReactiveDemo.csproj
@@ -14,6 +14,7 @@
     <WarningLevel>4</WarningLevel>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>
+    <CodeAnalysisRuleSet>..\..\src\reactiveui.tests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -70,9 +71,9 @@
     <None Include="App.config" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="NuGet.Client" Version="4.2.0"/>
-    <PackageReference Include="NuGet.Protocol.Core.v3" Version="4.2.0"/>
-    <PackageReference Include="ReactiveUI.WPF" Version="8.7.2"/>
+    <PackageReference Include="NuGet.Client" Version="4.2.0" />
+    <PackageReference Include="NuGet.Protocol.Core.v3" Version="4.2.0" />
+    <PackageReference Include="ReactiveUI.WPF" Version="9.1.1" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

After we've added the `ReactiveWindow<TViewModel>` and published ReactiveUI 9.1.1, it makes sense to update the getting started guide app to use `ReactiveWindow` instead of implementing IViewFor by hand for WPF, and to update package versions.

**What is the current behavior? (You can also link to an open issue here)**

Getting started app startup Window isn't Reactive.

**What is the new behavior (if this is a feature change)?**

Getting started app startup Window is Reactive.

**What might this PR break?**

Nothing.
