### PR TITLE
Prioritize DependencyObject over INPC for UWP based projects

### DIFF
--- a/src/ReactiveUI/Platforms/uap/DependencyObjectObservableForProperty.cs
+++ b/src/ReactiveUI/Platforms/uap/DependencyObjectObservableForProperty.cs
@@ -37,7 +37,13 @@ namespace ReactiveUI
                 return 0;
             }
 
+#if HAS_UNO
+            // DependencyObject must be prioritized compared to INotifyPropertyChanged (score == 5)
+            // until https://github.com/unoplatform/uno/issues/1551 is resolved.
+            return 6; 
+#else
             return 4;
+#endif
         }
 
         /// <inheritdoc/>

--- a/src/ReactiveUI/Platforms/uap/DependencyObjectObservableForProperty.cs
+++ b/src/ReactiveUI/Platforms/uap/DependencyObjectObservableForProperty.cs
@@ -37,13 +37,7 @@ namespace ReactiveUI
                 return 0;
             }
 
-#if HAS_UNO
-            // DependencyObject must be prioritized compared to INotifyPropertyChanged (score == 5)
-            // until https://github.com/unoplatform/uno/issues/1551 is resolved.
-            return 6; 
-#else
-            return 4;
-#endif
+            return 6;
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bug fix

**What is the current behavior?**
When building an Observable to observe a property of an object, if it inherits for `DependencyObject` and implements `INotifyPropertyChanged` the observable will be built using the `INotifyPropertyChanged.PropertyChanged` event.

The issue is that on iOS and Android the `UIElement` implements the `INotifyPropertyChanged` but it never raise the event: https://github.com/unoplatform/uno/issues/1551.

**What is the new behavior?**
On UNO projects, if an object inherit from `DependencyObject` we will create a observable from the `DependencyProperty` if found and fallback to the `INotifyPropertyChanged` otherwise.

**What might this PR break?**
If a `DependencyObject` has a `DependencyProperty` which is bypassed by the object's property getter / setter, the resulting observable won't produce any value.

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
The real issue is on the Uno side (https://github.com/unoplatform/uno/issues/1551) however it's safer / lighter to change the priority in ReactiveUI for now, and rollback this commit once the issue has been fixed in Uno.
