### PR TITLE
fix: NavigateBack ObserveOn Router Scheduler

### DIFF
--- a/src/ReactiveUI.Tests/Platforms/winforms/DefaultPropertyBindingTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/DefaultPropertyBindingTests.cs
@@ -18,7 +18,7 @@ namespace ReactiveUI.Tests.Winforms
 {
     public class DefaultPropertyBindingTests
     {
-        [Fact]
+        [Fact(Skip = "https://github.com/reactiveui/ReactiveUI/issues/2279")]
         public void WinformsCreatesObservableForPropertyWorksForTextboxes()
         {
             var input = new TextBox();
@@ -42,7 +42,7 @@ namespace ReactiveUI.Tests.Winforms
             Assert.Equal(1, output.Count);
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/reactiveui/ReactiveUI/issues/2279")]
         public void WinformsCreatesObservableForPropertyWorksForComponents()
         {
             var input = new ToolStripButton(); // ToolStripButton is a Component, not a Control
@@ -67,7 +67,7 @@ namespace ReactiveUI.Tests.Winforms
             Assert.Equal(1, output.Count);
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/reactiveui/ReactiveUI/issues/2279")]
         public void WinformsCreatesObservableForPropertyWorksForThirdPartyControls()
         {
             var input = new AThirdPartyNamespace.ThirdPartyControl();
@@ -91,7 +91,7 @@ namespace ReactiveUI.Tests.Winforms
             Assert.Equal(1, output.Count);
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/reactiveui/ReactiveUI/issues/2279")]
         public void CanBindViewModelToWinformControls()
         {
             var vm = new FakeWinformViewModel();
@@ -113,7 +113,7 @@ namespace ReactiveUI.Tests.Winforms
             Assert.Equal(vm.SomeDouble.ToString(), view.Property3.Text);
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/reactiveui/ReactiveUI/issues/2279")]
         public void SmokeTestWinformControls()
         {
             var vm = new FakeWinformViewModel();


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Fixes a bug where `NavigateBack` was not firing NavigationStack changes.

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

Resolves: #2286 

**What is the new behavior?**
<!-- If this is a feature change -->

When `NavigateBack` is called the NavigationStack changes fire on the `Router.Scheduler` thread and the navigation works correctly.

**What might this PR break?**

Backwards navigation on Xamarin.Forms

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

