### PR TITLE
Feature: Add warning when running .NET Standard

### DIFF
--- a/src/ReactiveUI/RxApp.cs
+++ b/src/ReactiveUI/RxApp.cs
@@ -149,7 +149,7 @@ namespace ReactiveUI
                     _hasSchedulerBeenChecked = true;
                     LogHost.Default.Warn("It seems you are running .NET Standard, but there is no host package installed!\n");
                     LogHost.Default.Warn("You will need to install the specific host package for your platform (ReactiveUI.WPF, ReactiveUI.Blazor, ...)\n");
-                    LogHost.Default.Warn("You can install the needed package via NuGet");
+                    LogHost.Default.Warn("You can install the needed package via NuGet, see https://reactiveui.net/docs/getting-started/installation/");
                 }
 
                 return _mainThreadScheduler;

--- a/src/ReactiveUI/RxApp.cs
+++ b/src/ReactiveUI/RxApp.cs
@@ -65,6 +65,7 @@ namespace ReactiveUI
         [ThreadStatic]
         private static ISuspensionHost _unitTestSuspensionHost;
         private static ISuspensionHost _suspensionHost;
+        private static bool _hasSchedulerBeenChecked;
 
         /// <summary>
         /// Initializes static members of the <see cref="RxApp"/> class.
@@ -135,7 +136,25 @@ namespace ReactiveUI
         /// </summary>
         public static IScheduler MainThreadScheduler
         {
-            get => _unitTestMainThreadScheduler ?? _mainThreadScheduler;
+            get
+            {
+                if (_unitTestMainThreadScheduler != null)
+                {
+                    return _unitTestMainThreadScheduler;
+                }
+
+                // If Scheduler is DefaultScheduler, user is likely using .NET Standard
+                if (!_hasSchedulerBeenChecked && _mainThreadScheduler == Scheduler.Default)
+                {
+                    _hasSchedulerBeenChecked = true;
+                    LogHost.Default.Warn("It seems you are running .NET Standard, but there is no host package installed!\n");
+                    LogHost.Default.Warn("You will need to install the specific host package for your platform (ReactiveUI.WPF, ReactiveUI.Blazor, ...)\n");
+                    LogHost.Default.Warn("You can install the needed package via NuGet");
+                }
+
+                return _mainThreadScheduler;
+            }
+
             set
             {
                 // N.B. The ThreadStatic dance here is for the unit test case -


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

Fixes #2164 

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
* Adds a warning message when running .NET Standard informing the user a host package needs to be installed.

**What is the current behavior?**
<!-- You can also link to an open issue here. -->
None


**What is the new behavior?**
<!-- If this is a feature change -->
None


**What might this PR break?**
Nothing


**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

