### PR TITLE
fix: adding special platform constructors to uno platform ReactiveUserControl as well

### DIFF
--- a/src/ReactiveUI/Platforms/windows-common/ReactiveUserControl.cs
+++ b/src/ReactiveUI/Platforms/windows-common/ReactiveUserControl.cs
@@ -3,6 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System;
 using System.Diagnostics.CodeAnalysis;
 #if NETFX_CORE || HAS_UNO
 using Windows.UI.Xaml;
@@ -81,6 +82,9 @@ namespace ReactiveUI
     /// <typeparam name="TViewModel">
     /// The type of the view model backing the view.
     /// </typeparam>
+#if HAS_UNO && IOS
+    [global::Foundation.Register]
+#endif
     [SuppressMessage("Design", "CA1010:Collections should implement generic interface", Justification = "Deliberate usage")]
     public abstract
 #if HAS_UNO
@@ -99,6 +103,48 @@ namespace ReactiveUI
                 typeof(TViewModel),
                 typeof(ReactiveUserControl<TViewModel>),
                 new PropertyMetadata(null));
+
+#if HAS_UNO
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReactiveUserControl{TViewModel}"/> class.
+        /// </summary>
+        protected ReactiveUserControl()
+        {
+            // needed so the others are optional.
+        }
+
+#if ANDROID
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReactiveUserControl{TViewModel}"/> class.
+        /// Native constructor, do not use explicitly.
+        /// </summary>
+        /// <remarks>
+        /// Used by the Xamarin Runtime to materialize native
+        /// objects that may have been collected in the managed world.
+        /// </remarks>
+        /// <param name="javaReference">A <see cref="IntPtr"/> containing a Java Native Interface (JNI) object reference.</param>
+        /// <param name="transfer">A <see cref="JniHandleOwnership"/> indicating how to handle handle.</param>
+        protected ReactiveUserControl(IntPtr javaReference, global::Android.Runtime.JniHandleOwnership transfer)
+            : base(javaReference, transfer)
+        {
+        }
+#endif
+#if IOS
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReactiveUserControl{TViewModel}"/> class.
+        /// Native constructor, do not use explicitly.
+        /// </summary>
+        /// <param name="handle">Handle to the native control.</param>
+        /// <remarks>
+        /// Used by the Xamarin Runtime to materialize native.
+        /// objects that may have been collected in the managed world.
+        /// </remarks>
+        protected ReactiveUserControl(IntPtr handle)
+            : base(handle)
+        {
+        }
+#endif
+#endif
 
         /// <summary>
         /// Gets the binding root view model.


### PR DESCRIPTION
Same as #2116 
These constructors appear to be required by the `ReactiveUserControl` as well.