### PR TITLE
housekeeping: Upgraded Cake to v0.32.1

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -22,7 +22,6 @@
 // TOOLS
 //////////////////////////////////////////////////////////////////////
 
-#tool "nuget:?package=GitReleaseManager&version=0.7.1"
 #tool "nuget:?package=OpenCover&version=4.6.519"
 #tool "nuget:?package=ReportGenerator&version=4.0.4"
 #tool "nuget:?package=vswhere&version=2.5.2"

--- a/build.sh
+++ b/build.sh
@@ -97,5 +97,6 @@ fi
 if $SHOW_VERSION; then
     exec mono "$CAKE_EXE" -version
 else
+    exec mono "$CAKE_EXE" --bootstrap
     exec mono "$CAKE_EXE" $SCRIPT -verbosity=$VERBOSITY -configuration=$CONFIGURATION -target=$TARGET $DRYRUN "${SCRIPT_ARGUMENTS[@]}"
 fi


### PR DESCRIPTION
- Fixed build.sh to bootstrap for modules
- Removed GitReleaseManager tool preprocessor

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Moving build to current Cake version.


**What is the current behavior? (You can also link to an open issue here)**
Cake is running version 0.31.0


**What is the new behavior (if this is a feature change)?**

Cake runs version 0.32.1

**What might this PR break?**
The build.,


**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

