### PR TITLE
housekeeping: Mention ReactiveUI packages required for Tizen

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Install the following packages to start building your own ReactiveUI app. <b>Not
 | Xamarin.Android   | [ReactiveUI.AndroidSupport][DroDoc] | [![DroBadge]][Dro]   | [ReactiveUI.Events][CoreEvents]         |
 | Xamarin.iOS       | [ReactiveUI][IosDoc]                | [![CoreBadge]][Core] | [ReactiveUI.Events][CoreEvents]         |
 | Xamarin.Mac       | [ReactiveUI][MacDoc]                | [![CoreBadge]][Core] | [ReactiveUI.Events][CoreEvents]         |
+| Tizen             | [ReactiveUI][CoreDoc]               | [![CoreBadge]][Core] | [ReactiveUI.Events][CoreEvents]         |
 | Avalonia          | [Avalonia.ReactiveUI][AvaDoc]       | [![AvaBadge]][Ava]   | None                                    |
 
 [Core]: https://www.nuget.org/packages/ReactiveUI/


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

README.md file was updated with info about ReactiveUI packages for Tizen platform.

**What is the current behavior? (You can also link to an open issue here)**

There is no info in README.md about which packages Tizen devs should install.

**What is the new behavior (if this is a feature change)?**

Info about which packages Tizen devs should install (`ReactiveUI` and `ReactiveUI.Events`) has been added.
