### PR TITLE
fix: WhenActivated on WPF by reverting to MsBuild.Sdk.Extras 1.6.18

### DIFF
--- a/src/ReactiveUI.Events/ReactiveUI.Events.csproj
+++ b/src/ReactiveUI.Events/ReactiveUI.Events.csproj
@@ -17,6 +17,12 @@
   </ItemGroup>
 
   <ItemGroup Condition="  $(TargetFramework.StartsWith('uap')) ">
+    <SDKReference Include="WindowsDesktop, Version=10.0.17763.0">
+      <Name>Windows Desktop Extensions for the UWP</Name>
+    </SDKReference>
+    <SDKReference Include="WindowsMobile, Version=10.0.17763.0"> 
+      <Name>Windows Mobile Extensions for the UWP</Name> 
+    </SDKReference> 
     <Compile Include="Events_UWP.cs" Condition="Exists('Events_UWP.cs')" />
   </ItemGroup>
 

--- a/src/ReactiveUI.Tests/Platforms/wpf/API/ApiApprovalTests.Wpf.net461.approved.txt
+++ b/src/ReactiveUI.Tests/Platforms/wpf/API/ApiApprovalTests.Wpf.net461.approved.txt
@@ -122,3 +122,15 @@ namespace ReactiveUI.Wpf
         public void Register(System.Action<System.Func<object>, System.Type> registerFunction) { }
     }
 }
+namespace XamlGeneratedNamespace
+{
+    public sealed class GeneratedInternalTypeHelper : System.Windows.Markup.InternalTypeHelper
+    {
+        public GeneratedInternalTypeHelper() { }
+        protected override void AddEventHandler(System.Reflection.EventInfo eventInfo, object target, System.Delegate handler) { }
+        protected override System.Delegate CreateDelegate(System.Type delegateType, object target, string handler) { }
+        protected override object CreateInstance(System.Type type, System.Globalization.CultureInfo culture) { }
+        protected override object GetPropertyValue(System.Reflection.PropertyInfo propertyInfo, object target, System.Globalization.CultureInfo culture) { }
+        protected override void SetPropertyValue(System.Reflection.PropertyInfo propertyInfo, object target, object value, System.Globalization.CultureInfo culture) { }
+    }
+}

--- a/src/global.json
+++ b/src/global.json
@@ -1,5 +1,5 @@
 {
     "msbuild-sdks": {
-        "MSBuild.Sdk.Extras": "2.0.24"
+        "MSBuild.Sdk.Extras": "1.6.68"
     }
 }

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "9.14",
+  "version": "9.15",
   "publicReleaseRefSpec": [
     "^refs/heads/master$", // we release out of master
     "^refs/heads/develop$", // we release out of develop


### PR DESCRIPTION
Downgrade to MsBuild.Sdk.Extras 1.6.68 since it was preventing WhenActivated was firing.

This should fix #2021 