### PR TITLE
housekeeping: Use string interpolation where appropriate

### DIFF
--- a/src/ReactiveUI.XamForms/RoutedViewHost.cs
+++ b/src/ReactiveUI.XamForms/RoutedViewHost.cs
@@ -195,9 +195,7 @@ namespace ReactiveUI.XamForms
             var ret = ViewLocator.Current.ResolveView(vm);
             if (ret == null)
             {
-                var msg = string.Format(
-                    "Couldn't find a View for ViewModel. You probably need to register an IViewFor<{0}>",
-                    vm.GetType().Name);
+                var msg = $"Couldn't find a View for ViewModel. You probably need to register an IViewFor<{vm.GetType().Name}>";
 
                 return Observable.Throw<Page>(new Exception(msg));
             }

--- a/src/ReactiveUI.XamForms/ViewModelViewHost.cs
+++ b/src/ReactiveUI.XamForms/ViewModelViewHost.cs
@@ -86,14 +86,14 @@ namespace ReactiveUI.XamForms
 
                         if (view == null)
                         {
-                            throw new Exception(string.Format("Couldn't find view for '{0}'.", x.ViewModel));
+                            throw new Exception($"Couldn't find view for '{x.ViewModel}'.");
                         }
 
                         var castView = view as View;
 
                         if (castView == null)
                         {
-                            throw new Exception(string.Format("View '{0}' is not a subclass of '{1}'.", view.GetType().FullName, typeof(View).FullName));
+                            throw new Exception($"View '{view.GetType().FullName}' is not a subclass of '{typeof(View).FullName}'.");
                         }
 
                         view.ViewModel = x.ViewModel;

--- a/src/ReactiveUI/Platforms/android/FlexibleCommandBinder.cs
+++ b/src/ReactiveUI/Platforms/android/FlexibleCommandBinder.cs
@@ -51,7 +51,7 @@ namespace ReactiveUI
 
             if (match == null)
             {
-                throw new NotSupportedException(string.Format("CommandBinding for {0} is not supported", type.Name));
+                throw new NotSupportedException($"CommandBinding for {type.Name} is not supported");
             }
 
             var typeProperties = _config[match];

--- a/src/ReactiveUI/Platforms/apple-common/ObservableForPropertyBase.cs
+++ b/src/ReactiveUI/Platforms/apple-common/ObservableForPropertyBase.cs
@@ -73,7 +73,7 @@ namespace ReactiveUI
 
             if (match == null)
             {
-                throw new NotSupportedException(string.Format("Notifications for {0}.{1} are not supported", type.Name, propertyName));
+                throw new NotSupportedException($"Notifications for {type.Name}.{propertyName} are not supported");
             }
 
             return match.CreateObservable((NSObject)sender, expression);

--- a/src/ReactiveUI/Platforms/apple-common/ViewModelViewHost.cs
+++ b/src/ReactiveUI/Platforms/apple-common/ViewModelViewHost.cs
@@ -120,11 +120,11 @@ namespace ReactiveUI
 
                         if (view == null)
                         {
-                            var message = string.Format("Unable to resolve view for \"{0}\"", x.ViewModel.GetType());
+                            var message = $"Unable to resolve view for \"{x.ViewModel.GetType()}\"";
 
                             if (x.Contract != null)
                             {
-                                message += string.Format(" and contract \"{0}\"", x.Contract.GetType());
+                                message += $" and contract \"{x.Contract.GetType()}\"";
                             }
 
                             message += ".";
@@ -135,11 +135,7 @@ namespace ReactiveUI
 
                         if (viewController == null)
                         {
-                            throw new Exception(
-                                string.Format(
-                                    "Resolved view type '{0}' is not a '{1}'.",
-                                    viewController.GetType().FullName,
-                                    typeof(NSViewController).FullName));
+                            throw new Exception($"Resolved view type '{viewController.GetType().FullName}' is not a '{typeof(NSViewController).FullName}'.");
                         }
 
                         view.ViewModel = x.ViewModel;
@@ -272,11 +268,11 @@ namespace ReactiveUI
                 // if not found, throw
                 if (viewController == null)
                 {
-                    var message = string.Format("Unable to resolve view for \"{0}\"", x.ViewModel.GetType());
+                    var message = $"Unable to resolve view for \"{x.ViewModel.GetType()}\"";
 
                     if (x.Contract != null)
                     {
-                        message += string.Format(" and contract \"{0}\"", x.Contract.GetType());
+                        message += $" and contract \"{x.Contract.GetType()}\"";
                     }
 
                     message += ".";
@@ -290,7 +286,7 @@ namespace ReactiveUI
                 // sanity check, view controllers are expect to have a view
                 if (viewLastAdded == null)
                 {
-                    var message = string.Format("No view associated with view controller {0}.", viewController.GetType());
+                    var message = $"No view associated with view controller {viewController.GetType()}.";
                     throw new Exception(message);
                 }
 

--- a/src/ReactiveUI/Platforms/net461/ComponentModelTypeConverter.cs
+++ b/src/ReactiveUI/Platforms/net461/ComponentModelTypeConverter.cs
@@ -49,7 +49,7 @@ namespace ReactiveUI
 
             if (converter == null)
             {
-                throw new ArgumentException(string.Format("Can't convert {0} to {1}. To fix this, register a IBindingTypeConverter", fromType, toType));
+                throw new ArgumentException($"Can't convert {fromType} to {toType}. To fix this, register a IBindingTypeConverter");
             }
 
             try
@@ -78,7 +78,7 @@ namespace ReactiveUI
                     return false;
                 }
 
-                throw new Exception(string.Format("Can't convert from {0} to {1}.", from.GetType(), toType), e);
+                throw new Exception($"Can't convert from {@from.GetType()} to {toType}.", e);
             }
         }
     }

--- a/src/ReactiveUI/Platforms/uikit-common/FlexibleCommandBinder.cs
+++ b/src/ReactiveUI/Platforms/uikit-common/FlexibleCommandBinder.cs
@@ -59,7 +59,7 @@ namespace ReactiveUI
 
             if (match == null)
             {
-                throw new NotSupportedException(string.Format("CommandBinding for {0} is not supported", type.Name));
+                throw new NotSupportedException($"CommandBinding for {type.Name} is not supported");
             }
 
             var typeProperties = _config[match];

--- a/src/ReactiveUI/Platforms/uikit-common/RoutedViewHost.cs
+++ b/src/ReactiveUI/Platforms/uikit-common/RoutedViewHost.cs
@@ -168,10 +168,7 @@ namespace ReactiveUI
 
             if (view == null)
             {
-                throw new Exception(
-                    string.Format(
-                        "Couldn't find a view for view model. You probably need to register an IViewFor<{0}>",
-                        viewModel.GetType().Name));
+                throw new Exception($"Couldn't find a view for view model. You probably need to register an IViewFor<{viewModel.GetType().Name}>");
             }
 
             view.ViewModel = viewModel;
@@ -179,11 +176,7 @@ namespace ReactiveUI
 
             if (viewController == null)
             {
-                throw new Exception(
-                    string.Format(
-                        "View type {0} for view model type {1} is not a UIViewController",
-                        view.GetType().Name,
-                        viewModel.GetType().Name));
+                throw new Exception($"View type {view.GetType().Name} for view model type {viewModel.GetType().Name} is not a UIViewController");
             }
 
             return viewController;
@@ -272,7 +265,7 @@ namespace ReactiveUI
                 }
                 else
                 {
-                    throw new Exception(string.Format("'{0}' must be an NSViewController or NSView", view.GetType().FullName));
+                    throw new Exception($"'{view.GetType().FullName}' must be an NSViewController or NSView");
                 }
 
                 targetView.AddSubview(viewLastAdded);

--- a/src/ReactiveUI/Platforms/windows-common/RoutedViewHost.cs
+++ b/src/ReactiveUI/Platforms/windows-common/RoutedViewHost.cs
@@ -146,7 +146,7 @@ namespace ReactiveUI
 
                         if (view == null)
                         {
-                            throw new Exception(string.Format("Couldn't find view for '{0}'.", x.Item1));
+                            throw new Exception($"Couldn't find view for '{x.Item1}'.");
                         }
 
                         view.ViewModel = x.Item1;

--- a/src/ReactiveUI/Platforms/xamarin-common/ComponentModelTypeConverter.cs
+++ b/src/ReactiveUI/Platforms/xamarin-common/ComponentModelTypeConverter.cs
@@ -49,7 +49,7 @@ namespace ReactiveUI
 
             if (converter == null)
             {
-                throw new ArgumentException(string.Format("Can't convert {0} to {1}. To fix this, register a IBindingTypeConverter", fromType, toType));
+                throw new ArgumentException($"Can't convert {fromType} to {toType}. To fix this, register a IBindingTypeConverter");
             }
 
             try
@@ -78,7 +78,7 @@ namespace ReactiveUI
                     return false;
                 }
 
-                throw new Exception(string.Format("Can't convert from {0} to {1}.", from.GetType(), toType), e);
+                throw new Exception($"Can't convert from {@from.GetType()} to {toType}.", e);
             }
         }
     }


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Housekeeping. Replacing string.Format with string interpolation.


**What is the current behavior? (You can also link to an open issue here)**
string.Format is used.


**What is the new behavior (if this is a feature change)?**
string interpolation is used where appropriate.


**What might this PR break?**
No idea.


**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
NA?

**Other information**:

