### PR TITLE
housekeeping: Use NuGet PackageLicenseLiteral, update fody.

### DIFF
--- a/directory.build.props
+++ b/directory.build.props
@@ -1,9 +1,8 @@
 <Project>
   <PropertyGroup>
     <Authors>.NET Foundation and Contributors</Authors>
-    <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)reactiveui.ruleset</CodeAnalysisRuleSet>  
     <Copyright>Copyright (c) .NET Foundation and Contributors</Copyright>
-    <PackageLicenseUrl>https://opensource.org/licenses/mit</PackageLicenseUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://reactiveui.net</PackageProjectUrl>
     <PackageIconUrl>https://i.imgur.com/7WDbqSy.png</PackageIconUrl>
     <Owners>xpaulbettsx;ghuntley</Owners>

--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -1,16 +1,9 @@
 <Project>
   <PropertyGroup>
-    <Authors>.NET Foundation and Contributors</Authors>
-    <Copyright>Copyright (c) .NET Foundation and Contributors</Copyright>
-    <PackageLicenseUrl>https://opensource.org/licenses/mit</PackageLicenseUrl>
-    <PackageProjectUrl>https://reactiveui.net</PackageProjectUrl>
-    <PackageIconUrl>https://i.imgur.com/7WDbqSy.png</PackageIconUrl>
     <Owners>xpaulbettsx;ghuntley</Owners>
     <Product>ReactiveUI ($(TargetFramework))</Product>
     <PackageTags>mvvm;reactiveui;rx;reactive extensions;observable;LINQ;events;frp;xamarin;android;ios;mac;forms;monodroid;monotouch;xamarin.android;xamarin.ios;xamarin.forms;xamarin.mac;xamarin.tvos;wpf;net;netstandard;net461;uwp;tizen</PackageTags>
     <PackageReleaseNotes>https://reactiveui.net/blog/</PackageReleaseNotes>
-    <RepositoryUrl>https://github.com/reactiveui/reactiveui</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591;1701;1702;1705;VSX1000</NoWarn>
     <Platform>AnyCPU</Platform>
@@ -70,4 +63,6 @@
   <ItemGroup>
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)stylecop.json" Link="stylecop.json" />
   </ItemGroup>
+
+  <Import Project="..\Directory.build.props" />
 </Project>

--- a/src/ReactiveUI.Events.WPF/ReactiveUI.Events.WPF.csproj
+++ b/src/ReactiveUI.Events.WPF/ReactiveUI.Events.WPF.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
     <TargetFrameworks>net461</TargetFrameworks>
-    <AssemblyName>ReactiveUI.Events.WPF</AssemblyName>
     <RootNamespace>ReactiveUI.Events</RootNamespace>
     <Description>Provides Observable-based events API for WPF UI controls/eventhandlers. The contents of this package is automatically generated, please target pull-requests to the code generator.</Description>
     <PackageId>ReactiveUI.Events.WPF</PackageId>

--- a/src/ReactiveUI.Fody.Helpers/ReactiveUI.Fody.Helpers.csproj
+++ b/src/ReactiveUI.Fody.Helpers/ReactiveUI.Fody.Helpers.csproj
@@ -1,8 +1,6 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461;uap10.0.16299;Xamarin.iOS10;Xamarin.Mac20;Xamarin.TVOS10;MonoAndroid81;netcoreapp2.0</TargetFrameworks>
-    <AssemblyName>ReactiveUI.Fody.Helpers</AssemblyName>
-    <RootNamespace>ReactiveUI.Fody.Helpers</RootNamespace>
     <Description>Fody extension to generate RaisePropertyChange notifications for properties and ObservableAsPropertyHelper properties.</Description>
 
     <!-- Override FodyPackaging since project is named differently than expected -->
@@ -12,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Fody" Version="3.3.4" PrivateAssets="None" />
-    <PackageReference Include="FodyPackaging" Version="3.3.4" PrivateAssets="All" />
+    <PackageReference Include="Fody" Version="3.3.5" PrivateAssets="None" />
+    <PackageReference Include="FodyPackaging" Version="3.3.5" PrivateAssets="All" />
     <PackageReference Include="System.Reactive" Version="4.0.0" />
   </ItemGroup>
 

--- a/src/ReactiveUI.Fody/ReactiveUI.Fody.csproj
+++ b/src/ReactiveUI.Fody/ReactiveUI.Fody.csproj
@@ -1,13 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
-    <AssemblyName>ReactiveUI.Fody</AssemblyName>
-    <RootNamespace>ReactiveUI.Fody</RootNamespace>
     <Description>Fody Weavers for ReactiveUI.Fody.</Description>
     <IsPackable>False</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FodyHelpers" Version="3.3.4" />
+    <PackageReference Include="FodyHelpers" Version="3.3.5" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- Nuget now wants either PackageLicenseLiteral or PackageLicenseFile. Using the literal for MIT
- Update to Fody 3.3.5 which removes issues for PackageLicenseLiteral.