### PR TITLE
feature: ReactiveUI.Events.Uno support

### DIFF
--- a/src/ReactiveUI.Events.Uno/ReactiveUI.Events.Uno.csproj
+++ b/src/ReactiveUI.Events.Uno/ReactiveUI.Events.Uno.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="MSBuild.Sdk.Extras">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard20;MonoAndroid90;Xamarin.iOS10;Xamarin.Mac20</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);uap10.0.16299</TargetFrameworks>
+    <AssemblyName>ReactiveUI.Events.Uno</AssemblyName>
+    <RootNamespace>ReactiveUI.Events</RootNamespace>
+    <PackageDescription>Provides Observable-based events API for Uno Platform including UWP, Android, iOS, Mac, and web (WASM).</PackageDescription>
+    <PackageId>ReactiveUI.Events.Uno</PackageId>
+    <NoWarn>$(NoWarn);CS1570;CA1812</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup Condition="  $(TargetFramework.StartsWith('uap')) ">
+    <SDKReference Include="WindowsDesktop, Version=10.0.16299.0">
+      <Name>Windows Desktop Extensions for the UWP</Name>
+    </SDKReference>
+    <SDKReference Include="WindowsMobile, Version=10.0.16299.0">
+      <Name>Windows Mobile Extensions for the UWP</Name>
+    </SDKReference>
+    <ProjectReference Include="..\ReactiveUI.Events\ReactiveUI.Events.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" !$(TargetFramework.StartsWith('uap')) ">
+    <PackageReference Include="Uno.UI" Version="2.*" />
+    <PackageReference Include="Pharmacist.MsBuild" Version="1.*" PrivateAssets="all" />
+    <PackageReference Include="Pharmacist.Common" Version="1.*" />
+  </ItemGroup>
+  
+</Project>

--- a/src/ReactiveUI.Events.sln
+++ b/src/ReactiveUI.Events.sln
@@ -20,6 +20,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ReactiveUI.Events", "Reacti
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ReactiveUI.Events.XamEssentials", "ReactiveUI.Events.XamEssentials\ReactiveUI.Events.XamEssentials.csproj", "{CAF8C047-6BB9-4629-884F-F8AFA6B95D11}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReactiveUI.Events.Uno", "ReactiveUI.Events.Uno\ReactiveUI.Events.Uno.csproj", "{7CD8BFEF-4879-4FF0-B67F-8E89337B0382}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Ad-Hoc|Any CPU = Ad-Hoc|Any CPU


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Preparation for `ReactiveUI.Events.Uno` support.

**What is the current behavior?**
There is currently no support for Uno Platform on ReactiveUI.Events.

**What is the new behavior?**
- In UAP project types, simply ports to ReactiveUI.Events.
- All other projects - generate and map to events from Uno.UI.

**What might this PR break?**
No breaking changes. Just new experiment.