### PR TITLE
Update and fix to ReactiveComponentBase and ReactiveLayoutComponentBase

### DIFF
--- a/src/ReactiveUI.Blazor/ReactiveComponentBase.cs
+++ b/src/ReactiveUI.Blazor/ReactiveComponentBase.cs
@@ -7,12 +7,10 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Reactive;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Runtime.CompilerServices;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 
 namespace ReactiveUI.Blazor
@@ -38,7 +36,7 @@ namespace ReactiveUI.Blazor
         public ReactiveComponentBase()
         {
             var viewModelsChangedObservable = this.WhenAnyValue(x => x.ViewModel)
-            .WhereNotNull()
+            .Where(x => x != null)
             .Select(x => Observable.FromEvent<PropertyChangedEventHandler, Unit>(
                 eventHandler =>
                 {
@@ -51,7 +49,7 @@ namespace ReactiveUI.Blazor
             .Switch();
 
             viewModelsChangedObservable.Do(_ => StateHasChanged()).Subscribe();
-            this.WhenAnyValue(x => x.ViewModel).WhereNotNull().Subscribe(_ => StateHasChanged());
+            this.WhenAnyValue(x => x.ViewModel).Where(x => x != null).Subscribe(_ => StateHasChanged());
         }
 
         /// <inheritdoc />

--- a/src/ReactiveUI.Blazor/ReactiveComponentBase.cs
+++ b/src/ReactiveUI.Blazor/ReactiveComponentBase.cs
@@ -35,7 +35,8 @@ namespace ReactiveUI.Blazor
         /// </summary>
         public ReactiveComponentBase()
         {
-            var viewModelsChangedObservable = this.WhenAnyValue(x => x.ViewModel)
+            this.WhenAnyValue(x => x.ViewModel).Where(x => x != null).Subscribe(_ => StateHasChanged());
+            var viewModelsPropertyChanged = this.WhenAnyValue(x => x.ViewModel)
                 .Where(x => x != null)
                 .Select(x => Observable.FromEvent<PropertyChangedEventHandler, Unit>(
                     eventHandler =>
@@ -48,8 +49,7 @@ namespace ReactiveUI.Blazor
                     eh => x.PropertyChanged -= eh))
                 .Switch();
 
-            viewModelsChangedObservable.Do(_ => StateHasChanged()).Subscribe();
-            this.WhenAnyValue(x => x.ViewModel).Where(x => x != null).Subscribe(_ => StateHasChanged());
+            viewModelsPropertyChanged.Do(_ => StateHasChanged()).Subscribe();
         }
 
         /// <inheritdoc />

--- a/src/ReactiveUI.Blazor/ReactiveComponentBase.cs
+++ b/src/ReactiveUI.Blazor/ReactiveComponentBase.cs
@@ -36,17 +36,17 @@ namespace ReactiveUI.Blazor
         public ReactiveComponentBase()
         {
             var viewModelsChangedObservable = this.WhenAnyValue(x => x.ViewModel)
-            .Where(x => x != null)
-            .Select(x => Observable.FromEvent<PropertyChangedEventHandler, Unit>(
-                eventHandler =>
-                {
-                    void Handler(object sender, PropertyChangedEventArgs e) => eventHandler(Unit.Default);
+                .Where(x => x != null)
+                .Select(x => Observable.FromEvent<PropertyChangedEventHandler, Unit>(
+                    eventHandler =>
+                    {
+                        void Handler(object sender, PropertyChangedEventArgs e) => eventHandler(Unit.Default);
 
-                    return Handler;
-                },
-                eh => x.PropertyChanged += eh,
-                eh => x.PropertyChanged -= eh))
-            .Switch();
+                        return Handler;
+                    },
+                    eh => x.PropertyChanged += eh,
+                    eh => x.PropertyChanged -= eh))
+                .Switch();
 
             viewModelsChangedObservable.Do(_ => StateHasChanged()).Subscribe();
             this.WhenAnyValue(x => x.ViewModel).Where(x => x != null).Subscribe(_ => StateHasChanged());

--- a/src/ReactiveUI.Blazor/ReactiveComponentBase.cs
+++ b/src/ReactiveUI.Blazor/ReactiveComponentBase.cs
@@ -37,7 +37,7 @@ namespace ReactiveUI.Blazor
         /// </summary>
         public ReactiveComponentBase()
         {
-            var propertyChangedObservable = this.WhenAnyValue(x => x.ViewModel)
+            var viewModelsChangedObservable = this.WhenAnyValue(x => x.ViewModel)
             .WhereNotNull()
             .Select(x => Observable.FromEvent<PropertyChangedEventHandler, Unit>(
                 eventHandler =>
@@ -50,8 +50,7 @@ namespace ReactiveUI.Blazor
                 eh => x.PropertyChanged -= eh))
             .Switch();
 
-            propertyChangedObservable.Do(_ => StateHasChanged()).Subscribe();
-
+            viewModelsChangedObservable.Do(_ => StateHasChanged()).Subscribe();
             this.WhenAnyValue(x => x.ViewModel).WhereNotNull().Subscribe(_ => StateHasChanged());
         }
 

--- a/src/ReactiveUI.Blazor/ReactiveComponentBase.cs
+++ b/src/ReactiveUI.Blazor/ReactiveComponentBase.cs
@@ -37,21 +37,22 @@ namespace ReactiveUI.Blazor
         /// </summary>
         public ReactiveComponentBase()
         {
-            this.WhenAnyValue(x => x.ViewModel).Subscribe(_ => StateHasChanged());
-            var viewModelsPropertyChanged = this.WhenAnyValue(x => x.ViewModel)
-                .Where(x => x != null)
-                .Select(x => Observable.FromEvent<PropertyChangedEventHandler, Unit>(
-                    eventHandler =>
-                    {
-                        void Handler(object sender, PropertyChangedEventArgs e) => eventHandler(Unit.Default);
+            var propertyChangedObservable = this.WhenAnyValue(x => x.ViewModel)
+            .WhereNotNull()
+            .Select(x => Observable.FromEvent<PropertyChangedEventHandler, Unit>(
+                eventHandler =>
+                {
+                    void Handler(object sender, PropertyChangedEventArgs e) => eventHandler(Unit.Default);
 
-                        return Handler;
-                    },
-                    eh => x.PropertyChanged += eh,
-                    eh => x.PropertyChanged -= eh))
-                .Switch();
+                    return Handler;
+                },
+                eh => x.PropertyChanged += eh,
+                eh => x.PropertyChanged -= eh))
+            .Switch();
 
-            viewModelsPropertyChanged.Do(_ => StateHasChanged()).Subscribe();
+            propertyChangedObservable.Do(_ => StateHasChanged()).Subscribe();
+
+            this.WhenAnyValue(x => x.ViewModel).WhereNotNull().Subscribe(_ => StateHasChanged());
         }
 
         /// <inheritdoc />

--- a/src/ReactiveUI.Blazor/ReactiveLayoutComponentBase.cs
+++ b/src/ReactiveUI.Blazor/ReactiveLayoutComponentBase.cs
@@ -34,17 +34,17 @@ namespace ReactiveUI.Blazor
         public ReactiveLayoutComponentBase()
         {
             var viewModelsChangedObservable = this.WhenAnyValue(x => x.ViewModel)
-            .Where(x => x != null)
-            .Select(x => Observable.FromEvent<PropertyChangedEventHandler, Unit>(
-                eventHandler =>
-                {
-                    void Handler(object sender, PropertyChangedEventArgs e) => eventHandler(Unit.Default);
+                .Where(x => x != null)
+                .Select(x => Observable.FromEvent<PropertyChangedEventHandler, Unit>(
+                    eventHandler =>
+                    {
+                        void Handler(object sender, PropertyChangedEventArgs e) => eventHandler(Unit.Default);
 
-                    return Handler;
-                },
-                eh => x.PropertyChanged += eh,
-                eh => x.PropertyChanged -= eh))
-            .Switch();
+                        return Handler;
+                    },
+                    eh => x.PropertyChanged += eh,
+                    eh => x.PropertyChanged -= eh))
+                .Switch();
 
             viewModelsChangedObservable.Do(_ => StateHasChanged()).Subscribe();
             this.WhenAnyValue(x => x.ViewModel).Where(x => x != null).Subscribe(_ => StateHasChanged());

--- a/src/ReactiveUI.Blazor/ReactiveLayoutComponentBase.cs
+++ b/src/ReactiveUI.Blazor/ReactiveLayoutComponentBase.cs
@@ -33,7 +33,8 @@ namespace ReactiveUI.Blazor
         /// </summary>
         public ReactiveLayoutComponentBase()
         {
-            var viewModelsChangedObservable = this.WhenAnyValue(x => x.ViewModel)
+            this.WhenAnyValue(x => x.ViewModel).Where(x => x != null).Subscribe(_ => StateHasChanged());
+            var viewModelsPropertyChanged = this.WhenAnyValue(x => x.ViewModel)
                 .Where(x => x != null)
                 .Select(x => Observable.FromEvent<PropertyChangedEventHandler, Unit>(
                     eventHandler =>
@@ -46,8 +47,7 @@ namespace ReactiveUI.Blazor
                     eh => x.PropertyChanged -= eh))
                 .Switch();
 
-            viewModelsChangedObservable.Do(_ => StateHasChanged()).Subscribe();
-            this.WhenAnyValue(x => x.ViewModel).Where(x => x != null).Subscribe(_ => StateHasChanged());
+            viewModelsPropertyChanged.Do(_ => StateHasChanged()).Subscribe();
         }
 
         /// <inheritdoc />

--- a/src/ReactiveUI.Blazor/ReactiveLayoutComponentBase.cs
+++ b/src/ReactiveUI.Blazor/ReactiveLayoutComponentBase.cs
@@ -33,21 +33,21 @@ namespace ReactiveUI.Blazor
         /// </summary>
         public ReactiveLayoutComponentBase()
         {
-            this.WhenAnyValue(x => x.ViewModel).Subscribe(_ => StateHasChanged());
-            var viewModelsPropertyChanged = this.WhenAnyValue(x => x.ViewModel)
-                .Where(x => x != null)
-                .Select(x => Observable.FromEvent<PropertyChangedEventHandler, Unit>(
-                    eventHandler =>
-                    {
-                        void Handler(object sender, PropertyChangedEventArgs e) => eventHandler(Unit.Default);
+            var viewModelsChangedObservable = this.WhenAnyValue(x => x.ViewModel)
+            .Where(x => x != null)
+            .Select(x => Observable.FromEvent<PropertyChangedEventHandler, Unit>(
+                eventHandler =>
+                {
+                    void Handler(object sender, PropertyChangedEventArgs e) => eventHandler(Unit.Default);
 
-                        return Handler;
-                    },
-                    eh => x.PropertyChanged += eh,
-                    eh => x.PropertyChanged -= eh))
-                .Switch();
+                    return Handler;
+                },
+                eh => x.PropertyChanged += eh,
+                eh => x.PropertyChanged -= eh))
+            .Switch();
 
-            viewModelsPropertyChanged.Do(_ => StateHasChanged()).Subscribe();
+            viewModelsChangedObservable.Do(_ => StateHasChanged()).Subscribe();
+            this.WhenAnyValue(x => x.ViewModel).Where(x => x != null).Subscribe(_ => StateHasChanged());
         }
 
         /// <inheritdoc />

--- a/src/ReactiveUI.Blazor/ReactiveUI.Blazor.csproj
+++ b/src/ReactiveUI.Blazor/ReactiveUI.Blazor.csproj
@@ -7,10 +7,11 @@
 
   <ItemGroup>
     <PackageReference Include="Reactive.Wasm" Version="1.*" />
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="3.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="3.1.1" />
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\ReactiveUI\ReactiveUI.csproj" />
+  <ItemGroup><!--<ProjectReference Include="..\ReactiveUI\ReactiveUI.csproj" />-->
+  
+    <PackageReference Include="ReactiveUI" Version="11.1.11" />
   </ItemGroup>
 </Project>

--- a/src/ReactiveUI.Blazor/ReactiveUI.Blazor.csproj
+++ b/src/ReactiveUI.Blazor/ReactiveUI.Blazor.csproj
@@ -10,8 +10,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Components" Version="3.1.1" />
   </ItemGroup>
 
-  <ItemGroup><!--<ProjectReference Include="..\ReactiveUI\ReactiveUI.csproj" />-->
-  
-    <PackageReference Include="ReactiveUI" Version="11.1.11" />
+  <ItemGroup>
+    <ProjectReference Include="..\ReactiveUI\ReactiveUI.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bug fix to resolve #2308 


**What is the current behavior?**

Views inheriting from `ReactiveComponentBase<T>` and/or `ReactiveLayoutComponentBase<T>` crash on initialization

**What is the new behavior?**

Views inheriting from `ReactiveComponentBase<T>` and/or `ReactiveLayoutComponentBase<T>` do not crash on initialization

**What might this PR break?**

Nothing that ain't already broken


**Please check if the PR fulfills these requirements**
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
