### PR TITLE
fix: allow IPlatformOperations to be public

### DIFF
--- a/src/ReactiveUI/Interfaces/IPlatformOperations.cs
+++ b/src/ReactiveUI/Interfaces/IPlatformOperations.cs
@@ -8,7 +8,7 @@ namespace ReactiveUI
     /// <summary>
     /// Additional details implemented by the different ReactiveUI platform projects.
     /// </summary>
-    internal interface IPlatformOperations
+    public interface IPlatformOperations
     {
         /// <summary>
         /// Gets a descriptor that describes (if applicable) the orientation


### PR DESCRIPTION
Pretty sure this one was changed but maybe I'm just late. But is that supposed to be a typo? 

<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->



**What is the current behavior?**
<!-- You can also link to an open issue here. -->



**What is the new behavior?**
<!-- If this is a feature change -->



**What might this PR break?**



**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

