### PR TITLE
housekeeping: Update to splat 9

### DIFF
--- a/integrationtests/IntegrationTests.WPF/IntegrationTests.WPF.csproj
+++ b/integrationtests/IntegrationTests.WPF/IntegrationTests.WPF.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net471</TargetFrameworks>        
     <Description>WPF specific example of IntegrationTests</Description>
     <PackageId>IntegrationTests.WPF</PackageId>
-    <ExtrasEnableWpfProjectSetup>true</ExtrasEnableWpfProjectSetup>
+    <UseWpf>true</ExtrasEnableWpfProjectSetup>
     <OutputType>WinExe</OutputType>
   </PropertyGroup>
 

--- a/integrationtests/IntegrationTests.WinForms/IntegrationTests.WinForms.csproj
+++ b/integrationtests/IntegrationTests.WinForms/IntegrationTests.WinForms.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net471</TargetFrameworks>        
     <Description>Winforms specific example of IntegrationTests</Description>
     <PackageId>IntegrationTests.WinForms</PackageId>
-    <ExtrasEnableWinFormsProjectSetup>true</ExtrasEnableWinFormsProjectSetup>
+    <UseWindowsForms>true</UseWindowsForms>
     <OutputType>WinExe</OutputType>
   </PropertyGroup>
 

--- a/integrationtests/global.json
+++ b/integrationtests/global.json
@@ -1,5 +1,8 @@
 {
+    "sdk": {
+        "version": "3.0.100-preview"
+    },
     "msbuild-sdks": {
-        "MSBuild.Sdk.Extras": "1.6.65"
+        "MSBuild.Sdk.Extras": "2.0.43"
     }
 }

--- a/src/ReactiveUI.Events.WPF/ReactiveUI.Events.WPF.csproj
+++ b/src/ReactiveUI.Events.WPF/ReactiveUI.Events.WPF.csproj
@@ -5,6 +5,7 @@
     <Description>Provides Observable-based events API for WPF UI controls/eventhandlers. The contents of this package is automatically generated, please target pull-requests to the code generator.</Description>
     <PackageId>ReactiveUI.Events.WPF</PackageId>
     <UseWpf>true</UseWpf>
+    <UseWindowsForms>true</UseWindowsForms>
     <NoWarn>$(NoWarn);CS1570;CA1812</NoWarn>
   </PropertyGroup>  
 
@@ -27,13 +28,11 @@
     </Otherwise>
   </Choose>
 
-  <ItemGroup Condition=" $(TargetFramework.StartsWith('netcoreapp3')) ">
-    <PackageReference Include="Pharmacist.MsBuild" Version="1.*" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.WindowsDesktop.App" Version="3.0.0-preview*" />
+  <ItemGroup>
+    <Compile Include="Events_WPF.cs" />
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) ">
-    <Compile Include="Events_WPF.cs" />
     <Reference Include="System.Xaml" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />

--- a/src/ReactiveUI.Events.WPF/ReactiveUI.Events.WPF.csproj
+++ b/src/ReactiveUI.Events.WPF/ReactiveUI.Events.WPF.csproj
@@ -5,7 +5,6 @@
     <Description>Provides Observable-based events API for WPF UI controls/eventhandlers. The contents of this package is automatically generated, please target pull-requests to the code generator.</Description>
     <PackageId>ReactiveUI.Events.WPF</PackageId>
     <UseWpf>true</UseWpf>
-    <ExtrasEnableWpfProjectSetup>true</ExtrasEnableWpfProjectSetup>
     <NoWarn>$(NoWarn);CS1570;CA1812</NoWarn>
   </PropertyGroup>  
 

--- a/src/ReactiveUI.Events.Winforms/ReactiveUI.Events.Winforms.csproj
+++ b/src/ReactiveUI.Events.Winforms/ReactiveUI.Events.Winforms.csproj
@@ -36,6 +36,5 @@
     <Reference Include="System" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
-    <Reference Include="System.Windows.Forms.DataVisualization" />
   </ItemGroup>
 </Project>

--- a/src/ReactiveUI.Events.Winforms/ReactiveUI.Events.Winforms.csproj
+++ b/src/ReactiveUI.Events.Winforms/ReactiveUI.Events.Winforms.csproj
@@ -28,20 +28,14 @@
     </Otherwise>
   </Choose>
 
-  <ItemGroup Condition=" $(TargetFramework.StartsWith('netcoreapp3')) ">
-    <PackageReference Include="Pharmacist.MsBuild" Version="1.*" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.WindowsDesktop.App" Version="3.0.0-preview.*" />
+  <ItemGroup>
+    <Compile Include="Events_Winforms.cs" />
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) ">
-    <Compile Include="Events_Winforms.cs" />
     <Reference Include="System" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.DirectoryServices" />
     <Reference Include="System.Drawing" />
-    <Reference Include="System.Messaging" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Windows.Forms.DataVisualization" />
-    <Reference Include="System.ServiceProcess" />
   </ItemGroup>
 </Project>

--- a/src/ReactiveUI.Events.Winforms/ReactiveUI.Events.Winforms.csproj
+++ b/src/ReactiveUI.Events.Winforms/ReactiveUI.Events.Winforms.csproj
@@ -5,7 +5,6 @@
     <RootNamespace>ReactiveUI.Events</RootNamespace>
     <Description>Provides Observable-based events API for Winforms UI controls/eventhandlers. The contents of this package is automatically generated, please target pull-requests to the code generator.</Description>
     <PackageId>ReactiveUI.Events.Winforms</PackageId>
-    <ExtrasEnableWinFormsProjectSetup>true</ExtrasEnableWinFormsProjectSetup>
     <UseWindowsForms>true</UseWindowsForms>
     <NoWarn>$(NoWarn);CS1570;CA1812</NoWarn>
   </PropertyGroup>  

--- a/src/ReactiveUI.Fody.Tests/FodyWeavers.xsd
+++ b/src/ReactiveUI.Fody.Tests/FodyWeavers.xsd
@@ -4,7 +4,6 @@
   <xs:element name="Weavers">
     <xs:complexType>
       <xs:all>
-        <xs:element name="ReactiveUI.Fody.deps" minOccurs="0" maxOccurs="1" type="xs:anyType" />
         <xs:element name="ReactiveUI" minOccurs="0" maxOccurs="1" type="xs:anyType" />
       </xs:all>
       <xs:attribute name="VerifyAssembly" type="xs:boolean">

--- a/src/ReactiveUI.Splat.Tests/ReactiveUI.Splat.Tests.csproj
+++ b/src/ReactiveUI.Splat.Tests/ReactiveUI.Splat.Tests.csproj
@@ -8,9 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Splat.Autofac" Version="8.*" />
-    <PackageReference Include="Splat.DryIoc" Version="8.*" />
-    <PackageReference Include="Splat.Ninject" Version="8.*" />
+    <PackageReference Include="Splat.Autofac" Version="9.*" />
+    <PackageReference Include="Splat.DryIoc" Version="9.*" />
+    <PackageReference Include="Splat.Ninject" Version="9.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.net461.approved.txt
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.net461.approved.txt
@@ -624,7 +624,6 @@ namespace ReactiveUI
         public const int SmallCacheLimit = 64;
         public static System.IObserver<System.Exception> DefaultExceptionHandler { get; set; }
         public static System.Reactive.Concurrency.IScheduler MainThreadScheduler { get; set; }
-        public static bool SupportsRangeNotifications { get; set; }
         public static bool SuppressViewCommandBindingMessage { get; set; }
         public static ReactiveUI.ISuspensionHost SuspensionHost { get; set; }
         public static System.Reactive.Concurrency.IScheduler TaskpoolScheduler { get; set; }

--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.netcoreapp2.0.approved.txt
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.netcoreapp2.0.approved.txt
@@ -618,7 +618,6 @@ namespace ReactiveUI
         public const int SmallCacheLimit = 64;
         public static System.IObserver<System.Exception> DefaultExceptionHandler { get; set; }
         public static System.Reactive.Concurrency.IScheduler MainThreadScheduler { get; set; }
-        public static bool SupportsRangeNotifications { get; set; }
         public static bool SuppressViewCommandBindingMessage { get; set; }
         public static ReactiveUI.ISuspensionHost SuspensionHost { get; set; }
         public static System.Reactive.Concurrency.IScheduler TaskpoolScheduler { get; set; }

--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.netcoreapp3.0.approved.txt
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.netcoreapp3.0.approved.txt
@@ -624,7 +624,6 @@ namespace ReactiveUI
         public const int SmallCacheLimit = 64;
         public static System.IObserver<System.Exception> DefaultExceptionHandler { get; set; }
         public static System.Reactive.Concurrency.IScheduler MainThreadScheduler { get; set; }
-        public static bool SupportsRangeNotifications { get; set; }
         public static bool SuppressViewCommandBindingMessage { get; set; }
         public static ReactiveUI.ISuspensionHost SuspensionHost { get; set; }
         public static System.Reactive.Concurrency.IScheduler TaskpoolScheduler { get; set; }

--- a/src/ReactiveUI.Tests/Platforms/common-gui/ProductionMode.cs
+++ b/src/ReactiveUI.Tests/Platforms/common-gui/ProductionMode.cs
@@ -9,12 +9,19 @@ using Splat;
 
 namespace ReactiveUI.Tests
 {
-    internal class ProductionMode : IModeDetector
+    internal class ProductionMode : IModeDetector, IPlatformModeDetector
     {
+        private static ProductionMode Instance = new ProductionMode();
+
         public static IDisposable Set()
         {
-            ModeDetector.OverrideModeDetector(new ProductionMode());
-            return Disposable.Create(() => ModeDetector.OverrideModeDetector(new PlatformModeDetector()));
+            PlatformModeDetector.OverrideModeDetector(Instance);
+            ModeDetector.OverrideModeDetector(Instance);
+            return Disposable.Create(() =>
+            {
+                PlatformModeDetector.OverrideModeDetector(new DefaultPlatformModeDetector());
+                ModeDetector.OverrideModeDetector(new DefaultModeDetector());
+            });
         }
 
         public bool? InUnitTestRunner()

--- a/src/ReactiveUI.Uno/ReactiveUI.Uno.csproj
+++ b/src/ReactiveUI.Uno/ReactiveUI.Uno.csproj
@@ -13,6 +13,10 @@
     <DefineConstants>HAS_UNO;WASM</DefineConstants>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Splat.Drawing" Version="9.0.4" />
+  </ItemGroup>
+
   <ItemGroup Condition=" !$(TargetFramework.StartsWith('uap')) ">
     <PackageReference Include="Uno.UI" Version="1.*" />
   </ItemGroup>

--- a/src/ReactiveUI.Uno/Registrations.cs
+++ b/src/ReactiveUI.Uno/Registrations.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Reactive.Concurrency;
 using System.Reactive.PlatformServices;
+using Splat;
 
 namespace ReactiveUI.Uno
 {
@@ -28,6 +29,9 @@ namespace ReactiveUI.Uno
             registerFunction(() => new DependencyObjectObservableForProperty(), typeof(ICreatesObservableForProperty));
             registerFunction(() => new BooleanToVisibilityTypeConverter(), typeof(IBindingTypeConverter));
             registerFunction(() => new AutoDataTemplateBindingHook(), typeof(IPropertyBindingHook));
+#if !NETSTANDARD
+            registerFunction(() => new PlatformBitmapLoader(), typeof(IBitmapLoader));
+#endif
 
             // Re-enable once the obsolete code in Uno has been worked out.
             ////registerFunction(() => new WinRTAppDataDriver(), typeof(ISuspensionDriver));

--- a/src/ReactiveUI.Winforms/ReactiveUI.Winforms.csproj
+++ b/src/ReactiveUI.Winforms/ReactiveUI.Winforms.csproj
@@ -7,12 +7,15 @@
     <Description>Windows Forms specific extensions to ReactiveUI</Description>
     <PackageId>ReactiveUI.WinForms</PackageId>
     <UseWindowsForms>true</UseWindowsForms>
-    <ExtrasEnableWinFormsProjectSetup>true</ExtrasEnableWinFormsProjectSetup>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\ReactiveUI\ReactiveUI.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Splat.Drawing" Version="9.*" />
   </ItemGroup>
 
   <Choose>

--- a/src/ReactiveUI.Winforms/Registrations.cs
+++ b/src/ReactiveUI.Winforms/Registrations.cs
@@ -34,6 +34,7 @@ namespace ReactiveUI.Winforms
             registerFunction(() => new PanelSetMethodBindingConverter(), typeof(ISetMethodBindingConverter));
             registerFunction(() => new TableContentSetMethodBindingConverter(), typeof(ISetMethodBindingConverter));
             registerFunction(() => new ComponentModelTypeConverter(), typeof(IBindingTypeConverter));
+            registerFunction(() => new PlatformBitmapLoader(), typeof(IBitmapLoader));
 
             if (!ModeDetector.InUnitTestRunner())
             {

--- a/src/ReactiveUI.Wpf/ReactiveUI.Wpf.csproj
+++ b/src/ReactiveUI.Wpf/ReactiveUI.Wpf.csproj
@@ -4,13 +4,16 @@
     <Description>WPF specific extensions to ReactiveUI</Description>
     <PackageId>ReactiveUI.WPF</PackageId>
     <UseWpf>true</UseWpf>
-    <ExtrasEnableWpfProjectSetup>true</ExtrasEnableWpfProjectSetup>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\ReactiveUI\ReactiveUI.csproj" />    
     <Compile Include="..\ReactiveUI\Platforms\windows-common\**\*.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Splat.Drawing" Version="9.*" />
   </ItemGroup>
 
   <Choose>

--- a/src/ReactiveUI.Wpf/Registrations.cs
+++ b/src/ReactiveUI.Wpf/Registrations.cs
@@ -5,8 +5,8 @@
 
 using System;
 using System.Reactive.Concurrency;
-
 using ReactiveUI;
+using Splat;
 
 namespace ReactiveUI.Wpf
 {
@@ -30,6 +30,7 @@ namespace ReactiveUI.Wpf
             registerFunction(() => new BooleanToVisibilityTypeConverter(), typeof(IBindingTypeConverter));
             registerFunction(() => new AutoDataTemplateBindingHook(), typeof(IPropertyBindingHook));
             registerFunction(() => new ComponentModelTypeConverter(), typeof(IBindingTypeConverter));
+            registerFunction(() => new PlatformBitmapLoader(), typeof(IBitmapLoader));
 
             RxApp.TaskpoolScheduler = TaskPoolScheduler.Default;
 

--- a/src/ReactiveUI/Platforms/android/PlatformRegistrations.cs
+++ b/src/ReactiveUI/Platforms/android/PlatformRegistrations.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Reactive.Concurrency;
+using Splat;
 
 namespace ReactiveUI
 {
@@ -29,6 +30,7 @@ namespace ReactiveUI
             RxApp.TaskpoolScheduler = TaskPoolScheduler.Default;
             RxApp.MainThreadScheduler = HandlerScheduler.MainThreadScheduler;
             registerFunction(() => new BundleSuspensionDriver(), typeof(ISuspensionDriver));
+            registerFunction(() => new PlatformBitmapLoader(), typeof(IBitmapLoader));
         }
     }
 }

--- a/src/ReactiveUI/Platforms/mac/PlatformRegistrations.cs
+++ b/src/ReactiveUI/Platforms/mac/PlatformRegistrations.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Reactive.Concurrency;
+using Splat;
 
 namespace ReactiveUI
 {
@@ -28,6 +29,7 @@ namespace ReactiveUI
             registerFunction(() => new TargetActionCommandBinder(), typeof(ICreatesCommandBinding));
             registerFunction(() => new DateTimeNSDateConverter(), typeof(IBindingTypeConverter));
             registerFunction(() => new KVOObservableForProperty(), typeof(ICreatesObservableForProperty));
+            registerFunction(() => new PlatformBitmapLoader(), typeof(IBitmapLoader));
             RxApp.TaskpoolScheduler = TaskPoolScheduler.Default;
             RxApp.MainThreadScheduler = new WaitForDispatcherScheduler(() => new NSRunloopScheduler());
             registerFunction(() => new AppSupportJsonSuspensionDriver(), typeof(ISuspensionDriver));

--- a/src/ReactiveUI/Platforms/net4/PlatformRegistrations.cs
+++ b/src/ReactiveUI/Platforms/net4/PlatformRegistrations.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Reactive.Concurrency;
+using Splat;
 
 namespace ReactiveUI
 {

--- a/src/ReactiveUI/Platforms/tizen/PlatformRegistrations.cs
+++ b/src/ReactiveUI/Platforms/tizen/PlatformRegistrations.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Reactive.Concurrency;
+using Splat;
 
 namespace ReactiveUI
 {
@@ -24,6 +25,7 @@ namespace ReactiveUI
 
             registerFunction(() => new PlatformOperations(), typeof(IPlatformOperations));
             registerFunction(() => new ComponentModelTypeConverter(), typeof(IBindingTypeConverter));
+            registerFunction(() => new PlatformBitmapLoader(), typeof(IBitmapLoader));
             RxApp.TaskpoolScheduler = TaskPoolScheduler.Default;
             RxApp.MainThreadScheduler = EcoreMainloopScheduler.MainThreadScheduler;
         }

--- a/src/ReactiveUI/Platforms/uap/PlatformRegistrations.cs
+++ b/src/ReactiveUI/Platforms/uap/PlatformRegistrations.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Reactive.Concurrency;
+using Splat;
 
 namespace ReactiveUI
 {
@@ -30,6 +31,7 @@ namespace ReactiveUI
             RxApp.TaskpoolScheduler = TaskPoolScheduler.Default;
             RxApp.MainThreadScheduler = new SingleWindowDispatcherScheduler();
             registerFunction(() => new WinRTAppDataDriver(), typeof(ISuspensionDriver));
+            registerFunction(() => new PlatformBitmapLoader(), typeof(IBitmapLoader));
         }
     }
 }

--- a/src/ReactiveUI/Platforms/uikit-common/PlatformRegistrations.cs
+++ b/src/ReactiveUI/Platforms/uikit-common/PlatformRegistrations.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Reactive.Concurrency;
+using Splat;
 
 namespace ReactiveUI
 {
@@ -31,6 +32,7 @@ namespace ReactiveUI
             RxApp.TaskpoolScheduler = TaskPoolScheduler.Default;
             RxApp.MainThreadScheduler = new WaitForDispatcherScheduler(() => new NSRunloopScheduler());
             registerFunction(() => new AppSupportJsonSuspensionDriver(), typeof(ISuspensionDriver));
+            registerFunction(() => new PlatformBitmapLoader(), typeof(IBitmapLoader));
         }
     }
 }

--- a/src/ReactiveUI/ReactiveUI.csproj
+++ b/src/ReactiveUI/ReactiveUI.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <Compile Remove="Platforms\**\*.cs" />
     <None Include="Platforms\**\*.cs" />
-    <PackageReference Include="Splat" Version="8.*" />
+    <PackageReference Include="Splat" Version="9.*" />
     <PackageReference Include="DynamicData" Version="6.*" />
     <PackageReference Include="System.Reactive" Version="4.1.6" />
   </ItemGroup>
@@ -28,6 +28,7 @@
   <ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) ">
     <Compile Include="Platforms\net4\**\*.cs" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+    <PackageReference Include="Splat.Drawing" Version="9.*" />
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('netstandard2')) ">
@@ -37,6 +38,7 @@
   <ItemGroup Condition=" $(TargetFramework.StartsWith('uap')) ">
     <Compile Include="Platforms\windows-common\**\*.cs" />
     <Compile Include="Platforms\uap\**\*.cs" />
+    <PackageReference Include="Splat.Drawing" Version="9.*" />
   </ItemGroup>
 
   <ItemGroup Label="Package" Condition=" $(TargetFramework.StartsWith('uap')) ">
@@ -49,6 +51,7 @@
     <Compile Include="Platforms\uikit-common\**\*.cs" />
     <Compile Include="Platforms\xamarin-common\**\*.cs" />
     <Reference Include="System.Runtime.Serialization" />
+    <PackageReference Include="Splat.Drawing" Version="9.*" />
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('Xamarin.Mac')) ">
@@ -57,6 +60,7 @@
     <Compile Include="Platforms\xamarin-common\**\*.cs" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="netstandard" />
+    <PackageReference Include="Splat.Drawing" Version="9.*" />
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('Xamarin.TVOS')) ">
@@ -65,12 +69,14 @@
     <Compile Include="Platforms\uikit-common\**\*.cs" />	
     <Compile Include="Platforms\xamarin-common\**\*.cs" />
     <Reference Include="System.Runtime.Serialization" />
+    <PackageReference Include="Splat.Drawing" Version="9.*" />
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('MonoAndroid')) ">
     <Compile Include="Platforms\android\**\*.cs" />
     <Compile Include="Platforms\xamarin-common\**\*.cs" />
     <Reference Include="System.Runtime.Serialization" />
+    <PackageReference Include="Splat.Drawing" Version="9.*" />
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('netcoreapp2')) ">
@@ -96,6 +102,7 @@
     <PackageReference Include="System.Text.Encoding.Extensions" Version="4.3.0" />
     <PackageReference Include="System.Threading" Version="4.3.0" />
     <PackageReference Include="Microsoft.Win32.Primitives" Version="4.3.0" />
+    <PackageReference Include="Splat.Drawing" Version="9.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ReactiveUI/RxApp.cs
+++ b/src/ReactiveUI/RxApp.cs
@@ -65,9 +65,6 @@ namespace ReactiveUI
         [ThreadStatic]
         private static ISuspensionHost _unitTestSuspensionHost;
         private static ISuspensionHost _suspensionHost;
-        [ThreadStatic]
-        private static bool? _unitTestSupportsRangeNotifications;
-        private static bool _supportsRangeNotifications;
 
         /// <summary>
         /// Initializes static members of the <see cref="RxApp"/> class.
@@ -77,14 +74,6 @@ namespace ReactiveUI
         {
 #if !PORTABLE
             _taskpoolScheduler = TaskPoolScheduler.Default;
-#endif
-
-            // Initialize this to false as most platforms do not support
-            // range notification for INotifyCollectionChanged
-#if WP8 || NETFX_CORE
-            SupportsRangeNotifications = false;
-#else
-            SupportsRangeNotifications = true;
 #endif
 
             Locator.RegisterResolverCallbackChanged(() =>
@@ -229,32 +218,6 @@ namespace ReactiveUI
                 else
                 {
                     _suspensionHost = value;
-                }
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether your UI framework is brain-dead or not and will blow
-        /// up if a INotifyCollectionChanged object returns a ranged Add.
-        /// </summary>
-        public static bool SupportsRangeNotifications
-        {
-            get => _unitTestSupportsRangeNotifications ?? _supportsRangeNotifications;
-            set
-            {
-                // N.B. The ThreadStatic dance here is for the unit test case -
-                // often, each test will override MainThreadScheduler with their
-                // own TestScheduler, and if this wasn't ThreadStatic, they would
-                // stomp on each other, causing test cases to randomly fail,
-                // then pass when you rerun them.
-                if (ModeDetector.InUnitTestRunner())
-                {
-                    _unitTestSupportsRangeNotifications = value;
-                    _supportsRangeNotifications = value;
-                }
-                else
-                {
-                    _supportsRangeNotifications = value;
                 }
             }
         }

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<packages>
-    <package id="Cake" version="0.33.0" />
-</packages>


### PR DESCRIPTION
Remove the indicator for range indicators from RxApp due to not needed since the removal of ReactiveList
Removed redundant ExtrasEnableWpfProjectSetup for projects.
