### PR TITLE
fix: added constructors required by Uno.UI for Android and iOS.

### DIFF
--- a/src/ReactiveUI/Platforms/windows-common/ReactivePage.cs
+++ b/src/ReactiveUI/Platforms/windows-common/ReactivePage.cs
@@ -114,8 +114,8 @@ namespace ReactiveUI
         /// Used by the Xamarin Runtime to materialize native
         /// objects that may have been collected in the managed world.
         /// </remarks>
-        /// <param name="javaReference">javaReference.</param>
-        /// <param name="transfer">transfer.</param>
+        /// <param name="javaReference">A <see cref="IntPtr"/> containing a Java Native Interface (JNI) object reference.</param>
+        /// <param name="transfer">A <see cref="JniHandleOwnership"/> indicating how to handle handle.</param>
         protected ReactivePage(IntPtr javaReference, global::Android.Runtime.JniHandleOwnership transfer)
             : base(javaReference, transfer)
         {
@@ -126,7 +126,7 @@ namespace ReactiveUI
         /// Initializes a new instance of the <see cref="ReactivePage{TViewModel}"/> class.
         /// Native constructor, do not use explicitly.
         /// </summary>
-        /// <param name="handle">handle.</param>
+        /// <param name="handle">Handle to the native control.</param>
         /// <remarks>
         /// Used by the Xamarin Runtime to materialize native.
         /// objects that may have been collected in the managed world.

--- a/src/ReactiveUI/Platforms/windows-common/ReactivePage.cs
+++ b/src/ReactiveUI/Platforms/windows-common/ReactivePage.cs
@@ -3,6 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System;
 using System.Diagnostics.CodeAnalysis;
 #if NETFX_CORE || HAS_UNO
 using Windows.UI.Xaml;
@@ -81,6 +82,9 @@ namespace ReactiveUI
     /// <typeparam name="TViewModel">
     /// The type of the view model backing the view.
     /// </typeparam>
+#if __IOS__
+    [global::Foundation.Register]
+#endif
     [SuppressMessage("Design", "CA1010:Collections should implement generic interface", Justification = "Deliberate usage")]
     public abstract
 #if HAS_UNO
@@ -99,6 +103,38 @@ namespace ReactiveUI
                 typeof(TViewModel),
                 typeof(ReactivePage<TViewModel>),
                 new PropertyMetadata(null));
+
+#if __ANDROID__
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReactivePage{TViewModel}"/> class.
+        /// Native constructor, do not use explicitly.
+        /// </summary>
+        /// <remarks>
+        /// Used by the Xamarin Runtime to materialize native
+        /// objects that may have been collected in the managed world.
+        /// </remarks>
+        /// <param name="javaReference">javaReference.</param>
+        /// <param name="transfer">transfer.</param>
+        protected ReactivePage(IntPtr javaReference, global::Android.Runtime.JniHandleOwnership transfer)
+            : base(javaReference, transfer)
+        {
+        }
+#endif
+#if __IOS__
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReactivePage{TViewModel}"/> class.
+        /// Native constructor, do not use explicitly.
+        /// </summary>
+        /// <param name="handle">handle.</param>
+        /// <remarks>
+        /// Used by the Xamarin Runtime to materialize native.
+        /// objects that may have been collected in the managed world.
+        /// </remarks>
+        protected ReactivePage(IntPtr handle)
+            : base(handle)
+        {
+        }
+#endif
 
         /// <summary>
         /// Gets the binding root view model.

--- a/src/ReactiveUI/Platforms/windows-common/ReactivePage.cs
+++ b/src/ReactiveUI/Platforms/windows-common/ReactivePage.cs
@@ -82,7 +82,7 @@ namespace ReactiveUI
     /// <typeparam name="TViewModel">
     /// The type of the view model backing the view.
     /// </typeparam>
-#if __IOS__
+#if HAS_UNO && IOS
     [global::Foundation.Register]
 #endif
     [SuppressMessage("Design", "CA1010:Collections should implement generic interface", Justification = "Deliberate usage")]
@@ -104,7 +104,8 @@ namespace ReactiveUI
                 typeof(ReactivePage<TViewModel>),
                 new PropertyMetadata(null));
 
-#if __ANDROID__
+#if HAS_UNO
+#if ANDROID
         /// <summary>
         /// Initializes a new instance of the <see cref="ReactivePage{TViewModel}"/> class.
         /// Native constructor, do not use explicitly.
@@ -120,7 +121,7 @@ namespace ReactiveUI
         {
         }
 #endif
-#if __IOS__
+#if IOS
         /// <summary>
         /// Initializes a new instance of the <see cref="ReactivePage{TViewModel}"/> class.
         /// Native constructor, do not use explicitly.
@@ -134,6 +135,7 @@ namespace ReactiveUI
             : base(handle)
         {
         }
+#endif
 #endif
 
         /// <summary>

--- a/src/ReactiveUI/Platforms/windows-common/ReactiveUserControl.cs
+++ b/src/ReactiveUI/Platforms/windows-common/ReactiveUserControl.cs
@@ -3,7 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.Diagnostics.CodeAnalysis;
 #if NETFX_CORE || HAS_UNO
 using Windows.UI.Xaml;

--- a/src/ReactiveUI/Platforms/windows-common/ReactiveUserControl.cs
+++ b/src/ReactiveUI/Platforms/windows-common/ReactiveUserControl.cs
@@ -3,6 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System;
 using System.Diagnostics.CodeAnalysis;
 #if NETFX_CORE || HAS_UNO
 using Windows.UI.Xaml;

--- a/src/ReactiveUI/Platforms/windows-common/ReactiveUserControl.cs
+++ b/src/ReactiveUI/Platforms/windows-common/ReactiveUserControl.cs
@@ -82,9 +82,6 @@ namespace ReactiveUI
     /// <typeparam name="TViewModel">
     /// The type of the view model backing the view.
     /// </typeparam>
-#if HAS_UNO && IOS
-    [global::Foundation.Register]
-#endif
     [SuppressMessage("Design", "CA1010:Collections should implement generic interface", Justification = "Deliberate usage")]
     public abstract
 #if HAS_UNO
@@ -103,40 +100,6 @@ namespace ReactiveUI
                 typeof(TViewModel),
                 typeof(ReactiveUserControl<TViewModel>),
                 new PropertyMetadata(null));
-
-#if HAS_UNO
-#if ANDROID
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ReactiveUserControl{TViewModel}"/> class.
-        /// Native constructor, do not use explicitly.
-        /// </summary>
-        /// <remarks>
-        /// Used by the Xamarin Runtime to materialize native
-        /// objects that may have been collected in the managed world.
-        /// </remarks>
-        /// <param name="javaReference">javaReference.</param>
-        /// <param name="transfer">transfer.</param>
-        protected ReactiveUserControl(IntPtr javaReference, global::Android.Runtime.JniHandleOwnership transfer)
-            : base(javaReference, transfer)
-        {
-        }
-#endif
-#if IOS
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ReactiveUserControl{TViewModel}"/> class.
-        /// Native constructor, do not use explicitly.
-        /// </summary>
-        /// <param name="handle">handle.</param>
-        /// <remarks>
-        /// Used by the Xamarin Runtime to materialize native.
-        /// objects that may have been collected in the managed world.
-        /// </remarks>
-        protected ReactiveUserControl(IntPtr handle)
-            : base(handle)
-        {
-        }
-#endif
-#endif
 
         /// <summary>
         /// Gets the binding root view model.

--- a/src/ReactiveUI/Platforms/windows-common/ReactiveUserControl.cs
+++ b/src/ReactiveUI/Platforms/windows-common/ReactiveUserControl.cs
@@ -81,6 +81,9 @@ namespace ReactiveUI
     /// <typeparam name="TViewModel">
     /// The type of the view model backing the view.
     /// </typeparam>
+#if __IOS__
+    [global::Foundation.Register]
+#endif
     [SuppressMessage("Design", "CA1010:Collections should implement generic interface", Justification = "Deliberate usage")]
     public abstract
 #if HAS_UNO
@@ -99,6 +102,38 @@ namespace ReactiveUI
                 typeof(TViewModel),
                 typeof(ReactiveUserControl<TViewModel>),
                 new PropertyMetadata(null));
+
+#if __ANDROID__
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReactiveUserControl{TViewModel}"/> class.
+        /// Native constructor, do not use explicitly.
+        /// </summary>
+        /// <remarks>
+        /// Used by the Xamarin Runtime to materialize native
+        /// objects that may have been collected in the managed world.
+        /// </remarks>
+        /// <param name="javaReference">javaReference.</param>
+        /// <param name="transfer">transfer.</param>
+        protected ReactiveUserControl(IntPtr javaReference, global::Android.Runtime.JniHandleOwnership transfer)
+            : base(javaReference, transfer)
+        {
+        }
+#endif
+#if __IOS__
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReactiveUserControl{TViewModel}"/> class.
+        /// Native constructor, do not use explicitly.
+        /// </summary>
+        /// <param name="handle">handle.</param>
+        /// <remarks>
+        /// Used by the Xamarin Runtime to materialize native.
+        /// objects that may have been collected in the managed world.
+        /// </remarks>
+        protected ReactiveUserControl(IntPtr handle)
+            : base(handle)
+        {
+        }
+#endif
 
         /// <summary>
         /// Gets the binding root view model.

--- a/src/ReactiveUI/Platforms/windows-common/ReactiveUserControl.cs
+++ b/src/ReactiveUI/Platforms/windows-common/ReactiveUserControl.cs
@@ -82,7 +82,7 @@ namespace ReactiveUI
     /// <typeparam name="TViewModel">
     /// The type of the view model backing the view.
     /// </typeparam>
-#if __IOS__
+#if HAS_UNO && IOS
     [global::Foundation.Register]
 #endif
     [SuppressMessage("Design", "CA1010:Collections should implement generic interface", Justification = "Deliberate usage")]
@@ -104,7 +104,8 @@ namespace ReactiveUI
                 typeof(ReactiveUserControl<TViewModel>),
                 new PropertyMetadata(null));
 
-#if __ANDROID__
+#if HAS_UNO
+#if ANDROID
         /// <summary>
         /// Initializes a new instance of the <see cref="ReactiveUserControl{TViewModel}"/> class.
         /// Native constructor, do not use explicitly.
@@ -120,7 +121,7 @@ namespace ReactiveUI
         {
         }
 #endif
-#if __IOS__
+#if IOS
         /// <summary>
         /// Initializes a new instance of the <see cref="ReactiveUserControl{TViewModel}"/> class.
         /// Native constructor, do not use explicitly.
@@ -134,6 +135,7 @@ namespace ReactiveUI
             : base(handle)
         {
         }
+#endif
 #endif
 
         /// <summary>


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Fixes missing constructors by Uno.UI.

**What is the current behavior?**
Uno complains about these missing constructors.

**What is the new behavior?**
Adds bridge constructors in the intermediate classes.

**What might this PR break?**
None

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

@jeromelaban Please have a look