### PR TITLE
housekeeping: removed external locks now splat mru cache has locking

### DIFF
--- a/src/ReactiveUI.Fody.Tests/FodyWeavers.xsd
+++ b/src/ReactiveUI.Fody.Tests/FodyWeavers.xsd
@@ -4,7 +4,6 @@
   <xs:element name="Weavers">
     <xs:complexType>
       <xs:all>
-        <xs:element name="ReactiveUI.Fody.deps" minOccurs="0" maxOccurs="1" type="xs:anyType" />
         <xs:element name="ReactiveUI" minOccurs="0" maxOccurs="1" type="xs:anyType" />
       </xs:all>
       <xs:attribute name="VerifyAssembly" type="xs:boolean">

--- a/src/ReactiveUI.Fody.Tests/FodyWeavers.xsd
+++ b/src/ReactiveUI.Fody.Tests/FodyWeavers.xsd
@@ -4,6 +4,7 @@
   <xs:element name="Weavers">
     <xs:complexType>
       <xs:all>
+		<xs:element name="ReactiveUI.Fody.deps" minOccurs="0" maxOccurs="1" type="xs:anyType" />
         <xs:element name="ReactiveUI" minOccurs="0" maxOccurs="1" type="xs:anyType" />
       </xs:all>
       <xs:attribute name="VerifyAssembly" type="xs:boolean">

--- a/src/ReactiveUI.Winforms/WinformsCreatesObservableForProperty.cs
+++ b/src/ReactiveUI.Winforms/WinformsCreatesObservableForProperty.cs
@@ -38,22 +38,14 @@ namespace ReactiveUI.Winforms
                 return 0;
             }
 
-            lock (eventInfoCache)
-            {
-                var ei = eventInfoCache.Get(Tuple.Create(type, propertyName));
-                return beforeChanged == false && ei != null ? 8 : 0;
-            }
+            var ei = eventInfoCache.Get(Tuple.Create(type, propertyName));
+            return beforeChanged == false && ei != null ? 8 : 0;
         }
 
         /// <inheritdoc/>
         public IObservable<IObservedChange<object, object>> GetNotificationForProperty(object sender, Expression expression, string propertyName, bool beforeChanged = false)
         {
-            var ei = default(EventInfo);
-
-            lock (eventInfoCache)
-            {
-                ei = eventInfoCache.Get(Tuple.Create(sender.GetType(), propertyName));
-            }
+            var ei = eventInfoCache.Get(Tuple.Create(sender.GetType(), propertyName));
 
             return Observable.Create<IObservedChange<object, object>>(subj =>
             {

--- a/src/ReactiveUI/Bindings/Command/CreatesCommandBinding.cs
+++ b/src/ReactiveUI/Bindings/Command/CreatesCommandBinding.cs
@@ -45,10 +45,7 @@ namespace ReactiveUI
             var binder = default(ICreatesCommandBinding);
             var type = target.GetType();
 
-            lock (bindCommandCache)
-            {
-                binder = bindCommandCache.Get(type);
-            }
+            binder = bindCommandCache.Get(type);
 
             if (binder == null)
             {

--- a/src/ReactiveUI/Bindings/Command/CreatesCommandBinding.cs
+++ b/src/ReactiveUI/Bindings/Command/CreatesCommandBinding.cs
@@ -42,10 +42,9 @@ namespace ReactiveUI
 
         public static IDisposable BindCommandToObject(ICommand command, object target, IObservable<object> commandParameter)
         {
-            var binder = default(ICreatesCommandBinding);
             var type = target.GetType();
 
-            binder = bindCommandCache.Get(type);
+            var binder = bindCommandCache.Get(type);
 
             if (binder == null)
             {

--- a/src/ReactiveUI/Bindings/Converter/EqualityTypeConverter.cs
+++ b/src/ReactiveUI/Bindings/Converter/EqualityTypeConverter.cs
@@ -105,11 +105,7 @@ namespace ReactiveUI
         {
             Contract.Requires(toType != null);
 
-            var mi = default(MethodInfo);
-            lock (_referenceCastCache)
-            {
-                mi = _referenceCastCache.Get(toType);
-            }
+            var mi = _referenceCastCache.Get(toType);
 
             try
             {

--- a/src/ReactiveUI/Bindings/Property/PropertyBinderImplementation.cs
+++ b/src/ReactiveUI/Bindings/Property/PropertyBinderImplementation.cs
@@ -426,10 +426,7 @@ namespace ReactiveUI
 
         internal static IBindingTypeConverter GetConverterForTypes(Type lhs, Type rhs)
         {
-            lock (_typeConverterCache)
-            {
-                return _typeConverterCache.Get((lhs, rhs));
-            }
+            return _typeConverterCache.Get((lhs, rhs));
         }
 
         private static Func<object, object, object[], object> GetSetConverter(Type fromType, Type targetType)
@@ -439,17 +436,14 @@ namespace ReactiveUI
                 return null;
             }
 
-            lock (_setMethodCache)
+            var setter = _setMethodCache.Get((fromType, targetType));
+
+            if (setter == null)
             {
-                var setter = _setMethodCache.Get((fromType, targetType));
-
-                if (setter == null)
-                {
-                    return null;
-                }
-
-                return setter.PerformSet;
+                return null;
             }
+
+            return setter.PerformSet;
         }
 
         private (IDisposable disposable, IObservable<TValue> value) BindToDirect<TTarget, TValue, TObs>(

--- a/src/ReactiveUI/Expression/Reflection.cs
+++ b/src/ReactiveUI/Expression/Reflection.cs
@@ -334,16 +334,13 @@ namespace ReactiveUI
         /// <exception cref="TypeLoadException">If we were unable to find the type.</exception>
         public static Type ReallyFindType(string type, bool throwOnFailure)
         {
-            lock (typeCache)
+            Type ret = typeCache.Get(type);
+            if (ret != null || !throwOnFailure)
             {
-                Type ret = typeCache.Get(type);
-                if (ret != null || !throwOnFailure)
-                {
-                    return ret;
-                }
-
-                throw new TypeLoadException();
+                return ret;
             }
+
+            throw new TypeLoadException();
         }
 
         /// <summary>

--- a/src/ReactiveUI/Mixins/AutoPersistHelper.cs
+++ b/src/ReactiveUI/Mixins/AutoPersistHelper.cs
@@ -93,19 +93,12 @@ namespace ReactiveUI
         {
             interval = interval ?? TimeSpan.FromSeconds(3.0);
 
-            lock (dataContractCheckCache)
+            if (!dataContractCheckCache.Get(@this.GetType()))
             {
-                if (!dataContractCheckCache.Get(@this.GetType()))
-                {
-                    throw new ArgumentException("AutoPersist can only be applied to objects with [DataContract]");
-                }
+                throw new ArgumentException("AutoPersist can only be applied to objects with [DataContract]");
             }
 
-            Dictionary<string, bool> persistableProperties;
-            lock (persistablePropertiesCache)
-            {
-                persistableProperties = persistablePropertiesCache.Get(@this.GetType());
-            }
+            Dictionary<string, bool> persistableProperties = persistablePropertiesCache.Get(@this.GetType());
 
             var saveHint = Observable.Merge(
                 @this.GetChangedObservable().Where(x => persistableProperties.ContainsKey(x.PropertyName)).Select(_ => Unit.Default),

--- a/src/ReactiveUI/Mixins/ReactiveNotifyPropertyChangedMixin.cs
+++ b/src/ReactiveUI/Mixins/ReactiveNotifyPropertyChangedMixin.cs
@@ -199,11 +199,7 @@ namespace ReactiveUI
         private static IObservable<IObservedChange<object, object>> NotifyForProperty(object sender, Expression expression, bool beforeChange)
         {
             var propertyName = expression.GetMemberInfo().Name;
-            var result = default(ICreatesObservableForProperty);
-            lock (notifyFactoryCache)
-            {
-                result = notifyFactoryCache.Get(Tuple.Create(sender.GetType(), propertyName, beforeChange));
-            }
+            var result = notifyFactoryCache.Get(Tuple.Create(sender.GetType(), propertyName, beforeChange));
 
             if (result == null)
             {

--- a/src/ReactiveUI/Platforms/apple-common/KVOObservableForProperty.cs
+++ b/src/ReactiveUI/Platforms/apple-common/KVOObservableForProperty.cs
@@ -63,10 +63,7 @@ namespace ReactiveUI
         /// <inheritdoc/>
         public int GetAffinityForObject(Type type, string propertyName, bool beforeChanged = false)
         {
-            lock (declaredInNSObject)
-            {
-                return declaredInNSObject.Get(Tuple.Create(type, propertyName)) ? 15 : 0;
-            }
+            return declaredInNSObject.Get(Tuple.Create(type, propertyName)) ? 15 : 0;
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Removed the external locks now the MRU cache has them in Splat v7

**What is the current behavior? (You can also link to an open issue here)**

locks were external due to MRU cache not being threadsafe.

**What is the new behavior (if this is a feature change)?**

MRU cache has internal locks.

**What might this PR break?**

hopefully nothing

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
