### PR TITLE
fix: Combobox not updating when using Bind() generated ViewModelViewHost

### DIFF
--- a/src/ReactiveUI.Tests/Platforms/xaml/ActivationForViewFetcherTest.cs
+++ b/src/ReactiveUI.Tests/Platforms/xaml/ActivationForViewFetcherTest.cs
@@ -59,12 +59,12 @@ namespace ReactiveUI.Tests
 
             uc.RaiseEvent(loaded);
 
-            // IsHitTestVisible still false
-            Array.Empty<bool>().AssertAreEqual(activated);
+            // Loaded has happened.
+            new[] { true }.AssertAreEqual(activated);
 
             uc.IsHitTestVisible = true;
 
-            // IsHitTestVisible true
+            // IsHitTestVisible true, we don't want the event to repeat unnecessarily.
             new[] { true }.AssertAreEqual(activated);
 
             var unloaded = new RoutedEventArgs();
@@ -72,6 +72,7 @@ namespace ReactiveUI.Tests
 
             uc.RaiseEvent(unloaded);
 
+            // We had both a loaded/hit test visible change/unloaded happen.
             new[] { true, false }.AssertAreEqual(activated);
         }
 

--- a/src/ReactiveUI.Wpf/TransitioningContentControl.cs
+++ b/src/ReactiveUI.Wpf/TransitioningContentControl.cs
@@ -250,20 +250,12 @@ namespace ReactiveUI
         {
             AbortTransition();
 
-            var handler = TransitionCompleted;
-            if (handler != null)
-            {
-                handler(this, new RoutedEventArgs());
-            }
+            TransitionCompleted?.Invoke(this, new RoutedEventArgs());
         }
 
         private void RaiseTransitionStarted()
         {
-            var handler = TransitionStarted;
-            if (handler != null)
-            {
-                handler(this, new RoutedEventArgs());
-            }
+            TransitionStarted?.Invoke(this, new RoutedEventArgs());
         }
 
         private void QueueTransition(object oldContent, object newContent)
@@ -282,8 +274,7 @@ namespace ReactiveUI
                     {
                         // Wire up the completion transition.
                         var transitionInName = Transition + "Transition_" + TransitionPartType.In;
-                        var transitionIn = GetTransitionStoryboardByName(transitionInName);
-                        CompletingTransition = transitionIn;
+                        CompletingTransition = GetTransitionStoryboardByName(transitionInName);
 
                         // Wire up the first transition to start the second transition when it's complete.
                         startingTransitionName = Transition + "Transition_" + TransitionPartType.Out;
@@ -294,8 +285,7 @@ namespace ReactiveUI
                     else
                     {
                         startingTransitionName = Transition + "Transition_" + TransitionPart;
-                        var transitionIn = GetTransitionStoryboardByName(startingTransitionName);
-                        CompletingTransition = transitionIn;
+                        CompletingTransition = GetTransitionStoryboardByName(startingTransitionName);
                     }
 
                     // Start the transition.

--- a/src/ReactiveUI/Platforms/windows-common/ActivationForViewFetcher.cs
+++ b/src/ReactiveUI/Platforms/windows-common/ActivationForViewFetcher.cs
@@ -40,21 +40,28 @@ namespace ReactiveUI
 #if WINDOWS_UWP
             var viewLoaded = WindowsObservable.FromEventPattern<FrameworkElement, object>(
                 x => fe.Loading += x,
-                x => fe.Loading -= x).Select(_ => true);
+                x => fe.Loading -= x)
+                .Select(_ => true);
 #else
             var viewLoaded = Observable.FromEventPattern<RoutedEventHandler, RoutedEventArgs>(
                 x => fe.Loaded += x,
-                x => fe.Loaded -= x).Select(_ => true);
+                x => fe.Loaded -= x)
+                .Select(_ => true);
 #endif
 
             var viewUnloaded = Observable.FromEventPattern<RoutedEventHandler, RoutedEventArgs>(
                 x => fe.Unloaded += x,
-                x => fe.Unloaded -= x).Select(_ => false);
+                x => fe.Unloaded -= x)
+                .Select(_ => false);
+
+            var hitTestVisible = Observable.FromEventPattern<DependencyPropertyChangedEventHandler, DependencyPropertyChangedEventArgs>(
+                x => fe.IsHitTestVisibleChanged += x,
+                x => fe.IsHitTestVisibleChanged -= x)
+                .Select(x => (bool)x.EventArgs.NewValue);
 
             return viewLoaded
                 .Merge(viewUnloaded)
-                .Select(b => b ? fe.WhenAnyValue(x => x.IsHitTestVisible).SkipWhile(x => !x) : Observables.False)
-                .Switch()
+                .Merge(hitTestVisible)
                 .DistinctUntilChanged();
         }
     }

--- a/src/ReactiveUI/Platforms/windows-common/ActivationForViewFetcher.cs
+++ b/src/ReactiveUI/Platforms/windows-common/ActivationForViewFetcher.cs
@@ -42,22 +42,24 @@ namespace ReactiveUI
                 x => fe.Loading += x,
                 x => fe.Loading -= x)
                 .Select(_ => true);
+
+            var hitTestVisible = fe.WhenAnyValue(x => x.IsHitTestVisible);
 #else
             var viewLoaded = Observable.FromEventPattern<RoutedEventHandler, RoutedEventArgs>(
                 x => fe.Loaded += x,
                 x => fe.Loaded -= x)
                 .Select(_ => true);
+
+             var hitTestVisible = Observable.FromEventPattern<DependencyPropertyChangedEventHandler, DependencyPropertyChangedEventArgs>(
+                x => fe.IsHitTestVisibleChanged += x,
+                x => fe.IsHitTestVisibleChanged -= x)
+                .Select(x => (bool)x.EventArgs.NewValue);
 #endif
 
             var viewUnloaded = Observable.FromEventPattern<RoutedEventHandler, RoutedEventArgs>(
                 x => fe.Unloaded += x,
                 x => fe.Unloaded -= x)
                 .Select(_ => false);
-
-            var hitTestVisible = Observable.FromEventPattern<DependencyPropertyChangedEventHandler, DependencyPropertyChangedEventArgs>(
-                x => fe.IsHitTestVisibleChanged += x,
-                x => fe.IsHitTestVisibleChanged -= x)
-                .Select(x => (bool)x.EventArgs.NewValue);
 
             return viewLoaded
                 .Merge(viewUnloaded)

--- a/src/ReactiveUI/Platforms/windows-common/ActivationForViewFetcher.cs
+++ b/src/ReactiveUI/Platforms/windows-common/ActivationForViewFetcher.cs
@@ -50,7 +50,7 @@ namespace ReactiveUI
                 x => fe.Loaded -= x)
                 .Select(_ => true);
 
-             var hitTestVisible = Observable.FromEventPattern<DependencyPropertyChangedEventHandler, DependencyPropertyChangedEventArgs>(
+            var hitTestVisible = Observable.FromEventPattern<DependencyPropertyChangedEventHandler, DependencyPropertyChangedEventArgs>(
                 x => fe.IsHitTestVisibleChanged += x,
                 x => fe.IsHitTestVisibleChanged -= x)
                 .Select(x => (bool)x.EventArgs.NewValue);

--- a/src/ReactiveUI/Platforms/windows-common/AutoDataTemplateBindingHook.cs
+++ b/src/ReactiveUI/Platforms/windows-common/AutoDataTemplateBindingHook.cs
@@ -38,7 +38,7 @@ namespace ReactiveUI
 #else
             const string template = "<DataTemplate xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation' " +
                      "xmlns:xaml='clr-namespace:ReactiveUI;assembly=__ASSEMBLYNAME__'> " +
-                 "<xaml:ViewModelViewHost ViewModel=\"{Binding}\" VerticalContentAlignment=\"Stretch\" HorizontalContentAlignment=\"Stretch\" IsTabStop=\"False\" />" +
+                 "<xaml:ViewModelViewHost ViewModel=\"{Binding Mode=OneWay}\" VerticalContentAlignment=\"Stretch\" HorizontalContentAlignment=\"Stretch\" IsTabStop=\"False\" />" +
              "</DataTemplate>";
 
             var assemblyName = typeof(AutoDataTemplateBindingHook).Assembly.FullName;

--- a/src/ReactiveUI/Platforms/windows-common/ViewModelViewHost.cs
+++ b/src/ReactiveUI/Platforms/windows-common/ViewModelViewHost.cs
@@ -37,7 +37,7 @@ namespace ReactiveUI
         /// The view model dependency property.
         /// </summary>
         public static readonly DependencyProperty ViewModelProperty =
-            DependencyProperty.Register("ViewModel", typeof(object), typeof(ViewModelViewHost), new PropertyMetadata(null, SomethingChanged));
+            DependencyProperty.Register(nameof(ViewModel), typeof(object), typeof(ViewModelViewHost), new PropertyMetadata(null, SomethingChanged));
 
         /// <summary>
         /// The view contract observable dependency property.

--- a/src/ReactiveUI/Platforms/windows-common/ViewModelViewHost.cs
+++ b/src/ReactiveUI/Platforms/windows-common/ViewModelViewHost.cs
@@ -43,7 +43,7 @@ namespace ReactiveUI
         /// The view contract observable dependency property.
         /// </summary>
         public static readonly DependencyProperty ViewContractObservableProperty =
-            DependencyProperty.Register("ViewContractObservable", typeof(IObservable<string>), typeof(ViewModelViewHost), new PropertyMetadata(Observable<string>.Default, SomethingChanged));
+            DependencyProperty.Register(nameof(ViewContractObservable), typeof(IObservable<string>), typeof(ViewModelViewHost), new PropertyMetadata(Observable<string>.Default, SomethingChanged));
 
         private readonly Subject<Unit> _updateViewModel = new Subject<Unit>();
         private string _viewContract;

--- a/src/ReactiveUI/Platforms/windows-common/ViewModelViewHost.cs
+++ b/src/ReactiveUI/Platforms/windows-common/ViewModelViewHost.cs
@@ -58,10 +58,10 @@ namespace ReactiveUI
             DefaultStyleKey = typeof(ViewModelViewHost);
 #endif
 
-            // NB: InUnitTestRunner also returns true in Design Mode
             if (ModeDetector.InUnitTestRunner())
             {
                 ViewContractObservable = Observable<string>.Never;
+                // NB: InUnitTestRunner also returns true in Design Mode
                 return;
             }
 

--- a/src/ReactiveUI/Platforms/windows-common/ViewModelViewHost.cs
+++ b/src/ReactiveUI/Platforms/windows-common/ViewModelViewHost.cs
@@ -61,6 +61,7 @@ namespace ReactiveUI
             if (ModeDetector.InUnitTestRunner())
             {
                 ViewContractObservable = Observable<string>.Never;
+
                 // NB: InUnitTestRunner also returns true in Design Mode
                 return;
             }

--- a/src/ReactiveUI/Platforms/windows-common/ViewModelViewHost.cs
+++ b/src/ReactiveUI/Platforms/windows-common/ViewModelViewHost.cs
@@ -31,7 +31,7 @@ namespace ReactiveUI
         /// The default content dependency property.
         /// </summary>
         public static readonly DependencyProperty DefaultContentProperty =
-            DependencyProperty.Register("DefaultContent", typeof(object), typeof(ViewModelViewHost), new PropertyMetadata(null));
+            DependencyProperty.Register(nameof(DefaultContent), typeof(object), typeof(ViewModelViewHost), new PropertyMetadata(null));
 
         /// <summary>
         /// The view model dependency property.

--- a/src/ReactiveUI/Platforms/windows-common/ViewModelViewHost.cs
+++ b/src/ReactiveUI/Platforms/windows-common/ViewModelViewHost.cs
@@ -31,7 +31,7 @@ namespace ReactiveUI
         /// The default content dependency property.
         /// </summary>
         public static readonly DependencyProperty DefaultContentProperty =
-            DependencyProperty.Register("DefaultContent", typeof(UIElement), typeof(ViewModelViewHost), new PropertyMetadata(null));
+            DependencyProperty.Register("DefaultContent", typeof(object), typeof(ViewModelViewHost), new PropertyMetadata(null));
 
         /// <summary>
         /// The view model dependency property.
@@ -106,9 +106,9 @@ namespace ReactiveUI
         /// <summary>
         /// Gets or sets the content displayed by default when no content is set.
         /// </summary>
-        public UIElement DefaultContent
+        public object DefaultContent
         {
-            get => (UIElement)GetValue(DefaultContentProperty);
+            get => GetValue(DefaultContentProperty);
             set => SetValue(DefaultContentProperty, value);
         }
 
@@ -171,7 +171,6 @@ namespace ReactiveUI
             if (viewModel == null)
             {
                 Content = DefaultContent;
-
                 return;
             }
 
@@ -185,9 +184,7 @@ namespace ReactiveUI
 
             viewInstance.ViewModel = viewModel;
 
-            var view = viewInstance as UIElement;
-
-            Content = view ?? throw new Exception($"The view found for {viewModel.GetType()} is not a valid {nameof(UIElement)}.");
+            Content = viewInstance;
         }
     }
 }

--- a/src/ReactiveUI/Platforms/windows-common/ViewModelViewHost.cs
+++ b/src/ReactiveUI/Platforms/windows-common/ViewModelViewHost.cs
@@ -57,6 +57,7 @@ namespace ReactiveUI
 #if NETFX_CORE
             DefaultStyleKey = typeof(ViewModelViewHost);
 #endif
+
             // NB: InUnitTestRunner also returns true in Design Mode
             if (ModeDetector.InUnitTestRunner())
             {

--- a/src/ReactiveUI/View/DefaultViewLocator.cs
+++ b/src/ReactiveUI/View/DefaultViewLocator.cs
@@ -132,15 +132,13 @@ namespace ReactiveUI
                 if (viewModelType.Name.StartsWith("I", StringComparison.InvariantCulture))
                 {
                     var toggledTypeName = DeinterfaceifyTypeName(viewModelTypeName);
-                    var toggledType = Reflection.ReallyFindType(toggledTypeName, throwOnFailure: false);
-                    return toggledType;
+                    return Reflection.ReallyFindType(toggledTypeName, throwOnFailure: false);
                 }
             }
             else
             {
                 var toggledTypeName = InterfaceifyTypeName(viewModelTypeName);
-                var toggledType = Reflection.ReallyFindType(toggledTypeName, throwOnFailure: false);
-                return toggledType;
+                return Reflection.ReallyFindType(toggledTypeName, throwOnFailure: false);
             }
 
             return null;
@@ -214,6 +212,8 @@ namespace ReactiveUI
                     this.Log().Debug("Resolve service type '{0}' does not implement '{1}'.", viewType.FullName, typeof(IViewFor).FullName);
                     return null;
                 }
+
+                this.Log().Debug("Resolved service type '{0}'", viewType.FullName);
 
                 return view;
             }


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
This fixes #1905 -- where a combobox does not correctly update in WPF if the combobox item is selected.

**What is the current behavior? (You can also link to an open issue here)**

The boxes remain empty.

**What is the new behavior (if this is a feature change)?**
Due to the fact Combobox item's are cloned when they become the main view item, WhenActivated events wouldn't be fired correctly. Now also include "IsHitTestEnabled" in the list of included events we monitor.

Also changed so the ViewModelViewHost doesn't rely on the RxUI binding which can potentially give some performance boosts but also might reduce memory leak potential.

**What might this PR break?**
Hopefully nothing. 
