### PR TITLE
fix: WhenNavigatingFromObservable completes when NavigateAndReset is invoked (#1875)

### DIFF
--- a/src/ReactiveUI.Tests/RoutableViewModelMixinTests.cs
+++ b/src/ReactiveUI.Tests/RoutableViewModelMixinTests.cs
@@ -3,9 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Reactive.Disposables;
-using DynamicData;
 using ReactiveUI.Tests.RoutableViewMixinTests;
 using Xunit;
 

--- a/src/ReactiveUI.Tests/RoutableViewModelMixinTests.cs
+++ b/src/ReactiveUI.Tests/RoutableViewModelMixinTests.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Reactive.Disposables;
+using DynamicData;
 using ReactiveUI.Tests.RoutableViewMixinTests;
 using Xunit;
 
@@ -190,6 +191,25 @@ namespace ReactiveUI.Tests
 
             screen.Router.Navigate.Execute(vm);
             screen.Router.NavigateBack.Execute();
+
+            Assert.Equal(1, count);
+        }
+
+        [Fact]
+        public void WhenNavigatingFromObservableCompletesWhenNavigationStackIsReset()
+        {
+            var count = 0;
+
+            var screen = new TestScreen();
+            var vm1 = new RoutableViewModel(screen);
+            var vm2 = new RoutableViewModel(screen);
+
+            vm1.WhenNavigatingFromObservable().Subscribe(
+                _ => { },
+                () => { count++; });
+
+            screen.Router.Navigate.Execute(vm1);
+            screen.Router.NavigateAndReset.Execute(vm2);
 
             Assert.Equal(1, count);
         }


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug Fix

**What is the current behavior? (You can also link to an open issue here)**
https://github.com/reactiveui/ReactiveUI/issues/1874

**What is the new behavior (if this is a feature change)?**
WhenNavigatingFromObservable completes when NavigateAndReset is invoked

**What might this PR break?**
Navigation operations

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
This is crucial for my project, as the `WhenNavigatingFromObservable()` feature is critical for cleanup.