### PR TITLE
fix: Blazor StateHasChanged not firing on ViewModel change

### DIFF
--- a/src/ReactiveUI.Blazor/ReactiveComponentBase.cs
+++ b/src/ReactiveUI.Blazor/ReactiveComponentBase.cs
@@ -37,7 +37,8 @@ namespace ReactiveUI.Blazor
         /// </summary>
         public ReactiveComponentBase()
         {
-            var propertyChangedObservable = this.WhenAnyValue(x => x.ViewModel)
+            this.WhenAnyValue(x => x.ViewModel).Subscribe(_ => StateHasChanged());
+            var viewModelsPropertyChanged = this.WhenAnyValue(x => x.ViewModel)
                 .Select(x => Observable.FromEvent<PropertyChangedEventHandler, Unit>(
                     eventHandler =>
                     {
@@ -49,7 +50,7 @@ namespace ReactiveUI.Blazor
                     eh => x.PropertyChanged -= eh))
                 .Switch();
 
-            propertyChangedObservable.Do(_ => StateHasChanged()).Subscribe();
+            viewModelsPropertyChanged.Do(_ => StateHasChanged()).Subscribe();
         }
 
         /// <inheritdoc />

--- a/src/ReactiveUI.Blazor/ReactiveLayoutComponentBase.cs
+++ b/src/ReactiveUI.Blazor/ReactiveLayoutComponentBase.cs
@@ -33,7 +33,8 @@ namespace ReactiveUI.Blazor
         /// </summary>
         public ReactiveLayoutComponentBase()
         {
-            var propertyChangedObservable = this.WhenAnyValue(x => x.ViewModel)
+            this.WhenAnyValue(x => x.ViewModel).Subscribe(_ => StateHasChanged());
+            var viewModelsPropertyChanged = this.WhenAnyValue(x => x.ViewModel)
                 .Select(x => Observable.FromEvent<PropertyChangedEventHandler, Unit>(
                     eventHandler =>
                     {
@@ -45,7 +46,7 @@ namespace ReactiveUI.Blazor
                     eh => x.PropertyChanged -= eh))
                 .Switch();
 
-            propertyChangedObservable.Do(_ => StateHasChanged()).Subscribe();
+            viewModelsPropertyChanged.Do(_ => StateHasChanged()).Subscribe();
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Fixes #2298 where the view model property being changed doesn't trigger a state refresh.