### PR TITLE
ReactiveDemo hack around VS xaml designer issue with inherits from generic classes

### DIFF
--- a/samples/getting-started/ReactiveDemo/NugetDetailsView.xaml
+++ b/samples/getting-started/ReactiveDemo/NugetDetailsView.xaml
@@ -1,6 +1,7 @@
-﻿<reactiveDemo:NugetDetailsViewBase
+﻿<reactiveui:ReactiveUserControl
     x:Class="ReactiveDemo.NugetDetailsView"
     xmlns:reactiveDemo="clr-namespace:ReactiveDemo"
+    x:TypeArguments="reactiveDemo:NugetDetailsViewModel"
     xmlns:reactiveui="http://reactiveui.net"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
@@ -20,4 +21,4 @@
           <Hyperlink x:Name="openButton">Open</Hyperlink>
         </TextBlock>
     </Grid>
-</reactiveDemo:NugetDetailsViewBase>
+</reactiveui:ReactiveUserControl>

--- a/samples/getting-started/ReactiveDemo/NugetDetailsView.xaml
+++ b/samples/getting-started/ReactiveDemo/NugetDetailsView.xaml
@@ -1,7 +1,6 @@
-﻿<reactiveui:ReactiveUserControl
+﻿<reactiveDemo:NugetDetailsViewBase
     x:Class="ReactiveDemo.NugetDetailsView"
     xmlns:reactiveDemo="clr-namespace:ReactiveDemo"
-    x:TypeArguments="reactiveDemo:NugetDetailsViewModel"
     xmlns:reactiveui="http://reactiveui.net"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
@@ -21,4 +20,4 @@
           <Hyperlink x:Name="openButton">Open</Hyperlink>
         </TextBlock>
     </Grid>
-</reactiveui:ReactiveUserControl>
+</reactiveDemo:NugetDetailsViewBase>

--- a/samples/getting-started/ReactiveDemo/NugetDetailsView.xaml.cs
+++ b/samples/getting-started/ReactiveDemo/NugetDetailsView.xaml.cs
@@ -4,11 +4,14 @@ using System.Windows.Media.Imaging;
 
 namespace ReactiveDemo
 {
-    // The class derives off ReactiveUserControl which contains the ViewModel property.
+    /// Nongeneric class that allows us to edit NugetDetailsView in Design view
+    public class NugetDetailsViewBase : ReactiveUserControl<NugetDetailsViewModel> { }
+
+    // Second level derived class off ReactiveUserControl which contains the ViewModel property.
     // In our MainWindow when we register the ListBox with the collection of 
     // NugetDetailsViewModels if no ItemTemplate has been declared it will search for 
     // a class derived off IViewFor<NugetDetailsViewModel> and show that for the item.
-    public partial class NugetDetailsView : ReactiveUserControl<NugetDetailsViewModel>
+    public partial class NugetDetailsView : NugetDetailsViewBase
     {
         public NugetDetailsView()
         {

--- a/samples/getting-started/ReactiveDemo/NugetDetailsView.xaml.cs
+++ b/samples/getting-started/ReactiveDemo/NugetDetailsView.xaml.cs
@@ -4,14 +4,11 @@ using System.Windows.Media.Imaging;
 
 namespace ReactiveDemo
 {
-    /// Nongeneric class that allows us to edit NugetDetailsView in Design view
-    public class NugetDetailsViewBase : ReactiveUserControl<NugetDetailsViewModel> { }
-
     // Second level derived class off ReactiveUserControl which contains the ViewModel property.
     // In our MainWindow when we register the ListBox with the collection of 
     // NugetDetailsViewModels if no ItemTemplate has been declared it will search for 
     // a class derived off IViewFor<NugetDetailsViewModel> and show that for the item.
-    public partial class NugetDetailsView : NugetDetailsViewBase
+    public partial class NugetDetailsView : ReactiveUserControl<NugetDetailsViewModel>
     {
         public NugetDetailsView()
         {

--- a/samples/getting-started/ReactiveDemo/ReactiveDemo.csproj
+++ b/samples/getting-started/ReactiveDemo/ReactiveDemo.csproj
@@ -75,5 +75,10 @@
     <PackageReference Include="NuGet.Protocol.Core.v3" Version="4.2.0" />
     <PackageReference Include="ReactiveUI.WPF" Version="*" />
   </ItemGroup>
+  <ItemGroup>
+    <Reference Include="PresentationCore" />
+    <Reference Include="PresentationFramework" />
+    <Reference Include="WindowsBase" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Update ReactiveDemo sample

**What is the current behavior? (You can also link to an open issue here)**
ReactiveDemo sample solution does not build. After adding missing dependencies, Views cannot be opened in designer.

**What is the new behavior (if this is a feature change)?**
In ReactiveDemo sample:
NugetDetailsView.xaml can be opened in Design view.
Fixes missing references to PresentationCore, PresentationFramework and WindowsBase.

**What might this PR break?**
Nothting. Just wonder now if missing dependencies are not actually missing. I mainly work in VS for Windows, but I don't know how the sample hs to be used to target e.g. Xamarin.


**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

