### PR TITLE
housekeeping: Fix typo in the [GitHub issues] url

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ public class ReactiveViewModel : ReactiveObject
 
 <h2>Support</h2>
 
-If you have a question, please see if any discussions in our [GitHub issues](github.com/reactiveui/ReactiveUI/issues) or [Stack Overflow](https://stackoverflow.com/questions/tagged/reactiveui) have already answered it.
+If you have a question, please see if any discussions in our [GitHub issues](https://github.com/reactiveui/ReactiveUI/issues) or [Stack Overflow](https://stackoverflow.com/questions/tagged/reactiveui) have already answered it.
 
 If you want to discuss something or just need help, here is our [Slack room](https://reactiveui.net/slack) where there are always individuals looking to help out!
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
[Very] Small change to README.md


**What is the current behavior? (You can also link to an open issue here)**
Without the http protocol (`http://` or `https://`), Markdown translates `github.com/reactiveui/ReactiveUI/issues` into `https://github.com/reactiveui/ReactiveUI/blob/master/github.com/reactiveui/ReactiveUI/issues`, which is not a page that exists!


**What is the new behavior (if this is a feature change)?**
The link works ⚡️ 

**What might this PR break?**
Nothing


**Please check if the PR fulfills these requirements**
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

**Other information**:
It works (without http/https) for `Passing on knowledge and teaching the next generation of developers`, unsure why to be frank.
