### PR TITLE
fix: Android WireUpControls throws exception in VS2019

### DIFF
--- a/src/ReactiveUI.AndroidSupport/ControlFetcherMixin.cs
+++ b/src/ReactiveUI.AndroidSupport/ControlFetcherMixin.cs
@@ -34,10 +34,9 @@ namespace ReactiveUI.AndroidSupport
 
         static ControlFetcherMixin()
         {
-            // NB: This is some hacky shit, but on Xamarin.Android at the moment,
-            // this is always the entry assembly.
-            var assm = AppDomain.CurrentDomain.GetAssemblies()[1];
-            var resources = assm.GetModules().SelectMany(x => x.GetTypes()).First(x => x.Name == "Resource");
+            var assemblyName = Assembly.GetCallingAssembly().GetName().Name;
+            var assembly = AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(i => i.GetName().Name == assemblyName);
+            var resources = assembly.GetModules().SelectMany(x => x.GetTypes()).First(x => x.Name == "Resource");
 
             controlIds = resources.GetNestedType("Id").GetFields()
                 .Where(x => x.FieldType == typeof(int))

--- a/src/ReactiveUI/Platforms/android/ControlFetcherMixin.cs
+++ b/src/ReactiveUI/Platforms/android/ControlFetcherMixin.cs
@@ -33,10 +33,9 @@ namespace ReactiveUI
         [SuppressMessage("Design", "CA1065: Not not throw exceptions in static constructor", Justification = "TODO: Future fix")]
         static ControlFetcherMixin()
         {
-            // NB: This is some hacky shit, but on Xamarin.Android at the moment,
-            // this is always the entry assembly.
-            var assm = AppDomain.CurrentDomain.GetAssemblies()[1];
-            var resources = assm.GetModules().SelectMany(x => x.GetTypes()).First(x => x.Name == "Resource");
+            var assemblyName = Assembly.GetCallingAssembly().GetName().Name;
+            var assembly = AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(i => i.GetName().Name == assemblyName);
+            var resources = assembly.GetModules().SelectMany(x => x.GetTypes()).First(x => x.Name == "Resource");
 
             try
             {


### PR DESCRIPTION
- Removed the assumption that the array holds a correct list as it's now alphabetical except for mscor.lib
- Changed the assumption to the calling assembly as this is "generally" the Assembly that will want to wire up the controls

**What kind of change does this PR introduce?**
Fixes #1993 

**What is the current behavior?**
When using ReactiveUI.Android it crashes the entire app due to the compiler in VS2019
#1993 

**What might this PR break?**
It assumes that the WireUpControls being called will be called from the Assembly that is interested in wiring up controls

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)

Unsure how to test this correctly, please advise which Test Solution to write this in?

- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

