### PR TITLE
Fix: the disposal analyzer errors

### DIFF
--- a/src/ReactiveUI.AndroidSupport/ReactivePagerAdapter.cs
+++ b/src/ReactiveUI.AndroidSupport/ReactivePagerAdapter.cs
@@ -106,7 +106,7 @@ namespace ReactiveUI.AndroidSupport
         {
             if (disposing)
             {
-                Interlocked.Exchange(ref _inner, Disposable.Empty).Dispose();
+                _inner?.Dispose();
                 _list?.Dispose();
             }
 

--- a/src/ReactiveUI.AndroidSupport/ReactiveRecyclerViewAdapter.cs
+++ b/src/ReactiveUI.AndroidSupport/ReactiveRecyclerViewAdapter.cs
@@ -91,7 +91,7 @@ namespace ReactiveUI.AndroidSupport
         {
             if (disposing)
             {
-                Interlocked.Exchange(ref _inner, Disposable.Empty).Dispose();
+                _inner?.Dispose();
                 _list?.Dispose();
             }
 

--- a/src/ReactiveUI.AndroidX/ReactivePagerAdapter.cs
+++ b/src/ReactiveUI.AndroidX/ReactivePagerAdapter.cs
@@ -106,7 +106,7 @@ namespace ReactiveUI.AndroidX
         {
             if (disposing)
             {
-                Interlocked.Exchange(ref _inner, Disposable.Empty).Dispose();
+                _inner?.Dispose();
                 _list?.Dispose();
             }
 

--- a/src/ReactiveUI.AndroidX/ReactiveRecyclerViewAdapter.cs
+++ b/src/ReactiveUI.AndroidX/ReactiveRecyclerViewAdapter.cs
@@ -84,7 +84,7 @@ namespace ReactiveUI.AndroidX
         {
             if (disposing)
             {
-                Interlocked.Exchange(ref _inner, Disposable.Empty).Dispose();
+                _inner?.Dispose();
                 _list?.Dispose();
             }
 


### PR DESCRIPTION
The build is broken on several disposable points. 

These don't need the Interlocked.Exchange since they have re-entry guards within them already.