### PR TITLE
fix: remove exception in .netstandard 2.0 code

### DIFF
--- a/src/ReactiveUI/Platforms/netstandard2.0/PlatformRegistrations.cs
+++ b/src/ReactiveUI/Platforms/netstandard2.0/PlatformRegistrations.cs
@@ -4,6 +4,7 @@
 // See the LICENSE file in the project root for full license information.
 
 using System;
+using System.Reactive.Concurrency;
 
 namespace ReactiveUI
 {
@@ -16,7 +17,13 @@ namespace ReactiveUI
         /// <inheritdoc/>
         public void Register(Action<Func<object>, Type> registerFunction)
         {
-            throw new Exception("You are referencing the Portable version of ReactiveUI in an App. Please change your reference to the specific version for your platform found here: https://reactiveui.net/docs/getting-started/installation");
+            if (registerFunction == null)
+            {
+                throw new ArgumentNullException(nameof(registerFunction));
+            }
+
+            RxApp.TaskpoolScheduler = TaskPoolScheduler.Default;
+            RxApp.MainThreadScheduler = DefaultScheduler.Instance;
         }
     }
 }


### PR DESCRIPTION
WASM projects will run under .net standard so the exception will likely cause issues in the future.

This removes the exception in the platform registrations.

This fixes #2162 