### PR TITLE
refactor: Remove ReactiveCommand abstract class.

### DIFF
--- a/src/ReactiveUI.Fody.Tests/ReactiveUI.Fody.Tests.csproj
+++ b/src/ReactiveUI.Fody.Tests/ReactiveUI.Fody.Tests.csproj
@@ -7,12 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="PublicApiGenerator" Version="8.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="PublicApiGenerator" Version="8.0.1" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Shouldly" Version=" 3.0.0" />
+    <PackageReference Include="Shouldly" Version="3.0.2" />
     <PackageReference Include="System.Reactive" Version="4.0.0" />
     <PackageReference Include="Microsoft.Reactive.Testing" Version="4.0.0" />
   </ItemGroup>

--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.approved.txt
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.approved.txt
@@ -458,13 +458,8 @@ namespace ReactiveUI
         public string PropertyName { get; set; }
     }
     public delegate void PropertyChangingEventHandler(object sender, ReactiveUI.PropertyChangingEventArgs e);
-    public abstract class ReactiveCommand : ReactiveUI.IHandleObservableErrors, System.IDisposable, System.Windows.Input.ICommand
+    public class static ReactiveCommand
     {
-        protected ReactiveCommand() { }
-        public abstract System.IObservable<bool> CanExecute { get; }
-        public abstract System.IObservable<bool> IsExecuting { get; }
-        public abstract System.IObservable<System.Exception> ThrownExceptions { get; }
-        public event System.EventHandler System.Windows.Input.ICommand.CanExecuteChanged;
         public static ReactiveUI.ReactiveCommand<System.Reactive.Unit, System.Reactive.Unit> Create(System.Action execute, System.IObservable<bool> canExecute = null, System.Reactive.Concurrency.IScheduler outputScheduler = null) { }
         public static ReactiveUI.ReactiveCommand<System.Reactive.Unit, TResult> Create<TResult>(System.Func<TResult> execute, System.IObservable<bool> canExecute = null, System.Reactive.Concurrency.IScheduler outputScheduler = null) { }
         public static ReactiveUI.ReactiveCommand<TParam, System.Reactive.Unit> Create<TParam>(System.Action<TParam> execute, System.IObservable<bool> canExecute = null, System.Reactive.Concurrency.IScheduler outputScheduler = null) { }
@@ -480,11 +475,6 @@ namespace ReactiveUI
         public static ReactiveUI.ReactiveCommand<TParam, TResult> CreateFromTask<TParam, TResult>(System.Func<TParam, System.Threading.CancellationToken, System.Threading.Tasks.Task<TResult>> execute, System.IObservable<bool> canExecute = null, System.Reactive.Concurrency.IScheduler outputScheduler = null) { }
         public static ReactiveUI.ReactiveCommand<TParam, System.Reactive.Unit> CreateFromTask<TParam>(System.Func<TParam, System.Threading.Tasks.Task> execute, System.IObservable<bool> canExecute = null, System.Reactive.Concurrency.IScheduler outputScheduler = null) { }
         public static ReactiveUI.ReactiveCommand<TParam, System.Reactive.Unit> CreateFromTask<TParam>(System.Func<TParam, System.Threading.CancellationToken, System.Threading.Tasks.Task> execute, System.IObservable<bool> canExecute = null, System.Reactive.Concurrency.IScheduler outputScheduler = null) { }
-        public void Dispose() { }
-        protected abstract void Dispose(bool disposing);
-        protected abstract bool ICommandCanExecute(object parameter);
-        protected abstract void ICommandExecute(object parameter);
-        protected void OnCanExecuteChanged() { }
     }
     public class ReactiveCommand<TParam, TResult> : ReactiveUI.ReactiveCommandBase<TParam, TResult>
     {
@@ -496,12 +486,19 @@ namespace ReactiveUI
         public override System.IObservable<TResult> Execute(TParam parameter = null) { }
         public override System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    public abstract class ReactiveCommandBase<TParam, TResult> : ReactiveUI.ReactiveCommand, System.IObservable<TResult>
+    public abstract class ReactiveCommandBase<TParam, TResult> : ReactiveUI.IHandleObservableErrors, System.IDisposable, System.IObservable<TResult>, System.Windows.Input.ICommand
     {
         protected ReactiveCommandBase() { }
+        public abstract System.IObservable<bool> CanExecute { get; }
+        public abstract System.IObservable<bool> IsExecuting { get; }
+        public abstract System.IObservable<System.Exception> ThrownExceptions { get; }
+        public event System.EventHandler System.Windows.Input.ICommand.CanExecuteChanged;
+        public void Dispose() { }
+        protected abstract void Dispose(bool disposing);
         public abstract System.IObservable<TResult> Execute(TParam parameter = null);
-        protected override bool ICommandCanExecute(object parameter) { }
-        protected override void ICommandExecute(object parameter) { }
+        protected virtual bool ICommandCanExecute(object parameter) { }
+        protected virtual void ICommandExecute(object parameter) { }
+        protected void OnCanExecuteChanged() { }
         public abstract System.IDisposable Subscribe(System.IObserver<TResult> observer);
     }
     public class static ReactiveCommandMixins

--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.approved.txt
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.approved.txt
@@ -259,6 +259,11 @@ namespace ReactiveUI
         TViewModel ViewModel { get; }
         System.Linq.Expressions.Expression ViewModelExpression { get; }
     }
+    public interface IReactiveCommand : ReactiveUI.IHandleObservableErrors, System.IDisposable
+    {
+        System.IObservable<bool> CanExecute { get; }
+        System.IObservable<bool> IsExecuting { get; }
+    }
     public interface IReactiveNotifyPropertyChanged<out TSender>
     {
         System.IObservable<ReactiveUI.IReactivePropertyChangedEventArgs<TSender>> Changed { get; }
@@ -486,7 +491,7 @@ namespace ReactiveUI
         public override System.IObservable<TResult> Execute(TParam parameter = null) { }
         public override System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    public abstract class ReactiveCommandBase<TParam, TResult> : ReactiveUI.IHandleObservableErrors, System.IDisposable, System.IObservable<TResult>, System.Windows.Input.ICommand
+    public abstract class ReactiveCommandBase<TParam, TResult> : ReactiveUI.IHandleObservableErrors, ReactiveUI.IReactiveCommand, System.IDisposable, System.IObservable<TResult>, System.Windows.Input.ICommand
     {
         protected ReactiveCommandBase() { }
         public abstract System.IObservable<bool> CanExecute { get; }

--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.approved.txt
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.approved.txt
@@ -259,11 +259,6 @@ namespace ReactiveUI
         TViewModel ViewModel { get; }
         System.Linq.Expressions.Expression ViewModelExpression { get; }
     }
-    public interface IReactiveCommand : ReactiveUI.IHandleObservableErrors, System.IDisposable
-    {
-        System.IObservable<bool> CanExecute { get; }
-        System.IObservable<bool> IsExecuting { get; }
-    }
     public interface IReactiveNotifyPropertyChanged<out TSender>
     {
         System.IObservable<ReactiveUI.IReactivePropertyChangedEventArgs<TSender>> Changed { get; }
@@ -491,7 +486,7 @@ namespace ReactiveUI
         public override System.IObservable<TResult> Execute(TParam parameter = null) { }
         public override System.IDisposable Subscribe(System.IObserver<TResult> observer) { }
     }
-    public abstract class ReactiveCommandBase<TParam, TResult> : ReactiveUI.IHandleObservableErrors, ReactiveUI.IReactiveCommand, System.IDisposable, System.IObservable<TResult>, System.Windows.Input.ICommand
+    public abstract class ReactiveCommandBase<TParam, TResult> : ReactiveUI.IHandleObservableErrors, System.IDisposable, System.IObservable<TResult>, System.Windows.Input.ICommand
     {
         protected ReactiveCommandBase() { }
         public abstract System.IObservable<bool> CanExecute { get; }

--- a/src/ReactiveUI.Tests/CommandBindingTests.cs
+++ b/src/ReactiveUI.Tests/CommandBindingTests.cs
@@ -17,7 +17,7 @@ namespace ReactiveUI.Tests
 {
     public class FakeViewModel : ReactiveObject
     {
-        public ReactiveCommand Cmd { get; protected set; }
+        public ReactiveCommand<Unit, Unit> Cmd { get; protected set; }
 
         public FakeViewModel()
         {
@@ -123,9 +123,9 @@ namespace ReactiveUI.Tests
 
     public class CommandBindViewModel : ReactiveObject
     {
-        public ReactiveCommand _Command1;
+        public ReactiveCommand<int, Unit> _Command1;
 
-        public ReactiveCommand Command1
+        public ReactiveCommand<int, Unit> Command1
         {
             get => _Command1;
             set => this.RaiseAndSetIfChanged(ref _Command1, value);
@@ -141,7 +141,7 @@ namespace ReactiveUI.Tests
 
         public CommandBindViewModel()
         {
-            Command1 = ReactiveCommand.Create(() => { });
+            Command1 = ReactiveCommand.Create<int, Unit>(_ => Unit.Default);
             Command2 = ReactiveCommand.Create(() => { });
         }
 
@@ -163,7 +163,7 @@ namespace ReactiveUI.Tests
             NestedCommand = ReactiveCommand.Create(() => { });
         }
 
-        public ReactiveCommand NestedCommand { get; protected set; }
+        public ReactiveCommand<Unit, Unit> NestedCommand { get; protected set; }
     }
 
     public class CustomClickButton : Button
@@ -235,7 +235,7 @@ namespace ReactiveUI.Tests
             var disp = view.BindCommand(vm, x => x.Command1, x => x.Command1);
             Assert.Equal(vm.Command1, view.Command1.Command);
 
-            var newCmd = ReactiveCommand.Create(() => { });
+            var newCmd = ReactiveCommand.Create<int>(_ => { });
             vm.Command1 = newCmd;
             Assert.Equal(newCmd, view.Command1.Command);
 
@@ -265,7 +265,7 @@ namespace ReactiveUI.Tests
             var view = new CommandBindView { ViewModel = vm };
 
             var canExecute1 = new BehaviorSubject<bool>(true);
-            var cmd1 = ReactiveCommand.Create(() => { }, canExecute1);
+            var cmd1 = ReactiveCommand.Create<int>(_ => { }, canExecute1);
             vm.Command1 = cmd1;
 
             var disp = view.BindCommand(vm, x => x.Command1, x => x.Command1);
@@ -280,7 +280,7 @@ namespace ReactiveUI.Tests
             var view = new CommandBindView { ViewModel = vm };
 
             var canExecute1 = new BehaviorSubject<bool>(true);
-            var cmd1 = ReactiveCommand.Create(() => { }, canExecute1);
+            var cmd1 = ReactiveCommand.Create<int>(_ => { }, canExecute1);
             vm.Command1 = cmd1;
 
             var disp = view.BindCommand(vm, x => x.Command1, x => x.Command1);
@@ -299,7 +299,7 @@ namespace ReactiveUI.Tests
             var view = new CommandBindView { ViewModel = vm };
 
             var canExecute1 = new BehaviorSubject<bool>(false);
-            var cmd1 = ReactiveCommand.Create(() => { }, canExecute1);
+            var cmd1 = ReactiveCommand.Create<int>(_ => { }, canExecute1);
             vm.Command1 = cmd1;
 
             var disp = view.BindCommand(vm, x => x.Command1, x => x.Command1);
@@ -314,7 +314,7 @@ namespace ReactiveUI.Tests
             var view = new CommandBindView { ViewModel = vm };
 
             var canExecute1 = new BehaviorSubject<bool>(true);
-            var cmd1 = ReactiveCommand.Create(() => { }, canExecute1);
+            var cmd1 = ReactiveCommand.Create<int>(_ => { }, canExecute1);
             vm.Command1 = cmd1;
 
             var disp = view.BindCommand(vm, x => x.Command1, x => x.Command1);
@@ -323,7 +323,7 @@ namespace ReactiveUI.Tests
 
             // Now  change to a disabled cmd
             var canExecute2 = new BehaviorSubject<bool>(false);
-            var cmd2 = ReactiveCommand.Create(() => { }, canExecute2);
+            var cmd2 = ReactiveCommand.Create<int>(_ => { }, canExecute2);
             vm.Command1 = cmd2;
 
             Assert.False(view.Command1.IsEnabled);

--- a/src/ReactiveUI.Tests/Platforms/winforms/CommandBindingTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/CommandBindingTests.cs
@@ -215,7 +215,7 @@ namespace ReactiveUI.Tests.Winforms
 
     public class FakeViewModel : ReactiveObject
     {
-        public ReactiveCommand Cmd { get; protected set; }
+        public ReactiveCommand<Unit, Unit> Cmd { get; protected set; }
 
         public FakeViewModel()
         {

--- a/src/ReactiveUI.Tests/ReactiveUI.Tests.csproj
+++ b/src/ReactiveUI.Tests/ReactiveUI.Tests.csproj
@@ -8,17 +8,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.console" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-    <PackageReference Include="Xunit.StaFact" Version="0.2.17" />
-    <PackageReference Include="Shouldly" Version=" 3.0.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.console" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Include="Xunit.StaFact" Version="0.3.5" />
+    <PackageReference Include="Shouldly" Version=" 3.0.2" />
     <PackageReference Include="Microsoft.Reactive.Testing" Version="4.0.0" />
-    <PackageReference Include="PublicApiGenerator" Version="8.0.0" />
+    <PackageReference Include="PublicApiGenerator" Version="8.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ReactiveUI.Tests/WeakEventManagerTest.cs
+++ b/src/ReactiveUI.Tests/WeakEventManagerTest.cs
@@ -16,7 +16,7 @@ namespace ReactiveUI.Tests
         public void ButtonDoesNotLeakTest()
         {
             var button = new Button();
-            ReactiveCommand command = ReactiveCommand.Create(() => { });
+            var command = ReactiveCommand.Create(() => { });
             button.Command = command;
 
             var buttonRef = new WeakReference(button);

--- a/src/ReactiveUI/Bindings/Command/CommandBinderImplementation.cs
+++ b/src/ReactiveUI/Bindings/Command/CommandBinderImplementation.cs
@@ -56,14 +56,13 @@ namespace ReactiveUI
 
             IDisposable bindingDisposable = BindCommandInternal(source, view, controlExpression, Observable.Defer(() => Observable.Return(withParameter())), toEvent, cmd =>
             {
-                var rc = cmd as ReactiveCommand;
+                var rc = cmd as IReactiveCommand;
                 if (rc == null)
                 {
                     return new RelayCommand(cmd.CanExecute, _ => cmd.Execute(withParameter()));
                 }
 
-                var ret = ReactiveCommand.Create(() => ((ICommand)rc).Execute(null), rc.CanExecute);
-                return ret;
+                return ReactiveCommand.Create(() => ((ICommand)rc).Execute(null), rc.CanExecute);
             });
 
             return new ReactiveBinding<TView, TViewModel, TProp>(

--- a/src/ReactiveUI/EventManagers/WeakEventManager.cs
+++ b/src/ReactiveUI/EventManagers/WeakEventManager.cs
@@ -293,11 +293,11 @@ namespace ReactiveUI
                     ReferenceEquals(_source.Target, source) &&
                     _originalHandler != null &&
                     (ReferenceEquals(_originalHandler.Target, handler) ||
-                    _originalHandler.Target is PropertyChangedEventHandler eventHandler &&
+                    (_originalHandler.Target is PropertyChangedEventHandler eventHandler &&
                     handler is PropertyChangedEventHandler &&
                     Equals(
                         eventHandler.Target,
-                        (handler as PropertyChangedEventHandler)?.Target));
+                        (handler as PropertyChangedEventHandler)?.Target)));
             }
         }
 

--- a/src/ReactiveUI/Platforms/uap10.0.16299/WinRTAutoSuspendApplication.cs
+++ b/src/ReactiveUI/Platforms/uap10.0.16299/WinRTAutoSuspendApplication.cs
@@ -20,8 +20,8 @@ namespace ReactiveUI
     /// <summary>
     /// AutoSuspend-based Application. To use AutoSuspend with WinRT, change your
     /// Application to inherit from this class, then call:
-    ///
-    /// Locator.Current.GetService.<ISuspensionHost>().SetupDefaultSuspendResume();
+    /// Locator.Current.GetService.&lt;ISuspensionHost&gt;().SetupDefaultSuspendResume();
+    /// This will register your suspension host.
     /// </summary>
     public class AutoSuspendHelper : IEnableLogger
     {

--- a/src/ReactiveUI/ReactiveCommand/IReactiveCommand.cs
+++ b/src/ReactiveUI/ReactiveCommand/IReactiveCommand.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace ReactiveUI
+{
+    /// <summary>
+    /// Encapsulates a user action behind a reactive interface.
+    /// </summary>
+    internal interface IReactiveCommand : IDisposable, IHandleObservableErrors
+    {
+        /// <summary>
+        /// Gets an observable whose value indicates whether the command is currently executing.
+        /// </summary>
+        /// <remarks>
+        /// This observable can be particularly useful for updating UI, such as showing an activity indicator whilst a command
+        /// is executing.
+        /// </remarks>
+        IObservable<bool> IsExecuting { get; }
+
+        /// <summary>
+        /// Gets an observable whose value indicates whether the command can currently execute.
+        /// </summary>
+        /// <remarks>
+        /// The value provided by this observable is governed both by any <c>canExecute</c> observable provided during
+        /// command creation, as well as the current execution status of the command. A command that is currently executing
+        /// will always yield <c>false</c> from this observable, even if the <c>canExecute</c> pipeline is currently <c>true</c>.
+        /// </remarks>
+        IObservable<bool> CanExecute { get; }
+    }
+}

--- a/src/ReactiveUI/ReactiveCommand/IReactiveCommand.cs
+++ b/src/ReactiveUI/ReactiveCommand/IReactiveCommand.cs
@@ -9,7 +9,7 @@ namespace ReactiveUI
     /// <summary>
     /// Encapsulates a user action behind a reactive interface.
     /// </summary>
-    internal interface IReactiveCommand : IDisposable, IHandleObservableErrors
+    public interface IReactiveCommand : IDisposable, IHandleObservableErrors
     {
         /// <summary>
         /// Gets an observable whose value indicates whether the command is currently executing.

--- a/src/ReactiveUI/ReactiveCommand/IReactiveCommand.cs
+++ b/src/ReactiveUI/ReactiveCommand/IReactiveCommand.cs
@@ -8,8 +8,11 @@ namespace ReactiveUI
 {
     /// <summary>
     /// Encapsulates a user action behind a reactive interface.
+    /// This is for interop inside for the command binding.
+    /// Not meant for external use due to the fact it doesn't implement ICommand
+    /// to force the user to favor the Reactive style command execution.
     /// </summary>
-    public interface IReactiveCommand : IDisposable, IHandleObservableErrors
+    internal interface IReactiveCommand : IDisposable, IHandleObservableErrors
     {
         /// <summary>
         /// Gets an observable whose value indicates whether the command is currently executing.

--- a/src/ReactiveUI/ReactiveCommand/ReactiveCommandBase.cs
+++ b/src/ReactiveUI/ReactiveCommand/ReactiveCommandBase.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Reactive.Linq;
+using System.Windows.Input;
 
 namespace ReactiveUI
 {
@@ -19,6 +20,47 @@ namespace ReactiveUI
     /// Because the result type is known by this class, it can implement <see cref="IObservable{T}"/>. However, the implementation
     /// is defined as abstract, so subclasses must provide it.
     /// </para>
+    /// <para>
+    /// Reactive commands encapsulate the behavior of running some execution logic and then surfacing the results on the UI
+    /// thread. Importantly, no scheduling is performed against input observables (the <c>canExecute</c> and execution pipelines).
+    /// </para>
+    /// <para>
+    /// To create an instance of <c>ReactiveCommand</c>, call one of the static creation methods defined by this class.
+    /// <see cref="Create"/> can be used when your execution logic is synchronous.
+    /// <see cref="CreateFromObservable{TResult}(Func{IObservable{TResult}}, IObservable{bool}, IScheduler)"/> and
+    /// <see cref="CreateFromTask(Func{Task}, IObservable{bool}, IScheduler)"/> (and overloads) can be used for asynchronous
+    /// execution logic. Optionally, you can provide an observable that governs the availability of the command for execution,
+    /// as well as a scheduler to which events will be delivered.
+    /// </para>
+    /// <para>
+    /// The <see cref="CanExecute"/> property provides an observable that can be used to determine whether the command is
+    /// eligible for execution. The value of this observable is determined by both the <c>canExecute</c> observable provided
+    /// during command creation, and the current execution status of the command. A command that is already executing will
+    /// yield <c>false</c> from its <see cref="CanExecute"/> observable regardless of the <c>canExecute</c> observable provided
+    /// during command creation.
+    /// </para>
+    /// <para>
+    /// The <see cref="IsExecuting"/> property provides an observable whose value indicates whether the command is currently
+    /// executing. This can be a useful means of triggering UI, such as displaying an activity indicator whilst a command is
+    /// executing.
+    /// </para>
+    /// <para>
+    /// As discussed above, you are under no obligation to somehow incorporate this into your <c>canExecute</c> observable
+    /// because that is taken care of for you. That is, if the value of <c>IsExecuting</c> is <c>true</c>, the value of
+    /// <c>CanExecute</c> will be <c>false</c>. However, if the value of <c>CanExecute</c> is <c>false</c>, that does not imply
+    /// the value of <c>IsExecuting</c> is <c>true</c>.
+    /// </para>
+    /// <para>
+    /// Any errors in your command's execution logic (including any <c>canExecute</c> observable you choose to provide) will be
+    /// surfaced via the <see cref="ThrownExceptions"/> observable. This gives you the opportunity to handle the error before
+    /// it triggers a default handler that tears down the application. For example, you might use this as a means of alerting
+    /// the user that something has gone wrong executing the command.
+    /// </para>
+    /// <para>
+    /// For the sake of convenience, all <c>ReactiveCommand</c> instances are also implementations of <see cref="ICommand"/>.
+    /// This allows you to easily integrate instances of <c>ReactiveCommand</c> into platforms that understands <c>ICommand</c>
+    /// natively (such as WPF and UWP).
+    /// </para>
     /// </remarks>
     /// <typeparam name="TParam">
     /// The type of parameter values passed in during command execution.
@@ -26,8 +68,74 @@ namespace ReactiveUI
     /// <typeparam name="TResult">
     /// The type of the values that are the result of command execution.
     /// </typeparam>
-    public abstract class ReactiveCommandBase<TParam, TResult> : ReactiveCommand, IObservable<TResult>
+    public abstract class ReactiveCommandBase<TParam, TResult> : IObservable<TResult>, ICommand, IReactiveCommand
     {
+        private EventHandler _canExecuteChanged;
+
+        /// <inheritdoc/>
+        event EventHandler ICommand.CanExecuteChanged
+        {
+            add => _canExecuteChanged += value;
+            remove => _canExecuteChanged -= value;
+        }
+
+        /// <summary>
+        /// An observable whose value indicates whether the command can currently execute.
+        /// </summary>
+        /// <remarks>
+        /// The value provided by this observable is governed both by any <c>canExecute</c> observable provided during
+        /// command creation, as well as the current execution status of the command. A command that is currently executing
+        /// will always yield <c>false</c> from this observable, even if the <c>canExecute</c> pipeline is currently <c>true</c>.
+        /// </remarks>
+        public abstract IObservable<bool> CanExecute
+        {
+            get;
+        }
+
+        /// <summary>
+        /// An observable whose value indicates whether the command is currently executing.
+        /// </summary>
+        /// <remarks>
+        /// This observable can be particularly useful for updating UI, such as showing an activity indicator whilst a command
+        /// is executing.
+        /// </remarks>
+        public abstract IObservable<bool> IsExecuting
+        {
+            get;
+        }
+
+        /// <summary>
+        /// An observable that ticks any exceptions in command execution logic.
+        /// </summary>
+        /// <remarks>
+        /// Any exceptions that are not observed via this observable will propagate out and cause the application to be torn
+        /// down. Therefore, you will always want to subscribe to this observable if you expect errors could occur (e.g. if
+        /// your command execution includes network activity).
+        /// </remarks>
+        public abstract IObservable<Exception> ThrownExceptions
+        {
+            get;
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <inheritdoc/>
+        bool ICommand.CanExecute(object parameter)
+        {
+            return ICommandCanExecute(parameter);
+        }
+
+        /// <inheritdoc/>
+        void ICommand.Execute(object parameter)
+        {
+            ICommandExecute(parameter);
+        }
+
         /// <summary>
         /// Subscribes to execution results from this command.
         /// </summary>
@@ -69,14 +177,37 @@ namespace ReactiveUI
         /// </returns>
         public abstract IObservable<TResult> Execute(TParam parameter = default(TParam));
 
-        /// <inheritdoc/>
-        protected override bool ICommandCanExecute(object parameter)
+        /// <summary>
+        /// Disposes of the managed resources.
+        /// </summary>
+        /// <param name="disposing">If its getting called by the Dispose() method.</param>
+        protected abstract void Dispose(bool disposing);
+
+        /// <summary>
+        /// Will trigger a event when the CanExecute condition has changed.
+        /// </summary>
+        protected void OnCanExecuteChanged()
+        {
+            _canExecuteChanged?.Invoke(this, EventArgs.Empty);
+        }
+
+        /// <summary>
+        /// Will be called by the methods from the ICommand interface.
+        /// This method is called when the Command should evaluate if it can execute.
+        /// </summary>
+        /// <param name="parameter">The parameter being passed to the ICommand.</param>
+        /// <returns>If the command can be executed.</returns>
+        protected virtual bool ICommandCanExecute(object parameter)
         {
             return CanExecute.FirstAsync().Wait();
         }
 
-        /// <inheritdoc/>
-        protected override void ICommandExecute(object parameter)
+        /// <summary>
+        /// Will be called by the methods from the ICommand interface.
+        /// This method is called when the Command should execute.
+        /// </summary>
+        /// <param name="parameter">The parameter being passed to the ICommand.</param>
+        protected virtual void ICommandExecute(object parameter)
         {
             // ensure that null is coerced to default(TParam) so that commands taking value types will use a sensible default if no parameter is supplied
             if (parameter == null)

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "9.1",
+  "version": "9.2",
   "publicReleaseRefSpec": [
     "^refs/heads/master$", // we release out of master
     "^refs/heads/develop$", // we release out of develop


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
This removes the abstract base class we use in ReactiveCommand.


**What is the current behavior? (You can also link to an open issue here)**
There is a abstract base class. Users can introduce subtle bugs by using it directly in their code. It was meant for interop with the ICommand but now ReactiveCommandBase<TParam, TResult> now implements that logic. There is also a interface allow some of the Command Binding code to keep functioning and exposes the observables for the user. It's deliberately not derived from ICommand due to us wanting the separation.


**What is the new behavior (if this is a feature change)?**
refactor.

**What might this PR break?**
Users who have a derived off the abstract base class. They will have to change their classes to derive from ReactiveCommandBase<TParam, TResult> now.


**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
Docs have already been modified to show the non-abstract class use.

This relates to https://github.com/reactiveui/rfcs/issues/19