### PR TITLE
Suppress binding warnings for BindCommand on WPF #2037

### DIFF
--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.approved.txt
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.approved.txt
@@ -1,4 +1,4 @@
-﻿[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("ReactiveUI.AndroidSupport")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("ReactiveUI.AndroidSupport")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("ReactiveUI.Tests")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("ReactiveUI.Winforms")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("ReactiveUI.Wpf")]
@@ -171,7 +171,7 @@ namespace ReactiveUI
     public interface ICreatesObservableForProperty : Splat.IEnableLogger
     {
         int GetAffinityForObject(System.Type type, string propertyName, bool beforeChanged = False);
-        System.IObservable<ReactiveUI.IObservedChange<object, object>> GetNotificationForProperty(object sender, System.Linq.Expressions.Expression expression, string propertyName, bool beforeChanged = False);
+        System.IObservable<ReactiveUI.IObservedChange<object, object>> GetNotificationForProperty(object sender, System.Linq.Expressions.Expression expression, string propertyName, bool beforeChanged = False, bool suppressWarnings = False);
     }
     public interface IHandleObservableErrors
     {
@@ -198,7 +198,7 @@ namespace ReactiveUI
     {
         public INPCObservableForProperty() { }
         public int GetAffinityForObject(System.Type type, string propertyName, bool beforeChanged) { }
-        public System.IObservable<ReactiveUI.IObservedChange<object, object>> GetNotificationForProperty(object sender, System.Linq.Expressions.Expression expression, string propertyName, bool beforeChanged) { }
+        public System.IObservable<ReactiveUI.IObservedChange<object, object>> GetNotificationForProperty(object sender, System.Linq.Expressions.Expression expression, string propertyName, bool beforeChanged, bool suppressWarnings = False) { }
     }
     public class Interaction<TInput, TOutput>
     {
@@ -293,7 +293,7 @@ namespace ReactiveUI
     {
         public IROObservableForProperty() { }
         public int GetAffinityForObject(System.Type type, string propertyName, bool beforeChanged = False) { }
-        public System.IObservable<ReactiveUI.IObservedChange<object, object>> GetNotificationForProperty(object sender, System.Linq.Expressions.Expression expression, string propertyName, bool beforeChanged = False) { }
+        public System.IObservable<ReactiveUI.IObservedChange<object, object>> GetNotificationForProperty(object sender, System.Linq.Expressions.Expression expression, string propertyName, bool beforeChanged = False, bool suppressWarnings = False) { }
     }
     public interface IRoutableViewModel : ReactiveUI.INotifyPropertyChanging, ReactiveUI.IReactiveObject, Splat.IEnableLogger, System.ComponentModel.INotifyPropertyChanged
     {
@@ -414,7 +414,7 @@ namespace ReactiveUI
     {
         public POCOObservableForProperty() { }
         public int GetAffinityForObject(System.Type type, string propertyName, bool beforeChanged = False) { }
-        public System.IObservable<ReactiveUI.IObservedChange<object, object>> GetNotificationForProperty(object sender, System.Linq.Expressions.Expression expression, string propertyName, bool beforeChanged = False) { }
+        public System.IObservable<ReactiveUI.IObservedChange<object, object>> GetNotificationForProperty(object sender, System.Linq.Expressions.Expression expression, string propertyName, bool beforeChanged = False, bool suppressWarnings = False) { }
     }
     public class PropertyBinderImplementation : ReactiveUI.IPropertyBinderImplementation, Splat.IEnableLogger
     {
@@ -609,6 +609,7 @@ namespace ReactiveUI
         public static System.IObserver<System.Exception> DefaultExceptionHandler { get; set; }
         public static System.Reactive.Concurrency.IScheduler MainThreadScheduler { get; set; }
         public static bool SupportsRangeNotifications { get; set; }
+        public static bool SuppressViewCommandBindingMessage { get; set; }
         public static ReactiveUI.ISuspensionHost SuspensionHost { get; set; }
         public static System.Reactive.Concurrency.IScheduler TaskpoolScheduler { get; set; }
     }

--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.net461.approved.txt
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.net461.approved.txt
@@ -171,7 +171,7 @@ namespace ReactiveUI
     public interface ICreatesObservableForProperty : Splat.IEnableLogger
     {
         int GetAffinityForObject(System.Type type, string propertyName, bool beforeChanged = False);
-        System.IObservable<ReactiveUI.IObservedChange<object, object>> GetNotificationForProperty(object sender, System.Linq.Expressions.Expression expression, string propertyName, bool beforeChanged = False);
+        System.IObservable<ReactiveUI.IObservedChange<object, object>> GetNotificationForProperty(object sender, System.Linq.Expressions.Expression expression, string propertyName, bool beforeChanged = False, bool suppressWarnings = False);
     }
     public interface IHandleObservableErrors
     {
@@ -198,7 +198,7 @@ namespace ReactiveUI
     {
         public INPCObservableForProperty() { }
         public int GetAffinityForObject(System.Type type, string propertyName, bool beforeChanged) { }
-        public System.IObservable<ReactiveUI.IObservedChange<object, object>> GetNotificationForProperty(object sender, System.Linq.Expressions.Expression expression, string propertyName, bool beforeChanged) { }
+        public System.IObservable<ReactiveUI.IObservedChange<object, object>> GetNotificationForProperty(object sender, System.Linq.Expressions.Expression expression, string propertyName, bool beforeChanged, bool suppressWarnings = False) { }
     }
     public class Interaction<TInput, TOutput>
     {
@@ -293,7 +293,7 @@ namespace ReactiveUI
     {
         public IROObservableForProperty() { }
         public int GetAffinityForObject(System.Type type, string propertyName, bool beforeChanged = False) { }
-        public System.IObservable<ReactiveUI.IObservedChange<object, object>> GetNotificationForProperty(object sender, System.Linq.Expressions.Expression expression, string propertyName, bool beforeChanged = False) { }
+        public System.IObservable<ReactiveUI.IObservedChange<object, object>> GetNotificationForProperty(object sender, System.Linq.Expressions.Expression expression, string propertyName, bool beforeChanged = False, bool suppressWarnings = False) { }
     }
     public interface IRoutableViewModel : ReactiveUI.INotifyPropertyChanging, ReactiveUI.IReactiveObject, Splat.IEnableLogger, System.ComponentModel.INotifyPropertyChanged
     {
@@ -419,7 +419,7 @@ namespace ReactiveUI
     {
         public POCOObservableForProperty() { }
         public int GetAffinityForObject(System.Type type, string propertyName, bool beforeChanged = False) { }
-        public System.IObservable<ReactiveUI.IObservedChange<object, object>> GetNotificationForProperty(object sender, System.Linq.Expressions.Expression expression, string propertyName, bool beforeChanged = False) { }
+        public System.IObservable<ReactiveUI.IObservedChange<object, object>> GetNotificationForProperty(object sender, System.Linq.Expressions.Expression expression, string propertyName, bool beforeChanged = False, bool suppressWarnings = False) { }
     }
     public class PropertyBinderImplementation : ReactiveUI.IPropertyBinderImplementation, Splat.IEnableLogger
     {
@@ -525,7 +525,7 @@ namespace ReactiveUI
         public static System.IObservable<ReactiveUI.IObservedChange<TSender, TValue>> ObservableForProperty<TSender, TValue>(this TSender @this, System.Linq.Expressions.Expression<System.Func<TSender, TValue>> property, bool beforeChange = False, bool skipInitial = True) { }
         public static System.IObservable<TRet> ObservableForProperty<TSender, TValue, TRet>(this TSender @this, System.Linq.Expressions.Expression<System.Func<TSender, TValue>> property, System.Func<TValue, TRet> selector, bool beforeChange = False)
             where TSender :  class { }
-        public static System.IObservable<ReactiveUI.IObservedChange<TSender, TValue>> SubscribeToExpressionChain<TSender, TValue>(this TSender source, System.Linq.Expressions.Expression expression, bool beforeChange = False, bool skipInitial = True) { }
+        public static System.IObservable<ReactiveUI.IObservedChange<TSender, TValue>> SubscribeToExpressionChain<TSender, TValue>(this TSender source, System.Linq.Expressions.Expression expression, bool beforeChange = False, bool skipInitial = True, bool suppressWarnings = False) { }
     }
     [System.Runtime.Serialization.DataContractAttribute()]
     public class ReactiveObject : ReactiveUI.IHandleObservableErrors, ReactiveUI.INotifyPropertyChanging, ReactiveUI.IReactiveNotifyPropertyChanged<ReactiveUI.IReactiveObject>, ReactiveUI.IReactiveObject, Splat.IEnableLogger, System.ComponentModel.INotifyPropertyChanged
@@ -613,6 +613,7 @@ namespace ReactiveUI
         public static System.IObserver<System.Exception> DefaultExceptionHandler { get; set; }
         public static System.Reactive.Concurrency.IScheduler MainThreadScheduler { get; set; }
         public static bool SupportsRangeNotifications { get; set; }
+        public static bool SuppressViewCommandBindingMessage { get; set; }
         public static ReactiveUI.ISuspensionHost SuspensionHost { get; set; }
         public static System.Reactive.Concurrency.IScheduler TaskpoolScheduler { get; set; }
     }

--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.netcoreapp2.0.approved.txt
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.netcoreapp2.0.approved.txt
@@ -165,7 +165,7 @@ namespace ReactiveUI
     public interface ICreatesObservableForProperty : Splat.IEnableLogger
     {
         int GetAffinityForObject(System.Type type, string propertyName, bool beforeChanged = False);
-        System.IObservable<ReactiveUI.IObservedChange<object, object>> GetNotificationForProperty(object sender, System.Linq.Expressions.Expression expression, string propertyName, bool beforeChanged = False);
+        System.IObservable<ReactiveUI.IObservedChange<object, object>> GetNotificationForProperty(object sender, System.Linq.Expressions.Expression expression, string propertyName, bool beforeChanged = False, bool suppressWarnings = False);
     }
     public interface IHandleObservableErrors
     {
@@ -192,7 +192,7 @@ namespace ReactiveUI
     {
         public INPCObservableForProperty() { }
         public int GetAffinityForObject(System.Type type, string propertyName, bool beforeChanged) { }
-        public System.IObservable<ReactiveUI.IObservedChange<object, object>> GetNotificationForProperty(object sender, System.Linq.Expressions.Expression expression, string propertyName, bool beforeChanged) { }
+        public System.IObservable<ReactiveUI.IObservedChange<object, object>> GetNotificationForProperty(object sender, System.Linq.Expressions.Expression expression, string propertyName, bool beforeChanged, bool suppressWarnings = False) { }
     }
     public class Interaction<TInput, TOutput>
     {
@@ -287,7 +287,7 @@ namespace ReactiveUI
     {
         public IROObservableForProperty() { }
         public int GetAffinityForObject(System.Type type, string propertyName, bool beforeChanged = False) { }
-        public System.IObservable<ReactiveUI.IObservedChange<object, object>> GetNotificationForProperty(object sender, System.Linq.Expressions.Expression expression, string propertyName, bool beforeChanged = False) { }
+        public System.IObservable<ReactiveUI.IObservedChange<object, object>> GetNotificationForProperty(object sender, System.Linq.Expressions.Expression expression, string propertyName, bool beforeChanged = False, bool suppressWarnings = False) { }
     }
     public interface IRoutableViewModel : ReactiveUI.INotifyPropertyChanging, ReactiveUI.IReactiveObject, Splat.IEnableLogger, System.ComponentModel.INotifyPropertyChanged
     {
@@ -413,7 +413,7 @@ namespace ReactiveUI
     {
         public POCOObservableForProperty() { }
         public int GetAffinityForObject(System.Type type, string propertyName, bool beforeChanged = False) { }
-        public System.IObservable<ReactiveUI.IObservedChange<object, object>> GetNotificationForProperty(object sender, System.Linq.Expressions.Expression expression, string propertyName, bool beforeChanged = False) { }
+        public System.IObservable<ReactiveUI.IObservedChange<object, object>> GetNotificationForProperty(object sender, System.Linq.Expressions.Expression expression, string propertyName, bool beforeChanged = False, bool suppressWarnings = False) { }
     }
     public class PropertyBinderImplementation : ReactiveUI.IPropertyBinderImplementation, Splat.IEnableLogger
     {
@@ -519,7 +519,7 @@ namespace ReactiveUI
         public static System.IObservable<ReactiveUI.IObservedChange<TSender, TValue>> ObservableForProperty<TSender, TValue>(this TSender @this, System.Linq.Expressions.Expression<System.Func<TSender, TValue>> property, bool beforeChange = False, bool skipInitial = True) { }
         public static System.IObservable<TRet> ObservableForProperty<TSender, TValue, TRet>(this TSender @this, System.Linq.Expressions.Expression<System.Func<TSender, TValue>> property, System.Func<TValue, TRet> selector, bool beforeChange = False)
             where TSender :  class { }
-        public static System.IObservable<ReactiveUI.IObservedChange<TSender, TValue>> SubscribeToExpressionChain<TSender, TValue>(this TSender source, System.Linq.Expressions.Expression expression, bool beforeChange = False, bool skipInitial = True) { }
+        public static System.IObservable<ReactiveUI.IObservedChange<TSender, TValue>> SubscribeToExpressionChain<TSender, TValue>(this TSender source, System.Linq.Expressions.Expression expression, bool beforeChange = False, bool skipInitial = True, bool suppressWarnings = False) { }
     }
     [System.Runtime.Serialization.DataContractAttribute()]
     public class ReactiveObject : ReactiveUI.IHandleObservableErrors, ReactiveUI.INotifyPropertyChanging, ReactiveUI.IReactiveNotifyPropertyChanged<ReactiveUI.IReactiveObject>, ReactiveUI.IReactiveObject, Splat.IEnableLogger, System.ComponentModel.INotifyPropertyChanged
@@ -607,6 +607,7 @@ namespace ReactiveUI
         public static System.IObserver<System.Exception> DefaultExceptionHandler { get; set; }
         public static System.Reactive.Concurrency.IScheduler MainThreadScheduler { get; set; }
         public static bool SupportsRangeNotifications { get; set; }
+        public static bool SuppressViewCommandBindingMessage { get; set; }
         public static ReactiveUI.ISuspensionHost SuspensionHost { get; set; }
         public static System.Reactive.Concurrency.IScheduler TaskpoolScheduler { get; set; }
     }

--- a/src/ReactiveUI.Tests/Platforms/winforms/API/ApiApprovalTests.Winforms.net461.approved.txt
+++ b/src/ReactiveUI.Tests/Platforms/winforms/API/ApiApprovalTests.Winforms.net461.approved.txt
@@ -104,7 +104,7 @@ namespace ReactiveUI.Winforms
     {
         public WinformsCreatesObservableForProperty() { }
         public int GetAffinityForObject(System.Type type, string propertyName, bool beforeChanged = False) { }
-        public System.IObservable<ReactiveUI.IObservedChange<object, object>> GetNotificationForProperty(object sender, System.Linq.Expressions.Expression expression, string propertyName, bool beforeChanged = False) { }
+        public System.IObservable<ReactiveUI.IObservedChange<object, object>> GetNotificationForProperty(object sender, System.Linq.Expressions.Expression expression, string propertyName, bool beforeChanged = False, bool suppressWarnings = False) { }
     }
 }
 namespace ReactiveUI.Winforms.Legacy

--- a/src/ReactiveUI.Tests/Platforms/wpf/API/ApiApprovalTests.Wpf.net461.approved.txt
+++ b/src/ReactiveUI.Tests/Platforms/wpf/API/ApiApprovalTests.Wpf.net461.approved.txt
@@ -37,7 +37,7 @@ namespace ReactiveUI
     {
         public DependencyObjectObservableForProperty() { }
         public int GetAffinityForObject(System.Type type, string propertyName, bool beforeChanged = False) { }
-        public System.IObservable<ReactiveUI.IObservedChange<object, object>> GetNotificationForProperty(object sender, System.Linq.Expressions.Expression expression, string propertyName, bool beforeChanged = False) { }
+        public System.IObservable<ReactiveUI.IObservedChange<object, object>> GetNotificationForProperty(object sender, System.Linq.Expressions.Expression expression, string propertyName, bool beforeChanged = False, bool suppressWarnings = False) { }
     }
     public class PlatformOperations
     {

--- a/src/ReactiveUI.Tests/Platforms/wpf/Mocks/FakeXamlCommandBindingView.cs
+++ b/src/ReactiveUI.Tests/Platforms/wpf/Mocks/FakeXamlCommandBindingView.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Windows.Controls;
+
+namespace ReactiveUI.Tests.Wpf
+{
+    public class FakeXamlCommandBindingView : IViewFor<CommandBindingViewModel>
+    {
+        private readonly Button _buttonDeclaredInXaml;
+
+        public FakeXamlCommandBindingView()
+        {
+            _buttonDeclaredInXaml = new Button();
+
+            this.BindCommand(ViewModel, vm => vm.Command2, v => v._buttonDeclaredInXaml);
+        }
+
+        public string NameOfButtonDeclaredInXaml => nameof(_buttonDeclaredInXaml);
+
+        object IViewFor.ViewModel
+        {
+            get => ViewModel;
+            set => ViewModel = (CommandBindingViewModel)value;
+        }
+
+        public CommandBindingViewModel ViewModel { get; set; }
+    }
+}

--- a/src/ReactiveUI.Tests/Platforms/wpf/WpfCommandBindingImplementationTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/wpf/WpfCommandBindingImplementationTests.cs
@@ -11,6 +11,8 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
 using ReactiveUI.Tests.Xaml;
+using Shouldly;
+using Splat;
 using Xunit;
 
 using FactAttribute = Xunit.WpfFactAttribute;
@@ -36,6 +38,18 @@ namespace ReactiveUI.Tests.Wpf
 
             view.Command2.RaiseEvent(new MouseButtonEventArgs(Mouse.PrimaryDevice, 0, MouseButton.Left) { RoutedEvent = UIElement.MouseUpEvent });
             Assert.Equal(1, invokeCount);
+        }
+
+        [Fact]
+        public void BindCommandShouldNotWarnWhenBindingToFieldDeclaredInXaml()
+        {
+            var testLogger = new TestLogger();
+            Locator.CurrentMutable.RegisterConstant<ILogger>(testLogger);
+
+            var vm = new CommandBindingViewModel();
+            var view = new FakeXamlCommandBindingView { ViewModel = vm };
+
+            testLogger.Messages.ShouldNotContain(t => t.Item1.Contains(nameof(POCOObservableForProperty)) && t.Item1.Contains(view.NameOfButtonDeclaredInXaml) && t.Item3 == LogLevel.Warn);
         }
     }
 }

--- a/src/ReactiveUI.Winforms/WinformsCreatesObservableForProperty.cs
+++ b/src/ReactiveUI.Winforms/WinformsCreatesObservableForProperty.cs
@@ -43,7 +43,7 @@ namespace ReactiveUI.Winforms
         }
 
         /// <inheritdoc/>
-        public IObservable<IObservedChange<object, object>> GetNotificationForProperty(object sender, Expression expression, string propertyName, bool beforeChanged = false)
+        public IObservable<IObservedChange<object, object>> GetNotificationForProperty(object sender, Expression expression, string propertyName, bool beforeChanged = false, bool suppressWarnings = false)
         {
             var ei = eventInfoCache.Get(Tuple.Create(sender.GetType(), propertyName));
 

--- a/src/ReactiveUI.Wpf/DependencyObjectObservableForProperty.cs
+++ b/src/ReactiveUI.Wpf/DependencyObjectObservableForProperty.cs
@@ -34,14 +34,18 @@ namespace ReactiveUI
         }
 
         /// <inheritdoc/>
-        public IObservable<IObservedChange<object, object>> GetNotificationForProperty(object sender, System.Linq.Expressions.Expression expression, string propertyName, bool beforeChanged = false)
+        public IObservable<IObservedChange<object, object>> GetNotificationForProperty(object sender, System.Linq.Expressions.Expression expression, string propertyName, bool beforeChanged = false, bool suppressWarnings = false)
         {
             var type = sender.GetType();
             var dpd = DependencyPropertyDescriptor.FromProperty(GetDependencyProperty(type, propertyName), type);
 
             if (dpd == null)
             {
-                this.Log().Error("Couldn't find dependency property " + propertyName + " on " + type.Name);
+                if (!suppressWarnings)
+                {
+                    this.Log().Error("Couldn't find dependency property " + propertyName + " on " + type.Name);
+                }
+
                 throw new NullReferenceException("Couldn't find dependency property " + propertyName + " on " + type.Name);
             }
 

--- a/src/ReactiveUI.Wpf/Registrations.cs
+++ b/src/ReactiveUI.Wpf/Registrations.cs
@@ -26,6 +26,8 @@ namespace ReactiveUI.Wpf
             RxApp.TaskpoolScheduler = TaskPoolScheduler.Default;
 
             RxApp.MainThreadScheduler = new WaitForDispatcherScheduler(() => DispatcherScheduler.Current);
+
+            RxApp.SuppressViewCommandBindingMessage = true;
         }
     }
 }

--- a/src/ReactiveUI/Bindings/Command/CommandBinderImplementation.cs
+++ b/src/ReactiveUI/Bindings/Command/CommandBinderImplementation.cs
@@ -138,7 +138,7 @@ namespace ReactiveUI
 
             var bindInfo = Observable.CombineLatest(
                 @this,
-                view.WhenAnyDynamic(controlExpression, x => x.Value),
+                view.SubscribeToExpressionChain<TView, object>(controlExpression, false, false, RxApp.SuppressViewCommandBindingMessage).Select(x => x.Value),
                 (val, host) => new { val, host });
 
             var propSub = bindInfo

--- a/src/ReactiveUI/Interfaces/ICreatesObservableForProperty.cs
+++ b/src/ReactiveUI/Interfaces/ICreatesObservableForProperty.cs
@@ -44,9 +44,10 @@ namespace ReactiveUI
         /// <param name="beforeChanged">If true, signal just before the
         /// property value actually changes. If false, signal after the
         /// property changes.</param>
+        /// <param name="suppressWarnings">If true, no warnings should be logged.</param>
         /// <returns>An IObservable which is signalled whenever the specified
         /// property on the object changes. If this cannot be done for a
         /// specified value of beforeChanged, return Observable.Never.</returns>
-        IObservable<IObservedChange<object, object>> GetNotificationForProperty(object sender, Expression expression, string propertyName, bool beforeChanged = false);
+        IObservable<IObservedChange<object, object>> GetNotificationForProperty(object sender, Expression expression, string propertyName, bool beforeChanged = false, bool suppressWarnings = false);
     }
 }

--- a/src/ReactiveUI/ObservableForProperty/INPCObservableForProperty.cs
+++ b/src/ReactiveUI/ObservableForProperty/INPCObservableForProperty.cs
@@ -26,7 +26,7 @@ namespace ReactiveUI
 
         /// <inheritdoc/>
         [SuppressMessage("Roslynator", "RCS1211", Justification = "Neater with else clause.")]
-        public IObservable<IObservedChange<object, object>> GetNotificationForProperty(object sender, Expression expression, string propertyName, bool beforeChanged)
+        public IObservable<IObservedChange<object, object>> GetNotificationForProperty(object sender, Expression expression, string propertyName, bool beforeChanged, bool suppressWarnings = false)
         {
             var before = sender as INotifyPropertyChanging;
             var after = sender as INotifyPropertyChanged;

--- a/src/ReactiveUI/ObservableForProperty/IROObservableForProperty.cs
+++ b/src/ReactiveUI/ObservableForProperty/IROObservableForProperty.cs
@@ -25,7 +25,7 @@ namespace ReactiveUI
         }
 
         /// <inheritdoc/>
-        public IObservable<IObservedChange<object, object>> GetNotificationForProperty(object sender, Expression expression, string propertyName, bool beforeChanged = false)
+        public IObservable<IObservedChange<object, object>> GetNotificationForProperty(object sender, Expression expression, string propertyName, bool beforeChanged = false, bool suppressWarnings = false)
         {
             var iro = sender as IReactiveObject;
             if (iro == null)

--- a/src/ReactiveUI/ObservableForProperty/POCOObservableForProperty.cs
+++ b/src/ReactiveUI/ObservableForProperty/POCOObservableForProperty.cs
@@ -28,10 +28,10 @@ namespace ReactiveUI
         }
 
         /// <inheritdoc/>
-        public IObservable<IObservedChange<object, object>> GetNotificationForProperty(object sender, Expression expression, string propertyName, bool beforeChanged = false)
+        public IObservable<IObservedChange<object, object>> GetNotificationForProperty(object sender, Expression expression, string propertyName, bool beforeChanged = false, bool suppressWarnings = false)
         {
             var type = sender.GetType();
-            if (!hasWarned.ContainsKey((type, propertyName)))
+            if (!hasWarned.ContainsKey((type, propertyName)) && !suppressWarnings)
             {
                 this.Log().Warn($"The class {type.FullName} property {propertyName} is a POCO type and won't send change notifications, WhenAny will only return a single value!");
                 hasWarned[(type, propertyName)] = true;

--- a/src/ReactiveUI/Platforms/android/AndroidObservableForWidgets.cs
+++ b/src/ReactiveUI/Platforms/android/AndroidObservableForWidgets.cs
@@ -52,7 +52,7 @@ namespace ReactiveUI
         }
 
         /// <inheritdoc/>
-        public IObservable<IObservedChange<object, object>> GetNotificationForProperty(object sender, Expression expression, string propertyName, bool beforeChanged = false)
+        public IObservable<IObservedChange<object, object>> GetNotificationForProperty(object sender, Expression expression, string propertyName, bool beforeChanged = false, bool suppressWarnings = false)
         {
             var type = sender.GetType();
             var tableItem = dispatchTable.Keys.First(x => x.Item1.IsAssignableFrom(type) && x.Item2 == propertyName);

--- a/src/ReactiveUI/Platforms/apple-common/KVOObservableForProperty.cs
+++ b/src/ReactiveUI/Platforms/apple-common/KVOObservableForProperty.cs
@@ -67,7 +67,7 @@ namespace ReactiveUI
         }
 
         /// <inheritdoc/>
-        public IObservable<IObservedChange<object, object>> GetNotificationForProperty(object sender, Expression expression, string propertyName, bool beforeChanged = false)
+        public IObservable<IObservedChange<object, object>> GetNotificationForProperty(object sender, Expression expression, string propertyName, bool beforeChanged = false, bool suppressWarnings = false)
         {
             var obj = sender as NSObject;
             if (obj == null)

--- a/src/ReactiveUI/Platforms/apple-common/ObservableForPropertyBase.cs
+++ b/src/ReactiveUI/Platforms/apple-common/ObservableForPropertyBase.cs
@@ -57,7 +57,7 @@ namespace ReactiveUI
         }
 
         /// <inheritdoc/>
-        public IObservable<IObservedChange<object, object>> GetNotificationForProperty(object sender, Expression expression, string propertyName, bool beforeChanged = false)
+        public IObservable<IObservedChange<object, object>> GetNotificationForProperty(object sender, Expression expression, string propertyName, bool beforeChanged = false, bool suppressWarnings = false)
         {
             if (beforeChanged)
             {

--- a/src/ReactiveUI/Platforms/uap/DependencyObjectObservableForProperty.cs
+++ b/src/ReactiveUI/Platforms/uap/DependencyObjectObservableForProperty.cs
@@ -37,7 +37,7 @@ namespace ReactiveUI
         }
 
         /// <inheritdoc/>
-        public IObservable<IObservedChange<object, object>> GetNotificationForProperty(object sender, System.Linq.Expressions.Expression expression, string propertyName, bool beforeChanged = false)
+        public IObservable<IObservedChange<object, object>> GetNotificationForProperty(object sender, System.Linq.Expressions.Expression expression, string propertyName, bool beforeChanged = false, bool suppressWarnings = false)
         {
             Contract.Requires(sender != null && sender is DependencyObject);
             var type = sender.GetType();
@@ -45,11 +45,14 @@ namespace ReactiveUI
 
             if (depSender == null)
             {
-                this.Log().Warn(
-                    CultureInfo.InvariantCulture,
-                    "Tried to bind DP on a non-DependencyObject. Binding as POCO object",
-                    type.FullName,
-                    propertyName);
+                if (!suppressWarnings)
+                {
+                    this.Log().Warn(
+                                    CultureInfo.InvariantCulture,
+                                    "Tried to bind DP on a non-DependencyObject. Binding as POCO object",
+                                    type.FullName,
+                                    propertyName);
+                }
 
                 var ret = new POCOObservableForProperty();
                 return ret.GetNotificationForProperty(sender, expression, propertyName, beforeChanged);

--- a/src/ReactiveUI/RxApp.cs
+++ b/src/ReactiveUI/RxApp.cs
@@ -190,6 +190,11 @@ namespace ReactiveUI
         }
 
         /// <summary>
+        /// Gets or sets a value indicating whether log messages should be suppressed for command bindings in the view.
+        /// </summary>
+        public static bool SuppressViewCommandBindingMessage { get; set; }
+
+        /// <summary>
         /// Gets or sets the Observer which signalled whenever an object that has a
         /// ThrownExceptions property doesn't Subscribe to that Observable. Use
         /// Observer.Create to set up what will happen - the default is to crash


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bug fix


**What is the current behavior?**
BindCommand will output warnings when binding ViewModel command to view button on WPF #2037



**What is the new behavior?**
Warnings are suppressed for the specific scenario.



**What might this PR break?**
API approval tests


**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

