### PR TITLE
feature: add view model change observables to android ReactiveRecyclerViewViewHolder 

### DIFF
--- a/src/ReactiveUI.AndroidSupport/ReactiveRecyclerViewViewHolder.cs
+++ b/src/ReactiveUI.AndroidSupport/ReactiveRecyclerViewViewHolder.cs
@@ -63,7 +63,7 @@ namespace ReactiveUI.AndroidSupport
             SelectedWithViewModel = Observable.FromEvent<EventHandler, TViewModel>(
                                 eventHandler =>
                                 {
-                                    void Handler(object sender, View.LongClickEventArgs e) => eventHandler(ViewModel);
+                                    void Handler(object sender, EventArgs e) => eventHandler(ViewModel);
                                     return Handler;
                                 },
                                 h => view.Click += h,

--- a/src/ReactiveUI.AndroidSupport/ReactiveRecyclerViewViewHolder.cs
+++ b/src/ReactiveUI.AndroidSupport/ReactiveRecyclerViewViewHolder.cs
@@ -42,25 +42,41 @@ namespace ReactiveUI.AndroidSupport
         {
             SetupRxObj();
 
-            Selected = Observable.FromEvent<EventHandler, TViewModel>(
-                                                                      h => view.Click += h,
-                                                                      h => view.Click -= h)
-                                 .Select(_ => AdapterPosition);
+            Selected = Observable.FromEvent<EventHandler, int>(
+                                eventHandler =>
+                                {
+                                    void Handler(object sender, EventArgs e) => eventHandler(AdapterPosition);
+                                    return Handler;
+                                },
+                                h => view.Click += h,
+                                h => view.Click -= h);
 
-            LongClicked = Observable.FromEvent<EventHandler<View.LongClickEventArgs>, TViewModel>(
-                                                                         h => view.LongClick += h,
-                                                                         h => view.LongClick -= h)
-                                    .Select(_ => AdapterPosition);
+            LongClicked = Observable.FromEvent<EventHandler<View.LongClickEventArgs>, int>(
+                                eventHandler =>
+                                {
+                                    void Handler(object sender, View.LongClickEventArgs e) => eventHandler(AdapterPosition);
+                                    return Handler;
+                                },
+                                h => view.LongClick += h,
+                                h => view.LongClick -= h);
 
             SelectedWithViewModel = Observable.FromEvent<EventHandler, TViewModel>(
-                                                                                   h => view.Click += h,
-                                                                                   h => view.Click -= h)
-                                              .Select(_ => ViewModel);
+                                eventHandler =>
+                                {
+                                    void Handler(object sender, View.LongClickEventArgs e) => eventHandler(ViewModel);
+                                    return Handler;
+                                },
+                                h => view.Click += h,
+                                h => view.Click -= h);
 
             LongClickedWithViewModel = Observable.FromEvent<EventHandler<View.LongClickEventArgs>, TViewModel>(
-                                                                                      h => view.LongClick += h,
-                                                                                      h => view.LongClick -= h)
-                                                 .Select(_ => ViewModel);
+                                eventHandler =>
+                                {
+                                    void Handler(object sender, View.LongClickEventArgs e) => eventHandler(ViewModel);
+                                    return Handler;
+                                },
+                                h => view.LongClick += h,
+                                h => view.LongClick -= h);
         }
 
         /// <inheritdoc/>

--- a/src/ReactiveUI.AndroidSupport/ReactiveRecyclerViewViewHolder.cs
+++ b/src/ReactiveUI.AndroidSupport/ReactiveRecyclerViewViewHolder.cs
@@ -51,6 +51,16 @@ namespace ReactiveUI.AndroidSupport
                 h => view.LongClick += h,
                 h => view.LongClick -= h)
                     .Select(_ => AdapterPosition);
+
+            SelectedWithViewModel = Observable.FromEventPattern(
+                h => view.Click += h,
+                h => view.Click -= h)
+                                 .Select(_ => ViewModel);
+
+            LongClickedWithViewModel = Observable.FromEventPattern<View.LongClickEventArgs>(
+                h => view.LongClick += h,
+                h => view.LongClick -= h)
+                                    .Select(_ => ViewModel);
         }
 
         /// <inheritdoc/>
@@ -76,12 +86,26 @@ namespace ReactiveUI.AndroidSupport
         public IObservable<int> Selected { get; }
 
         /// <summary>
+        /// Gets an observable that signals that this ViewHolder has been selected.
+        ///
+        /// The <see cref="TViewModel"/> is the ViewModel of this ViewHolder in the <see cref="RecyclerView"/>.
+        /// </summary>
+        public IObservable<TViewModel> SelectedWithViewModel { get; }
+
+        /// <summary>
         /// Gets an observable that signals that this ViewHolder has been long-clicked.
         ///
         /// The <see cref="int"/> is the position of this ViewHolder in the <see cref="RecyclerView"/>
         /// and corresponds to the <see cref="RecyclerView.ViewHolder.AdapterPosition"/> property.
         /// </summary>
         public IObservable<int> LongClicked { get; }
+
+        /// <summary>
+        /// Gets an observable that signals that this ViewHolder has been long-clicked.
+        ///
+        /// The <see cref="TViewModel"/> is the ViewModel of this ViewHolder in the <see cref="RecyclerView"/>.
+        /// </summary>
+        public IObservable<TViewModel> LongClickedWithViewModel { get; }
 
         /// <summary>
         /// Gets the current view being shown.

--- a/src/ReactiveUI.AndroidSupport/ReactiveRecyclerViewViewHolder.cs
+++ b/src/ReactiveUI.AndroidSupport/ReactiveRecyclerViewViewHolder.cs
@@ -42,25 +42,25 @@ namespace ReactiveUI.AndroidSupport
         {
             SetupRxObj();
 
-            Selected = Observable.FromEventPattern(
-                h => view.Click += h,
-                h => view.Click -= h)
-                    .Select(_ => AdapterPosition);
+            Selected = Observable.FromEvent<EventHandler, TViewModel>(
+                                                                      h => view.Click += h,
+                                                                      h => view.Click -= h)
+                                 .Select(_ => AdapterPosition);
 
-            LongClicked = Observable.FromEventPattern<View.LongClickEventArgs>(
-                h => view.LongClick += h,
-                h => view.LongClick -= h)
-                    .Select(_ => AdapterPosition);
+            LongClicked = Observable.FromEvent<EventHandler<View.LongClickEventArgs>, TViewModel>(
+                                                                         h => view.LongClick += h,
+                                                                         h => view.LongClick -= h)
+                                    .Select(_ => AdapterPosition);
 
-            SelectedWithViewModel = Observable.FromEventPattern(
-                h => view.Click += h,
-                h => view.Click -= h)
-                                 .Select(_ => ViewModel);
+            SelectedWithViewModel = Observable.FromEvent<EventHandler, TViewModel>(
+                                                                                   h => view.Click += h,
+                                                                                   h => view.Click -= h)
+                                              .Select(_ => ViewModel);
 
-            LongClickedWithViewModel = Observable.FromEventPattern<View.LongClickEventArgs>(
-                h => view.LongClick += h,
-                h => view.LongClick -= h)
-                                    .Select(_ => ViewModel);
+            LongClickedWithViewModel = Observable.FromEvent<EventHandler<View.LongClickEventArgs>, TViewModel>(
+                                                                                      h => view.LongClick += h,
+                                                                                      h => view.LongClick -= h)
+                                                 .Select(_ => ViewModel);
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
Thus eliminating the need to have a collection to get the ViewModel from.
This is helpful when using IObservable<IChangeSet<TViewModel>> as we don't have a list if it has been sorted during the Dynamic Data connection

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature to return the ViewModel of the item that is selected in the adaptor for Android

**What might this PR break?**
None


**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

