### PR TITLE
Feature:  ReactiveRecyclerViewAdapter.GetItemViewType now passed view model type

### DIFF
--- a/src/ReactiveUI.AndroidSupport/ReactiveRecyclerViewAdapter.cs
+++ b/src/ReactiveUI.AndroidSupport/ReactiveRecyclerViewAdapter.cs
@@ -90,7 +90,7 @@ namespace ReactiveUI.AndroidSupport
 
         private TViewModel GetViewModelByPosition(int position)
         {
-            return _list.Count > position ? null : _list.Items.ElementAt(position);
+            return position > _list.Count ? null : _list.Items.ElementAt(position);
         }
 
         private void UpdateBindings(Change<TViewModel> change)

--- a/src/ReactiveUI.AndroidSupport/ReactiveRecyclerViewAdapter.cs
+++ b/src/ReactiveUI.AndroidSupport/ReactiveRecyclerViewAdapter.cs
@@ -53,9 +53,27 @@ namespace ReactiveUI.AndroidSupport
         public override int ItemCount => _list.Count;
 
         /// <inheritdoc/>
+        public override int GetItemViewType(int position)
+        {
+            return GetItemViewType(position, GetViewModelByPosition(position));
+        }
+
+        /// <summary>
+        /// Determine the View that will be used/re-used in lists where
+        /// the list contains different cell designs.
+        /// </summary>
+        /// <param name="position">The position of the current view in the list.</param>
+        /// <param name="viewModel">The ViewModel associated with the current View.</param>
+        /// <returns>An ID to be used in OnCreateViewHolder.</returns>
+        public int GetItemViewType(int position, TViewModel viewModel)
+        {
+            return base.GetItemViewType(position);
+        }
+
+        /// <inheritdoc/>
         public override void OnBindViewHolder(RecyclerView.ViewHolder holder, int position)
         {
-            ((IViewFor)holder).ViewModel = _list.Items.ElementAt(position);
+            ((IViewFor)holder).ViewModel = GetViewModelByPosition(position);
         }
 
         /// <inheritdoc/>
@@ -68,6 +86,11 @@ namespace ReactiveUI.AndroidSupport
             }
 
             base.Dispose(disposing);
+        }
+
+        private TViewModel GetViewModelByPosition(int position)
+        {
+            return _list.Count > position ? null : _list.Items.ElementAt(position);
         }
 
         private void UpdateBindings(Change<TViewModel> change)


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Feature

**What is the current behavior?**
The GetItemViewType is standard with only a position ID, which cannot be used to work out what item belongs in the sourceList.

**What is the new behavior?**
The GetItemViewType addition, now bubbles up the current position as well as the ViewModel so that the cell view type can be worked out.  This is important following best practices when a RecyclerView has different ViewHolders inside it.  With different View Cells.

**What might this PR break?**
Unsure


**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

