### PR TITLE
feature: Add Universal Windows routing example

### DIFF
--- a/samples/uwp/ReactiveUI.UwpRouting.sln
+++ b/samples/uwp/ReactiveUI.UwpRouting.sln
@@ -1,0 +1,51 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.489
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReactiveUI.UwpRouting", "ReactiveUI.UwpRouting\ReactiveUI.UwpRouting.csproj", "{702CB6D2-A9E0-40A4-A64D-BAACC63893A8}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|ARM = Debug|ARM
+		Debug|ARM64 = Debug|ARM64
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|ARM = Release|ARM
+		Release|ARM64 = Release|ARM64
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{702CB6D2-A9E0-40A4-A64D-BAACC63893A8}.Debug|ARM.ActiveCfg = Debug|ARM
+		{702CB6D2-A9E0-40A4-A64D-BAACC63893A8}.Debug|ARM.Build.0 = Debug|ARM
+		{702CB6D2-A9E0-40A4-A64D-BAACC63893A8}.Debug|ARM.Deploy.0 = Debug|ARM
+		{702CB6D2-A9E0-40A4-A64D-BAACC63893A8}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{702CB6D2-A9E0-40A4-A64D-BAACC63893A8}.Debug|ARM64.Build.0 = Debug|ARM64
+		{702CB6D2-A9E0-40A4-A64D-BAACC63893A8}.Debug|ARM64.Deploy.0 = Debug|ARM64
+		{702CB6D2-A9E0-40A4-A64D-BAACC63893A8}.Debug|x64.ActiveCfg = Debug|x64
+		{702CB6D2-A9E0-40A4-A64D-BAACC63893A8}.Debug|x64.Build.0 = Debug|x64
+		{702CB6D2-A9E0-40A4-A64D-BAACC63893A8}.Debug|x64.Deploy.0 = Debug|x64
+		{702CB6D2-A9E0-40A4-A64D-BAACC63893A8}.Debug|x86.ActiveCfg = Debug|x86
+		{702CB6D2-A9E0-40A4-A64D-BAACC63893A8}.Debug|x86.Build.0 = Debug|x86
+		{702CB6D2-A9E0-40A4-A64D-BAACC63893A8}.Debug|x86.Deploy.0 = Debug|x86
+		{702CB6D2-A9E0-40A4-A64D-BAACC63893A8}.Release|ARM.ActiveCfg = Release|ARM
+		{702CB6D2-A9E0-40A4-A64D-BAACC63893A8}.Release|ARM.Build.0 = Release|ARM
+		{702CB6D2-A9E0-40A4-A64D-BAACC63893A8}.Release|ARM.Deploy.0 = Release|ARM
+		{702CB6D2-A9E0-40A4-A64D-BAACC63893A8}.Release|ARM64.ActiveCfg = Release|ARM64
+		{702CB6D2-A9E0-40A4-A64D-BAACC63893A8}.Release|ARM64.Build.0 = Release|ARM64
+		{702CB6D2-A9E0-40A4-A64D-BAACC63893A8}.Release|ARM64.Deploy.0 = Release|ARM64
+		{702CB6D2-A9E0-40A4-A64D-BAACC63893A8}.Release|x64.ActiveCfg = Release|x64
+		{702CB6D2-A9E0-40A4-A64D-BAACC63893A8}.Release|x64.Build.0 = Release|x64
+		{702CB6D2-A9E0-40A4-A64D-BAACC63893A8}.Release|x64.Deploy.0 = Release|x64
+		{702CB6D2-A9E0-40A4-A64D-BAACC63893A8}.Release|x86.ActiveCfg = Release|x86
+		{702CB6D2-A9E0-40A4-A64D-BAACC63893A8}.Release|x86.Build.0 = Release|x86
+		{702CB6D2-A9E0-40A4-A64D-BAACC63893A8}.Release|x86.Deploy.0 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {7F4403AB-47C8-4125-8E65-DC8E07DBDA1E}
+	EndGlobalSection
+EndGlobal

--- a/samples/uwp/ReactiveUI.UwpRouting/App.xaml
+++ b/samples/uwp/ReactiveUI.UwpRouting/App.xaml
@@ -1,0 +1,5 @@
+﻿<Application
+    x:Class="ReactiveUI.UwpRouting.App"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+</Application>

--- a/samples/uwp/ReactiveUI.UwpRouting/App.xaml.cs
+++ b/samples/uwp/ReactiveUI.UwpRouting/App.xaml.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using Windows.ApplicationModel.Activation;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Navigation;
+using ReactiveUI.UwpRouting.Views;
+
+namespace ReactiveUI.UwpRouting
+{
+    public sealed partial class App : Application
+    {
+        public App() => InitializeComponent();
+
+        protected override void OnLaunched(LaunchActivatedEventArgs e)
+        {
+            if (!(Window.Current.Content is Frame rootFrame))
+            {
+                rootFrame = new Frame();
+                rootFrame.NavigationFailed += OnNavigationFailed;
+                Window.Current.Content = rootFrame;
+            }
+
+            if (e.PrelaunchActivated != false) return;
+            if (rootFrame.Content == null) rootFrame.Navigate(typeof(MainView), e.Arguments);
+            Window.Current.Activate();
+        }
+
+        private static void OnNavigationFailed(object sender, NavigationFailedEventArgs e)
+        {
+            throw new Exception("Failed to load Page " + e.SourcePageType.FullName);
+        }
+    }
+}

--- a/samples/uwp/ReactiveUI.UwpRouting/Assets/LockScreenLogo.scale-200.png
+++ b/samples/uwp/ReactiveUI.UwpRouting/Assets/LockScreenLogo.scale-200.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a41a053b3fc3b0c109720ccd437a19725ae9163ea75990222a12b596b9c7ca76
+size 1430

--- a/samples/uwp/ReactiveUI.UwpRouting/Assets/SplashScreen.scale-200.png
+++ b/samples/uwp/ReactiveUI.UwpRouting/Assets/SplashScreen.scale-200.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a3382b0b1b834e95b888f06d483dc2d78fa1b3855e0683d5cfbd5167be9731a6
+size 7700

--- a/samples/uwp/ReactiveUI.UwpRouting/Assets/Square150x150Logo.scale-200.png
+++ b/samples/uwp/ReactiveUI.UwpRouting/Assets/Square150x150Logo.scale-200.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7f3cb5738e8f05544445f79996a313f8b47dee22dbc9c7be859d2707710f0c73
+size 2937

--- a/samples/uwp/ReactiveUI.UwpRouting/Assets/Square44x44Logo.scale-200.png
+++ b/samples/uwp/ReactiveUI.UwpRouting/Assets/Square44x44Logo.scale-200.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:594492a25070951d7462c091d9f899a66f55ba992bb9b05d98d50f67cdfb2abe
+size 1647

--- a/samples/uwp/ReactiveUI.UwpRouting/Assets/Square44x44Logo.targetsize-24_altform-unplated.png
+++ b/samples/uwp/ReactiveUI.UwpRouting/Assets/Square44x44Logo.targetsize-24_altform-unplated.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:48cf9c22156a0b3d77982641f972785e7861a7257f7bcf155be7d5a12e1aa3d8
+size 1255

--- a/samples/uwp/ReactiveUI.UwpRouting/Assets/StoreLogo.png
+++ b/samples/uwp/ReactiveUI.UwpRouting/Assets/StoreLogo.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ae95e99a96251abaf8de15c9cdaddb8cefb1b8b320b10a4f1f4e1dc3c25c1b1a
+size 1451

--- a/samples/uwp/ReactiveUI.UwpRouting/Assets/Wide310x150Logo.scale-200.png
+++ b/samples/uwp/ReactiveUI.UwpRouting/Assets/Wide310x150Logo.scale-200.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b5b7754832c08e58faacfe64ea4b9f8b59b52a658e4eea4aab3790cfb89faa03
+size 3204

--- a/samples/uwp/ReactiveUI.UwpRouting/Package.appxmanifest
+++ b/samples/uwp/ReactiveUI.UwpRouting/Package.appxmanifest
@@ -1,0 +1,49 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+
+<Package
+  xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+  xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"
+  xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+  IgnorableNamespaces="uap mp">
+
+  <Identity
+    Name="4ecf45f7-871e-41da-873d-953df44e2fe2"
+    Publisher="CN=prizr"
+    Version="1.0.0.0" />
+
+  <mp:PhoneIdentity PhoneProductId="4ecf45f7-871e-41da-873d-953df44e2fe2" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
+
+  <Properties>
+    <DisplayName>ReactiveUI.UwpRouting</DisplayName>
+    <PublisherDisplayName>prizr</PublisherDisplayName>
+    <Logo>Assets\StoreLogo.png</Logo>
+  </Properties>
+
+  <Dependencies>
+    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.0.0" MaxVersionTested="10.0.0.0" />
+  </Dependencies>
+
+  <Resources>
+    <Resource Language="x-generate"/>
+  </Resources>
+
+  <Applications>
+    <Application Id="App"
+      Executable="$targetnametoken$.exe"
+      EntryPoint="ReactiveUI.UwpRouting.App">
+      <uap:VisualElements
+        DisplayName="ReactiveUI.UwpRouting"
+        Square150x150Logo="Assets\Square150x150Logo.png"
+        Square44x44Logo="Assets\Square44x44Logo.png"
+        Description="ReactiveUI.UwpRouting"
+        BackgroundColor="transparent">
+        <uap:DefaultTile Wide310x150Logo="Assets\Wide310x150Logo.png"/>
+        <uap:SplashScreen Image="Assets\SplashScreen.png" />
+      </uap:VisualElements>
+    </Application>
+  </Applications>
+
+  <Capabilities>
+    <Capability Name="internetClient" />
+  </Capabilities>
+</Package>

--- a/samples/uwp/ReactiveUI.UwpRouting/Properties/AssemblyInfo.cs
+++ b/samples/uwp/ReactiveUI.UwpRouting/Properties/AssemblyInfo.cs
@@ -1,0 +1,29 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("ReactiveUI.UwpRouting")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("ReactiveUI.UwpRouting")]
+[assembly: AssemblyCopyright("Copyright ©  2019")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: ComVisible(false)]

--- a/samples/uwp/ReactiveUI.UwpRouting/Properties/Default.rd.xml
+++ b/samples/uwp/ReactiveUI.UwpRouting/Properties/Default.rd.xml
@@ -1,0 +1,31 @@
+<!--
+    This file contains Runtime Directives used by .NET Native. The defaults here are suitable for most
+    developers. However, you can modify these parameters to modify the behavior of the .NET Native
+    optimizer.
+
+    Runtime Directives are documented at https://go.microsoft.com/fwlink/?LinkID=391919
+
+    To fully enable reflection for App1.MyClass and all of its public/private members
+    <Type Name="App1.MyClass" Dynamic="Required All"/>
+
+    To enable dynamic creation of the specific instantiation of AppClass<T> over System.Int32
+    <TypeInstantiation Name="App1.AppClass" Arguments="System.Int32" Activate="Required Public" />
+
+    Using the Namespace directive to apply reflection policy to all the types in a particular namespace
+    <Namespace Name="DataClasses.ViewModels" Serialize="All" />
+-->
+
+<Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
+  <Application>
+    <!--
+      An Assembly element with Name="*Application*" applies to all assemblies in
+      the application package. The asterisks are not wildcards.
+    -->
+    <Assembly Name="*Application*" Dynamic="Required All" />
+    
+    
+    <!-- Add your application specific runtime directives here. -->
+
+
+  </Application>
+</Directives>

--- a/samples/uwp/ReactiveUI.UwpRouting/ReactiveUI.UwpRouting.csproj
+++ b/samples/uwp/ReactiveUI.UwpRouting/ReactiveUI.UwpRouting.csproj
@@ -1,0 +1,181 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+    <ProjectGuid>{702CB6D2-A9E0-40A4-A64D-BAACC63893A8}</ProjectGuid>
+    <OutputType>AppContainerExe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ReactiveUI.UwpRouting</RootNamespace>
+    <AssemblyName>ReactiveUI.UwpRouting</AssemblyName>
+    <DefaultLanguage>en-US</DefaultLanguage>
+    <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
+    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.17763.0</TargetPlatformVersion>
+    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+    <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <WindowsXamlEnableOverview>true</WindowsXamlEnableOverview>
+    <PackageCertificateKeyFile>ReactiveUI.UwpRouting_TemporaryKey.pfx</PackageCertificateKeyFile>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x86\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
+    <OutputPath>bin\x86\Release\</OutputPath>
+    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <Optimize>true</Optimize>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+    <Prefer32Bit>true</Prefer32Bit>
+    <UseDotNetNativeToolchain>true</UseDotNetNativeToolchain>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\ARM\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>full</DebugType>
+    <PlatformTarget>ARM</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|ARM'">
+    <OutputPath>bin\ARM\Release\</OutputPath>
+    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <Optimize>true</Optimize>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>ARM</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+    <Prefer32Bit>true</Prefer32Bit>
+    <UseDotNetNativeToolchain>true</UseDotNetNativeToolchain>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\ARM64\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>full</DebugType>
+    <PlatformTarget>ARM64</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+    <Prefer32Bit>true</Prefer32Bit>
+    <UseDotNetNativeToolchain>true</UseDotNetNativeToolchain>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|ARM64'">
+    <OutputPath>bin\ARM64\Release\</OutputPath>
+    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <Optimize>true</Optimize>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>ARM64</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+    <Prefer32Bit>true</Prefer32Bit>
+    <UseDotNetNativeToolchain>true</UseDotNetNativeToolchain>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x64\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <OutputPath>bin\x64\Release\</OutputPath>
+    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <Optimize>true</Optimize>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+    <Prefer32Bit>true</Prefer32Bit>
+    <UseDotNetNativeToolchain>true</UseDotNetNativeToolchain>
+  </PropertyGroup>
+  <PropertyGroup>
+    <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="App.xaml.cs">
+      <DependentUpon>App.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ViewModels\FirstViewModel.cs" />
+    <Compile Include="ViewModels\MainViewModel.cs" />
+    <Compile Include="Views\FirstView.xaml.cs">
+      <DependentUpon>FirstView.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Views\MainView.xaml.cs">
+      <DependentUpon>MainView.xaml</DependentUpon>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <AppxManifest Include="Package.appxmanifest">
+      <SubType>Designer</SubType>
+    </AppxManifest>
+    <None Include="ReactiveUI.UwpRouting_TemporaryKey.pfx" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Properties\Default.rd.xml" />
+    <Content Include="Assets\LockScreenLogo.scale-200.png" />
+    <Content Include="Assets\SplashScreen.scale-200.png" />
+    <Content Include="Assets\Square150x150Logo.scale-200.png" />
+    <Content Include="Assets\Square44x44Logo.scale-200.png" />
+    <Content Include="Assets\Square44x44Logo.targetsize-24_altform-unplated.png" />
+    <Content Include="Assets\StoreLogo.png" />
+    <Content Include="Assets\Wide310x150Logo.scale-200.png" />
+  </ItemGroup>
+  <ItemGroup>
+    <ApplicationDefinition Include="App.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </ApplicationDefinition>
+    <Page Include="Views\FirstView.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Views\MainView.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
+      <Version>6.2.8</Version>
+    </PackageReference>
+    <PackageReference Include="ReactiveUI">
+      <Version>9.15.1</Version>
+    </PackageReference>
+  </ItemGroup>
+  <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
+    <VisualStudioVersion>14.0</VisualStudioVersion>
+  </PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/samples/uwp/ReactiveUI.UwpRouting/ViewModels/FirstViewModel.cs
+++ b/samples/uwp/ReactiveUI.UwpRouting/ViewModels/FirstViewModel.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace ReactiveUI.UwpRouting.ViewModels
+{
+    public class FirstViewModel : ReactiveObject, IRoutableViewModel
+    {
+        // Reference to IScreen that owns the routable view model.
+        public IScreen HostScreen { get; }
+
+        // Unique identifier for the routable view model.
+        public string UrlPathSegment { get; } = Guid.NewGuid().ToString().Substring(0, 5);
+
+        public FirstViewModel(IScreen screen) => HostScreen = screen;
+    }
+}

--- a/samples/uwp/ReactiveUI.UwpRouting/ViewModels/MainViewModel.cs
+++ b/samples/uwp/ReactiveUI.UwpRouting/ViewModels/MainViewModel.cs
@@ -1,0 +1,39 @@
+﻿using System.Reactive;
+using ReactiveUI.UwpRouting.Views;
+using Splat;
+
+namespace ReactiveUI.UwpRouting.ViewModels
+{
+    public class MainViewModel : ReactiveObject, IScreen
+    {
+        // The Router associated with this Screen.
+        // Required by the IScreen interface.
+        public RoutingState Router { get; } = new RoutingState();
+
+        // The command that navigates a user to first view model.
+        public ReactiveCommand<Unit, IRoutableViewModel> GoNext { get; }
+
+        // The command that navigates a user back.
+        public ReactiveCommand<Unit, Unit> GoBack => Router.NavigateBack;
+
+        public MainViewModel()
+        {
+            // Router uses Splat.Locator to resolve views for
+            // view models, so we need to register our views
+            // using Locator.CurrentMutable.Register* methods.
+            //
+            Locator.CurrentMutable.Register(() => new FirstView(), typeof(IViewFor<FirstViewModel>));
+
+            // Manage the routing state. Use the Router.Navigate.Execute
+            // command to navigate to different view models. 
+            //
+            // Note, that the Navigate.Execute method accepts an instance 
+            // of a view model, this allows you to pass parameters to 
+            // your view models, or to reuse existing view models.
+            //
+            GoNext = ReactiveCommand.CreateFromObservable(
+                () => Router.Navigate.Execute(new FirstViewModel(this))
+            );
+        }
+    }
+}

--- a/samples/uwp/ReactiveUI.UwpRouting/Views/FirstView.xaml
+++ b/samples/uwp/ReactiveUI.UwpRouting/Views/FirstView.xaml
@@ -1,0 +1,16 @@
+﻿<UserControl x:Class="ReactiveUI.UwpRouting.Views.FirstView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <UserControl.Transitions>
+        <TransitionCollection>
+            <AddDeleteThemeTransition />
+        </TransitionCollection>
+    </UserControl.Transitions>
+    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+        <StackPanel HorizontalAlignment="Center"
+                    VerticalAlignment="Center">
+            <TextBlock Text="Hello, I'm first view!" />
+            <TextBlock Text="{x:Bind ViewModel.UrlPathSegment, Mode=OneWay}" />
+        </StackPanel>
+    </Grid>
+</UserControl>

--- a/samples/uwp/ReactiveUI.UwpRouting/Views/FirstView.xaml.cs
+++ b/samples/uwp/ReactiveUI.UwpRouting/Views/FirstView.xaml.cs
@@ -1,0 +1,30 @@
+﻿using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using ReactiveUI.UwpRouting.ViewModels;
+
+namespace ReactiveUI.UwpRouting.Views
+{
+    public sealed partial class FirstView : UserControl, IViewFor<FirstViewModel>
+    {
+        public static readonly DependencyProperty ViewModelProperty = DependencyProperty
+            .Register(nameof(ViewModel), typeof(FirstViewModel), typeof(FirstView), null);
+
+        public FirstView()
+        {
+            InitializeComponent();
+            this.WhenActivated(disposables => { });
+        }
+
+        public FirstViewModel ViewModel
+        {
+            get => (FirstViewModel)GetValue(ViewModelProperty);
+            set => SetValue(ViewModelProperty, value);
+        }
+
+        object IViewFor.ViewModel
+        {
+            get => ViewModel;
+            set => ViewModel = (FirstViewModel)value;
+        }
+    }
+}

--- a/samples/uwp/ReactiveUI.UwpRouting/Views/MainView.xaml
+++ b/samples/uwp/ReactiveUI.UwpRouting/Views/MainView.xaml
@@ -1,0 +1,19 @@
+﻿<Page x:Class="ReactiveUI.UwpRouting.Views.MainView"
+      Background="{ThemeResource SystemControlChromeLowAcrylicWindowBrush}"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:reactiveUi="using:ReactiveUI">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+        <reactiveUi:RoutedViewHost Router="{x:Bind ViewModel.Router, Mode=OneWay}" />
+        <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="15">
+            <Button Content="Go next" Command="{x:Bind ViewModel.GoNext, Mode=OneWay}" />
+            <Button Content="Go back" Command="{x:Bind ViewModel.GoBack, Mode=OneWay}" Margin="5 0" />
+            <TextBlock Text="{x:Bind ViewModel.Router.NavigationStack.Count, Mode=OneWay}"
+                       VerticalAlignment="Center" />
+        </StackPanel>
+    </Grid>
+</Page>

--- a/samples/uwp/ReactiveUI.UwpRouting/Views/MainView.xaml.cs
+++ b/samples/uwp/ReactiveUI.UwpRouting/Views/MainView.xaml.cs
@@ -1,0 +1,31 @@
+﻿using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using ReactiveUI.UwpRouting.ViewModels;
+
+namespace ReactiveUI.UwpRouting.Views
+{
+    public sealed partial class MainView : Page, IViewFor<MainViewModel>
+    {
+        public static readonly DependencyProperty ViewModelProperty = DependencyProperty
+            .Register(nameof(ViewModel), typeof(MainViewModel), typeof(MainView), null);
+
+        public MainView()
+        {
+            InitializeComponent();
+            ViewModel = new MainViewModel();
+            this.WhenActivated(disposables => { });
+        }
+
+        public MainViewModel ViewModel
+        {
+            get => (MainViewModel)GetValue(ViewModelProperty);
+            set => SetValue(ViewModelProperty, value);
+        }
+
+        object IViewFor.ViewModel
+        {
+            get => ViewModel;
+            set => ViewModel = (MainViewModel)value;
+        }
+    }
+}


### PR DESCRIPTION
**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

This PR adds a basic Universal Windows Platform routing example powered by ReactiveUI.

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

There are no UWP sample apps now in the samples directory.

**What is the new behavior?**
<!-- If this is a feature change -->

A new UWP sample app is added, showing up ReactiveUI routing (with animations)

**What might this PR break?**

Nothing.