### PR TITLE
Fix NRE when accessing RxApp.SuspensionHost

### DIFF
--- a/src/ReactiveUI/RxApp.cs
+++ b/src/ReactiveUI/RxApp.cs
@@ -125,7 +125,7 @@ namespace ReactiveUI
                 _mainThreadScheduler = DefaultScheduler.Instance;
             }
 
-            SuspensionHost = new SuspensionHost();
+            _suspensionHost = new SuspensionHost();
         }
 
         /// <summary>
@@ -202,12 +202,7 @@ namespace ReactiveUI
         /// </summary>
         public static ISuspensionHost SuspensionHost
         {
-            get
-            {
-                var host = _unitTestSuspensionHost ?? _suspensionHost;
-                return host;
-            }
-
+            get => _unitTestSuspensionHost ?? _suspensionHost;
             set
             {
                 if (ModeDetector.InUnitTestRunner())

--- a/src/ReactiveUI/RxApp.cs
+++ b/src/ReactiveUI/RxApp.cs
@@ -107,6 +107,7 @@ namespace ReactiveUI
                 });
             });
 
+            _suspensionHost = new SuspensionHost();
             if (ModeDetector.InUnitTestRunner())
             {
                 LogHost.Default.Warn("*** Detected Unit Test Runner, setting MainThreadScheduler to CurrentThread ***");
@@ -124,8 +125,6 @@ namespace ReactiveUI
             {
                 _mainThreadScheduler = DefaultScheduler.Instance;
             }
-
-            _suspensionHost = new SuspensionHost();
         }
 
         /// <summary>


### PR DESCRIPTION
**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

This PR fixes `RxApp.SuspensionHost` being null in a unit test runner starting from ReactiveUI 10.3.1. We stumbled upon this when [trying to update](https://github.com/AvaloniaUI/Avalonia/pull/3045) `Avalonia.ReactiveUI` to use latest ReactiveUI 10.3.1, there we got 4 failing tests due to `RxApp.SuspensionHost` containing the `null` value — a `NullReferenceException` was thrown from the [AutoSuspendHelper](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.ReactiveUI/AutoSuspendHelper.cs) constructor.

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

Starting from ReactiveUI 10.3.1, `RxApp.SuspensionHost` doesn't get initialized if a unit test runner is detected. This is probably caused by the upgrade to Splat 9 where the unit test mode detector started working, there is no `NullReferenceException` on ReactiveUI 10.2.2 or lower.

 https://github.com/reactiveui/ReactiveUI/blob/master/src/ReactiveUI/RxApp.cs#L110-L119

**What is the new behavior?**
<!-- If this is a feature change -->

`RxApp.SuspensionHost` is now initialized before the `ModeDetector` check.

**What might this PR break?**

Nothing. This is required for https://github.com/AvaloniaUI/Avalonia/pull/3045