### PR TITLE
feature: Enable WASM on Blazor

### DIFF
--- a/src/ReactiveUI.Blazor/ReactiveUI.Blazor.csproj
+++ b/src/ReactiveUI.Blazor/ReactiveUI.Blazor.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
-
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PackageDescription>Contains the ReactiveUI platform specific extensions for Blazor</PackageDescription>
@@ -8,8 +7,10 @@
 
   <ItemGroup>
     <PackageReference Include="Reactive.Wasm" Version="1.*" />
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="3.1.0" />
-    <PackageReference Include="ReactiveUI" Version="11.0.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="3.1.0" />    
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\ReactiveUI\ReactiveUI.csproj" />    
+  </ItemGroup>
 </Project>

--- a/src/ReactiveUI.Blazor/ReactiveUI.Blazor.csproj
+++ b/src/ReactiveUI.Blazor/ReactiveUI.Blazor.csproj
@@ -7,10 +7,10 @@
 
   <ItemGroup>
     <PackageReference Include="Reactive.Wasm" Version="1.*" />
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="3.1.0" />    
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="3.1.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\ReactiveUI\ReactiveUI.csproj" />    
+    <ProjectReference Include="..\ReactiveUI\ReactiveUI.csproj" />
   </ItemGroup>
 </Project>

--- a/src/ReactiveUI.Blazor/ReactiveUI.Blazor.csproj
+++ b/src/ReactiveUI.Blazor/ReactiveUI.Blazor.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Reactive.Wasm" Version="1.0.1-preview.12" />
     <PackageReference Include="Microsoft.AspNetCore.Components" Version="3.1.0" />
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Users\richardb\source\repos\richbryant\Reactive.Wasm\src\System.Reactive.Wasm\System.Reactive.Wasm.csproj" />
     <ProjectReference Include="..\ReactiveUI\ReactiveUI.csproj" />
   </ItemGroup>
 

--- a/src/ReactiveUI.Blazor/ReactiveUI.Blazor.csproj
+++ b/src/ReactiveUI.Blazor/ReactiveUI.Blazor.csproj
@@ -8,11 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components" Version="3.1.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\..\Users\richardb\source\repos\richbryant\Reactive.Wasm\src\System.Reactive.Wasm\System.Reactive.Wasm.csproj" />
-    <ProjectReference Include="..\ReactiveUI\ReactiveUI.csproj" />
+    <PackageReference Include="Reactive.Wasm" Version="1.0.1-preview.12" />
+    <PackageReference Include="ReactiveUI" Version="11.0.6" />
   </ItemGroup>
 
 </Project>

--- a/src/ReactiveUI.Blazor/ReactiveUI.Blazor.csproj
+++ b/src/ReactiveUI.Blazor/ReactiveUI.Blazor.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components" Version="3.1.0" />
-    <PackageReference Include="Reactive.Wasm" Version="1.*" />
+    <PackageReference Include="Reactive.Wasm" Version="1.0.1-preview.12" />
     <PackageReference Include="ReactiveUI" Version="11.0.6" />
   </ItemGroup>
 

--- a/src/ReactiveUI.Blazor/ReactiveUI.Blazor.csproj
+++ b/src/ReactiveUI.Blazor/ReactiveUI.Blazor.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components" Version="3.1.0" />
-    <PackageReference Include="Reactive.Wasm" Version="1.0.1-preview.12" />
+    <PackageReference Include="Reactive.Wasm" Version="1.*" />
     <PackageReference Include="ReactiveUI" Version="11.0.6" />
   </ItemGroup>
 

--- a/src/ReactiveUI.Blazor/Registrations.cs
+++ b/src/ReactiveUI.Blazor/Registrations.cs
@@ -31,7 +31,7 @@ namespace ReactiveUI.Blazor
             }
 
             RxApp.TaskpoolScheduler = TaskPoolScheduler.Default;
-            RxApp.MainThreadScheduler = new WaitForDispatcherScheduler(() => CurrentThreadScheduler.Instance);
+            RxApp.MainThreadScheduler = CurrentThreadScheduler.Instance;
         }
     }
 }

--- a/src/ReactiveUI.Blazor/Registrations.cs
+++ b/src/ReactiveUI.Blazor/Registrations.cs
@@ -4,10 +4,8 @@
 // See the LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.Reactive.Concurrency;
 using System.Reactive.PlatformServices;
-using System.Text;
 
 namespace ReactiveUI.Blazor
 {
@@ -27,18 +25,13 @@ namespace ReactiveUI.Blazor
 
             registerFunction(() => new PlatformOperations(), typeof(IPlatformOperations));
 
-#if NETSTANDARD
-            if (WasmPlatformEnlightenmentProvider.IsWasm)
+            if (Type.GetType("Mono.Runtime") != null)
             {
-                RxApp.TaskpoolScheduler = WasmScheduler.Default;
-                RxApp.MainThreadScheduler = WasmScheduler.Default;
+                PlatformEnlightenmentProvider.Current.EnableWasm();
             }
-            else
-#endif
-            {
-                RxApp.TaskpoolScheduler = TaskPoolScheduler.Default;
-                RxApp.MainThreadScheduler = new WaitForDispatcherScheduler(() => CurrentThreadScheduler.Instance);
-            }
+
+            RxApp.TaskpoolScheduler = TaskPoolScheduler.Default;
+            RxApp.MainThreadScheduler = new WaitForDispatcherScheduler(() => CurrentThreadScheduler.Instance);
         }
     }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bug fix.  Changes to Registrations class to enable ReactiveUI.Blazor to determine operating platform effectively, Scheduler initialization

**What is the current behavior?**

mono-wasm throws errors when initializing ReactiveCommand

**What is the new behavior?**

No errors, commands work.

**What might this PR break?**

Potential to break ReactiveUI.Blazor on Server *IF* scheduling changes.  Potential to become obsolete once mono-wasm utilizes wasm threading.

**Other information**:

Requires latest PR raised against System.Reactive.Wasm