### PR TITLE
fix: .NET Native Support

### DIFF
--- a/src/ReactiveUI/Platforms/uap10.0.16299/ReactiveUI.rd.xml
+++ b/src/ReactiveUI/Platforms/uap10.0.16299/ReactiveUI.rd.xml
@@ -1,0 +1,8 @@
+<Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
+  <Library Name="ReactiveUI">
+    <Assembly Name="ReactiveUI" Activate="Required All" Browse="Required All" Serialize="Required All" Dynamic="Required All" />
+    <!-- See https://github.com/reactiveui/ReactiveUI/issues/1330 -->
+    <Namespace Name="Windows.UI.Xaml.Controls" Dynamic="Required All" />
+    <Namespace Name="Windows.UI.Xaml" Dynamic="Required All" />
+  </Library>
+</Directives>

--- a/src/ReactiveUI/ReactiveUI.csproj
+++ b/src/ReactiveUI/ReactiveUI.csproj
@@ -38,6 +38,10 @@
     <Compile Include="Platforms\uap10.0.16299\**\*.cs" />
   </ItemGroup>
 
+  <ItemGroup Label="Package" Condition=" $(TargetFramework.StartsWith('uap')) ">
+  	<None Include="Platforms\uap10.0.16299\ReactiveUI.rd.xml" PackagePath="lib\uap10.0.16299\ReactiveUI\Properties\ReactiveUI.rd.xml" Pack="true" />
+  </ItemGroup>
+
   <ItemGroup Condition=" $(TargetFramework.StartsWith('Xamarin.iOS')) ">
     <Compile Include="Platforms\apple-common\**\*.cs" />
     <Compile Include="Platforms\ios\**\*.cs" />


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Fixes https://github.com/reactiveui/ReactiveUI/issues/1750

**What is the current behavior? (You can also link to an open issue here)**

ReactiveUI code-behind type safe bindings are [broken](https://github.com/reactiveui/ReactiveUI/issues/1750) for Universal Windows Platform applications when compiling those with .NET Native toolchain. There are several temporary solutions for this:
1. Turning .NET Native compiler off
2. Using `{x:Bind }` bindings instead of ReactiveUI `Bind` and `BindCommand` methods
3. Editing `Properties\Default.rd.xml` file to include type info for controls used by the app:
```xml
<Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
  <Application>
    <Assembly Name="*Application*" Dynamic="Required All" />
    <Namespace Name="Windows.UI.Xaml.Controls" Dynamic="Required All" />
    <Namespace Name="Windows.UI.Xaml" Dynamic="Required All" />
  </Application>
</Directives>
```

Users have to spend time googling, reading documentation and following GitHub threads to get started with using ReactiveUI fluent bindings with .NET Native, if we could make this feature work out of the box, it would improve Universal Windows developer experience.

**What is the new behavior (if this is a feature change)?**

Now, the `.rd.xml` file which includes runtime type information for `Windows.UI.Xaml` and `Windows.UI.Xaml.Controls` namespaces is added to ReactiveUI library targeting UWP, as suggested [here](https://github.com/reactiveui/ReactiveUI/issues/1330#issuecomment-294258199) and [here](https://github.com/reactiveui/ReactiveUI/issues/1750#issuecomment-431547140). It should get included into ReactiveUI package for `uap` platform, see [Including content in a package](https://docs.microsoft.com/en-us/nuget/reference/msbuild-targets#including-content-in-a-package). This solution [is used by Caliburn.Micro](https://github.com/Caliburn-Micro/Caliburn.Micro/blob/master/src/Caliburn.Micro.Platform/Caliburn.Micro.Platform.csproj#L35) framework, so *should work* for ReactiveUI too. 

**What might this PR break?**

Hopefully nothing.