### PR TITLE
feature: add a UAP target in ReactiveUI.Uno with namespace differences.

### DIFF
--- a/src/ReactiveUI.Uno/ReactiveUI.Uno.csproj
+++ b/src/ReactiveUI.Uno/ReactiveUI.Uno.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
     <TargetFrameworks>netstandard20;MonoAndroid81;MonoAndroid90;Xamarin.iOS10;Xamarin.Mac20</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);uap10.0.17763</TargetFrameworks>
     <PackageId>ReactiveUI.Uno</PackageId>
     <Description>Uno Platform specific extensions for ReactiveUI</Description>
     <DefineConstants>HAS_UNO</DefineConstants>
@@ -12,7 +13,7 @@
     <DefineConstants>HAS_UNO;WASM</DefineConstants>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition=" !$(TargetFramework.StartsWith('uap')) ">
     <PackageReference Include="Uno.UI" Version="1.*" />
   </ItemGroup>
 


### PR DESCRIPTION
A user friendly feature.

Allow the users to use the ReactiveUI.Uno namespace for UAP namespaces if they include it in. This will allow UAP users to use the same XAML files both all platforms.