### PR TITLE
refactor: Make the wasm project use wildcard versioning

### DIFF
--- a/src/ReactiveUI.Blazor/ReactiveUI.Blazor.csproj
+++ b/src/ReactiveUI.Blazor/ReactiveUI.Blazor.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Reactive.Wasm" Version="1.0.1-preview.12" />
+    <PackageReference Include="Reactive.Wasm" Version="1.*" />
     <PackageReference Include="Microsoft.AspNetCore.Components" Version="3.1.0" />
   </ItemGroup>
 

--- a/src/ReactiveUI.Uno/ReactiveUI.Uno.csproj
+++ b/src/ReactiveUI.Uno/ReactiveUI.Uno.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('netstandard')) ">
-    <PackageReference Include="Reactive.Wasm" Version="1.0.1-preview.12" />
+    <PackageReference Include="Reactive.Wasm" Version="1.*" />
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('uap')) ">


### PR DESCRIPTION
Uses wildcard matching now that I have brought the wasm project out of preview.