### PR TITLE
housekeeping: update msbuild.sdk.extras 1.6.65, and eventbuilder updates (#1877)

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -106,7 +106,7 @@ Action<string, string, bool, bool> Build = (solution, outputFolder, createPackag
 
     var msBuildSettings = new MSBuildSettings() {
             ToolPath = msBuildPath,
-            ArgumentCustomization = args => args.Append("/m /restore")
+            ArgumentCustomization = args => args.Append("/m /restore /NoWarn:VSX1000")
         }
         .WithProperty("TreatWarningsAsErrors", treatWarningsAsErrors.ToString())
         .SetConfiguration("Release")                        
@@ -145,60 +145,38 @@ Task("GenerateEvents")
     .Does (() =>
 {
     var workingDirectory = artifactDirectory + "eventbuilder/";
-    var eventBuilder = workingDirectory + "EventBuilder.exe";
+    var eventBuilder = workingDirectory + "EventBuilder.dll";
     var referenceAssembliesPath = vsLocation.CombineWithFilePath("./Common7/IDE/ReferenceAssemblies/Microsoft/Framework");
 
     Information(referenceAssembliesPath.ToString());
 
     Action<string, string> generate = (string platform, string directory) =>
     {
-        using(var process = StartAndReturnProcess(eventBuilder,
-            new ProcessSettings{
-                Arguments = new ProcessArgumentBuilder()
-                    .AppendSwitch("--platform","=", platform)
-                    .AppendSwitchQuoted("--reference","=", referenceAssembliesPath.ToString()),
-                WorkingDirectory = workingDirectory,
-                RedirectStandardOutput = true }))
+        var settings = new DotNetCoreExecuteSettings
         {
-            // super important to ensure that the platform is always
-            // uppercase so that the events are written to the write
-            // filename as UNIX is case-sensitive - even though OSX
-            // isn't by default.
-            platform = platform.ToUpper();
+            WorkingDirectory = workingDirectory,
+        };
 
-            Information("Generating events for '{0}'", platform);
-            
-            int timeout = 10 * 60 * 1000;   // x Minute, y Second, z Millisecond
-            process.WaitForExit(timeout);
+        var filename = String.Format("Events_{0}.cs", platform);
+        var output = MakeAbsolute(File(System.IO.Path.Combine(directory, filename))).ToString().Quote();
 
-            var stdout = process.GetStandardOutput();
+        Information("Generating events for '{0}'", platform);
+        DotNetCoreExecute(
+                    eventBuilder,
+                    new ProcessArgumentBuilder()
+                        .AppendSwitch("--platform","=", platform)
+                        .AppendSwitchQuoted("--reference","=", referenceAssembliesPath.ToString())
+                        .AppendSwitchQuoted("--output-path", "=", output),
+                    settings);
 
-            int success = 0;    // exit code aka %ERRORLEVEL% or $?
-            if (process.GetExitCode() != success)
-            {
-                Error("Failed to generate events for '{0}'", platform);
-
-                foreach (var line in stdout)
-                {
-                    Error(line);
-                }
-
-                Abort();
-            }
-
-            var filename = String.Format("Events_{0}.cs", platform);
-            var output = System.IO.Path.Combine(directory, filename);
-
-            FileWriteLines(output, stdout.ToArray());
-            Information("The events have been written to '{0}'", output);
-        }
+        Information("The events have been written to '{0}'", output);
     };
 
     generate("android", "src/ReactiveUI.Events/");
     generate("ios", "src/ReactiveUI.Events/");
     generate("mac", "src/ReactiveUI.Events/");
     generate("uwp", "src/ReactiveUI.Events/");
-    generate("tizen", "src/ReactiveUI.Events/");
+    generate("tizen4", "src/ReactiveUI.Events/");
     generate("wpf", "src/ReactiveUI.Events.WPF/");
     generate("xamforms", "src/ReactiveUI.Events.XamForms/");
     generate("winforms", "src/ReactiveUI.Events.Winforms/");

--- a/src/EventBuilder.sln
+++ b/src/EventBuilder.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26228.12
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EventBuilder", "EventBuilder\EventBuilder.csproj", "{A6B86E12-057F-4591-98A3-FD50E9CEAE69}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EventBuilder", "EventBuilder\EventBuilder.csproj", "{A6B86E12-057F-4591-98A3-FD50E9CEAE69}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -18,5 +18,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {238383E8-35F5-48A0-9043-8347D6C27876}
 	EndGlobalSection
 EndGlobal

--- a/src/EventBuilder/App.config
+++ b/src/EventBuilder/App.config
@@ -11,7 +11,9 @@ See the LICENSE file in the project root for more information.
   </startup>
   <appSettings>
     <add key="serilog:minimum-level" value="Verbose"/>
-    <add key="serilog:write-to:ColoredConsole.restrictedToMinimumLevel" value="Fatal"/>
+    <add key="serilog:using:File" value="Serilog.Sinks.File" />
     <add key="serilog:write-to:File.path" value="EventBuilder.log"/>
+    <add key="serilog:using:ColoredConsole" value="Serilog.Sinks.ColoredConsole" />
+    <add key="serilog:write-to:ColoredConsole.restrictedToMinimumLevel" value="Warning"/>
   </appSettings>
 </configuration>

--- a/src/EventBuilder/AutoPlatform.cs
+++ b/src/EventBuilder/AutoPlatform.cs
@@ -30,7 +30,7 @@
         /// <summary>
         /// Tizen platform.
         /// </summary>
-        Tizen,
+        Tizen4,
 
         /// <summary>
         /// WPF platform.

--- a/src/EventBuilder/Cecil/EventTemplateInformation.cs
+++ b/src/EventBuilder/Cecil/EventTemplateInformation.cs
@@ -4,10 +4,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using EventBuilder.Entities;
 using Mono.Cecil;
+using Serilog;
 
 namespace EventBuilder.Cecil
 {
@@ -127,10 +129,18 @@ namespace EventBuilder.Cecil
             return typeName;
         }
 
+        [SuppressMessage("Globalization", "CA1307: Specify StringComparison", Justification = "Replace overload is for .NET Standard only")]
         private static string GetEventArgsTypeForEvent(EventDefinition ei)
         {
             // Find the EventArgs type parameter of the event via digging around via reflection
             var type = ei.EventType.Resolve();
+
+            if (type == null)
+            {
+                Log.Debug($"Type for {ei.EventType} is not valid");
+                return null;
+            }
+
             var invoke = type.Methods.First(x => x.Name == "Invoke");
             if (invoke.Parameters.Count < 2)
             {

--- a/src/EventBuilder/Cecil/PathSearchAssemblyResolver.cs
+++ b/src/EventBuilder/Cecil/PathSearchAssemblyResolver.cs
@@ -51,7 +51,7 @@ namespace EventBuilder.Cecil
 
             // NB: This hacks WinRT's weird mscorlib to just use the regular one
             // We forget why this was needed, maybe it's not needed anymore?
-            if (fullName.Contains("mscorlib") && fullName.Contains("255"))
+            if (fullName.Contains("mscorlib", StringComparison.InvariantCulture) && fullName.Contains("255", StringComparison.InvariantCulture))
             {
                 fullPath =
                     Environment.ExpandEnvironmentVariables(
@@ -85,11 +85,9 @@ namespace EventBuilder.Cecil
             }
 
             // NB: This hacks WinRT's weird mscorlib to just use the regular one
-            if (fullName.Contains("mscorlib") && fullName.Contains("255"))
+            if (fullName.Contains("mscorlib", StringComparison.InvariantCulture) && fullName.Contains("255", StringComparison.InvariantCulture))
             {
-                fullPath =
-                    Environment.ExpandEnvironmentVariables(
-                        @"%SystemRoot%\Microsoft.NET\Framework\v4.0.30319\mscorlib.dll");
+                fullPath = Environment.ExpandEnvironmentVariables(@"%SystemRoot%\Microsoft.NET\Framework\v4.0.30319\mscorlib.dll");
             }
 
             if (fullPath == null)

--- a/src/EventBuilder/Cecil/SafeTypes.cs
+++ b/src/EventBuilder/Cecil/SafeTypes.cs
@@ -17,7 +17,6 @@ namespace EventBuilder.Cecil
         /// </summary>
         /// <param name="a">The assembly definition.</param>
         /// <returns>Type definitions from the assembly.</returns>
-        public static TypeDefinition[] GetSafeTypes(AssemblyDefinition a) =>
-            a.Modules.SelectMany(x => x.GetTypes()).ToArray();
+        public static TypeDefinition[] GetSafeTypes(AssemblyDefinition a) => a.Modules.SelectMany(x => x.GetTypes()).ToArray();
     }
 }

--- a/src/EventBuilder/Cecil/StaticEventTemplateInformation.cs
+++ b/src/EventBuilder/Cecil/StaticEventTemplateInformation.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using EventBuilder.Entities;
@@ -79,6 +80,7 @@ namespace EventBuilder.Cecil
             }
         }
 
+        [SuppressMessage("Globalization", "CA1307: Specify StringComparison", Justification = "Replace overload is for .NET Standard only")]
         private static string GetEventArgsTypeForEvent(EventDefinition ei)
         {
             // Find the EventArgs type parameter of the event via digging around via reflection
@@ -149,10 +151,7 @@ namespace EventBuilder.Cecil
             return
                 t.Events
 
-                    .Where(x =>
-                    {
-                        return x.AddMethod.IsPublic && GetEventArgsTypeForEvent(x) != null;
-                    })
+                    .Where(x => x.AddMethod.IsPublic && GetEventArgsTypeForEvent(x) != null)
                     .ToArray();
         }
     }

--- a/src/EventBuilder/CommandLineOptions.cs
+++ b/src/EventBuilder/CommandLineOptions.cs
@@ -14,16 +14,16 @@ namespace EventBuilder
     public class CommandLineOptions
     {
         /// <summary>
-        /// Gets or sets the last state of the parser.
-        /// </summary>
-        [ParserState]
-        public IParserState LastParserState { get; set; }
-
-        /// <summary>
         /// Gets or sets the platform.
         /// </summary>
         [Option('p', "platform", Required = true, HelpText = "Platform to automatically generate. Possible options include: NONE, ANDROID, IOS, WPF, MAC, TIZEN, UWP, XAMFORMS, WINFORMS, TVOS")]
         public AutoPlatform Platform { get; set; }
+
+        /// <summary>
+        /// Gets or sets the path where to output the contents.
+        /// </summary>
+        [Option('o', "output-path", Required = true, HelpText = "The file path where to output the contents.")]
+        public string OutputPath { get; set; }
 
         /// <summary>
         /// Gets or sets the template.
@@ -41,21 +41,9 @@ namespace EventBuilder
         /// Gets or sets the assemblies.
         /// Manual generation using the specified assemblies. Use with --platform=NONE.
         /// </summary>
-        [ValueList(typeof(List<string>))]
+        [Option('a', "assemblies", Required = false, HelpText = "List of assemblies to process. Used for the NONE option")]
 #pragma warning disable CA2227 // Collection properties should be read only
-        public List<string> Assemblies { get; set; }
+        public IEnumerable<string> Assemblies { get; set; }
 #pragma warning restore CA2227 // Collection properties should be read only
-
-        /// <summary>
-        /// Gets the usage.
-        /// </summary>
-        /// <returns>The help text usage.</returns>
-        [HelpOption]
-        public string GetUsage()
-        {
-            return HelpText.AutoBuild(
-                this,
-                current => HelpText.DefaultParsingErrorsHandler(this, current));
-        }
     }
 }

--- a/src/EventBuilder/EventBuilder.csproj
+++ b/src/EventBuilder/EventBuilder.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <AssemblyName>EventBuilder</AssemblyName>
     <RootNamespace>EventBuilder</RootNamespace>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
-  
   
   <ItemGroup>
     <Content Include="DefaultTemplate.mustache">
@@ -17,13 +17,16 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="1.9.71" />
-    <PackageReference Include="Microsoft.Web.Xdt" Version="2.1.2" />
+    <PackageReference Include="CommandLineParser" Version="2.3.0" />
     <PackageReference Include="Mono.Cecil" Version="0.10.1" />
-    <PackageReference Include="Nustache" Version="1.16.0.8" />
-    <PackageReference Include="Polly" Version="6.1.1" />
+    <PackageReference Include="Polly" Version="6.1.2" />
     <PackageReference Include="Serilog" Version="2.7.1" />
     <PackageReference Include="Serilog.Settings.AppSettings" Version="2.2.2" />
-    <PackageReference Include="NuGet.Core" Version="2.14.0" />
+    <PackageReference Include="serilog.sinks.coloredconsole" Version="3.0.1" />
+    <PackageReference Include="Serilog.Sinks.File" Version="4.0.0" />
+    <PackageReference Include="Stubble.Core" Version="1.2.7" />
+    <PackageReference Include="NuGet.Protocol" Version="4.9.2" />
+    <PackageReference Include="NuGet.Packaging" Version="4.9.2" />
+    <PackageReference Include="NuGet.PackageManagement.NetStandard" Version="4.9.2" />
   </ItemGroup>
 </Project>

--- a/src/EventBuilder/NuGet/NuGetLogger.cs
+++ b/src/EventBuilder/NuGet/NuGetLogger.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NuGet.Common;
+
+namespace EventBuilder.NuGet
+{
+    /// <summary>
+    /// A logger provider for the NuGet clients API.
+    /// </summary>
+    internal class NuGetLogger : ILogger
+    {
+        /// <inheritdoc />
+        public void Log(LogLevel level, string data)
+        {
+            switch (level)
+            {
+                case LogLevel.Warning:
+                    Serilog.Log.Warning(data);
+                    break;
+                case LogLevel.Error:
+                    Serilog.Log.Error(data);
+                    break;
+                case LogLevel.Information:
+                    Serilog.Log.Information(data);
+                    break;
+                case LogLevel.Debug:
+                    Serilog.Log.Debug(data);
+                    break;
+                default:
+                    Serilog.Log.Verbose(data);
+                    break;
+            }
+        }
+
+        /// <inheritdoc />
+        public void Log(ILogMessage message)
+        {
+            Log(message.Level, message.Message);
+        }
+
+        /// <inheritdoc />
+        public Task LogAsync(LogLevel level, string data)
+        {
+            Log(level, data);
+            return Task.CompletedTask;
+        }
+
+        /// <inheritdoc />
+        public Task LogAsync(ILogMessage message)
+        {
+            Log(message);
+            return Task.CompletedTask;
+        }
+
+        /// <inheritdoc />
+        public void LogDebug(string data)
+        {
+            Serilog.Log.Debug(data);
+        }
+
+        /// <inheritdoc />
+        public void LogError(string data)
+        {
+            Serilog.Log.Error(data);
+        }
+
+        /// <inheritdoc />
+        public void LogInformation(string data)
+        {
+            Serilog.Log.Information(data);
+        }
+
+        /// <inheritdoc />
+        public void LogInformationSummary(string data)
+        {
+            Serilog.Log.Information(data);
+        }
+
+        /// <inheritdoc />
+        public void LogMinimal(string data)
+        {
+            Serilog.Log.Information(data);
+        }
+
+        /// <inheritdoc />
+        public void LogVerbose(string data)
+        {
+            Serilog.Log.Verbose(data);
+        }
+
+        /// <inheritdoc />
+        public void LogWarning(string data)
+        {
+            Serilog.Log.Warning(data);
+        }
+    }
+}

--- a/src/EventBuilder/NuGet/NuGetPackageHelper.cs
+++ b/src/EventBuilder/NuGet/NuGetPackageHelper.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Configuration;
+using NuGet.Frameworks;
+using NuGet.PackageManagement;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+using NuGet.ProjectManagement;
+using NuGet.Protocol.Core.Types;
+using NuGet.Resolver;
+using Polly;
+using Serilog;
+
+namespace EventBuilder.NuGet
+{
+    /// <summary>
+    /// A helper class for handling NuGet packages.
+    /// </summary>
+    public static class NuGetPackageHelper
+    {
+        /// <summary>
+        /// Installs a nuget package into the specified directory.
+        /// </summary>
+        /// <param name="packageIdentities">The identities of the packages to find.</param>
+        /// <param name="platform">The name of the platform.</param>
+        /// <param name="framework">Optional framework parameter which will force NuGet to evaluate as the specified Framework. If null it will use .NET Standard 2.0.</param>
+        /// <returns>The directory where the NuGet packages are unzipped to.</returns>
+        public static async Task<string> InstallPackages(IEnumerable<PackageIdentity> packageIdentities, AutoPlatform platform, NuGetFramework framework = null)
+        {
+            var packageUnzipPath = Path.Combine(Path.GetTempPath(), "EventBuilder.NuGet", platform.ToString());
+            if (!Directory.Exists(packageUnzipPath))
+            {
+                Directory.CreateDirectory(packageUnzipPath);
+            }
+
+            await Task.WhenAll(packageIdentities.Select(x => InstallPackage(x, packageUnzipPath, framework))).ConfigureAwait(false);
+
+            return packageUnzipPath;
+        }
+
+        private static async Task InstallPackage(PackageIdentity packageIdentity, string packageRoot, NuGetFramework framework)
+        {
+            var packagesPath = Path.Combine(packageRoot, "packages");
+            var settings = Settings.LoadDefaultSettings(packageRoot, null, new XPlatMachineWideSetting());
+            var sourceRepositoryProvider = new SourceRepositoryProvider(settings);
+            var folder = new FolderNuGetProject(packageRoot, new PackagePathResolver(packageRoot), framework ?? FrameworkConstants.CommonFrameworks.NetStandard20);
+            var packageManager = new NuGetPackageManager(sourceRepositoryProvider, settings, packagesPath)
+            {
+                PackagesFolderNuGetProject = folder
+            };
+
+            var resolutionContext = new ResolutionContext(
+                DependencyBehavior.Lowest,
+                includePrelease: false,
+                includeUnlisted: false,
+                VersionConstraints.None);
+            var projectContext = new NuGetProjectContext(settings);
+
+            var retryPolicy = Policy
+                .Handle<Exception>()
+                .WaitAndRetryAsync(
+                    5,
+                    retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)),
+                    (exception, _, __) =>
+                    {
+                        Log.Warning(
+                            "An exception was thrown whilst retrieving or installing {0}: {1}",
+                            packageIdentity,
+                            exception);
+                    });
+
+            await retryPolicy.ExecuteAsync(async () =>
+            {
+                await packageManager.InstallPackageAsync(
+                    packageManager.PackagesFolderNuGetProject,
+                    packageIdentity,
+                    resolutionContext,
+                    projectContext,
+                    sourceRepositoryProvider.GetDefaultRepositories(),
+                    Array.Empty<SourceRepository>(),
+                    CancellationToken.None).ConfigureAwait(false);
+            }).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/EventBuilder/NuGet/NuGetProjectContext.cs
+++ b/src/EventBuilder/NuGet/NuGetProjectContext.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using NuGet.Configuration;
+using NuGet.Packaging;
+using NuGet.Packaging.Signing;
+using NuGet.ProjectManagement;
+
+namespace EventBuilder.NuGet
+{
+    /// <summary>
+    /// Context for handling logging inside the nuget project system.
+    /// </summary>
+    internal class NuGetProjectContext : INuGetProjectContext
+    {
+        public NuGetProjectContext(ISettings settings)
+        {
+            var nuGetLogger = new NuGetLogger();
+            PackageExtractionContext = new PackageExtractionContext(
+                PackageSaveMode.Files,
+                XmlDocFileSaveMode.None,
+                ClientPolicyContext.GetClientPolicy(settings, nuGetLogger),
+                nuGetLogger);
+        }
+
+        /// <inheritdoc />
+        public PackageExtractionContext PackageExtractionContext { get; set; }
+
+        /// <inheritdoc />
+        public XDocument OriginalPackagesConfig { get; set; }
+
+        /// <inheritdoc />
+        public NuGetActionType ActionType { get; set; }
+
+        /// <inheritdoc />
+        public Guid OperationId { get; set; }
+
+        /// <inheritdoc />
+        public ISourceControlManagerProvider SourceControlManagerProvider => null;
+
+        /// <inheritdoc />
+        public ExecutionContext ExecutionContext => null;
+
+        /// <inheritdoc />
+        public void Log(MessageLevel level, string message, params object[] args)
+        {
+            switch (level)
+            {
+                case MessageLevel.Warning:
+                    Serilog.Log.Warning(message, args);
+                    break;
+                case MessageLevel.Error:
+                    Serilog.Log.Error(message, args);
+                    break;
+                case MessageLevel.Info:
+                    Serilog.Log.Information(message, args);
+                    break;
+                case MessageLevel.Debug:
+                    Serilog.Log.Debug(message, args);
+                    break;
+                default:
+                    Serilog.Log.Verbose(message, args);
+                    break;
+            }
+        }
+
+        /// <inheritdoc />
+        public FileConflictAction ResolveFileConflict(string message) => FileConflictAction.Ignore;
+
+        /// <inheritdoc />
+        public void ReportError(string message)
+        {
+            Serilog.Log.Error(message);
+        }
+    }
+}

--- a/src/EventBuilder/NuGet/SourceRepositoryProvider.cs
+++ b/src/EventBuilder/NuGet/SourceRepositoryProvider.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NuGet.Configuration;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
+
+namespace EventBuilder.NuGet
+{
+    /// <summary>
+    /// Based off Dave Glick's articles here: https://daveaglick.com/posts/exploring-the-nuget-v3-libraries-part-3
+    /// Creates and caches SourceRepository objects, which are
+    /// the combination of PackageSource instances with a set
+    /// of supported resource providers. It also manages the set
+    /// of default source repositories.
+    /// </summary>
+    internal class SourceRepositoryProvider : ISourceRepositoryProvider
+    {
+        private static readonly string[] DefaultSources =
+        {
+            "https://api.nuget.org/v3/index.json"
+        };
+
+        private readonly List<SourceRepository> _defaultRepositories = new List<SourceRepository>();
+
+        private readonly ConcurrentDictionary<PackageSource, SourceRepository> _repositoryCache
+            = new ConcurrentDictionary<PackageSource, SourceRepository>();
+
+        private readonly List<Lazy<INuGetResourceProvider>> _resourceProviders;
+
+        public SourceRepositoryProvider(ISettings settings)
+        {
+            // Create the package source provider (needed primarily to get default sources)
+            PackageSourceProvider = new PackageSourceProvider(settings);
+
+            // Add the v3 provider as default
+            _resourceProviders = new List<Lazy<INuGetResourceProvider>>();
+            _resourceProviders.AddRange(Repository.Provider.GetCoreV3());
+
+            AddGlobalDefaults();
+            AddDefaultPackageSources();
+        }
+
+        /// <inheritdoc />
+        public IPackageSourceProvider PackageSourceProvider { get; }
+
+        /// <summary>
+        /// Add the global sources to the default repositories.
+        /// </summary>
+        public void AddGlobalDefaults()
+        {
+            _defaultRepositories.AddRange(PackageSourceProvider.LoadPackageSources()
+                .Where(x => x.IsEnabled)
+                .Select(x => new SourceRepository(x, _resourceProviders)));
+        }
+
+        public void AddDefaultPackageSources()
+        {
+            foreach (string defaultSource in DefaultSources)
+            {
+                AddDefaultRepository(defaultSource);
+            }
+        }
+
+        /// <summary>
+        /// Adds a default source repository to the front of the list.
+        /// </summary>
+        public void AddDefaultRepository(string packageSource) => _defaultRepositories.Insert(0, CreateRepository(packageSource));
+
+        public IEnumerable<SourceRepository> GetDefaultRepositories() => _defaultRepositories;
+
+        /// <summary>
+        /// Creates or gets a non-default source repository.
+        /// </summary>
+        public SourceRepository CreateRepository(string packageSource) => CreateRepository(new PackageSource(packageSource), FeedType.Undefined);
+
+        /// <summary>
+        /// Creates or gets a non-default source repository by PackageSource.
+        /// </summary>
+        public SourceRepository CreateRepository(PackageSource packageSource) => CreateRepository(packageSource, FeedType.Undefined);
+
+        /// <summary>
+        /// Creates or gets a non-default source repository by PackageSource.
+        /// </summary>
+        public SourceRepository CreateRepository(PackageSource packageSource, FeedType feedType) =>
+            _repositoryCache.GetOrAdd(packageSource, x => new SourceRepository(packageSource, _resourceProviders));
+
+        /// <summary>
+        /// Gets all cached repositories.
+        /// </summary>
+        public IEnumerable<SourceRepository> GetRepositories() => _repositoryCache.Values;
+    }
+}

--- a/src/EventBuilder/Platforms/Android.cs
+++ b/src/EventBuilder/Platforms/Android.cs
@@ -2,8 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace EventBuilder.Platforms
 {
@@ -14,11 +16,22 @@ namespace EventBuilder.Platforms
     /// <seealso cref="BasePlatform" />
     public class Android : BasePlatform
     {
+        private readonly string _referenceAssembliesLocation;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="Android" /> class.
         /// </summary>
         /// <param name="referenceAssembliesLocation">The reference assemblies location.</param>
         public Android(string referenceAssembliesLocation)
+        {
+            _referenceAssembliesLocation = referenceAssembliesLocation;
+        }
+
+        /// <inheritdoc />
+        public override AutoPlatform Platform => AutoPlatform.Android;
+
+        /// <inheritdoc />
+        public override Task Extract()
         {
             if (PlatformHelper.IsRunningOnMono())
             {
@@ -39,20 +52,19 @@ namespace EventBuilder.Platforms
             {
                 var assemblies =
                    Directory.GetFiles(
-                       Path.Combine(referenceAssembliesLocation, "MonoAndroid"),
+                       Path.Combine(_referenceAssembliesLocation, "MonoAndroid"),
                        "Mono.Android.dll",
                        SearchOption.AllDirectories);
 
                 // Pin to a particular framework version https://github.com/reactiveui/ReactiveUI/issues/1517
-                var latestVersion = assemblies.Last(x => x.Contains("v8.1"));
+                var latestVersion = assemblies.Last(x => x.Contains("v8.1", StringComparison.InvariantCulture));
                 Assemblies.Add(latestVersion);
 
                 CecilSearchDirectories.Add(Path.GetDirectoryName(latestVersion));
-                CecilSearchDirectories.Add(Path.Combine(referenceAssembliesLocation, "MonoAndroid", "v1.0"));
+                CecilSearchDirectories.Add(Path.Combine(_referenceAssembliesLocation, "MonoAndroid", "v1.0"));
             }
-        }
 
-        /// <inheritdoc />
-        public override AutoPlatform Platform => AutoPlatform.Android;
+            return Task.CompletedTask;
+        }
     }
 }

--- a/src/EventBuilder/Platforms/BasePlatform.cs
+++ b/src/EventBuilder/Platforms/BasePlatform.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace EventBuilder.Platforms
 {
@@ -29,5 +30,8 @@ namespace EventBuilder.Platforms
 
         /// <inheritdoc />
         public List<string> CecilSearchDirectories { get; }
+
+        /// <inheritdoc />
+        public abstract Task Extract();
     }
 }

--- a/src/EventBuilder/Platforms/Bespoke.cs
+++ b/src/EventBuilder/Platforms/Bespoke.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Threading.Tasks;
+
 namespace EventBuilder.Platforms
 {
     /// <inheritdoc />
@@ -13,5 +15,11 @@ namespace EventBuilder.Platforms
     {
         /// <inheritdoc />
         public override AutoPlatform Platform => AutoPlatform.None;
+
+        /// <inheritdoc />
+        public override Task Extract()
+        {
+            return Task.CompletedTask;
+        }
     }
 }

--- a/src/EventBuilder/Platforms/IPlatform.cs
+++ b/src/EventBuilder/Platforms/IPlatform.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace EventBuilder.Platforms
 {
@@ -26,5 +27,11 @@ namespace EventBuilder.Platforms
         /// Cecil when run on Mono needs some direction as to the location of the platform specific MSCORLIB.
         /// </summary>
         List<string> CecilSearchDirectories { get; }
+
+        /// <summary>
+        /// Extract details about the platform.
+        /// </summary>
+        /// <returns>A task to monitor the progress.</returns>
+        Task Extract();
     }
 }

--- a/src/EventBuilder/Platforms/Mac.cs
+++ b/src/EventBuilder/Platforms/Mac.cs
@@ -4,6 +4,7 @@
 
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace EventBuilder.Platforms
 {
@@ -14,11 +15,22 @@ namespace EventBuilder.Platforms
     // ReSharper disable once InconsistentNaming
     public class Mac : BasePlatform
     {
+        private readonly string _referenceAssembliesLocation;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="Mac"/> class.
         /// </summary>
         /// <param name="referenceAssembliesLocation">The reference assemblies location.</param>
         public Mac(string referenceAssembliesLocation)
+        {
+            _referenceAssembliesLocation = referenceAssembliesLocation;
+        }
+
+        /// <inheritdoc />
+        public override AutoPlatform Platform => AutoPlatform.Mac;
+
+        /// <inheritdoc />
+        public override Task Extract()
         {
             if (PlatformHelper.IsRunningOnMono())
             {
@@ -32,7 +44,7 @@ namespace EventBuilder.Platforms
             {
                 var assemblies =
                     Directory.GetFiles(
-                        Path.Combine(referenceAssembliesLocation, "Xamarin.Mac"),
+                        Path.Combine(_referenceAssembliesLocation, "Xamarin.Mac"),
                         "Xamarin.Mac.dll",
                         SearchOption.AllDirectories);
 
@@ -41,9 +53,8 @@ namespace EventBuilder.Platforms
 
                 CecilSearchDirectories.Add(Path.GetDirectoryName(latestVersion));
             }
-        }
 
-        /// <inheritdoc />
-        public override AutoPlatform Platform => AutoPlatform.Mac;
+            return Task.CompletedTask;
+        }
     }
 }

--- a/src/EventBuilder/Platforms/Tizen.cs
+++ b/src/EventBuilder/Platforms/Tizen.cs
@@ -2,11 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.IO;
-using System.Linq;
-using NuGet;
-using Polly;
+using System.Threading.Tasks;
+using EventBuilder.NuGet;
+using NuGet.Frameworks;
+using NuGet.Packaging.Core;
+using NuGet.Versioning;
 using Serilog;
 
 namespace EventBuilder.Platforms
@@ -17,53 +18,30 @@ namespace EventBuilder.Platforms
     /// <seealso cref="EventBuilder.Platforms.BasePlatform" />
     public class Tizen : BasePlatform
     {
-        private const string _packageName = "Tizen.NET";
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Tizen"/> class.
-        /// </summary>
-        public Tizen()
+        private readonly PackageIdentity[] _packageNames = new[]
         {
-            var packageUnzipPath = Environment.CurrentDirectory;
+            new PackageIdentity("Tizen.Net", new NuGetVersion("5.0.0.14562")),
+            new PackageIdentity("NetStandard.Library", new NuGetVersion("2.0.0")),
+        };
+
+        /// <inheritdoc />
+        public override AutoPlatform Platform => AutoPlatform.Tizen4;
+
+        /// <inheritdoc />
+        public async override Task Extract()
+        {
+            var packageUnzipPath = await NuGetPackageHelper.InstallPackages(_packageNames, Platform, FrameworkConstants.CommonFrameworks.Tizen4).ConfigureAwait(false);
 
             Log.Debug($"Package unzip path is {packageUnzipPath}");
 
-            var retryPolicy = Policy
-                .Handle<Exception>()
-                .WaitAndRetry(
-                    5,
-                    retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)),
-                    (exception, timeSpan, context) =>
-                    {
-                        Log.Warning(
-                            "An exception was thrown whilst retrieving or installing {0}: {1}",
-                            _packageName,
-                            exception);
-                    });
+            Assemblies.AddRange(Directory.GetFiles(packageUnzipPath, "ElmSharp*.dll", SearchOption.AllDirectories));
+            Assemblies.AddRange(Directory.GetFiles(packageUnzipPath, "Tizen*.dll", SearchOption.AllDirectories));
+            Assemblies.AddRange(Directory.GetFiles(packageUnzipPath, "netstandard.dll", SearchOption.AllDirectories));
 
-            retryPolicy.Execute(() =>
+            foreach (var directory in Directory.GetDirectories(packageUnzipPath, "*.*", SearchOption.AllDirectories))
             {
-                var repo = PackageRepositoryFactory.Default.CreateRepository("https://packages.nuget.org/api/v2");
-                var packageManager = new PackageManager(repo, packageUnzipPath);
-                var package = repo.FindPackagesById(_packageName).Single(x => x.Version.ToString() == "4.0.0");
-
-                Log.Debug("Using Tizen.NET {0} released on {1}", package.Version, package.Published);
-                Log.Debug("{0}", package.ReleaseNotes);
-
-                packageManager.InstallPackage(package, ignoreDependencies: true, allowPrereleaseVersions: false);
-            });
-
-            var elmSharp = Directory.GetFiles(packageUnzipPath, "ElmSharp*.dll", SearchOption.AllDirectories);
-            Assemblies.AddRange(elmSharp);
-
-            var tizenNet = Directory.GetFiles(packageUnzipPath, "Tizen*.dll", SearchOption.AllDirectories);
-            Assemblies.AddRange(tizenNet);
-
-            CecilSearchDirectories.Add($"{packageUnzipPath}\\Tizen.NET.4.0.0\\build\\tizen40\\ref");
-            CecilSearchDirectories.Add($"{packageUnzipPath}\\Tizen.NET.4.0.0\\lib\\netstandard2.0");
+                CecilSearchDirectories.Add(directory);
+            }
         }
-
-        /// <inheritdoc />
-        public override AutoPlatform Platform => AutoPlatform.Tizen;
     }
 }

--- a/src/EventBuilder/Platforms/UWP.cs
+++ b/src/EventBuilder/Platforms/UWP.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Threading.Tasks;
 
 namespace EventBuilder.Platforms
 {
@@ -12,11 +13,11 @@ namespace EventBuilder.Platforms
     /// <seealso cref="EventBuilder.Platforms.BasePlatform" />
     public class UWP : BasePlatform
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="UWP"/> class.
-        /// </summary>
-        /// <exception cref="NotSupportedException">Building events for UWP on Mac is not implemented yet.</exception>
-        public UWP()
+        /// <inheritdoc />
+        public override AutoPlatform Platform => AutoPlatform.UWP;
+
+        /// <inheritdoc />
+        public override Task Extract()
         {
             if (PlatformHelper.IsRunningOnMono())
             {
@@ -24,9 +25,8 @@ namespace EventBuilder.Platforms
             }
 
             Assemblies.Add(@"C:\Program Files (x86)\Windows Kits\10\UnionMetadata\10.0.16299.0\Windows.winmd");
-        }
 
-        /// <inheritdoc />
-        public override AutoPlatform Platform => AutoPlatform.UWP;
+            return Task.CompletedTask;
+        }
     }
 }

--- a/src/EventBuilder/Platforms/WPF.cs
+++ b/src/EventBuilder/Platforms/WPF.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Threading.Tasks;
 
 namespace EventBuilder.Platforms
 {
@@ -12,11 +13,12 @@ namespace EventBuilder.Platforms
     /// <seealso cref="EventBuilder.Platforms.BasePlatform" />
     public class WPF : BasePlatform
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="WPF"/> class.
-        /// </summary>
+        /// <inheritdoc />
+        public override AutoPlatform Platform => AutoPlatform.WPF;
+
+        /// <inheritdoc />
         /// <exception cref="NotSupportedException">Building events for WPF on Mac is not implemented.</exception>
-        public WPF()
+        public override Task Extract()
         {
             if (PlatformHelper.IsRunningOnMono())
             {
@@ -28,9 +30,8 @@ namespace EventBuilder.Platforms
             Assemblies.Add(@"C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.6.1\PresentationFramework.dll");
 
             CecilSearchDirectories.Add(@"C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.6.1");
-        }
 
-        /// <inheritdoc />
-        public override AutoPlatform Platform => AutoPlatform.WPF;
+            return Task.CompletedTask;
+        }
     }
 }

--- a/src/EventBuilder/Platforms/Winforms.cs
+++ b/src/EventBuilder/Platforms/Winforms.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Threading.Tasks;
 
 namespace EventBuilder.Platforms
 {
@@ -12,11 +13,12 @@ namespace EventBuilder.Platforms
     /// <seealso cref="EventBuilder.Platforms.BasePlatform" />
     public class Winforms : BasePlatform
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Winforms"/> class.
-        /// </summary>
+        /// <inheritdoc />
+        public override AutoPlatform Platform => AutoPlatform.Winforms;
+
+        /// <inheritdoc />
         /// <exception cref="NotSupportedException">Building events for Winforms on Mac is not implemented.</exception>
-        public Winforms()
+        public override Task Extract()
         {
             if (PlatformHelper.IsRunningOnMono())
             {
@@ -120,9 +122,8 @@ namespace EventBuilder.Platforms
             Assemblies.Add(@"C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.6.1\System.ServiceProcess.dll");
 
             CecilSearchDirectories.Add(@"C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.6.1");
-        }
 
-        /// <inheritdoc />
-        public override AutoPlatform Platform => AutoPlatform.Winforms;
+            return Task.CompletedTask;
+        }
     }
 }

--- a/src/EventBuilder/Platforms/iOS.cs
+++ b/src/EventBuilder/Platforms/iOS.cs
@@ -4,6 +4,7 @@
 
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace EventBuilder.Platforms
 {
@@ -19,11 +20,22 @@ namespace EventBuilder.Platforms
 #pragma warning restore SA1300 // Element should begin with upper-case letter
 #pragma warning restore IDE1006 // Naming Styles
     {
+        private readonly string _referenceAssembliesLocation;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="iOS"/> class.
         /// </summary>
         /// <param name="referenceAssembliesLocation">The reference assemblies location.</param>
         public iOS(string referenceAssembliesLocation)
+        {
+            _referenceAssembliesLocation = referenceAssembliesLocation;
+        }
+
+        /// <inheritdoc />
+        public override AutoPlatform Platform => AutoPlatform.iOS;
+
+        /// <inheritdoc />
+        public override Task Extract()
         {
             if (PlatformHelper.IsRunningOnMono())
             {
@@ -37,7 +49,7 @@ namespace EventBuilder.Platforms
             {
                 var assemblies =
                     Directory.GetFiles(
-                        Path.Combine(referenceAssembliesLocation, "Xamarin.iOS"),
+                        Path.Combine(_referenceAssembliesLocation, "Xamarin.iOS"),
                         "Xamarin.iOS.dll",
                         SearchOption.AllDirectories);
 
@@ -46,9 +58,8 @@ namespace EventBuilder.Platforms
 
                 CecilSearchDirectories.Add(Path.GetDirectoryName(latestVersion));
             }
-        }
 
-        /// <inheritdoc />
-        public override AutoPlatform Platform => AutoPlatform.iOS;
+            return Task.CompletedTask;
+        }
     }
 }

--- a/src/EventBuilder/Platforms/tvOS.cs
+++ b/src/EventBuilder/Platforms/tvOS.cs
@@ -4,6 +4,7 @@
 
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace EventBuilder.Platforms
 {
@@ -14,11 +15,22 @@ namespace EventBuilder.Platforms
     // ReSharper disable once InconsistentNaming
     public class TVOS : BasePlatform
     {
+        private readonly string _referenceAssembliesLocation;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="TVOS"/> class.
         /// </summary>
         /// <param name="referenceAssembliesLocation">The reference assemblies location.</param>
         public TVOS(string referenceAssembliesLocation)
+        {
+            _referenceAssembliesLocation = referenceAssembliesLocation;
+        }
+
+        /// <inheritdoc />
+        public override AutoPlatform Platform => AutoPlatform.TVOS;
+
+        /// <inheritdoc />
+        public override Task Extract()
         {
             if (PlatformHelper.IsRunningOnMono())
             {
@@ -32,7 +44,7 @@ namespace EventBuilder.Platforms
             {
                 var assemblies =
                     Directory.GetFiles(
-                        Path.Combine(referenceAssembliesLocation, "Xamarin.TVOS"),
+                        Path.Combine(_referenceAssembliesLocation, "Xamarin.TVOS"),
                         "Xamarin.TVOS.dll",
                         SearchOption.AllDirectories);
 
@@ -41,9 +53,8 @@ namespace EventBuilder.Platforms
 
                 CecilSearchDirectories.Add(Path.GetDirectoryName(latestVersion));
             }
-        }
 
-        /// <inheritdoc />
-        public override AutoPlatform Platform => AutoPlatform.TVOS;
+            return Task.CompletedTask;
+        }
     }
 }

--- a/src/EventBuilder/XamarinEssentialsTemplate.mustache
+++ b/src/EventBuilder/XamarinEssentialsTemplate.mustache
@@ -45,5 +45,3 @@ namespace {{Name}}
         }
         }
         {{/Namespaces}}
-
-#pragma warning restore 1591,0618,0105,0672

--- a/src/global.json
+++ b/src/global.json
@@ -1,5 +1,5 @@
 {
     "msbuild-sdks": {
-        "MSBuild.Sdk.Extras": "1.6.61"
+        "MSBuild.Sdk.Extras": "1.6.65"
     }
 }


### PR DESCRIPTION
- Now supports Tizen 4 types, separated into Tizen 4 so we can support Tizen 5 in the future.
- NuGet is updated with the latest framework
- MsBuild.Sdk.Extras is updated, allowing the latest Tizen NugetPackages