### PR TITLE
Fix: fatal exception "Element not found" in UWP multiple views apps

### DIFF
--- a/src/ReactiveUI/Platforms/uap/SingleWindowDispatcherScheduler.cs
+++ b/src/ReactiveUI/Platforms/uap/SingleWindowDispatcherScheduler.cs
@@ -1,9 +1,10 @@
-﻿// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;
+using System.Linq;
 using System.Reactive.Concurrency;
 using System.Reactive.Disposables;
 using System.Reactive.PlatformServices;
@@ -149,22 +150,9 @@ namespace ReactiveUI
 
         private IDisposable ScheduleOnDispatcherNow<TState>(TState state, Func<IScheduler, TState, IDisposable> action)
         {
-            // Bugfix for issue 2188
-            // Check _dispatcher has been initialized to prevent always calling CoreApplication.Views[0].Dispatcher
-            if (Volatile.Read(ref _dispatcher) is null)
-            {
-                try
-                {
-                    Interlocked.CompareExchange(ref _dispatcher, CoreApplication.Views[0].Dispatcher, null);
-                }
-                catch (Exception ex)
-                {
-                    // Catching exception "Element not found" on getting dispatcher
-                    return Disposable.Empty;
-                }
-            }
+            Interlocked.CompareExchange(ref _dispatcher, CoreApplication.Views.FirstOrDefault()?.Dispatcher, null);
 
-            if (_dispatcher.HasThreadAccess)
+            if (_dispatcher == null || _dispatcher.HasThreadAccess)
             {
                 return action(this, state);
             }

--- a/src/ReactiveUI/Platforms/uap/SingleWindowDispatcherScheduler.cs
+++ b/src/ReactiveUI/Platforms/uap/SingleWindowDispatcherScheduler.cs
@@ -160,7 +160,6 @@ namespace ReactiveUI
                 catch (Exception ex)
                 {
                     // Catching exception "Element not found" on getting dispatcher
-                    RaiseUnhandledException(ex);
                     return Disposable.Empty;
                 }
             }


### PR DESCRIPTION
1 Check _dispatcher has been initialized to prevent always calling CoreApplication.Views[0].Dispatcher
2 Wrapped Interlocked.CompareExchange by try...catch to call standard exception handler

**What kind of change does this PR introduce?**
It is bugfix and fixes #2188 

**What is the current behavior?**
https://github.com/reactiveui/ReactiveUI/issues/2188

**What is the new behavior?**
App is not crashing on getting the first app view dispatcher in multiple views apps.