### PR TITLE
fix: add null check for blazor view model property changes

### DIFF
--- a/src/ReactiveUI.Blazor/ReactiveComponentBase.cs
+++ b/src/ReactiveUI.Blazor/ReactiveComponentBase.cs
@@ -39,6 +39,7 @@ namespace ReactiveUI.Blazor
         {
             this.WhenAnyValue(x => x.ViewModel).Subscribe(_ => StateHasChanged());
             var viewModelsPropertyChanged = this.WhenAnyValue(x => x.ViewModel)
+                .Where(x => x != null)
                 .Select(x => Observable.FromEvent<PropertyChangedEventHandler, Unit>(
                     eventHandler =>
                     {

--- a/src/ReactiveUI.Blazor/ReactiveLayoutComponentBase.cs
+++ b/src/ReactiveUI.Blazor/ReactiveLayoutComponentBase.cs
@@ -35,6 +35,7 @@ namespace ReactiveUI.Blazor
         {
             this.WhenAnyValue(x => x.ViewModel).Subscribe(_ => StateHasChanged());
             var viewModelsPropertyChanged = this.WhenAnyValue(x => x.ViewModel)
+                .Where(x => x != null)
                 .Select(x => Observable.FromEvent<PropertyChangedEventHandler, Unit>(
                     eventHandler =>
                     {


### PR DESCRIPTION
As pointed out by @michaelstonis  in #2298 a null check is needed for the view model.