### PR TITLE
fix: RefCount of ValueTuple breaks Xamarin.Android

### DIFF
--- a/src/ReactiveUI/Bindings/Property/PropertyBinderImplementation.cs
+++ b/src/ReactiveUI/Bindings/Property/PropertyBinderImplementation.cs
@@ -628,9 +628,9 @@ namespace ReactiveUI
                 return null;
             }
 
-            IObservable<(object view, bool isViewModel)> changes = changeWithValues.Where(value => value != null).Select(value => (value.Item1, value.Item2)).Publish();
+            var changes = changeWithValues.Where(value => value != null).Select(value => (view: value.Item1, isViewModel: value.Item2)).Publish();
 
-            IDisposable disposable = changes.Subscribe(isVmWithLatestValue =>
+            var changesDisposable = changes.Subscribe(isVmWithLatestValue =>
             {
                 if (isVmWithLatestValue.isViewModel)
                 {
@@ -642,6 +642,9 @@ namespace ReactiveUI
                 }
             });
 
+            var connectDisposable = changes.Connect();
+            var disposable = new CompositeDisposable(changesDisposable, connectDisposable);
+            
             // NB: Even though it's technically a two-way bind, most people
             // want the ViewModel to win at first.
             signalInitialUpdate.OnNext(true);

--- a/src/ReactiveUI/Bindings/Property/PropertyBinderImplementation.cs
+++ b/src/ReactiveUI/Bindings/Property/PropertyBinderImplementation.cs
@@ -601,25 +601,25 @@ namespace ReactiveUI
                 if (!Reflection.TryGetValueForPropertyChain(out TVMProp vmValue, view.ViewModel, vmExpression.GetExpressionChain()) ||
                     !Reflection.TryGetValueForPropertyChain(out TVProp vValue, view, viewExpression.GetExpressionChain()))
                 {
-                    return null;
+                    return default;
                 }
 
                 if (isVm)
                 {
                     if (!vmToViewConverter(vmValue, out TVProp vmAsView) || EqualityComparer<TVProp>.Default.Equals(vValue, vmAsView))
                     {
-                        return null;
+                        return default;
                     }
 
-                    return Tuple.Create((object)vmAsView, isVm);
+                    return ((object)vmAsView, isVm);
                 }
 
                 if (!viewToVmConverter(vValue, out TVMProp vAsViewModel) || EqualityComparer<TVMProp>.Default.Equals(vmValue, vAsViewModel))
                 {
-                    return null;
+                    return default;
                 }
 
-                return Tuple.Create((object)vAsViewModel, isVm);
+                return ((object)vAsViewModel, isVm);
             });
 
             var ret = EvalBindingHooks(viewModel, view, vmExpression, viewExpression, BindingDirection.TwoWay);
@@ -628,7 +628,7 @@ namespace ReactiveUI
                 return null;
             }
 
-            var changes = changeWithValues.Where(value => value != null).Select(value => (view: value.Item1, isViewModel: value.Item2));
+            var changes = changeWithValues.Where(value => value != default).Select(value => new { view = value.Item1, isViewModel = value.Item2});
 
             var disposable = changes.Subscribe(isVmWithLatestValue =>
             {

--- a/src/ReactiveUI/Bindings/Property/PropertyBinderImplementation.cs
+++ b/src/ReactiveUI/Bindings/Property/PropertyBinderImplementation.cs
@@ -611,7 +611,7 @@ namespace ReactiveUI
                         return default;
                     }
 
-                    return ((object)vmAsView, isVm);
+                    return (view: (object)vmAsView, isViewModel: isVm);
                 }
 
                 if (!viewToVmConverter(vValue, out TVMProp vAsViewModel) || EqualityComparer<TVMProp>.Default.Equals(vmValue, vAsViewModel))
@@ -619,7 +619,7 @@ namespace ReactiveUI
                     return default;
                 }
 
-                return ((object)vAsViewModel, isVm);
+                return (view:(object)vAsViewModel, isViewModel: isVm);
             });
 
             var ret = EvalBindingHooks(viewModel, view, vmExpression, viewExpression, BindingDirection.TwoWay);
@@ -628,7 +628,7 @@ namespace ReactiveUI
                 return null;
             }
 
-            var changes = changeWithValues.Where(value => value != default).Select(value => (view: value.Item1, isViewModel: value.Item2));
+            var changes = changeWithValues.Where(value => value.view != null).Select(value => (view: value.view, isViewModel: value.isViewModel));
 
             var disposable = changes.Subscribe(isVmWithLatestValue =>
             {

--- a/src/ReactiveUI/Bindings/Property/PropertyBinderImplementation.cs
+++ b/src/ReactiveUI/Bindings/Property/PropertyBinderImplementation.cs
@@ -644,7 +644,7 @@ namespace ReactiveUI
 
             var connectDisposable = changes.Connect();
             var disposable = new CompositeDisposable(changesDisposable, connectDisposable);
-            
+
             // NB: Even though it's technically a two-way bind, most people
             // want the ViewModel to win at first.
             signalInitialUpdate.OnNext(true);

--- a/src/ReactiveUI/Bindings/Property/PropertyBinderImplementation.cs
+++ b/src/ReactiveUI/Bindings/Property/PropertyBinderImplementation.cs
@@ -628,9 +628,9 @@ namespace ReactiveUI
                 return null;
             }
 
-            var changes = changeWithValues.Where(value => value != null).Select(value => (view: value.Item1, isViewModel: value.Item2)).Publish();
+            var changes = changeWithValues.Where(value => value != null).Select(value => (view: value.Item1, isViewModel: value.Item2));
 
-            var changesDisposable = changes.Subscribe(isVmWithLatestValue =>
+            var disposable = changes.Subscribe(isVmWithLatestValue =>
             {
                 if (isVmWithLatestValue.isViewModel)
                 {
@@ -641,9 +641,6 @@ namespace ReactiveUI
                     Reflection.TrySetValueToPropertyChain(view.ViewModel, vmExpression.GetExpressionChain(), isVmWithLatestValue.view, false);
                 }
             });
-
-            var connectDisposable = changes.Connect();
-            var disposable = new CompositeDisposable(changesDisposable, connectDisposable);
 
             // NB: Even though it's technically a two-way bind, most people
             // want the ViewModel to win at first.

--- a/src/ReactiveUI/Bindings/Property/PropertyBinderImplementation.cs
+++ b/src/ReactiveUI/Bindings/Property/PropertyBinderImplementation.cs
@@ -628,7 +628,7 @@ namespace ReactiveUI
                 return null;
             }
 
-            var changes = changeWithValues.Where(value => value != default).Select(value => new { view = value.Item1, isViewModel = value.Item2});
+            var changes = changeWithValues.Where(value => value != default).Select(value => (view: value.Item1, isViewModel: value.Item2));
 
             var disposable = changes.Subscribe(isVmWithLatestValue =>
             {

--- a/src/ReactiveUI/Bindings/Property/PropertyBinderImplementation.cs
+++ b/src/ReactiveUI/Bindings/Property/PropertyBinderImplementation.cs
@@ -628,7 +628,7 @@ namespace ReactiveUI
                 return null;
             }
 
-            IObservable<(object view, bool isViewModel)> changes = changeWithValues.Where(value => value != null).Select(value => (value.Item1, value.Item2)).Publish().RefCount();
+            IObservable<(object view, bool isViewModel)> changes = changeWithValues.Where(value => value != null).Select(value => (value.Item1, value.Item2)).Publish();
 
             IDisposable disposable = changes.Subscribe(isVmWithLatestValue =>
             {

--- a/src/ReactiveUI/Expression/Reflection.cs
+++ b/src/ReactiveUI/Expression/Reflection.cs
@@ -392,11 +392,11 @@ namespace ReactiveUI
                 .Select(x =>
                 {
                     IEnumerable<MethodInfo> methods = targetObject.GetType().GetTypeInfo().DeclaredMethods;
-                    return (methodName: x, methodImplementation: methods.FirstOrDefault(y => y.Name == x));
+                    return new { methodName = x, methodImplementation = methods.FirstOrDefault(y => y.Name == x) };
                 })
                 .FirstOrDefault(x => x.methodImplementation == null);
 
-            if (missingMethod.methodImplementation == default)
+            if (missingMethod != null)
             {
                 throw new Exception($"Your class must implement {missingMethod.methodName} and call {callingTypeName}.{missingMethod.methodName}");
             }


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Fixes Xamarin.Anrdroid `this.Bind` implementation.

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

Resolves: #2170 

**What is the new behavior?**
<!-- If this is a feature change -->

This removes the `RefCount` which isn't generally someone cares about during binding.

**What might this PR break?**

`this.Bind`

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

