### PR TITLE
Bump System.Reactive, fix ReactiveUI.Uno compilation

### DIFF
--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -48,7 +48,7 @@
     <PackageReference Include="Xunit.StaFact" Version="0.3.18" />
     <PackageReference Include="Shouldly" Version="4.0.0-beta0002" />
     <PackageReference Include="Microsoft.Reactive.Testing" Version="4.1.6" />
-    <PackageReference Include="PublicApiGenerator" Version="9.1.0" />
+    <PackageReference Include="PublicApiGenerator" Version="9.3.0" />
   </ItemGroup>
   
   <ItemGroup Condition="$(IsTestProject)">
@@ -68,7 +68,7 @@
   </ItemGroup>
    
   <ItemGroup>	
-    <PackageReference Include="Nerdbank.GitVersioning" Version="2.3.183" PrivateAssets="all" />	
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.0.24" PrivateAssets="all" />	
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -47,7 +47,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <PackageReference Include="Xunit.StaFact" Version="0.3.18" />
     <PackageReference Include="Shouldly" Version="4.0.0-beta0002" />
-    <PackageReference Include="Microsoft.Reactive.Testing" Version="4.1.5" />
+    <PackageReference Include="Microsoft.Reactive.Testing" Version="4.1.6" />
     <PackageReference Include="PublicApiGenerator" Version="9.1.0" />
   </ItemGroup>
   

--- a/src/ReactiveUI.Fody.Helpers/ReactiveUI.Fody.Helpers.csproj
+++ b/src/ReactiveUI.Fody.Helpers/ReactiveUI.Fody.Helpers.csproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="Fody" Version="5.1.1" PrivateAssets="None" />
     <PackageReference Include="FodyPackaging" Version="5.1.1" PrivateAssets="All" />
-    <PackageReference Include="System.Reactive" Version="4.1.5" />
+    <PackageReference Include="System.Reactive" Version="4.1.6" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('netstandard'))">

--- a/src/ReactiveUI.Testing/ReactiveUI.Testing.csproj
+++ b/src/ReactiveUI.Testing/ReactiveUI.Testing.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Reactive.Testing" Version="4.1.5" />
+    <PackageReference Include="Microsoft.Reactive.Testing" Version="4.1.6" />
     <ProjectReference Include="..\ReactiveUI\ReactiveUI.csproj" />
   </ItemGroup>
 

--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.net461.approved.txt
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.net461.approved.txt
@@ -15,7 +15,7 @@ namespace ReactiveUI
             where TItem : ReactiveUI.IReactiveObject { }
         public static System.IDisposable ActOnEveryObject<TItem, TCollection>(this TCollection @this, System.Action<TItem> onAdd, System.Action<TItem> onRemove)
             where TItem : ReactiveUI.IReactiveObject
-            where TCollection : System.Collections.Specialized.INotifyCollectionChanged, System.Collections.Generic.IEnumerable<> { }
+            where TCollection : System.Collections.Specialized.INotifyCollectionChanged, System.Collections.Generic.IEnumerable<TItem> { }
         public static System.IDisposable ActOnEveryObject<TItem>(this System.IObservable<DynamicData.IChangeSet<TItem>> @this, System.Action<TItem> onAdd, System.Action<TItem> onRemove)
             where TItem : ReactiveUI.IReactiveObject { }
         public static System.IDisposable AutoPersist<T>(this T @this, System.Func<T, System.IObservable<System.Reactive.Unit>> doPersist, System.Nullable<System.TimeSpan> interval = null)
@@ -30,7 +30,7 @@ namespace ReactiveUI
             where TItem : ReactiveUI.IReactiveObject { }
         public static System.IDisposable AutoPersistCollection<TItem, TCollection, TDontCare>(this TCollection @this, System.Func<TItem, System.IObservable<System.Reactive.Unit>> doPersist, System.IObservable<TDontCare> manualSaveSignal, System.Nullable<System.TimeSpan> interval = null)
             where TItem : ReactiveUI.IReactiveObject
-            where TCollection : System.Collections.Specialized.INotifyCollectionChanged, System.Collections.Generic.IEnumerable<> { }
+            where TCollection : System.Collections.Specialized.INotifyCollectionChanged, System.Collections.Generic.IEnumerable<TItem> { }
     }
     public enum BindingDirection
     {
@@ -52,7 +52,7 @@ namespace ReactiveUI
     }
     public class CombinedReactiveCommand<TParam, TResult> : ReactiveUI.ReactiveCommandBase<TParam, System.Collections.Generic.IList<TResult>>
     {
-        protected internal CombinedReactiveCommand(System.Collections.Generic.IEnumerable<ReactiveUI.ReactiveCommandBase<TParam, TResult>> childCommands, System.IObservable<bool> canExecute, System.Reactive.Concurrency.IScheduler outputScheduler) { }
+        protected CombinedReactiveCommand(System.Collections.Generic.IEnumerable<ReactiveUI.ReactiveCommandBase<TParam, TResult>> childCommands, System.IObservable<bool> canExecute, System.Reactive.Concurrency.IScheduler outputScheduler) { }
         public override System.IObservable<bool> CanExecute { get; }
         public override System.IObservable<bool> IsExecuting { get; }
         public override System.IObservable<System.Exception> ThrownExceptions { get; }
@@ -63,15 +63,15 @@ namespace ReactiveUI
     public class static CommandBinder
     {
         public static ReactiveUI.IReactiveBinding<TView, TViewModel, TProp> BindCommand<TView, TViewModel, TProp, TControl, TParam>(this TView view, TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> propertyName, System.Linq.Expressions.Expression<System.Func<TView, TControl>> controlName, System.IObservable<TParam> withParameter, string toEvent = null)
-            where TView :  class, ReactiveUI.IViewFor<>
+            where TView :  class, ReactiveUI.IViewFor<TViewModel>
             where TViewModel :  class
             where TProp : System.Windows.Input.ICommand { }
         public static ReactiveUI.IReactiveBinding<TView, TViewModel, TProp> BindCommand<TView, TViewModel, TProp, TControl>(this TView view, TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> propertyName, System.Linq.Expressions.Expression<System.Func<TView, TControl>> controlName, string toEvent = null)
-            where TView :  class, ReactiveUI.IViewFor<>
+            where TView :  class, ReactiveUI.IViewFor<TViewModel>
             where TViewModel :  class
             where TProp : System.Windows.Input.ICommand { }
         public static ReactiveUI.IReactiveBinding<TView, TViewModel, TProp> BindCommand<TView, TViewModel, TProp, TControl, TParam>(this TView view, TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> propertyName, System.Linq.Expressions.Expression<System.Func<TView, TControl>> controlName, System.Linq.Expressions.Expression<System.Func<TViewModel, TParam>> withParameter, string toEvent = null)
-            where TView :  class, ReactiveUI.IViewFor<>
+            where TView :  class, ReactiveUI.IViewFor<TViewModel>
             where TViewModel :  class
             where TProp : System.Windows.Input.ICommand { }
     }
@@ -79,11 +79,11 @@ namespace ReactiveUI
     {
         public CommandBinderImplementation() { }
         public ReactiveUI.IReactiveBinding<TView, TViewModel, TProp> BindCommand<TView, TViewModel, TProp, TControl, TParam>(TViewModel viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TControl>> controlProperty, System.Func<TParam> withParameter, string toEvent = null)
-            where TView :  class, ReactiveUI.IViewFor<>
+            where TView :  class, ReactiveUI.IViewFor<TViewModel>
             where TViewModel :  class
             where TProp : System.Windows.Input.ICommand { }
         public ReactiveUI.IReactiveBinding<TView, TViewModel, TProp> BindCommand<TView, TViewModel, TProp, TControl, TParam>(TViewModel viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TControl>> controlProperty, System.IObservable<TParam> withParameter, string toEvent = null)
-            where TView :  class, ReactiveUI.IViewFor<>
+            where TView :  class, ReactiveUI.IViewFor<TViewModel>
             where TViewModel :  class
             where TProp : System.Windows.Input.ICommand { }
     }
@@ -359,11 +359,11 @@ namespace ReactiveUI
     {
         public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj source, System.Linq.Expressions.Expression<System.Func<TObj, TRet>> property, TRet initialValue = null, bool deferSubscription = False, System.Reactive.Concurrency.IScheduler scheduler = null)
             where TObj :  class, ReactiveUI.IReactiveObject { }
-        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj source, System.Linq.Expressions.Expression<System.Func<TObj, TRet>> property, out ReactiveUI.ObservableAsPropertyHelper<> result, TRet initialValue = null, bool deferSubscription = False, System.Reactive.Concurrency.IScheduler scheduler = null)
+        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj source, System.Linq.Expressions.Expression<System.Func<TObj, TRet>> property, out ReactiveUI.ObservableAsPropertyHelper<TRet> result, TRet initialValue = null, bool deferSubscription = False, System.Reactive.Concurrency.IScheduler scheduler = null)
             where TObj :  class, ReactiveUI.IReactiveObject { }
         public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj source, string property, TRet initialValue = null, bool deferSubscription = False, System.Reactive.Concurrency.IScheduler scheduler = null)
             where TObj :  class, ReactiveUI.IReactiveObject { }
-        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj source, string property, out ReactiveUI.ObservableAsPropertyHelper<> result, TRet initialValue = null, bool deferSubscription = False, System.Reactive.Concurrency.IScheduler scheduler = null)
+        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj source, string property, out ReactiveUI.ObservableAsPropertyHelper<TRet> result, TRet initialValue = null, bool deferSubscription = False, System.Reactive.Concurrency.IScheduler scheduler = null)
             where TObj :  class, ReactiveUI.IReactiveObject { }
     }
     public sealed class ObservableAsPropertyHelper<T> : ReactiveUI.IHandleObservableErrors, Splat.IEnableLogger, System.IDisposable
@@ -513,7 +513,7 @@ namespace ReactiveUI
     }
     public class ReactiveCommand<TParam, TResult> : ReactiveUI.ReactiveCommandBase<TParam, TResult>
     {
-        protected internal ReactiveCommand(System.Func<TParam, System.IObservable<TResult>> execute, System.IObservable<bool> canExecute, System.Reactive.Concurrency.IScheduler outputScheduler) { }
+        protected ReactiveCommand(System.Func<TParam, System.IObservable<TResult>> execute, System.IObservable<bool> canExecute, System.Reactive.Concurrency.IScheduler outputScheduler) { }
         public override System.IObservable<bool> CanExecute { get; }
         public override System.IObservable<bool> IsExecuting { get; }
         public override System.IObservable<System.Exception> ThrownExceptions { get; }
@@ -566,7 +566,7 @@ namespace ReactiveUI
         public static System.Type ReallyFindType(string type, bool throwOnFailure) { }
         public static System.Linq.Expressions.Expression Rewrite(System.Linq.Expressions.Expression expression) { }
         public static void ThrowIfMethodsNotOverloaded(string callingTypeName, object targetObject, params string[] methodsToCheck) { }
-        public static bool TryGetAllValuesForPropertyChain(out ReactiveUI.IObservedChange<, > changeValues, object current, System.Collections.Generic.IEnumerable<System.Linq.Expressions.Expression> expressionChain) { }
+        public static bool TryGetAllValuesForPropertyChain(out ReactiveUI.IObservedChange<, >[] changeValues, object current, System.Collections.Generic.IEnumerable<System.Linq.Expressions.Expression> expressionChain) { }
         public static bool TryGetValueForPropertyChain<TValue>(out TValue changeValue, object current, System.Collections.Generic.IEnumerable<System.Linq.Expressions.Expression> expressionChain) { }
         public static bool TrySetValueToPropertyChain<TValue>(object target, System.Collections.Generic.IEnumerable<System.Linq.Expressions.Expression> expressionChain, TValue value, bool shouldThrow = True) { }
     }
@@ -898,7 +898,7 @@ namespace ReactiveUI.Legacy
         public static ReactiveUI.Legacy.IReactiveDerivedList<T> CreateCollection<T>(this System.IObservable<T> fromObservable, System.Nullable<System.TimeSpan> withDelay = null, System.Action<System.Exception> onError = null, System.Reactive.Concurrency.IScheduler scheduler = null) { }
     }
     [System.Diagnostics.DebuggerDisplayAttribute("Count = {Count}")]
-    [System.Diagnostics.DebuggerTypeProxyAttribute(typeof(ReactiveUI.Legacy.CollectionDebugView<>))]
+    [System.Diagnostics.DebuggerTypeProxyAttribute(typeof(ReactiveUI.Legacy.CollectionDebugView<T>))]
     [System.ObsoleteAttribute("ReactiveList is no longer supported. We suggest replacing it with DynamicData htt" +
         "ps://github.com/rolandpheasant/dynamicdata")]
     public class ReactiveList<T> : ReactiveUI.INotifyCollectionChanging, ReactiveUI.INotifyPropertyChanging, ReactiveUI.IReactiveObject, ReactiveUI.Legacy.IReactiveCollection<T>, ReactiveUI.Legacy.IReactiveList<T>, ReactiveUI.Legacy.IReactiveNotifyCollectionChanged<T>, ReactiveUI.Legacy.IReactiveNotifyCollectionItemChanged<T>, ReactiveUI.Legacy.IReadOnlyReactiveCollection<T>, ReactiveUI.Legacy.IReadOnlyReactiveList<T>, Splat.IEnableLogger, System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList, System.Collections.Specialized.INotifyCollectionChanged, System.ComponentModel.INotifyPropertyChanged

--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.netcoreapp2.0.approved.txt
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.netcoreapp2.0.approved.txt
@@ -15,7 +15,7 @@ namespace ReactiveUI
             where TItem : ReactiveUI.IReactiveObject { }
         public static System.IDisposable ActOnEveryObject<TItem, TCollection>(this TCollection @this, System.Action<TItem> onAdd, System.Action<TItem> onRemove)
             where TItem : ReactiveUI.IReactiveObject
-            where TCollection : System.Collections.Specialized.INotifyCollectionChanged, System.Collections.Generic.IEnumerable<> { }
+            where TCollection : System.Collections.Specialized.INotifyCollectionChanged, System.Collections.Generic.IEnumerable<TItem> { }
         public static System.IDisposable ActOnEveryObject<TItem>(this System.IObservable<DynamicData.IChangeSet<TItem>> @this, System.Action<TItem> onAdd, System.Action<TItem> onRemove)
             where TItem : ReactiveUI.IReactiveObject { }
         public static System.IDisposable AutoPersist<T>(this T @this, System.Func<T, System.IObservable<System.Reactive.Unit>> doPersist, System.Nullable<System.TimeSpan> interval = null)
@@ -30,7 +30,7 @@ namespace ReactiveUI
             where TItem : ReactiveUI.IReactiveObject { }
         public static System.IDisposable AutoPersistCollection<TItem, TCollection, TDontCare>(this TCollection @this, System.Func<TItem, System.IObservable<System.Reactive.Unit>> doPersist, System.IObservable<TDontCare> manualSaveSignal, System.Nullable<System.TimeSpan> interval = null)
             where TItem : ReactiveUI.IReactiveObject
-            where TCollection : System.Collections.Specialized.INotifyCollectionChanged, System.Collections.Generic.IEnumerable<> { }
+            where TCollection : System.Collections.Specialized.INotifyCollectionChanged, System.Collections.Generic.IEnumerable<TItem> { }
     }
     public enum BindingDirection
     {
@@ -52,7 +52,7 @@ namespace ReactiveUI
     }
     public class CombinedReactiveCommand<TParam, TResult> : ReactiveUI.ReactiveCommandBase<TParam, System.Collections.Generic.IList<TResult>>
     {
-        protected internal CombinedReactiveCommand(System.Collections.Generic.IEnumerable<ReactiveUI.ReactiveCommandBase<TParam, TResult>> childCommands, System.IObservable<bool> canExecute, System.Reactive.Concurrency.IScheduler outputScheduler) { }
+        protected CombinedReactiveCommand(System.Collections.Generic.IEnumerable<ReactiveUI.ReactiveCommandBase<TParam, TResult>> childCommands, System.IObservable<bool> canExecute, System.Reactive.Concurrency.IScheduler outputScheduler) { }
         public override System.IObservable<bool> CanExecute { get; }
         public override System.IObservable<bool> IsExecuting { get; }
         public override System.IObservable<System.Exception> ThrownExceptions { get; }
@@ -63,15 +63,15 @@ namespace ReactiveUI
     public class static CommandBinder
     {
         public static ReactiveUI.IReactiveBinding<TView, TViewModel, TProp> BindCommand<TView, TViewModel, TProp, TControl, TParam>(this TView view, TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> propertyName, System.Linq.Expressions.Expression<System.Func<TView, TControl>> controlName, System.IObservable<TParam> withParameter, string toEvent = null)
-            where TView :  class, ReactiveUI.IViewFor<>
+            where TView :  class, ReactiveUI.IViewFor<TViewModel>
             where TViewModel :  class
             where TProp : System.Windows.Input.ICommand { }
         public static ReactiveUI.IReactiveBinding<TView, TViewModel, TProp> BindCommand<TView, TViewModel, TProp, TControl>(this TView view, TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> propertyName, System.Linq.Expressions.Expression<System.Func<TView, TControl>> controlName, string toEvent = null)
-            where TView :  class, ReactiveUI.IViewFor<>
+            where TView :  class, ReactiveUI.IViewFor<TViewModel>
             where TViewModel :  class
             where TProp : System.Windows.Input.ICommand { }
         public static ReactiveUI.IReactiveBinding<TView, TViewModel, TProp> BindCommand<TView, TViewModel, TProp, TControl, TParam>(this TView view, TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> propertyName, System.Linq.Expressions.Expression<System.Func<TView, TControl>> controlName, System.Linq.Expressions.Expression<System.Func<TViewModel, TParam>> withParameter, string toEvent = null)
-            where TView :  class, ReactiveUI.IViewFor<>
+            where TView :  class, ReactiveUI.IViewFor<TViewModel>
             where TViewModel :  class
             where TProp : System.Windows.Input.ICommand { }
     }
@@ -79,11 +79,11 @@ namespace ReactiveUI
     {
         public CommandBinderImplementation() { }
         public ReactiveUI.IReactiveBinding<TView, TViewModel, TProp> BindCommand<TView, TViewModel, TProp, TControl, TParam>(TViewModel viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TControl>> controlProperty, System.Func<TParam> withParameter, string toEvent = null)
-            where TView :  class, ReactiveUI.IViewFor<>
+            where TView :  class, ReactiveUI.IViewFor<TViewModel>
             where TViewModel :  class
             where TProp : System.Windows.Input.ICommand { }
         public ReactiveUI.IReactiveBinding<TView, TViewModel, TProp> BindCommand<TView, TViewModel, TProp, TControl, TParam>(TViewModel viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TControl>> controlProperty, System.IObservable<TParam> withParameter, string toEvent = null)
-            where TView :  class, ReactiveUI.IViewFor<>
+            where TView :  class, ReactiveUI.IViewFor<TViewModel>
             where TViewModel :  class
             where TProp : System.Windows.Input.ICommand { }
     }
@@ -353,11 +353,11 @@ namespace ReactiveUI
     {
         public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj source, System.Linq.Expressions.Expression<System.Func<TObj, TRet>> property, TRet initialValue = null, bool deferSubscription = False, System.Reactive.Concurrency.IScheduler scheduler = null)
             where TObj :  class, ReactiveUI.IReactiveObject { }
-        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj source, System.Linq.Expressions.Expression<System.Func<TObj, TRet>> property, out ReactiveUI.ObservableAsPropertyHelper<> result, TRet initialValue = null, bool deferSubscription = False, System.Reactive.Concurrency.IScheduler scheduler = null)
+        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj source, System.Linq.Expressions.Expression<System.Func<TObj, TRet>> property, out ReactiveUI.ObservableAsPropertyHelper<TRet> result, TRet initialValue = null, bool deferSubscription = False, System.Reactive.Concurrency.IScheduler scheduler = null)
             where TObj :  class, ReactiveUI.IReactiveObject { }
         public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj source, string property, TRet initialValue = null, bool deferSubscription = False, System.Reactive.Concurrency.IScheduler scheduler = null)
             where TObj :  class, ReactiveUI.IReactiveObject { }
-        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj source, string property, out ReactiveUI.ObservableAsPropertyHelper<> result, TRet initialValue = null, bool deferSubscription = False, System.Reactive.Concurrency.IScheduler scheduler = null)
+        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj source, string property, out ReactiveUI.ObservableAsPropertyHelper<TRet> result, TRet initialValue = null, bool deferSubscription = False, System.Reactive.Concurrency.IScheduler scheduler = null)
             where TObj :  class, ReactiveUI.IReactiveObject { }
     }
     public sealed class ObservableAsPropertyHelper<T> : ReactiveUI.IHandleObservableErrors, Splat.IEnableLogger, System.IDisposable
@@ -507,7 +507,7 @@ namespace ReactiveUI
     }
     public class ReactiveCommand<TParam, TResult> : ReactiveUI.ReactiveCommandBase<TParam, TResult>
     {
-        protected internal ReactiveCommand(System.Func<TParam, System.IObservable<TResult>> execute, System.IObservable<bool> canExecute, System.Reactive.Concurrency.IScheduler outputScheduler) { }
+        protected ReactiveCommand(System.Func<TParam, System.IObservable<TResult>> execute, System.IObservable<bool> canExecute, System.Reactive.Concurrency.IScheduler outputScheduler) { }
         public override System.IObservable<bool> CanExecute { get; }
         public override System.IObservable<bool> IsExecuting { get; }
         public override System.IObservable<System.Exception> ThrownExceptions { get; }
@@ -560,7 +560,7 @@ namespace ReactiveUI
         public static System.Type ReallyFindType(string type, bool throwOnFailure) { }
         public static System.Linq.Expressions.Expression Rewrite(System.Linq.Expressions.Expression expression) { }
         public static void ThrowIfMethodsNotOverloaded(string callingTypeName, object targetObject, params string[] methodsToCheck) { }
-        public static bool TryGetAllValuesForPropertyChain(out ReactiveUI.IObservedChange<, > changeValues, object current, System.Collections.Generic.IEnumerable<System.Linq.Expressions.Expression> expressionChain) { }
+        public static bool TryGetAllValuesForPropertyChain(out ReactiveUI.IObservedChange<, >[] changeValues, object current, System.Collections.Generic.IEnumerable<System.Linq.Expressions.Expression> expressionChain) { }
         public static bool TryGetValueForPropertyChain<TValue>(out TValue changeValue, object current, System.Collections.Generic.IEnumerable<System.Linq.Expressions.Expression> expressionChain) { }
         public static bool TrySetValueToPropertyChain<TValue>(object target, System.Collections.Generic.IEnumerable<System.Linq.Expressions.Expression> expressionChain, TValue value, bool shouldThrow = True) { }
     }
@@ -892,7 +892,7 @@ namespace ReactiveUI.Legacy
         public static ReactiveUI.Legacy.IReactiveDerivedList<T> CreateCollection<T>(this System.IObservable<T> fromObservable, System.Nullable<System.TimeSpan> withDelay = null, System.Action<System.Exception> onError = null, System.Reactive.Concurrency.IScheduler scheduler = null) { }
     }
     [System.Diagnostics.DebuggerDisplayAttribute("Count = {Count}")]
-    [System.Diagnostics.DebuggerTypeProxyAttribute(typeof(ReactiveUI.Legacy.CollectionDebugView<>))]
+    [System.Diagnostics.DebuggerTypeProxyAttribute(typeof(ReactiveUI.Legacy.CollectionDebugView<T>))]
     [System.ObsoleteAttribute("ReactiveList is no longer supported. We suggest replacing it with DynamicData htt" +
         "ps://github.com/rolandpheasant/dynamicdata")]
     public class ReactiveList<T> : ReactiveUI.INotifyCollectionChanging, ReactiveUI.INotifyPropertyChanging, ReactiveUI.IReactiveObject, ReactiveUI.Legacy.IReactiveCollection<T>, ReactiveUI.Legacy.IReactiveList<T>, ReactiveUI.Legacy.IReactiveNotifyCollectionChanged<T>, ReactiveUI.Legacy.IReactiveNotifyCollectionItemChanged<T>, ReactiveUI.Legacy.IReadOnlyReactiveCollection<T>, ReactiveUI.Legacy.IReadOnlyReactiveList<T>, Splat.IEnableLogger, System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList, System.Collections.Specialized.INotifyCollectionChanged, System.ComponentModel.INotifyPropertyChanged

--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.Testing.net461.approved.txt
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.Testing.net461.approved.txt
@@ -6,15 +6,15 @@ namespace ReactiveUI.Testing
     {
         public static TBuilder With<TBuilder, TField>(this TBuilder builder, ref TField field, TField value)
             where TBuilder : ReactiveUI.Testing.IBuilder { }
-        public static TBuilder With<TBuilder, TField>(this TBuilder builder, ref System.Collections.Generic.List<> field, System.Collections.Generic.IEnumerable<TField> values)
+        public static TBuilder With<TBuilder, TField>(this TBuilder builder, ref System.Collections.Generic.List<TField> field, System.Collections.Generic.IEnumerable<TField> values)
             where TBuilder : ReactiveUI.Testing.IBuilder { }
-        public static TBuilder With<TBuilder, TField>(this TBuilder builder, ref System.Collections.Generic.List<> field, TField value)
+        public static TBuilder With<TBuilder, TField>(this TBuilder builder, ref System.Collections.Generic.List<TField> field, TField value)
             where TBuilder : ReactiveUI.Testing.IBuilder { }
-        public static TBuilder With<TBuilder, TKey, TField>(this TBuilder builder, ref System.Collections.Generic.Dictionary<, > dictionary, System.Collections.Generic.KeyValuePair<TKey, TField> keyValuePair)
+        public static TBuilder With<TBuilder, TKey, TField>(this TBuilder builder, ref System.Collections.Generic.Dictionary<TKey, TField> dictionary, System.Collections.Generic.KeyValuePair<TKey, TField> keyValuePair)
             where TBuilder : ReactiveUI.Testing.IBuilder { }
-        public static TBuilder With<TBuilder, TKey, TField>(this TBuilder builder, ref System.Collections.Generic.Dictionary<, > dictionary, TKey key, TField value)
+        public static TBuilder With<TBuilder, TKey, TField>(this TBuilder builder, ref System.Collections.Generic.Dictionary<TKey, TField> dictionary, TKey key, TField value)
             where TBuilder : ReactiveUI.Testing.IBuilder { }
-        public static TBuilder With<TBuilder, TKey, TField>(this TBuilder builder, ref System.Collections.Generic.Dictionary<, > dictionary, System.Collections.Generic.IDictionary<TKey, TField> keyValuePair) { }
+        public static TBuilder With<TBuilder, TKey, TField>(this TBuilder builder, ref System.Collections.Generic.Dictionary<TKey, TField> dictionary, System.Collections.Generic.IDictionary<TKey, TField> keyValuePair) { }
     }
     public class static MessageBusExtensions
     {

--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.Testing.netcoreapp2.0.approved.txt
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.Testing.netcoreapp2.0.approved.txt
@@ -6,15 +6,15 @@ namespace ReactiveUI.Testing
     {
         public static TBuilder With<TBuilder, TField>(this TBuilder builder, ref TField field, TField value)
             where TBuilder : ReactiveUI.Testing.IBuilder { }
-        public static TBuilder With<TBuilder, TField>(this TBuilder builder, ref System.Collections.Generic.List<> field, System.Collections.Generic.IEnumerable<TField> values)
+        public static TBuilder With<TBuilder, TField>(this TBuilder builder, ref System.Collections.Generic.List<TField> field, System.Collections.Generic.IEnumerable<TField> values)
             where TBuilder : ReactiveUI.Testing.IBuilder { }
-        public static TBuilder With<TBuilder, TField>(this TBuilder builder, ref System.Collections.Generic.List<> field, TField value)
+        public static TBuilder With<TBuilder, TField>(this TBuilder builder, ref System.Collections.Generic.List<TField> field, TField value)
             where TBuilder : ReactiveUI.Testing.IBuilder { }
-        public static TBuilder With<TBuilder, TKey, TField>(this TBuilder builder, ref System.Collections.Generic.Dictionary<, > dictionary, System.Collections.Generic.KeyValuePair<TKey, TField> keyValuePair)
+        public static TBuilder With<TBuilder, TKey, TField>(this TBuilder builder, ref System.Collections.Generic.Dictionary<TKey, TField> dictionary, System.Collections.Generic.KeyValuePair<TKey, TField> keyValuePair)
             where TBuilder : ReactiveUI.Testing.IBuilder { }
-        public static TBuilder With<TBuilder, TKey, TField>(this TBuilder builder, ref System.Collections.Generic.Dictionary<, > dictionary, TKey key, TField value)
+        public static TBuilder With<TBuilder, TKey, TField>(this TBuilder builder, ref System.Collections.Generic.Dictionary<TKey, TField> dictionary, TKey key, TField value)
             where TBuilder : ReactiveUI.Testing.IBuilder { }
-        public static TBuilder With<TBuilder, TKey, TField>(this TBuilder builder, ref System.Collections.Generic.Dictionary<, > dictionary, System.Collections.Generic.IDictionary<TKey, TField> keyValuePair) { }
+        public static TBuilder With<TBuilder, TKey, TField>(this TBuilder builder, ref System.Collections.Generic.Dictionary<TKey, TField> dictionary, System.Collections.Generic.IDictionary<TKey, TField> keyValuePair) { }
     }
     public class static MessageBusExtensions
     {

--- a/src/ReactiveUI.Tests/Platforms/wpf/API/ApiApprovalTests.Wpf.net461.approved.txt
+++ b/src/ReactiveUI.Tests/Platforms/wpf/API/ApiApprovalTests.Wpf.net461.approved.txt
@@ -130,15 +130,3 @@ namespace ReactiveUI.Wpf
         public void Register(System.Action<System.Func<object>, System.Type> registerFunction) { }
     }
 }
-namespace XamlGeneratedNamespace
-{
-    public sealed class GeneratedInternalTypeHelper : System.Windows.Markup.InternalTypeHelper
-    {
-        public GeneratedInternalTypeHelper() { }
-        protected override void AddEventHandler(System.Reflection.EventInfo eventInfo, object target, System.Delegate handler) { }
-        protected override System.Delegate CreateDelegate(System.Type delegateType, object target, string handler) { }
-        protected override object CreateInstance(System.Type type, System.Globalization.CultureInfo culture) { }
-        protected override object GetPropertyValue(System.Reflection.PropertyInfo propertyInfo, object target, System.Globalization.CultureInfo culture) { }
-        protected override void SetPropertyValue(System.Reflection.PropertyInfo propertyInfo, object target, object value, System.Globalization.CultureInfo culture) { }
-    }
-}

--- a/src/ReactiveUI.Uno/ActivationForViewFetcher.cs
+++ b/src/ReactiveUI.Uno/ActivationForViewFetcher.cs
@@ -38,7 +38,7 @@ namespace ReactiveUI.Uno
             }
 
 #pragma warning disable SA1114 // Parameter list after.
-#if NETSTANDARD || MAC
+#if NETSTANDARD
             var viewLoaded = Observable.FromEvent<RoutedEventHandler, bool>(
 #else
             var viewLoaded = Observable.FromEvent<TypedEventHandler<DependencyObject, object>, bool>(

--- a/src/ReactiveUI/ReactiveUI.csproj
+++ b/src/ReactiveUI/ReactiveUI.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <Compile Remove="Platforms\**\*.cs" />
     <None Include="Platforms\**\*.cs" />
-    <PackageReference Include="System.Reactive" Version="4.1.5" />
+    <PackageReference Include="System.Reactive" Version="4.1.6" />
     <PackageReference Include="Splat" Version="8.*" />
     <PackageReference Include="DynamicData" Version="6.*" />
   </ItemGroup>


### PR DESCRIPTION
**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Fix ReactiveUI.Uno project compilation.

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

Something changed in Uno API so our CI checks fail now with `CS0201` and ` CS0029`

**What is the new behavior?**
<!-- If this is a feature change -->

The solution builds locally so let's see if it does on the CI server.

**What might this PR break?**

Nothing.