### PR TITLE
fix: Fix when a combobox SelectedIndex -1 it would crash

### DIFF
--- a/src/ReactiveUI/Platforms/windows-common/ViewModelViewHost.cs
+++ b/src/ReactiveUI/Platforms/windows-common/ViewModelViewHost.cs
@@ -181,7 +181,9 @@ namespace ReactiveUI
 
             if (viewInstance == null)
             {
-                throw new Exception($"The {nameof(ViewModelViewHost)} could not find a valid view for the view model of type {viewModel.GetType()} and value {viewModel}.");
+                Content = DefaultContent;
+                this.Log().Warn($"The {nameof(ViewModelViewHost)} could not find a valid view for the view model of type {viewModel.GetType()} and value {viewModel}.");
+                return;
             }
 
             viewInstance.ViewModel = viewModel;


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
fixes #1920 

**What is the current behavior? (You can also link to an open issue here)**
When a combobox is set to -1, it would previously cause a exception, 

**What is the new behavior (if this is a feature change)?**
will now just give a warning and set to default content.
