### PR TITLE
fix: issues with binding to library

### DIFF
--- a/src/ReactiveUI/Mixins/DependencyResolverMixins.cs
+++ b/src/ReactiveUI/Mixins/DependencyResolverMixins.cs
@@ -46,7 +46,6 @@ namespace ReactiveUI
             var assemblyName = new AssemblyName(fdr.AssemblyQualifiedName.Replace(fdr.FullName + ", ", string.Empty));
 
             extraNs
-                .Where(GetNamespaceExists)
                 .ForEach(ns => ProcessRegistrationForNamespace(ns, assemblyName, resolver));
         }
 
@@ -109,10 +108,10 @@ namespace ReactiveUI
         }
 
         [SuppressMessage("Globalization", "CA1307: operator could change based on locale settings", Justification = "Replace() does not have third parameter on all platforms")]
-        private static void ProcessRegistrationForNamespace(string ns, AssemblyName assemblyName, IMutableDependencyResolver resolver)
+        private static void ProcessRegistrationForNamespace(string namespaceName, AssemblyName assemblyName, IMutableDependencyResolver resolver)
         {
-            var targetType = ns + ".Registrations";
-            var fullName = targetType + ", " + assemblyName.FullName.Replace(assemblyName.Name, ns);
+            var targetType = namespaceName + ".Registrations";
+            var fullName = targetType + ", " + assemblyName.FullName.Replace(assemblyName.Name, namespaceName);
 
             var registerTypeClass = Reflection.ReallyFindType(fullName, false);
             if (registerTypeClass != null)
@@ -120,13 +119,6 @@ namespace ReactiveUI
                 var registerer = (IWantsToRegisterStuff)Activator.CreateInstance(registerTypeClass);
                 registerer.Register((f, t) => resolver.RegisterConstant(f(), t));
             }
-        }
-
-        private static bool GetNamespaceExists(string namespaceName)
-        {
-            string folderPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-            string assemblyPath = Path.Combine(folderPath, new AssemblyName(namespaceName).Name + ".dll");
-            return File.Exists(assemblyPath);
         }
     }
 }


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

fixes #2264 

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

That it fails to load assemblies on .net native. It attempts to check to see if the assemblies exist.

**What is the new behavior?**
<!-- If this is a feature change -->

Will have the old exception back for unknown assemblies. This will be fixed with init() changes later.

**What might this PR break?**

Goes back to old functionality so shouldn't.
