### PR TITLE
fix: BindCommand unhandled exceptions don't fire on Xamarin Android

### DIFF
--- a/src/ReactiveUI/Platforms/android/HandlerScheduler.cs
+++ b/src/ReactiveUI/Platforms/android/HandlerScheduler.cs
@@ -51,11 +51,6 @@ namespace ReactiveUI
             bool isCancelled = false;
             var innerDisp = new SerialDisposable() { Disposable = Disposable.Empty };
 
-            if (_looperId > 0 && _looperId == Java.Lang.Thread.CurrentThread().Id)
-            {
-                return action(this, state);
-            }
-
             _handler.Post(() =>
             {
                 if (isCancelled)


### PR DESCRIPTION
Fixes #1859 where the android bind command will swallow exceptions.