### PR TITLE
housekeeping: Correct ReactiveUserControl xml docs

### DIFF
--- a/src/ReactiveUI/Platforms/windows-common/ReactiveUserControl.cs
+++ b/src/ReactiveUI/Platforms/windows-common/ReactiveUserControl.cs
@@ -26,11 +26,15 @@ namespace ReactiveUI
     /// <code>
     /// <![CDATA[
     /// <rxui:ReactiveUserControl
-    ///         x:Class="views:YourView"
+    ///         x:Class="Foo.Bar.Views.YourView"
     ///         x:TypeArguments="vms:YourViewModel"
     ///         xmlns:rxui="http://reactiveui.net"
-    ///         xmlns:views="clr-namespace:Foo.Bar.Views"
-    ///         xmlns:vms="clr-namespace:Foo.Bar.ViewModels">
+    ///         xmlns:vms="clr-namespace:Foo.Bar.ViewModels"
+    ///         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    ///         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    ///         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    ///         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    ///         mc:Ignorable="d">
     ///     <!-- view XAML here -->
     /// </rxui:ReactiveUserControl>
     /// ]]>
@@ -54,10 +58,14 @@ namespace ReactiveUI
     /// <code>
     /// <![CDATA[
     /// <views:YourViewBase
-    ///         x:Class="views:YourView"
+    ///         x:Class="Foo.Bar.Views.YourView"
     ///         xmlns:rxui="http://reactiveui.net"
-    ///         xmlns:views="clr-namespace:Foo.Bar.Views"
-    ///         xmlns:vms="clr-namespace:Foo.Bar.ViewModels">
+    ///         xmlns:vms="clr-namespace:Foo.Bar.ViewModels"
+    ///         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    ///         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    ///         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    ///         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    ///         mc:Ignorable="d">
     ///     <!-- view XAML here -->
     /// </views:YourViewBase>
     /// ]]>


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

This PR fixes two documentation issues, see https://github.com/reactiveui/website/issues/122 and https://github.com/reactiveui/website/issues/127

**What is the current behavior? (You can also link to an open issue here)**

`ReactiveUserControl<TViewModel>` xml-doc describing it's usage is wrong, there are missing XAML directives `xmlns` and `xmlns:x`, also `x:Class` syntax is wrong, if someone would copy-paste that snippet, their project won't compile.

**What is the new behavior (if this is a feature change)?**

Missing directives are added, alongside with `xmlns:mc` and `xmlns:d` as they are also common.

**What might this PR break?**

Nothing.