### PR TITLE
fix: Uno ReactivePage has no parameterless constructor

### DIFF
--- a/src/ReactiveUI/Platforms/windows-common/ReactivePage.cs
+++ b/src/ReactiveUI/Platforms/windows-common/ReactivePage.cs
@@ -105,6 +105,14 @@ namespace ReactiveUI
                 new PropertyMetadata(null));
 
 #if HAS_UNO
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReactivePage{TViewModel}"/> class.
+        /// </summary>
+        protected ReactivePage()
+        {
+            // needed so the others are optional.
+        }
+
 #if ANDROID
         /// <summary>
         /// Initializes a new instance of the <see cref="ReactivePage{TViewModel}"/> class.


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Adds a parameterless constructor to the Uno ReactivePage