### PR TITLE
Fix: Android ShouldPersistState fires twice

### DIFF
--- a/src/ReactiveUI/Platforms/android/AutoSuspendHelper.cs
+++ b/src/ReactiveUI/Platforms/android/AutoSuspendHelper.cs
@@ -49,10 +49,7 @@ namespace ReactiveUI
             RxApp.SuspensionHost.IsLaunchingNew = _onCreate.Where(x => x == null).Select(_ => Unit.Default);
             RxApp.SuspensionHost.IsResuming = _onCreate.Where(x => x != null).Select(_ => Unit.Default);
             RxApp.SuspensionHost.IsUnpausing = _onRestart;
-
-            RxApp.SuspensionHost.ShouldPersistState = Observable.Merge(
-                                                                       _onPause.Select(_ => Disposable.Empty), _onSaveInstanceState.Select(_ => Disposable.Empty));
-
+            RxApp.SuspensionHost.ShouldPersistState = _onPause.Select(_ => Disposable.Empty);
             RxApp.SuspensionHost.ShouldInvalidateState = UntimelyDemise;
         }
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
closes #1865, closes #991


**What is the current behavior? (You can also link to an open issue here)**
ShouldPersistState fires twice upon sending the app to the background.


**What is the new behavior (if this is a feature change)?**
Won't fire multiple times.


**What might this PR break?**
Nothing


**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
Android documentation strongly recommends saving persistent data in OnPause rather than OnSaveInstanceState. OnPause is invoked every time OnSaveInstanceState is (hence the duplicate ShouldPersistState emission), but not the other way around. Plus, OnSaveInstanceState is meant for [saving **transient UI** state](https://developer.android.com/guide/components/activities/activity-lifecycle#saras), e.g. saving a search query that the user entered in a text box.
