### PR TITLE
fix: Rethrow exception on RaiseAndSetIfChanged

### DIFF
--- a/src/ReactiveUI.Tests/ReactiveObject/ReactiveObjectTests.cs
+++ b/src/ReactiveUI.Tests/ReactiveObject/ReactiveObjectTests.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reactive.Concurrency;
+using System.Reactive.Linq;
 using DynamicData;
 using Xunit;
 
@@ -195,6 +196,19 @@ namespace ReactiveUI.Tests
 
             output.AssertAreEqual(output_changing);
             results.AssertAreEqual(output);
+        }
+
+        [Fact]
+        public void ReactiveObjectShouldRethrowException()
+        {
+            var fixture = new TestFixture();
+            var observable = fixture.WhenAnyValue(x => x.IsOnlyOneWord).Skip(1);
+            observable.Subscribe(x => throw new Exception("This is a test."));
+
+            var result = Record.Exception(() => fixture.IsOnlyOneWord = "Two Words");
+
+            Assert.IsType<Exception>(result);
+            Assert.Equal("This is a test.", result.Message);
         }
     }
 }

--- a/src/ReactiveUI/ReactiveObject/IReactiveObjectExtensions.cs
+++ b/src/ReactiveUI/ReactiveObject/IReactiveObjectExtensions.cs
@@ -391,6 +391,7 @@ namespace ReactiveUI
                     if (_thrownExceptions.IsValueCreated)
                     {
                         _thrownExceptions.Value.OnNext(ex);
+                        return;
                     }
 
                     throw;

--- a/src/ReactiveUI/ReactiveObject/IReactiveObjectExtensions.cs
+++ b/src/ReactiveUI/ReactiveObject/IReactiveObjectExtensions.cs
@@ -392,6 +392,8 @@ namespace ReactiveUI
                     {
                         _thrownExceptions.Value.OnNext(ex);
                     }
+
+                    throw;
                 }
             }
         }


### PR DESCRIPTION
**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Resolves: #2013 

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

Exceptions thrown on `RaiseAndSetIfChanged` are not being rethrown if there is no "ThrownExceptions" subscribed.

**What is the new behavior?**
<!-- If this is a feature change -->

Exceptions thrown on `RaiseAndSetIfChanged` are rethrown if there is no "ThrownExceptions" observable subscriptions.

**What might this PR break?**



**Please check if the PR fulfills these requirements**
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
