### PR TITLE
fix: warnings about package downgrade

### DIFF
--- a/src/ReactiveUI.Uno/ReactiveUI.Uno.csproj
+++ b/src/ReactiveUI.Uno/ReactiveUI.Uno.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Splat.Drawing" Version="9.3.4" />
+    <PackageReference Include="Splat.Drawing" Version="9.*" />
   </ItemGroup>
 
   <ItemGroup Condition=" !$(TargetFramework.StartsWith('uap')) ">


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bug fix

**What is the current behavior?**
When targeting `ReactiveUI.Uno`, I'm getting warnings such as this one:

![image](https://user-images.githubusercontent.com/2716316/71563188-17bcd880-2a94-11ea-8e4d-48f5d9b547aa.png)

**What is the new behavior?**
Let's make it equal to the main ReactiveUI project, that depends on `Splat.Drawing` version `9.*`, rather than a specific version.
This causes warnings.

