### PR TITLE
housekeeping: Correct links to Installation docs

### DIFF
--- a/src/ReactiveUI/Mixins/ReactiveNotifyPropertyChangedMixin.cs
+++ b/src/ReactiveUI/Mixins/ReactiveNotifyPropertyChangedMixin.cs
@@ -205,7 +205,7 @@ namespace ReactiveUI
 
             if (result == null)
             {
-                throw new Exception($"Could not find a ICreatesObservableForProperty for {sender.GetType()} property {propertyName}. This should never happen, your service locator is probably broken. Please make sure you have installed the latest version of the ReactiveUI packages for your platform. See https://reactiveui.net/docs/getting-started/installation/nuget-packages for guidance.");
+                throw new Exception($"Could not find a ICreatesObservableForProperty for {sender.GetType()} property {propertyName}. This should never happen, your service locator is probably broken. Please make sure you have installed the latest version of the ReactiveUI packages for your platform. See https://reactiveui.net/docs/getting-started/installation for guidance.");
             }
 
             return result.GetNotificationForProperty(sender, expression, propertyName, beforeChange, suppressWarnings);

--- a/src/ReactiveUI/Platforms/netstandard2.0/PlatformRegistrations.cs
+++ b/src/ReactiveUI/Platforms/netstandard2.0/PlatformRegistrations.cs
@@ -16,7 +16,7 @@ namespace ReactiveUI
         /// <inheritdoc/>
         public void Register(Action<Func<object>, Type> registerFunction)
         {
-            throw new Exception("You are referencing the Portable version of ReactiveUI in an App. Please change your reference to the specific version for your platform found here: https://reactiveui.net/docs/getting-started/installation/nuget-packages");
+            throw new Exception("You are referencing the Portable version of ReactiveUI in an App. Please change your reference to the specific version for your platform found here: https://reactiveui.net/docs/getting-started/installation");
         }
     }
 }

--- a/src/ReactiveUI/Platforms/windows-common/RoutedViewHost.cs
+++ b/src/ReactiveUI/Platforms/windows-common/RoutedViewHost.cs
@@ -69,7 +69,7 @@ namespace ReactiveUI
             {
                 // NB: This used to be an error but WPF design mode can't read
                 // good or do other stuff good.
-                this.Log().Error("Couldn't find an IPlatformOperations implementation. Please make sure you have installed the latest version of the ReactiveUI packages for your platform. See https://reactiveui.net/docs/getting-started/installation/nuget-packages for guidance.");
+                this.Log().Error("Couldn't find an IPlatformOperations implementation. Please make sure you have installed the latest version of the ReactiveUI packages for your platform. See https://reactiveui.net/docs/getting-started/installation for guidance.");
             }
             else
             {

--- a/src/ReactiveUI/Platforms/windows-common/ViewModelViewHost.cs
+++ b/src/ReactiveUI/Platforms/windows-common/ViewModelViewHost.cs
@@ -73,7 +73,7 @@ namespace ReactiveUI
             {
                 // NB: This used to be an error but WPF design mode can't read
                 // good or do other stuff good.
-                this.Log().Error("Couldn't find an IPlatformOperations implementation. Please make sure you have installed the latest version of the ReactiveUI packages for your platform. See https://reactiveui.net/docs/getting-started/installation/nuget-packages for guidance.");
+                this.Log().Error("Couldn't find an IPlatformOperations implementation. Please make sure you have installed the latest version of the ReactiveUI packages for your platform. See https://reactiveui.net/docs/getting-started/installation for guidance.");
             }
             else
             {


### PR DESCRIPTION
**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Fix https://github.com/reactiveui/ReactiveUI/issues/2053

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

Links to the [Installation](https://reactiveui.net/docs/getting-started/installation/) page are broken.

**What is the new behavior?**
<!-- If this is a feature change -->

Links to the [Installation](https://reactiveui.net/docs/getting-started/installation/) page are no longer broken.

**What might this PR break?**

Nothing.
