### PR TITLE
fix: in non-UI .netcoreapp3.0 applications a compile error is produced.

### DIFF
--- a/src/ReactiveUI/ReactiveUI.csproj
+++ b/src/ReactiveUI/ReactiveUI.csproj
@@ -14,20 +14,8 @@
     <None Include="Platforms\**\*.cs" />
     <PackageReference Include="Splat" Version="8.*" />
     <PackageReference Include="DynamicData" Version="6.*" />
+    <PackageReference Include="System.Reactive" Version="4.1.6" />
   </ItemGroup>
-
-  <Choose>
-    <When Condition=" $(TargetFramework.StartsWith('netcoreapp3.0')) ">
-      <ItemGroup>
-          <PackageReference Include="System.Reactive" Version="4.2.0-preview.625" />
-      </ItemGroup>
-    </When>
-    <Otherwise>
-      <ItemGroup>
-          <PackageReference Include="System.Reactive" Version="4.1.6" />
-      </ItemGroup>
-    </Otherwise>
-  </Choose>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('netstandard')) ">
     <Compile Include="Platforms\netstandard2.0\**\*.cs" />


### PR DESCRIPTION
The preview versions of Reactive Extensions contain `UseWPF` and `UseWinforms`, which will force the client library to attempt to find those. This does not work on non-windows builds of .net core app 3.0 applications.

The WPF/WinForms versions contain the preview System.Reactive with these changes which will still allow those .net core app users to use WPF/WinForms on .net core app 3.0