### PR TITLE
Check for DisableAnimation attribute before PopToRootAsync

### DIFF
--- a/src/ReactiveUI.XamForms/RoutedViewHost.cs
+++ b/src/ReactiveUI.XamForms/RoutedViewHost.cs
@@ -99,20 +99,19 @@ namespace ReactiveUI.XamForms
                     .SelectMany(_ => PageForViewModel(Router.GetCurrentViewModel()))
                     .SelectMany(async page =>
                     {
+                        bool animated = true;
+                        var attribute = page.GetType().GetCustomAttribute<DisableAnimationAttribute>();
+                        if (attribute != null)
+                        {
+                            animated = false;
+                        }
                         if (popToRootPending && Navigation.NavigationStack.Count > 0)
                         {
                             Navigation.InsertPageBefore(page, Navigation.NavigationStack[0]);
-                            await PopToRootAsync();
+                            await PopToRootAsync(animated);
                         }
                         else
                         {
-                            bool animated = true;
-                            var attribute = page.GetType().GetCustomAttribute<DisableAnimationAttribute>();
-                            if (attribute != null)
-                            {
-                                animated = false;
-                            }
-
                             await PushAsync(page, animated);
                         }
 

--- a/src/ReactiveUI.XamForms/RoutedViewHost.cs
+++ b/src/ReactiveUI.XamForms/RoutedViewHost.cs
@@ -105,6 +105,7 @@ namespace ReactiveUI.XamForms
                         {
                             animated = false;
                         }
+
                         if (popToRootPending && Navigation.NavigationStack.Count > 0)
                         {
                             Navigation.InsertPageBefore(page, Navigation.NavigationStack[0]);


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bug Fix for Xamarin Forms



**What is the current behavior?**
It defaults to animate the transition even if the user has specified the [DisableAnimation] attribute.



**What is the new behavior?**
It checks whether the user has disabled animation or not



**What might this PR break?**
PopToRoot functionality on Xamarin Forms 


**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

