### PR TITLE
fix: exception happening on startup of applications

### DIFF
--- a/src/ReactiveUI/Mixins/DependencyResolverMixins.cs
+++ b/src/ReactiveUI/Mixins/DependencyResolverMixins.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -44,7 +45,9 @@ namespace ReactiveUI
 
             var assemblyName = new AssemblyName(fdr.AssemblyQualifiedName.Replace(fdr.FullName + ", ", string.Empty));
 
-            extraNs.ForEach(ns => ProcessRegistrationForNamespace(ns, assemblyName, resolver));
+            extraNs
+                .Where(x => File.Exists(x + ".dll"))
+                .ForEach(ns => ProcessRegistrationForNamespace(ns, assemblyName, resolver));
         }
 
         /// <summary>

--- a/src/ReactiveUI/Mixins/DependencyResolverMixins.cs
+++ b/src/ReactiveUI/Mixins/DependencyResolverMixins.cs
@@ -46,7 +46,7 @@ namespace ReactiveUI
             var assemblyName = new AssemblyName(fdr.AssemblyQualifiedName.Replace(fdr.FullName + ", ", string.Empty));
 
             extraNs
-                .Where(x => File.Exists(x + ".dll"))
+                .Where(GetNamespaceExists)
                 .ForEach(ns => ProcessRegistrationForNamespace(ns, assemblyName, resolver));
         }
 
@@ -120,6 +120,13 @@ namespace ReactiveUI
                 var registerer = (IWantsToRegisterStuff)Activator.CreateInstance(registerTypeClass);
                 registerer.Register((f, t) => resolver.RegisterConstant(f(), t));
             }
+        }
+
+        private static bool GetNamespaceExists(string namespaceName)
+        {
+            string folderPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            string assemblyPath = Path.Combine(folderPath, new AssemblyName(namespaceName).Name + ".dll");
+            return File.Exists(assemblyPath);
         }
     }
 }


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
bug fix.


**What is the current behavior?**
<!-- You can also link to an open issue here. -->

when loading on different platforms it will attempt to load DLLs for all the available NuGet packages we support. This will throw a FileNotFoundException. 

**What is the new behavior?**
<!-- If this is a feature change -->

Does a file check to make sure the DLL is available before attempting to load the DLL.

**What might this PR break?**

Hopefully nobody.

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

