### PR TITLE
fix: the WPF designer by removing abstract

### DIFF
--- a/src/ReactiveUI.Tests/Platforms/wpf/API/ApiApprovalTests.Wpf.net461.approved.txt
+++ b/src/ReactiveUI.Tests/Platforms/wpf/API/ApiApprovalTests.Wpf.net461.approved.txt
@@ -44,27 +44,27 @@ namespace ReactiveUI
         public PlatformOperations() { }
         public string GetOrientation() { }
     }
-    public abstract class ReactivePage<TViewModel> : System.Windows.Controls.Page, ReactiveUI.IActivatableView, ReactiveUI.IViewFor, ReactiveUI.IViewFor<TViewModel>
+    public class ReactivePage<TViewModel> : System.Windows.Controls.Page, ReactiveUI.IActivatableView, ReactiveUI.IViewFor, ReactiveUI.IViewFor<TViewModel>
         where TViewModel :  class
     {
         public static readonly System.Windows.DependencyProperty ViewModelProperty;
-        protected ReactivePage() { }
+        public ReactivePage() { }
         public TViewModel BindingRoot { get; }
         public TViewModel ViewModel { get; set; }
     }
-    public abstract class ReactiveUserControl<TViewModel> : System.Windows.Controls.UserControl, ReactiveUI.IActivatableView, ReactiveUI.IViewFor, ReactiveUI.IViewFor<TViewModel>
+    public class ReactiveUserControl<TViewModel> : System.Windows.Controls.UserControl, ReactiveUI.IActivatableView, ReactiveUI.IViewFor, ReactiveUI.IViewFor<TViewModel>
         where TViewModel :  class
     {
         public static readonly System.Windows.DependencyProperty ViewModelProperty;
-        protected ReactiveUserControl() { }
+        public ReactiveUserControl() { }
         public TViewModel BindingRoot { get; }
         public TViewModel ViewModel { get; set; }
     }
-    public abstract class ReactiveWindow<TViewModel> : System.Windows.Window, ReactiveUI.IActivatableView, ReactiveUI.IViewFor, ReactiveUI.IViewFor<TViewModel>
+    public class ReactiveWindow<TViewModel> : System.Windows.Window, ReactiveUI.IActivatableView, ReactiveUI.IViewFor, ReactiveUI.IViewFor<TViewModel>
         where TViewModel :  class
     {
         public static readonly System.Windows.DependencyProperty ViewModelProperty;
-        protected ReactiveWindow() { }
+        public ReactiveWindow() { }
         public TViewModel BindingRoot { get; }
         public TViewModel ViewModel { get; set; }
     }

--- a/src/ReactiveUI.Tests/Platforms/wpf/API/ApiApprovalTests.Wpf.netcoreapp3.0.approved.txt
+++ b/src/ReactiveUI.Tests/Platforms/wpf/API/ApiApprovalTests.Wpf.netcoreapp3.0.approved.txt
@@ -44,27 +44,27 @@ namespace ReactiveUI
         public PlatformOperations() { }
         public string GetOrientation() { }
     }
-    public abstract class ReactivePage<TViewModel> : System.Windows.Controls.Page, ReactiveUI.IActivatableView, ReactiveUI.IViewFor, ReactiveUI.IViewFor<TViewModel>
+    public class ReactivePage<TViewModel> : System.Windows.Controls.Page, ReactiveUI.IActivatableView, ReactiveUI.IViewFor, ReactiveUI.IViewFor<TViewModel>
         where TViewModel :  class
     {
         public static readonly System.Windows.DependencyProperty ViewModelProperty;
-        protected ReactivePage() { }
+        public ReactivePage() { }
         public TViewModel BindingRoot { get; }
         public TViewModel ViewModel { get; set; }
     }
-    public abstract class ReactiveUserControl<TViewModel> : System.Windows.Controls.UserControl, ReactiveUI.IActivatableView, ReactiveUI.IViewFor, ReactiveUI.IViewFor<TViewModel>
+    public class ReactiveUserControl<TViewModel> : System.Windows.Controls.UserControl, ReactiveUI.IActivatableView, ReactiveUI.IViewFor, ReactiveUI.IViewFor<TViewModel>
         where TViewModel :  class
     {
         public static readonly System.Windows.DependencyProperty ViewModelProperty;
-        protected ReactiveUserControl() { }
+        public ReactiveUserControl() { }
         public TViewModel BindingRoot { get; }
         public TViewModel ViewModel { get; set; }
     }
-    public abstract class ReactiveWindow<TViewModel> : System.Windows.Window, ReactiveUI.IActivatableView, ReactiveUI.IViewFor, ReactiveUI.IViewFor<TViewModel>
+    public class ReactiveWindow<TViewModel> : System.Windows.Window, ReactiveUI.IActivatableView, ReactiveUI.IViewFor, ReactiveUI.IViewFor<TViewModel>
         where TViewModel :  class
     {
         public static readonly System.Windows.DependencyProperty ViewModelProperty;
-        protected ReactiveWindow() { }
+        public ReactiveWindow() { }
         public TViewModel BindingRoot { get; }
         public TViewModel ViewModel { get; set; }
     }

--- a/src/ReactiveUI.Wpf/ReactiveWindow.cs
+++ b/src/ReactiveUI.Wpf/ReactiveWindow.cs
@@ -39,7 +39,7 @@ namespace ReactiveUI
     /// <typeparam name="TViewModel">
     /// The type of the view model backing the view.
     /// </typeparam>
-    public abstract class ReactiveWindow<TViewModel> :
+    public class ReactiveWindow<TViewModel> :
         Window, IViewFor<TViewModel>
         where TViewModel : class
     {

--- a/src/ReactiveUI/Platforms/windows-common/ReactivePage.cs
+++ b/src/ReactiveUI/Platforms/windows-common/ReactivePage.cs
@@ -86,7 +86,7 @@ namespace ReactiveUI
     [global::Foundation.Register]
 #endif
     [SuppressMessage("Design", "CA1010:Collections should implement generic interface", Justification = "Deliberate usage")]
-    public abstract
+    public
 #if HAS_UNO
         partial
 #endif

--- a/src/ReactiveUI/Platforms/windows-common/ReactiveUserControl.cs
+++ b/src/ReactiveUI/Platforms/windows-common/ReactiveUserControl.cs
@@ -86,7 +86,7 @@ namespace ReactiveUI
     [global::Foundation.Register]
 #endif
     [SuppressMessage("Design", "CA1010:Collections should implement generic interface", Justification = "Deliberate usage")]
-    public abstract
+    public
 #if HAS_UNO
         partial
 #endif


### PR DESCRIPTION
Chris Pullman on Slack noticed that if classes aren't marked as abstract, the designer will function for WPF, where previously they wouldn't.

Removing the abstract on these classes to allow for the designer to function.