### PR TITLE
fix: Downgrade MsBuild.Sdk.Extras

### DIFF
--- a/src/global.json
+++ b/src/global.json
@@ -3,6 +3,6 @@
         "version": "3.0.100-preview"
     },
     "msbuild-sdks": {
-        "MSBuild.Sdk.Extras": "2.0.41"
+        "MSBuild.Sdk.Extras": "2.0.31"
     }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Fixed the Azure Pipelines build

**What is the current behavior?**
The build is broken

**What is the new behavior?**
The build succeeds

**What might this PR break?**
Nothing
