### PR TITLE
housekeeping: Correct ReactiveWindow usage example

### DIFF
--- a/src/ReactiveUI.Wpf/ReactiveWindow.cs
+++ b/src/ReactiveUI.Wpf/ReactiveWindow.cs
@@ -20,11 +20,15 @@ namespace ReactiveUI
     /// <code>
     /// <![CDATA[
     /// <rxui:ReactiveWindow
-    ///         x:Class="views:YourView"
+    ///         x:Class="Foo.Bar.Views.YourView"
     ///         x:TypeArguments="vms:YourViewModel"
     ///         xmlns:rxui="http://reactiveui.net"
-    ///         xmlns:views="clr-namespace:Foo.Bar.Views"
-    ///         xmlns:vms="clr-namespace:Foo.Bar.ViewModels">
+    ///         xmlns:vms="clr-namespace:Foo.Bar.ViewModels"
+    ///         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    ///         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    ///         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    ///         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    ///         mc:Ignorable="d">
     ///     <!-- view XAML here -->
     /// </rxui:ReactiveWindow>
     /// ]]>


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

This is documentation improvement. Related to https://github.com/reactiveui/ReactiveUI/pull/1888

**What is the current behavior? (You can also link to an open issue here)**

When bootstrapping a new WPF project with ReactiveUI, I copy-pasted XAML markup snippet from [API docs](https://reactiveui.net/api/reactiveui/reactivewindow_1/) page and it didn't compile due to missing xmlns directives and wrong `x:Class` syntax.

**What is the new behavior (if this is a feature change)?**

Now, the sample compiles, and uses correct syntax and correct `xmlns` directives.

**What might this PR break?**

Nothing.
