### PR TITLE
Fix: TypeLoadException in .net core app 3.0

### DIFF
--- a/src/ReactiveUI.Wpf/Registrations.cs
+++ b/src/ReactiveUI.Wpf/Registrations.cs
@@ -34,7 +34,11 @@ namespace ReactiveUI.Wpf
 
             RxApp.TaskpoolScheduler = TaskPoolScheduler.Default;
 
-            RxApp.MainThreadScheduler = new WaitForDispatcherScheduler(() => DispatcherScheduler.Current);
+            if (!ModeDetector.InUnitTestRunner())
+            {
+                // NB: On .NET Core, trying to touch DispatcherScheduler blows up :cry:
+                RxApp.MainThreadScheduler = new WaitForDispatcherScheduler(() => DispatcherScheduler.Current);
+            }
 
             RxApp.SuppressViewCommandBindingMessage = true;
         }


### PR DESCRIPTION
Fixes #2194

**What might this PR break?**

Should be fine, anyone using .NET Framework where this works will have MainThreadScheduler paved by RxApp itself later anyways