### PR TITLE
feature: add monoandroid80 TargetFramework

### DIFF
--- a/src/ReactiveUI.Uno/ReactiveUI.Uno.csproj
+++ b/src/ReactiveUI.Uno/ReactiveUI.Uno.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
-    <TargetFrameworks>netstandard20;MonoAndroid81;MonoAndroid90;Xamarin.iOS10;Xamarin.Mac20</TargetFrameworks>
+    <TargetFrameworks>netstandard20;MonoAndroid80;MonoAndroid81;MonoAndroid90;Xamarin.iOS10;Xamarin.Mac20</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);uap10.0.17763</TargetFrameworks>
     <PackageId>ReactiveUI.Uno</PackageId>
     <Description>Uno Platform specific extensions for ReactiveUI</Description>


### PR DESCRIPTION
Enables ReactiveUI.Uno support for MonoAndroid80.

The reason for adding this is that otherwise, an obsolete Droid project of that platform will fallback to .NET Standard 2.0, requiring `Reactive.Wasm` package.