### PR TITLE
performance: Added ReactiveCommand Benchmarks

### DIFF
--- a/src/Benchmarks/AutoPersistBenchmark.cs
+++ b/src/Benchmarks/AutoPersistBenchmark.cs
@@ -1,4 +1,9 @@
-﻿using System;
+﻿// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
 using System.Collections.ObjectModel;
 using System.Reactive;
 using System.Reactive.Disposables;

--- a/src/Benchmarks/CreateReactiveListBenchmark.cs
+++ b/src/Benchmarks/CreateReactiveListBenchmark.cs
@@ -1,4 +1,9 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using BenchmarkDotNet.Attributes;
 using DynamicData;

--- a/src/Benchmarks/INPCObservableForPropertyBenchmarks.cs
+++ b/src/Benchmarks/INPCObservableForPropertyBenchmarks.cs
@@ -1,4 +1,9 @@
-﻿using System;
+﻿// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq.Expressions;

--- a/src/Benchmarks/Mocks/MockHostScreen.cs
+++ b/src/Benchmarks/Mocks/MockHostScreen.cs
@@ -1,4 +1,9 @@
-﻿namespace ReactiveUI.Benchmarks
+﻿// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace ReactiveUI.Benchmarks
 {
     /// <summary>
     /// A mock for the screen in ReactiveUI. This will only contain the routing state.

--- a/src/Benchmarks/Mocks/MockViewModel.cs
+++ b/src/Benchmarks/Mocks/MockViewModel.cs
@@ -1,4 +1,9 @@
-﻿using System.Runtime.Serialization;
+﻿// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Runtime.Serialization;
 
 namespace ReactiveUI.Benchmarks
 {

--- a/src/Benchmarks/NavigationStackBenchmark.cs
+++ b/src/Benchmarks/NavigationStackBenchmark.cs
@@ -1,4 +1,9 @@
-﻿using System;
+﻿// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reactive.Concurrency;
@@ -20,7 +25,7 @@ namespace ReactiveUI.Benchmarks
         private RoutingState _router;
 
         /// <summary>
-        /// Initializes static members of the NavigationStackBenchmark class.
+        /// Initializes static members of the <see cref="NavigationStackBenchmark"/> class.
         /// </summary>
         static NavigationStackBenchmark()
         {

--- a/src/Benchmarks/Program.cs
+++ b/src/Benchmarks/Program.cs
@@ -1,4 +1,9 @@
-﻿using System;
+﻿// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/Benchmarks/ReactiveCommandCreateBenchmark.cs
+++ b/src/Benchmarks/ReactiveCommandCreateBenchmark.cs
@@ -1,0 +1,109 @@
+﻿// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+
+namespace ReactiveUI.Benchmarks
+{
+    /// <summary>
+    /// Benchmarks associated with the ReactiveCommand object.
+    /// </summary>
+    [ClrJob]
+    [CoreJob]
+    [MemoryDiagnoser]
+    [MarkdownExporterAttribute.GitHub]
+    public class ReactiveCommandCreateBenchmark
+    {
+        private readonly IObservable<bool> _canExecute = new Subject<bool>().AsObservable();
+
+        /// <summary>
+        /// Gets or sets from observable.
+        /// </summary>
+        public Subject<MockViewModel> FromObservable { get; set; }
+
+        /// <summary>
+        /// Gets or sets from task.
+        /// </summary>
+        public Task FromTask { get; set; }
+
+        /// <summary>
+        /// Setup for all benchmark instances being run.
+        /// </summary>
+        [GlobalSetup]
+        public void Setup()
+        {
+            FromObservable = new Subject<MockViewModel>();
+
+            FromTask = Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Benchmark for creating a ReactiveCommand.
+        /// </summary>
+        /// <returns>The command.</returns>
+        [Benchmark(Baseline = true)]
+        public object CreateReactiveCommand() => ReactiveCommand.Create(() => { });
+
+        /// <summary>
+        /// Benchmark for creating a ReactiveCommand from an observable.
+        /// </summary>
+        /// <returns>The command.</returns>
+        [Benchmark]
+        public object CreateReactiveCommandFromObservable() => ReactiveCommand.CreateFromObservable(() => FromObservable.AsObservable());
+
+        /// <summary>
+        /// Benchmark for creating a ReactiveCommand a task.
+        /// </summary>
+        /// <returns>The command.</returns>
+        [Benchmark]
+        public object CreateReactiveCommandFromTask() => ReactiveCommand.CreateFromTask(async () => await FromTask);
+
+        /// <summary>
+        /// Benchmark for creating a ReactiveCommand with a can execute observable.
+        /// </summary>
+        /// <returns>The command.</returns>
+        [Benchmark]
+        public object CreateWithCanExecute() => ReactiveCommand.Create(() => { }, _canExecute);
+
+        /// <summary>
+        /// Benchmark for creating a ReactiveCommand from an observable with a can execute observable.
+        /// </summary>
+        /// <returns>The command.</returns>
+        [Benchmark]
+        public object CreateFromObservableWithCanExecute() => ReactiveCommand.CreateFromObservable(() => FromObservable.AsObservable(), _canExecute);
+
+        /// <summary>
+        /// Benchmark for creating a ReactiveCommand from a task with a can execute observable.
+        /// </summary>
+        /// <returns>The command.</returns>
+        [Benchmark]
+        public object CreateFromTaskWithCanExecute() => ReactiveCommand.CreateFromTask(async () => await FromTask, _canExecute);
+
+        /// <summary>
+        /// Benchmark for creating a ReactiveCommand with a can execute observable.
+        /// </summary>
+        /// <returns>The command.</returns>
+        [Benchmark]
+        public object CreateWithCanExecuteAndScheduler() => ReactiveCommand.Create(() => { }, _canExecute, RxApp.MainThreadScheduler);
+
+        /// <summary>
+        /// Benchmark for creating a ReactiveCommand from an observable with a can execute observable.
+        /// </summary>
+        /// <returns>The command.</returns>
+        [Benchmark]
+        public object CreateFromObservableWithCanExecuteAndScheduler() => ReactiveCommand.CreateFromObservable(() => FromObservable.AsObservable(), _canExecute, RxApp.MainThreadScheduler);
+
+        /// <summary>
+        /// Benchmark for creating a ReactiveCommand from a task with a can execute observable.
+        /// </summary>
+        /// <returns>The command.</returns>
+        [Benchmark]
+        public object CreateFromTaskWithCanExecuteAndScheduler() => ReactiveCommand.CreateFromTask(async () => await FromTask, _canExecute, RxApp.MainThreadScheduler);
+    }
+}

--- a/src/Benchmarks/ReactiveListOperationBenchmark.cs
+++ b/src/Benchmarks/ReactiveListOperationBenchmark.cs
@@ -1,4 +1,9 @@
-﻿using BenchmarkDotNet.Attributes;
+﻿// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Order;
 using DynamicData;
 

--- a/src/Benchmarks/ReactiveUI.Benchmarks.csproj
+++ b/src/Benchmarks/ReactiveUI.Benchmarks.csproj
@@ -12,12 +12,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Remove="ReactiveUI.Benchmarks\**" />
-    <EmbeddedResource Remove="ReactiveUI.Benchmarks\**" />
-    <None Remove="ReactiveUI.Benchmarks\**" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="DynamicData" Version="*" />
     <PackageReference Include="BenchmarkDotNet" Version="*" />
   </ItemGroup>

--- a/src/Benchmarks/RoutableViewModelMixinsBenchmarks.cs
+++ b/src/Benchmarks/RoutableViewModelMixinsBenchmarks.cs
@@ -1,4 +1,9 @@
-﻿using System;
+﻿// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
 using System.Reactive.Concurrency;
 using System.Reactive.Linq;
 using BenchmarkDotNet.Attributes;

--- a/src/ReactiveUI/ReactiveUI.csproj
+++ b/src/ReactiveUI/ReactiveUI.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;Xamarin.iOS10;Xamarin.Mac20;Xamarin.TVOS10;MonoAndroid81;netcoreapp2.0;tizen50</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;Xamarin.iOS10;Xamarin.Mac20;Xamarin.TVOS10;MonoAndroid81;netcoreapp2.0;tizen40</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net461;uap10.0.16299</TargetFrameworks>
     <AssemblyName>ReactiveUI</AssemblyName>
     <RootNamespace>ReactiveUI</RootNamespace>

--- a/src/ReactiveUI/ReactiveUI.csproj
+++ b/src/ReactiveUI/ReactiveUI.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;Xamarin.iOS10;Xamarin.Mac20;Xamarin.TVOS10;MonoAndroid81;netcoreapp2.0;tizen40</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;Xamarin.iOS10;Xamarin.Mac20;Xamarin.TVOS10;MonoAndroid81;netcoreapp2.0;tizen50</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net461;uap10.0.16299</TargetFrameworks>
     <AssemblyName>ReactiveUI</AssemblyName>
     <RootNamespace>ReactiveUI</RootNamespace>


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Add Benchmarks for `ReactiveCommand.Create`

**What is the current behavior?**
Relates To: #1734 

**What is the new behavior?**
Benchmarks are created for the following

1. Create
2. CreateFromTask
3. CreateFromObservable


**What might this PR break?**

Nothing

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

