### PR TITLE
Housekeeping: Msbuild nuget package description validation

### DIFF
--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -12,7 +12,8 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://reactiveui.net</PackageProjectUrl>
     <PackageIconUrl>https://github.com/reactiveui/styleguide/blob/master/logo/main.png?raw=true</PackageIconUrl>
-    <PackageDescription>A MVVM framework that integrates with the Reactive Extensions for .NET to create elegant, testable User Interfaces that run on any mobile or desktop platform. Supports Xamarin.iOS, Xamarin.Android, Xamarin.Mac, Xamarin Forms, Xamarin.TVOS, Tizen, WPF, Windows Forms, Universal Windows Platform (UWP) and the Uno Platform.</PackageDescription>    
+    <DefaultPackageDescription>A MVVM framework that integrates with the Reactive Extensions for .NET to create elegant, testable User Interfaces that run on any mobile or desktop platform. Supports Xamarin.iOS, Xamarin.Android, Xamarin.Mac, Xamarin Forms, Xamarin.TVOS, Tizen, WPF, Windows Forms, Universal Windows Platform (UWP) and the Uno Platform.</DefaultPackageDescription>
+    <PackageDescription>$(DefaultPackageDescription)</PackageDescription>
     <Owners>xanaisbettsx;ghuntley</Owners>
     <PackageTags>mvvm;reactiveui;rx;reactive extensions;observable;LINQ;events;frp;xamarin;android;ios;mac;forms;monodroid;monotouch;xamarin.android;xamarin.ios;xamarin.forms;xamarin.mac;xamarin.tvos;wpf;net;netstandard;net461;uwp;tizen;unoplatform</PackageTags>
     <PackageReleaseNotes>https://github.com/reactiveui/ReactiveUI/releases</PackageReleaseNotes>

--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -4,7 +4,6 @@
     <NoWarn>$(NoWarn);1591;1701;1702;1705;VSX1000</NoWarn>
     <Platform>AnyCPU</Platform>
     <IsTestProject>$(MSBuildProjectName.Contains('Tests'))</IsTestProject>
-    <IsTestHelperProject>$(MSBuildProjectName.Contains('Testing'))</IsTestHelperProject>
     <DebugType>embedded</DebugType>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)analyzers.ruleset</CodeAnalysisRuleSet>
 

--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -4,6 +4,7 @@
     <NoWarn>$(NoWarn);1591;1701;1702;1705;VSX1000</NoWarn>
     <Platform>AnyCPU</Platform>
     <IsTestProject>$(MSBuildProjectName.Contains('Tests'))</IsTestProject>
+    <IsTestHelperProject>$(MSBuildProjectName.Contains('Testing'))</IsTestHelperProject>
     <DebugType>embedded</DebugType>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)analyzers.ruleset</CodeAnalysisRuleSet>
 

--- a/src/Directory.build.targets
+++ b/src/Directory.build.targets
@@ -39,7 +39,7 @@
     <DefineConstants>$(DefineConstants);TIZEN</DefineConstants>
   </PropertyGroup>
 
-  <Target Name="ValidateNugetProperties" BeforeTargets="Build">
+  <Target Name="ValidateNugetProperties" Condition="(!$(IsTestProject) or $(IsTestProject) == '') and (!$(IsTestHelperProject) or $(IsTestHelperProject) == '')" BeforeTargets="Compile">
       <Error Condition="$(PackageDescription) == '' or $(PackageDescription) == $(DefaultPackageDescription)" Text="The Nuget PackageDescription property needs to be set for the project. Currently : '$(PackageDescription)'" />
   </Target>
 </Project>

--- a/src/Directory.build.targets
+++ b/src/Directory.build.targets
@@ -1,7 +1,7 @@
 <Project>
   <!-- This props all need to be set in targets as they depend on the values set earlier -->
-  
-  <PropertyGroup>  
+
+  <PropertyGroup>
     <Product>$(AssemblyName) ($(TargetFramework))</Product>
     <AndroidUseIntermediateDesignerFile>False</AndroidUseIntermediateDesignerFile>
     <EnableVSTestReferences>false</EnableVSTestReferences>
@@ -38,4 +38,8 @@
   <PropertyGroup Condition="$(TargetFramework.StartsWith('tizen'))">
     <DefineConstants>$(DefineConstants);TIZEN</DefineConstants>
   </PropertyGroup>
+
+  <Target Name="ValidateNugetProperties" BeforeTargets="Build">
+      <Error Condition="$(PackageDescription) == '' or $(PackageDescription) == $(DefaultPackageDescription)" Text="The Nuget PackageDescription property needs to be set for the project. Currently : '$(PackageDescription)'" />
+  </Target>
 </Project>

--- a/src/Directory.build.targets
+++ b/src/Directory.build.targets
@@ -39,7 +39,7 @@
     <DefineConstants>$(DefineConstants);TIZEN</DefineConstants>
   </PropertyGroup>
 
-  <Target Name="ValidateNugetProperties" Condition="(!$(IsTestProject) or $(IsTestProject) == '') and (!$(IsTestHelperProject) or $(IsTestHelperProject) == '')" BeforeTargets="Compile">
+  <Target Name="ValidateNugetProperties" Condition="!$(IsTestProject) or $(IsTestProject) == ''" BeforeTargets="Compile">
       <Error Condition="$(PackageDescription) == '' or $(PackageDescription) == $(DefaultPackageDescription)" Text="The Nuget PackageDescription property needs to be set for the project. Currently : '$(PackageDescription)'" />
   </Target>
 </Project>


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Housekeeping for build process to enforce #2182 and ensure nuget package descriptions are set AND not the default.


**What is the current behavior?**
#2182 all packages have same description

**What is the new behavior?**
msbuild task in targets file to validate pre-compile stage.


**What might this PR break?**



**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

merge after #2182 as it will break the build prior to that being completed.