### PR TITLE
fix: Memory usage of OAPH and ReactiveObject

### DIFF
--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.net461.approved.txt
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.net461.approved.txt
@@ -277,11 +277,11 @@ namespace ReactiveUI
     }
     public class static IReactiveObjectExtensions
     {
-        public static TRet RaiseAndSetIfChanged<TObj, TRet>(this TObj @this, ref TRet backingField, TRet newValue, [System.Runtime.CompilerServices.CallerMemberNameAttribute()] string propertyName = null)
+        public static TRet RaiseAndSetIfChanged<TObj, TRet>(this TObj reactiveObject, ref TRet backingField, TRet newValue, [System.Runtime.CompilerServices.CallerMemberNameAttribute()] string propertyName = null)
             where TObj : ReactiveUI.IReactiveObject { }
-        public static void RaisePropertyChanged<TSender>(this TSender @this, [System.Runtime.CompilerServices.CallerMemberNameAttribute()] string propertyName = null)
+        public static void RaisePropertyChanged<TSender>(this TSender reactiveObject, [System.Runtime.CompilerServices.CallerMemberNameAttribute()] string propertyName = null)
             where TSender : ReactiveUI.IReactiveObject { }
-        public static void RaisePropertyChanging<TSender>(this TSender @this, [System.Runtime.CompilerServices.CallerMemberNameAttribute()] string propertyName = null)
+        public static void RaisePropertyChanging<TSender>(this TSender reactiveObject, [System.Runtime.CompilerServices.CallerMemberNameAttribute()] string propertyName = null)
             where TSender : ReactiveUI.IReactiveObject { }
     }
     public interface IReactivePropertyChangedEventArgs<out TSender>

--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.netcoreapp2.0.approved.txt
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.netcoreapp2.0.approved.txt
@@ -271,11 +271,11 @@ namespace ReactiveUI
     }
     public class static IReactiveObjectExtensions
     {
-        public static TRet RaiseAndSetIfChanged<TObj, TRet>(this TObj @this, ref TRet backingField, TRet newValue, [System.Runtime.CompilerServices.CallerMemberNameAttribute()] string propertyName = null)
+        public static TRet RaiseAndSetIfChanged<TObj, TRet>(this TObj reactiveObject, ref TRet backingField, TRet newValue, [System.Runtime.CompilerServices.CallerMemberNameAttribute()] string propertyName = null)
             where TObj : ReactiveUI.IReactiveObject { }
-        public static void RaisePropertyChanged<TSender>(this TSender @this, [System.Runtime.CompilerServices.CallerMemberNameAttribute()] string propertyName = null)
+        public static void RaisePropertyChanged<TSender>(this TSender reactiveObject, [System.Runtime.CompilerServices.CallerMemberNameAttribute()] string propertyName = null)
             where TSender : ReactiveUI.IReactiveObject { }
-        public static void RaisePropertyChanging<TSender>(this TSender @this, [System.Runtime.CompilerServices.CallerMemberNameAttribute()] string propertyName = null)
+        public static void RaisePropertyChanging<TSender>(this TSender reactiveObject, [System.Runtime.CompilerServices.CallerMemberNameAttribute()] string propertyName = null)
             where TSender : ReactiveUI.IReactiveObject { }
     }
     public interface IReactivePropertyChangedEventArgs<out TSender>

--- a/src/ReactiveUI.Tests/ObservableAsPropertyHelper/ObservableAsPropertyHelperTest.cs
+++ b/src/ReactiveUI.Tests/ObservableAsPropertyHelper/ObservableAsPropertyHelperTest.cs
@@ -194,7 +194,7 @@ namespace ReactiveUI.Tests
             new TestScheduler().With(sched =>
             {
                 var input = new Subject<int>();
-                var fixture = new ObservableAsPropertyHelper<int>(input, _ => { }, -5);
+                var fixture = new ObservableAsPropertyHelper<int>(input, _ => { }, -5, scheduler: ImmediateScheduler.Instance);
 
                 Assert.Equal(-5, fixture.Value);
                 new[] { 1, 2, 3, 4 }.Run(x => input.OnNext(x));

--- a/src/ReactiveUI/ObservableForProperty/OAPHCreationHelperMixin.cs
+++ b/src/ReactiveUI/ObservableForProperty/OAPHCreationHelperMixin.cs
@@ -20,7 +20,7 @@ namespace ReactiveUI
         /// automatically provides the onChanged method to raise the property
         /// changed notification.
         /// </summary>
-        /// <typeparam name="TObj">The onject type.</typeparam>
+        /// <typeparam name="TObj">The object type.</typeparam>
         /// <typeparam name="TRet">The result type.</typeparam>
         /// <param name="target">
         /// The observable to convert to an ObservableAsPropertyHelper.
@@ -114,7 +114,7 @@ namespace ReactiveUI
         /// automatically provides the onChanged method to raise the property
         /// changed notification.
         /// </summary>
-        /// <typeparam name="TObj">The onject type.</typeparam>
+        /// <typeparam name="TObj">The object type.</typeparam>
         /// <typeparam name="TRet">The result type.</typeparam>
         /// <param name="target">
         /// The observable to convert to an ObservableAsPropertyHelper.
@@ -157,7 +157,7 @@ namespace ReactiveUI
         /// automatically provides the onChanged method to raise the property
         /// changed notification.
         /// </summary>
-        /// <typeparam name="TObj">The onject type.</typeparam>
+        /// <typeparam name="TObj">The object type.</typeparam>
         /// <typeparam name="TRet">The result type.</typeparam>
         /// <param name="target">
         /// The observable to convert to an ObservableAsPropertyHelper.
@@ -234,15 +234,13 @@ namespace ReactiveUI
                 name += "[]";
             }
 
-            var ret = new ObservableAsPropertyHelper<TRet>(
+            return new ObservableAsPropertyHelper<TRet>(
                 observable,
                 _ => target.RaisingPropertyChanged(name),
                 _ => target.RaisingPropertyChanging(name),
                 initialValue,
                 deferSubscription,
                 scheduler);
-
-            return ret;
         }
 
         private static ObservableAsPropertyHelper<TRet> ObservableToProperty<TObj, TRet>(

--- a/src/ReactiveUI/Platforms/uikit-common/CommonReactiveSource.cs
+++ b/src/ReactiveUI/Platforms/uikit-common/CommonReactiveSource.cs
@@ -193,9 +193,10 @@ namespace ReactiveUI
                 this.Log().Warn(CultureInfo.InvariantCulture, "[#{0}] SectionInfo {1} does not implement INotifyCollectionChanged - any added or removed sections will not be reflected in the UI.", sectionInfoId, sectionInfo);
             }
 
-            var sectionChanged = notifyCollectionChanged == null ?
+            var sectionChanged = (notifyCollectionChanged == null ?
                 Observable<Unit>.Never :
-                notifyCollectionChanged.ObserveCollectionChanges().Select(_ => Unit.Default);
+                notifyCollectionChanged.ObserveCollectionChanges().Select(_ => Unit.Default))
+                    .StartWith(Unit.Default);
 
             var disposables = new CompositeDisposable();
             disposables.Add(Disposable.Create(() => this.Log().Debug(CultureInfo.InvariantCulture, "[#{0}] Disposed of section info", sectionInfoId)));

--- a/src/ReactiveUI/ReactiveObject/IReactiveObjectExtensions.cs
+++ b/src/ReactiveUI/ReactiveObject/IReactiveObjectExtensions.cs
@@ -92,7 +92,7 @@ namespace ReactiveUI
         /// </summary>
         /// <typeparam name="TObj">The type of the This.</typeparam>
         /// <typeparam name="TRet">The type of the return value.</typeparam>
-        /// <param name="this">The <see cref="ReactiveObject"/> raising the notification.</param>
+        /// <param name="reactiveObject">The <see cref="ReactiveObject"/> raising the notification.</param>
         /// <param name="backingField">A Reference to the backing field for this
         /// property.</param>
         /// <param name="newValue">The new value.</param>
@@ -100,7 +100,7 @@ namespace ReactiveUI
         /// automatically provided through the CallerMemberName attribute.</param>
         /// <returns>The newly set value, normally discarded.</returns>
         public static TRet RaiseAndSetIfChanged<TObj, TRet>(
-            this TObj @this,
+            this TObj reactiveObject,
             ref TRet backingField,
             TRet newValue,
             [CallerMemberName] string propertyName = null)
@@ -113,9 +113,9 @@ namespace ReactiveUI
                 return newValue;
             }
 
-            @this.RaisingPropertyChanging(propertyName);
+            reactiveObject.RaisingPropertyChanging(propertyName);
             backingField = newValue;
-            @this.RaisingPropertyChanged(propertyName);
+            reactiveObject.RaisingPropertyChanged(propertyName);
             return newValue;
         }
 
@@ -124,15 +124,15 @@ namespace ReactiveUI
         /// properties where raiseAndSetIfChanged doesn't suffice.
         /// </summary>
         /// <typeparam name="TSender">The sender type.</typeparam>
-        /// <param name="this">The instance of ReactiveObject on which the property has changed.</param>
+        /// <param name="reactiveObject">The instance of ReactiveObject on which the property has changed.</param>
         /// <param name="propertyName">
         /// A string representing the name of the property that has been changed.
         /// Leave <c>null</c> to let the runtime set to caller member name.
         /// </param>
-        public static void RaisePropertyChanged<TSender>(this TSender @this, [CallerMemberName] string propertyName = null)
+        public static void RaisePropertyChanged<TSender>(this TSender reactiveObject, [CallerMemberName] string propertyName = null)
             where TSender : IReactiveObject
         {
-            @this.RaisingPropertyChanged(propertyName);
+            reactiveObject.RaisingPropertyChanged(propertyName);
         }
 
         /// <summary>
@@ -140,78 +140,78 @@ namespace ReactiveUI
         /// properties where raiseAndSetIfChanged doesn't suffice.
         /// </summary>
         /// <typeparam name="TSender">The sender type.</typeparam>
-        /// <param name="this">The instance of ReactiveObject on which the property has changed.</param>
+        /// <param name="reactiveObject">The instance of ReactiveObject on which the property has changed.</param>
         /// <param name="propertyName">
         /// A string representing the name of the property that has been changed.
         /// Leave <c>null</c> to let the runtime set to caller member name.
         /// </param>
-        public static void RaisePropertyChanging<TSender>(this TSender @this, [CallerMemberName] string propertyName = null)
+        public static void RaisePropertyChanging<TSender>(this TSender reactiveObject, [CallerMemberName] string propertyName = null)
             where TSender : IReactiveObject
         {
-            @this.RaisingPropertyChanging(propertyName);
+            reactiveObject.RaisingPropertyChanging(propertyName);
         }
 
-        internal static IObservable<IReactivePropertyChangedEventArgs<TSender>> GetChangedObservable<TSender>(this TSender @this)
+        internal static IObservable<IReactivePropertyChangedEventArgs<TSender>> GetChangedObservable<TSender>(this TSender reactiveObject)
             where TSender : IReactiveObject
         {
-            var val = state.GetValue(@this, key => (IExtensionState<IReactiveObject>)new ExtensionState<TSender>(@this));
+            var val = state.GetValue(reactiveObject, _ => (IExtensionState<IReactiveObject>)new ExtensionState<TSender>(reactiveObject));
             return val.Changed.Cast<IReactivePropertyChangedEventArgs<TSender>>();
         }
 
-        internal static IObservable<IReactivePropertyChangedEventArgs<TSender>> GetChangingObservable<TSender>(this TSender @this)
+        internal static IObservable<IReactivePropertyChangedEventArgs<TSender>> GetChangingObservable<TSender>(this TSender reactiveObject)
             where TSender : IReactiveObject
         {
-            var val = state.GetValue(@this, key => (IExtensionState<IReactiveObject>)new ExtensionState<TSender>(@this));
+            var val = state.GetValue(reactiveObject, _ => (IExtensionState<IReactiveObject>)new ExtensionState<TSender>(reactiveObject));
             return val.Changing.Cast<IReactivePropertyChangedEventArgs<TSender>>();
         }
 
-        internal static IObservable<Exception> GetThrownExceptionsObservable<TSender>(this TSender @this)
+        internal static IObservable<Exception> GetThrownExceptionsObservable<TSender>(this TSender reactiveObject)
             where TSender : IReactiveObject
         {
-            var s = state.GetValue(@this, key => (IExtensionState<IReactiveObject>)new ExtensionState<TSender>(@this));
+            var s = state.GetValue(reactiveObject, _ => (IExtensionState<IReactiveObject>)new ExtensionState<TSender>(reactiveObject));
             return s.ThrownExceptions;
         }
 
-        internal static void RaisingPropertyChanging<TSender>(this TSender @this, string propertyName)
+        internal static void RaisingPropertyChanging<TSender>(this TSender reactiveObject, string propertyName)
             where TSender : IReactiveObject
         {
             Contract.Requires(propertyName != null);
 
-            var s = state.GetValue(@this, key => (IExtensionState<IReactiveObject>)new ExtensionState<TSender>(@this));
+            var s = state.GetValue(reactiveObject, _ => (IExtensionState<IReactiveObject>)new ExtensionState<TSender>(reactiveObject));
 
             s.RaisePropertyChanging(propertyName);
         }
 
-        internal static void RaisingPropertyChanged<TSender>(this TSender @this, string propertyName)
+        internal static void RaisingPropertyChanged<TSender>(this TSender reactiveObject, string propertyName)
             where TSender : IReactiveObject
         {
             Contract.Requires(propertyName != null);
 
-            var s = state.GetValue(@this, key => (IExtensionState<IReactiveObject>)new ExtensionState<TSender>(@this));
+            var s = state.GetValue(reactiveObject, _ => (IExtensionState<IReactiveObject>)new ExtensionState<TSender>(reactiveObject));
 
             s.RaisePropertyChanged(propertyName);
         }
 
-        internal static IDisposable SuppressChangeNotifications<TSender>(this TSender @this)
+        internal static IDisposable SuppressChangeNotifications<TSender>(this TSender reactiveObject)
             where TSender : IReactiveObject
         {
-            var s = state.GetValue(@this, key => (IExtensionState<IReactiveObject>)new ExtensionState<TSender>(@this));
+            var s = state.GetValue(reactiveObject, _ => (IExtensionState<IReactiveObject>)new ExtensionState<TSender>(reactiveObject));
 
             return s.SuppressChangeNotifications();
         }
 
-        internal static bool AreChangeNotificationsEnabled<TSender>(this TSender @this)
+        internal static bool AreChangeNotificationsEnabled<TSender>(this TSender reactiveObject)
             where TSender : IReactiveObject
         {
-            var s = state.GetValue(@this, key => (IExtensionState<IReactiveObject>)new ExtensionState<TSender>(@this));
+            var s = state.GetValue(reactiveObject, _ => (IExtensionState<IReactiveObject>)new ExtensionState<TSender>(reactiveObject));
 
             return s.AreChangeNotificationsEnabled();
         }
 
-        internal static IDisposable DelayChangeNotifications<TSender>(this TSender @this)
+        internal static IDisposable DelayChangeNotifications<TSender>(this TSender reactiveObject)
             where TSender : IReactiveObject
         {
-            var s = state.GetValue(@this, key => (IExtensionState<IReactiveObject>)new ExtensionState<TSender>(@this));
+            var s = state.GetValue(reactiveObject, _ => (IExtensionState<IReactiveObject>)new ExtensionState<TSender>(reactiveObject));
 
             return s.DelayChangeNotifications();
         }
@@ -243,13 +243,12 @@ namespace ReactiveUI
         private class ExtensionState<TSender> : IExtensionState<TSender>
             where TSender : IReactiveObject
         {
-            private readonly ISubject<IReactivePropertyChangedEventArgs<TSender>> _changingSubject;
-            private readonly IObservable<IReactivePropertyChangedEventArgs<TSender>> _changingObservable;
-            private readonly ISubject<IReactivePropertyChangedEventArgs<TSender>> _changedSubject;
-            private readonly IObservable<IReactivePropertyChangedEventArgs<TSender>> _changedObservable;
-            private readonly ISubject<Exception> _thrownExceptions;
-            private readonly ISubject<Unit> _startDelayNotifications;
+            private readonly Lazy<ISubject<Exception>> _thrownExceptions = new Lazy<ISubject<Exception>>(() => new ScheduledSubject<Exception>(Scheduler.Immediate, RxApp.DefaultExceptionHandler));
+            private readonly Lazy<Subject<Unit>> _startDelayNotifications = new Lazy<Subject<Unit>>();
             private readonly TSender _sender;
+            private readonly Lazy<(ISubject<IReactivePropertyChangedEventArgs<TSender>> subject, IObservable<IReactivePropertyChangedEventArgs<TSender>> observable)> _changing;
+            private readonly Lazy<(ISubject<IReactivePropertyChangedEventArgs<TSender>> subject, IObservable<IReactivePropertyChangedEventArgs<TSender>> observable)> _changed;
+
             private long _changeNotificationsSuppressed;
             private long _changeNotificationsDelayed;
 
@@ -260,35 +259,40 @@ namespace ReactiveUI
             public ExtensionState(TSender sender)
             {
                 _sender = sender;
-                _changingSubject = new Subject<IReactivePropertyChangedEventArgs<TSender>>();
-                _changedSubject = new Subject<IReactivePropertyChangedEventArgs<TSender>>();
-                _startDelayNotifications = new Subject<Unit>();
-                _thrownExceptions = new ScheduledSubject<Exception>(Scheduler.Immediate, RxApp.DefaultExceptionHandler);
+                _changing = new Lazy<(ISubject<IReactivePropertyChangedEventArgs<TSender>>, IObservable<IReactivePropertyChangedEventArgs<TSender>>)>(() =>
+                {
+                    var changingSubject = new Subject<IReactivePropertyChangedEventArgs<TSender>>();
+                    var changedObs = changingSubject
+                        .Buffer(
+                            Observable.Merge(
+                                changingSubject.Where(_ => !AreChangeNotificationsDelayed()).Select(_ => Unit.Default), _startDelayNotifications.Value))
+                        .SelectMany(Dedup)
+                        .Publish()
+                        .RefCount();
 
-                _changedObservable = _changedSubject
-                    .Buffer(
-                        Observable.Merge(
-                            _changedSubject.Where(_ => !AreChangeNotificationsDelayed()).Select(_ => Unit.Default),
-                            _startDelayNotifications))
-                    .SelectMany(Dedup)
-                    .Publish()
-                    .RefCount();
+                    return (changingSubject, changedObs);
+                });
 
-                _changingObservable = _changingSubject
-                    .Buffer(
-                        Observable.Merge(
-                            _changingSubject.Where(_ => !AreChangeNotificationsDelayed()).Select(_ => Unit.Default),
-                            _startDelayNotifications))
-                    .SelectMany(Dedup)
-                    .Publish()
-                    .RefCount();
+                _changed = new Lazy<(ISubject<IReactivePropertyChangedEventArgs<TSender>> subject, IObservable<IReactivePropertyChangedEventArgs<TSender>> observable)>(() =>
+                {
+                    var changedSubject = new Subject<IReactivePropertyChangedEventArgs<TSender>>();
+                    var changedObs = changedSubject
+                        .Buffer(
+                            Observable.Merge(
+                                changedSubject.Where(_ => !AreChangeNotificationsDelayed()).Select(_ => Unit.Default), _startDelayNotifications.Value))
+                        .SelectMany(Dedup)
+                        .Publish()
+                        .RefCount();
+
+                    return (changedSubject, changedObs);
+                });
             }
 
-            public IObservable<IReactivePropertyChangedEventArgs<TSender>> Changing => _changingObservable;
+            public IObservable<IReactivePropertyChangedEventArgs<TSender>> Changing => _changing.Value.observable;
 
-            public IObservable<IReactivePropertyChangedEventArgs<TSender>> Changed => _changedObservable;
+            public IObservable<IReactivePropertyChangedEventArgs<TSender>> Changed => _changed.Value.observable;
 
-            public IObservable<Exception> ThrownExceptions => _thrownExceptions;
+            public IObservable<Exception> ThrownExceptions => _thrownExceptions.Value;
 
             public bool AreChangeNotificationsEnabled()
             {
@@ -325,14 +329,20 @@ namespace ReactiveUI
             {
                 if (Interlocked.Increment(ref _changeNotificationsDelayed) == 1)
                 {
-                    _startDelayNotifications.OnNext(Unit.Default);
+                    if (_startDelayNotifications.IsValueCreated)
+                    {
+                        _startDelayNotifications.Value.OnNext(Unit.Default);
+                    }
                 }
 
                 return Disposable.Create(() =>
                 {
                     if (Interlocked.Decrement(ref _changeNotificationsDelayed) == 0)
                     {
-                        _startDelayNotifications.OnNext(Unit.Default);
+                        if (_startDelayNotifications.IsValueCreated)
+                        {
+                            _startDelayNotifications.Value.OnNext(Unit.Default);
+                        }
                     }
                 });
             }
@@ -347,7 +357,10 @@ namespace ReactiveUI
                 var changing = new ReactivePropertyChangingEventArgs<TSender>(_sender, propertyName);
                 _sender.RaisePropertyChanging(changing);
 
-                NotifyObservable(_sender, changing, _changingSubject);
+                if (_changing.IsValueCreated)
+                {
+                    NotifyObservable(_sender, changing, _changing?.Value.subject);
+                }
             }
 
             public void RaisePropertyChanged(string propertyName)
@@ -360,7 +373,10 @@ namespace ReactiveUI
                 var changed = new ReactivePropertyChangedEventArgs<TSender>(_sender, propertyName);
                 _sender.RaisePropertyChanged(changed);
 
-                NotifyObservable(_sender, changed, _changedSubject);
+                if (_changed.IsValueCreated)
+                {
+                    NotifyObservable(_sender, changed, _changed.Value.subject);
+                }
             }
 
             internal void NotifyObservable<T>(TSender rxObj, T item, ISubject<T> subject)
@@ -372,7 +388,10 @@ namespace ReactiveUI
                 catch (Exception ex)
                 {
                     rxObj.Log().ErrorException("ReactiveObject Subscriber threw exception", ex);
-                    _thrownExceptions.OnNext(ex);
+                    if (_thrownExceptions.IsValueCreated)
+                    {
+                        _thrownExceptions.Value.OnNext(ex);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fixes #823 

This fixes both performance related aspects and memory usage of the `ObservableAsPropertyHelper`

Thanks to @cabauman for assisting in tracking down the problem.

The following was used as a benchmark:

```cs
    /// <summary>
    /// A mock that wraps a ObservableAsPropertyHelper property.
    /// </summary>
    public class MockOAPHViewModel : ReactiveObject
    {
        private readonly ObservableAsPropertyHelper<bool> _myVar1;

        /// <summary>
        /// Initializes a new instance of the <see cref="MockOAPHViewModel"/> class.
        /// </summary>
        public MockOAPHViewModel()
        {
            _myVar1 = Observable.Never<bool>().ToProperty(this, nameof(MyProperty1));
        }

        /// <summary>
        /// Gets a value indicating whether the OAPH value is set.
        /// </summary>
        public bool MyProperty1 => _myVar1.Value;
    }
```

```cs
       [Benchmark]
        public void Create()
        {
            var items = new List<MockOAPHViewModel>();
            for (int i = 0; i < 3000; i++)
            {
                items.Add(new MockOAPHViewModel());
            }
        }
 ```

It does this by using `Lazy<T>` around key areas. In the ReactiveObject it uses Lazy with PublicationOnly, since the same Observable will be retrieve.

Also with OAPH rather than using Multicast() just delay Subscription if we are in a deferred situation. 

The following benchmarks were retrieved:

With the current implementation on .Net Core 2.1 and System.Reactive 4.0.

``` ini

BenchmarkDotNet=v0.11.3.20190129-develop, OS=Windows 10.0.17763.253 (1809/October2018Update/Redstone5)
Intel Core i7-8550U CPU 1.80GHz (Kaby Lake R), 1 CPU, 8 logical and 4 physical cores
  [Host]     : .NET Framework 4.7.2 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.3324.0
  Job-RDTNRF : .NET Core 2.1.7 (CoreCLR 4.6.27129.04, CoreFX 4.6.27129.04), 64bit RyuJIT

Jit=RyuJit  Platform=X64  Toolchain=.NET Core 2.1  

```
| Method |     Mean |    Error |   StdDev | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|------- |---------:|---------:|---------:|------------:|------------:|------------:|--------------------:|
| Create | 130.4 ms | 2.567 ms | 5.127 ms |   6000.0000 |   2000.0000 |   1000.0000 |            38.14 MB |

With the new implementation:

``` ini

BenchmarkDotNet=v0.11.3.20190129-develop, OS=Windows 10.0.17763.253 (1809/October2018Update/Redstone5)
Intel Core i7-8550U CPU 1.80GHz (Kaby Lake R), 1 CPU, 8 logical and 4 physical cores
  [Host]     : .NET Framework 4.7.2 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.3324.0
  Job-RDTNRF : .NET Core 2.1.7 (CoreCLR 4.6.27129.04, CoreFX 4.6.27129.04), 64bit RyuJIT

Jit=RyuJit  Platform=X64  Toolchain=.NET Core 2.1  

```
| Method |     Mean |    Error |   StdDev | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|------- |---------:|---------:|---------:|------------:|------------:|------------:|--------------------:|
| Create | 134.4 ms | 2.680 ms | 7.775 ms |   5000.0000 |   2000.0000 |    750.0000 |            27.29 MB |
