### PR TITLE
housekeeping: now use cake 0.30.0

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -6,10 +6,10 @@
 // ADDINS
 //////////////////////////////////////////////////////////////////////
 
-#addin "nuget:?package=Cake.FileHelpers&version=3.0.0"
+#addin "nuget:?package=Cake.FileHelpers&version=3.1.0"
 #addin "nuget:?package=Cake.Coveralls&version=0.9.0"
-#addin "nuget:?package=Cake.PinNuGetDependency&version=3.0.1"
-#addin "nuget:?package=Cake.Powershell&version=0.4.5"
+#addin "nuget:?package=Cake.PinNuGetDependency&version=3.1.0"
+#addin "nuget:?package=Cake.Powershell&version=0.4.7"
 
 //////////////////////////////////////////////////////////////////////
 // TOOLS
@@ -18,9 +18,9 @@
 #tool "nuget:?package=GitReleaseManager&version=0.7.1"
 #tool "nuget:?package=coveralls.io&version=1.4.2"
 #tool "nuget:?package=OpenCover&version=4.6.519"
-#tool "nuget:?package=ReportGenerator&version=3.1.2"
+#tool "nuget:?package=ReportGenerator&version=4.0.4"
 #tool "nuget:?package=vswhere&version=2.5.2"
-#tool "nuget:?package=xunit.runner.console&version=2.4.0"
+#tool "nuget:?package=xunit.runner.console&version=2.4.1"
 
 //////////////////////////////////////////////////////////////////////
 // ARGUMENTS

--- a/build.cmd
+++ b/build.cmd
@@ -1,5 +1,5 @@
 @echo off
-tools\nuget\nuget.exe install Cake -OutputDirectory tools -ExcludeVersion -Version 0.22.1 
+tools\nuget\nuget.exe install Cake -OutputDirectory tools -ExcludeVersion -Version 0.30.0
 
 tools\Cake\Cake.exe build.cake --target=%1 
 

--- a/src/global.json
+++ b/src/global.json
@@ -1,5 +1,5 @@
 {
     "msbuild-sdks": {
-        "MSBuild.Sdk.Extras": "1.6.61"
+        "MSBuild.Sdk.Extras": "1.6.65"
     }
 }

--- a/src/global.json
+++ b/src/global.json
@@ -1,5 +1,5 @@
 {
     "msbuild-sdks": {
-        "MSBuild.Sdk.Extras": "1.6.65"
+        "MSBuild.Sdk.Extras": "1.6.61"
     }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Update cake from 0.22.0 to 0.30.0 with all the latest dependencies.
Update msbuild.sdk.extras from 0.6.61 to 0.6.65