### PR TITLE
fix: Fix UWP activating too soon

### DIFF
--- a/src/ReactiveUI.Wpf/ActivationForViewFetcher.cs
+++ b/src/ReactiveUI.Wpf/ActivationForViewFetcher.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reflection;
+using System.Windows;
+
+namespace ReactiveUI
+{
+    /// <summary>
+    /// ActiveationForViewFetcher is how ReactiveUI determine when a
+    /// View is activated or deactivated. This is usually only used when porting
+    /// ReactiveUI to a new UI framework.
+    /// </summary>
+    public class ActivationForViewFetcher : IActivationForViewFetcher
+    {
+        /// <inheritdoc/>
+        public int GetAffinityForView(Type view)
+        {
+            return typeof(FrameworkElement).GetTypeInfo().IsAssignableFrom(view.GetTypeInfo()) ? 10 : 0;
+        }
+
+        /// <inheritdoc/>
+        public IObservable<bool> GetActivationForView(IActivatable view)
+        {
+            var fe = view as FrameworkElement;
+
+            if (fe == null)
+            {
+                return Observable<bool>.Empty;
+            }
+
+            var viewLoaded = Observable.FromEventPattern<RoutedEventHandler, RoutedEventArgs>(
+                x => fe.Loaded += x,
+                x => fe.Loaded -= x)
+                .Select(_ => true);
+
+            var hitTestVisible = Observable.FromEventPattern<DependencyPropertyChangedEventHandler, DependencyPropertyChangedEventArgs>(
+                x => fe.IsHitTestVisibleChanged += x,
+                x => fe.IsHitTestVisibleChanged -= x)
+                .Select(x => (bool)x.EventArgs.NewValue);
+
+            var viewUnloaded = Observable.FromEventPattern<RoutedEventHandler, RoutedEventArgs>(
+                x => fe.Unloaded += x,
+                x => fe.Unloaded -= x)
+                .Select(_ => false);
+
+            return viewLoaded
+                .Merge(viewUnloaded)
+                .Merge(hitTestVisible)
+                .DistinctUntilChanged();
+        }
+    }
+}

--- a/src/ReactiveUI/Platforms/uap10.0.16299/ActivationForViewFetcher.cs
+++ b/src/ReactiveUI/Platforms/uap10.0.16299/ActivationForViewFetcher.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
@@ -9,9 +9,7 @@ using System.Reactive.Linq;
 using System.Reflection;
 using System.Windows;
 
-#if NETFX_CORE
 using Windows.UI.Xaml;
-#endif
 
 namespace ReactiveUI
 {
@@ -37,33 +35,19 @@ namespace ReactiveUI
             {
                 return Observable<bool>.Empty;
             }
-#if WINDOWS_UWP
+
             var viewLoaded = WindowsObservable.FromEventPattern<FrameworkElement, object>(
                 x => fe.Loading += x,
-                x => fe.Loading -= x)
-                .Select(_ => true);
-
-            var hitTestVisible = fe.WhenAnyValue(x => x.IsHitTestVisible);
-#else
-            var viewLoaded = Observable.FromEventPattern<RoutedEventHandler, RoutedEventArgs>(
-                x => fe.Loaded += x,
-                x => fe.Loaded -= x)
-                .Select(_ => true);
-
-            var hitTestVisible = Observable.FromEventPattern<DependencyPropertyChangedEventHandler, DependencyPropertyChangedEventArgs>(
-                x => fe.IsHitTestVisibleChanged += x,
-                x => fe.IsHitTestVisibleChanged -= x)
-                .Select(x => (bool)x.EventArgs.NewValue);
-#endif
+                x => fe.Loading -= x).Select(_ => true);
 
             var viewUnloaded = Observable.FromEventPattern<RoutedEventHandler, RoutedEventArgs>(
                 x => fe.Unloaded += x,
-                x => fe.Unloaded -= x)
-                .Select(_ => false);
+                x => fe.Unloaded -= x).Select(_ => false);
 
             return viewLoaded
                 .Merge(viewUnloaded)
-                .Merge(hitTestVisible)
+                .Select(b => b ? fe.WhenAnyValue(x => x.IsHitTestVisible).SkipWhile(x => !x) : Observables.False)
+                .Switch()
                 .DistinctUntilChanged();
         }
     }


### PR DESCRIPTION
UWP had special  logic where it would use loading instead of Load for performance reasons, and then wait for IsHitTestVisible. This would cause problems with certain use cases in WPF.

Now splitting the two ActivationForViewFetcher class into their own classes with the required logic.

This fixes #1928 