### PR TITLE
fix: uno not including ReactiveUI NuGet package

### DIFF
--- a/src/ReactiveUI.Uno/ActivationForViewFetcher.cs
+++ b/src/ReactiveUI.Uno/ActivationForViewFetcher.cs
@@ -12,7 +12,7 @@ using System.Reflection;
 using Windows.Foundation;
 using Windows.UI.Xaml;
 
-namespace ReactiveUI
+namespace ReactiveUI.Uno
 {
     /// <summary>
     /// ActiveationForViewFetcher is how ReactiveUI determine when a

--- a/src/ReactiveUI.Uno/PlatformRegistrations.cs
+++ b/src/ReactiveUI.Uno/PlatformRegistrations.cs
@@ -7,7 +7,7 @@ using System;
 using System.Reactive.Concurrency;
 using System.Reactive.PlatformServices;
 
-namespace ReactiveUI
+namespace ReactiveUI.Uno
 {
     /// <summary>
     /// UWP platform registrations.
@@ -23,7 +23,9 @@ namespace ReactiveUI
             registerFunction(() => new DependencyObjectObservableForProperty(), typeof(ICreatesObservableForProperty));
             registerFunction(() => new BooleanToVisibilityTypeConverter(), typeof(IBindingTypeConverter));
             registerFunction(() => new AutoDataTemplateBindingHook(), typeof(IPropertyBindingHook));
-            registerFunction(() => new WinRTAppDataDriver(), typeof(ISuspensionDriver));
+
+            // Re-enable once the obsolete code in Uno has been worked out.
+            ////registerFunction(() => new WinRTAppDataDriver(), typeof(ISuspensionDriver));
 
 #if NETSTANDARD
             if (WasmPlatformEnlightenmentProvider.IsWasm)

--- a/src/ReactiveUI.Uno/ReactiveUI.Uno.csproj
+++ b/src/ReactiveUI.Uno/ReactiveUI.Uno.csproj
@@ -12,22 +12,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Uno.UI" Version="1.44.1" />
-    <PackageReference Include="System.Reactive" Version="4.1.5" />
-    <PackageReference Include="Splat" Version="7.*" />
-    <PackageReference Include="DynamicData" Version="6.*" />
+    <PackageReference Include="Uno.UI" Version="1.*" />
   </ItemGroup>
 
   <ItemGroup>
-    <!-- Include all the files under RxUI, due to the way Uno works we need to duplicate -->
-    <Compile Include="..\ReactiveUI\**\*.cs" LinkBase="ReactiveUI" />
-
-    <Compile Remove="..\ReactiveUI\Platforms\**\*.*" />
-    <Compile Remove="..\ReactiveUI\**\bin\**\*.*" />
-    <Compile Remove="..\ReactiveUI\**\obj\**\*.*" />
-
-    <Compile Remove=".\Platforms\**\*.*" />
-
     <Compile Include="..\ReactiveUI\Platforms\uap\TransitioningContentControl.Empty.cs" LinkBase="ReactiveUI\Platforms\uap" />
     <Compile Include="..\ReactiveUI\Platforms\uap\DependencyObjectObservableForProperty.cs" LinkBase="ReactiveUI\Platforms\uap" />
     <Compile Include="..\ReactiveUI\Platforms\windows-common\**\*.cs" LinkBase="ReactiveUI\Platforms\windows-common" />
@@ -40,4 +28,7 @@
     <Compile Include=".\Platforms\netstandard\**\*.cs" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\ReactiveUI\ReactiveUI.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/ReactiveUI.Uno/WinRTAppDataDriver.cs
+++ b/src/ReactiveUI.Uno/WinRTAppDataDriver.cs
@@ -18,7 +18,7 @@ using System.Xml.Serialization;
 using Windows.Storage;
 using UnicodeEncoding = Windows.Storage.Streams.UnicodeEncoding;
 
-namespace ReactiveUI
+namespace ReactiveUI.Uno
 {
     /// <summary>
     /// Loads and saves state to persistent storage.

--- a/src/ReactiveUI/Platforms/uap/DependencyObjectObservableForProperty.cs
+++ b/src/ReactiveUI/Platforms/uap/DependencyObjectObservableForProperty.cs
@@ -13,7 +13,11 @@ using System.Windows;
 using Splat;
 using Windows.UI.Xaml;
 
+#if HAS_UNO
+namespace ReactiveUI.Uno
+#else
 namespace ReactiveUI
+#endif
 {
     /// <summary>
     /// Creates a observable for a property if available that is based on a DependencyProperty.

--- a/src/ReactiveUI/Platforms/uap/TransitioningContentControl.Empty.cs
+++ b/src/ReactiveUI/Platforms/uap/TransitioningContentControl.Empty.cs
@@ -6,7 +6,11 @@
 using System.Diagnostics.CodeAnalysis;
 using Windows.UI.Xaml.Controls;
 
+#if HAS_UNO
+namespace ReactiveUI.Uno
+#else
 namespace ReactiveUI
+#endif
 {
     /// <summary>
     /// A control with a single transition.

--- a/src/ReactiveUI/Platforms/windows-common/AutoDataTemplateBindingHook.cs
+++ b/src/ReactiveUI/Platforms/windows-common/AutoDataTemplateBindingHook.cs
@@ -16,7 +16,11 @@ using System.Windows.Controls;
 using System.Windows.Markup;
 #endif
 
+#if HAS_UNO
+namespace ReactiveUI.Uno
+#else
 namespace ReactiveUI
+#endif
 {
     /// <summary>
     /// AutoDataTemplateBindingHook is a binding hook that checks ItemsControls

--- a/src/ReactiveUI/Platforms/windows-common/BooleanToVisibilityHint.cs
+++ b/src/ReactiveUI/Platforms/windows-common/BooleanToVisibilityHint.cs
@@ -11,7 +11,11 @@ using Windows.UI.Xaml;
 using System.Windows;
 #endif
 
+#if HAS_UNO
+namespace ReactiveUI.Uno
+#else
 namespace ReactiveUI
+#endif
 {
     /// <summary>
     /// Enum that hints at the visibility of a ui element.

--- a/src/ReactiveUI/Platforms/windows-common/BooleanToVisibilityTypeConverter.cs
+++ b/src/ReactiveUI/Platforms/windows-common/BooleanToVisibilityTypeConverter.cs
@@ -10,7 +10,11 @@ using Windows.UI.Xaml;
 using System.Windows;
 #endif
 
+#if HAS_UNO
+namespace ReactiveUI.Uno
+#else
 namespace ReactiveUI
+#endif
 {
     /// <summary>
     /// This type convert converts between Boolean and XAML Visibility - the

--- a/src/ReactiveUI/Platforms/windows-common/PlatformOperations.cs
+++ b/src/ReactiveUI/Platforms/windows-common/PlatformOperations.cs
@@ -9,7 +9,11 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
+#if HAS_UNO
+namespace ReactiveUI.Uno
+#else
 namespace ReactiveUI
+#endif
 {
     /// <summary>
     /// Returns the current orientation of the device on Windows.

--- a/src/ReactiveUI/Platforms/windows-common/ReactivePage.cs
+++ b/src/ReactiveUI/Platforms/windows-common/ReactivePage.cs
@@ -3,17 +3,21 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-namespace ReactiveUI
-{
-    using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 #if NETFX_CORE || HAS_UNO
-    using Windows.UI.Xaml;
-    using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
 #else
-    using System.Windows;
-    using System.Windows.Controls;
+using System.Windows;
+using System.Windows.Controls;
 #endif
 
+#if HAS_UNO
+namespace ReactiveUI.Uno
+#else
+namespace ReactiveUI
+#endif
+{
     /// <summary>
     /// A <see cref="Page"/> that is reactive.
     /// </summary>

--- a/src/ReactiveUI/Platforms/windows-common/ReactiveUserControl.cs
+++ b/src/ReactiveUI/Platforms/windows-common/ReactiveUserControl.cs
@@ -3,17 +3,21 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-namespace ReactiveUI
-{
-    using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 #if NETFX_CORE || HAS_UNO
-    using Windows.UI.Xaml;
-    using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
 #else
-    using System.Windows;
-    using System.Windows.Controls;
+using System.Windows;
+using System.Windows.Controls;
 #endif
 
+#if HAS_UNO
+namespace ReactiveUI.Uno
+#else
+namespace ReactiveUI
+#endif
+{
     /// <summary>
     /// A <see cref="UserControl"/> that is reactive.
     /// </summary>

--- a/src/ReactiveUI/Platforms/windows-common/RoutedViewHost.cs
+++ b/src/ReactiveUI/Platforms/windows-common/RoutedViewHost.cs
@@ -19,7 +19,11 @@ using Windows.UI.Xaml.Controls;
 using System.Windows.Controls;
 #endif
 
+#if HAS_UNO
+namespace ReactiveUI.Uno
+#else
 namespace ReactiveUI
+#endif
 {
     /// <summary>
     /// This control hosts the View associated with a Router, and will display

--- a/src/ReactiveUI/Platforms/windows-common/ViewModelViewHost.cs
+++ b/src/ReactiveUI/Platforms/windows-common/ViewModelViewHost.cs
@@ -19,7 +19,11 @@ using Windows.UI.Xaml.Controls;
 using System.Windows.Controls;
 #endif
 
+#if HAS_UNO
+namespace ReactiveUI.Uno
+#else
 namespace ReactiveUI
+#endif
 {
     /// <summary>
     /// This content control will automatically load the View associated with


### PR DESCRIPTION
- Changed so that the ReactiveUI.Uno.csproj now references ReactiveUI.csproj
- Change UAP/Windows Common to put items into the ReactiveUI.Uno if HAS_UNO is defined.
- Don't register the WinRTAppDataDriver for Uno at the moment until we work out the replacement methods that aren't implemented in Uno, these are 
  ```
  WinRTAppDataDriver.cs(32,34): warning Uno0001: Windows.Storage.FileIO.ReadTextAsync(Windows.Storage.IStorageFile, Windows.Storage.Streams.UnicodeEncoding) is not implemented in Uno [C:\source\reactiveui\ReactiveUI\src\ReactiveUI.Uno\ReactiveUI.Uno.csproj]
   WinRTAppDataDriver.cs(32,58): warning Uno0001: Windows.Storage.Streams.UnicodeEncoding.Utf8 is not implemented in Uno [C:\source\reactiveui\ReactiveUI\src\ReactiveUI.Uno\ReactiveUI.Uno.csproj]
   WinRTAppDataDriver.cs(71,61): warning Uno0001: Windows.Storage.StorageFile.DeleteAsync() is not implemented in Uno [C:\source\reactiveui\ReactiveUI\src\ReactiveUI.Uno\ReactiveUI.Uno.csproj]
   WinRTAppDataDriver.cs(59,65): warning Uno0001: Windows.Storage.FileIO.WriteBytesAsync(Windows.Storage.IStorageFile, byte[]) is not implemented in Uno [C:\source\reactiveui\ReactiveUI\src\ReactiveUI.Uno\ReactiveUI.Uno.csproj]
  ```

Perhaps @jeromelaban knows good alternative methods.