### PR TITLE
Fix and refactor Visual Studio snippets

### DIFF
--- a/snippets/Visual Studio/ruicommand.snippet
+++ b/snippets/Visual Studio/ruicommand.snippet
@@ -12,9 +12,14 @@
 		<Snippet>
 			<Declarations>
 				<Literal>
-					<ID>type</ID>
-					<ToolTip>Command type</ToolTip>
-					<Default>object</Default>
+					<ID>TParam</ID>
+					<ToolTip>Type of parameter</ToolTip>
+					<Default>Unit</Default>					
+				</Literal>
+				<Literal>
+					<ID>TResult</ID>
+					<ToolTip>Type of result</ToolTip>
+					<Default>Unit</Default>					
 				</Literal>
 				<Literal>
 					<ID>command</ID>
@@ -22,8 +27,16 @@
 					<Default>DoSomething</Default>
 				</Literal>
 			</Declarations>
+			<Imports>
+				<Import>
+					<Namespace>System.Reactive</Namespace>
+				</Import>
+				<Import>
+					<Namespace>ReactiveUI</Namespace>
+				</Import>
+			</Imports>
 			<Code Language="csharp">
-				<![CDATA[public ReactiveCommand<$type$> $command$ { get; private set; }$end$]]>
+				<![CDATA[public ReactiveCommand<$TParam$, $TResult$> $command$ { get; }$end$]]>
 			</Code>
 		</Snippet>
 	</CodeSnippet>

--- a/snippets/Visual Studio/ruiinteraction.snippet
+++ b/snippets/Visual Studio/ruiinteraction.snippet
@@ -21,6 +21,11 @@
 					<Default>Unit</Default>
 					<ToolTip>Interaction's output type</ToolTip>
 				</Literal>
+				<Literal>
+					<ID>interaction</ID>
+					<ToolTip>Interaction name</ToolTip>
+					<Default>DoSomethingInteraction</Default>
+				</Literal>
 			</Declarations>
 			<Imports>
 				<Import>
@@ -31,7 +36,7 @@
 				</Import>
 			</Imports>
 			<Code Language="CSharp">
-				<![CDATA[public Interaction<$TInput$, $TOutput$> DoSomethingInteraction => new Interaction<$TInput$, $TOutput$>();$end$]]>
+				<![CDATA[public Interaction<$TInput$, $TOutput$> $interaction$ { get; } = new Interaction<$TInput$, $TOutput$>();$end$]]>
 			</Code>
 		</Snippet>
 	</CodeSnippet>

--- a/snippets/Visual Studio/ruiiv4.snippet
+++ b/snippets/Visual Studio/ruiiv4.snippet
@@ -20,7 +20,7 @@
       </Declarations>
       <Code Language="csharp">
         <![CDATA[public static readonly DependencyProperty ViewModelProperty =
-            DependencyProperty.Register(nameof(ViewModel), typeof($classname$Model), typeof($classname$), new PropertyMetadata(null));
+            DependencyProperty.Register(nameof(ViewModel), typeof($classname$Model), typeof($classname$), new PropertyMetadata(default($classname$Model)));
 
         public $classname$Model ViewModel
         {

--- a/snippets/Visual Studio/ruiiv4.snippet
+++ b/snippets/Visual Studio/ruiiv4.snippet
@@ -20,18 +20,18 @@
       </Declarations>
       <Code Language="csharp">
         <![CDATA[public static readonly DependencyProperty ViewModelProperty =
-            DependencyProperty.Register("ViewModel", typeof($classname$Model), typeof($classname$), new PropertyMetadata(null));
+            DependencyProperty.Register(nameof(ViewModel), typeof($classname$Model), typeof($classname$), new PropertyMetadata(null));
 
         public $classname$Model ViewModel
         {
-            get { return ($classname$Model)GetValue(ViewModelProperty); }
-            set { SetValue(ViewModelProperty, value); }
+            get => ($classname$Model)GetValue(ViewModelProperty);
+            set => SetValue(ViewModelProperty, value);
         }
 
         object IViewFor.ViewModel
         {
-            get { return ViewModel; }
-            set { ViewModel = ($classname$Model)value; }
+            get => ViewModel;
+            set => ViewModel = ($classname$Model)value;
         }$end$]]>
       </Code>
     </Snippet>

--- a/snippets/Visual Studio/ruioaph.snippet
+++ b/snippets/Visual Studio/ruioaph.snippet
@@ -17,16 +17,24 @@
 					<Default>int</Default>
 				</Literal>
 				<Literal>
-					<ID>property</ID>
-					<ToolTip>Property name</ToolTip>
-					<Default>MyProperty</Default>
+                    <ID>fieldName</ID>
+					<ToolTip>Name of backing field</ToolTip>
+					<Default>myField</Default>
+				</Literal>
+				<Literal>
+				  <ID>propertyName</ID>
+				  <ToolTip>Name of property</ToolTip>
+				  <Default>MyProperty</Default>
 				</Literal>
 			</Declarations>
-			<Code Language="csharp"><![CDATA[private ObservableAsPropertyHelper<$type$> _$property$;
-			public $type$ $property$ 
-			{ 
-				get {return _$property$.Value;}
-			}$end$]]>
+			<Imports>
+				<Import>
+					<Namespace>ReactiveUI</Namespace>
+				</Import>
+			</Imports>
+			<Code Language="csharp">
+				<![CDATA[private ObservableAsPropertyHelper<$type$> $fieldName$;
+				public $type$ $propertyName$ => $fieldName$.Value;$end$]]>
 			</Code>
 		</Snippet>
 	</CodeSnippet>

--- a/snippets/Visual Studio/ruiprop.snippet
+++ b/snippets/Visual Studio/ruiprop.snippet
@@ -24,11 +24,17 @@
         <Literal Editable="true">
           <ID>propertyName</ID>
           <ToolTip>Name of property</ToolTip>
-          <Default>myProperty</Default>
+          <Default>MyProperty</Default>
         </Literal>
       </Declarations>
-      <Code Language="csharp" Delimiter="$"><![CDATA[public $type$ $propertyName$ { get => $fieldName$; set => this.RaiseAndSetIfChanged(ref $fieldName$, value); }$end$]]>
-			</Code>
+      <Code Language="csharp" Delimiter="$">
+        <![CDATA[private $type$ $fieldName$;
+		public $type$ $propertyName$ 
+        { 
+            get => $fieldName$; 
+            set => this.RaiseAndSetIfChanged(ref $fieldName$, value); 
+        }$end$]]>
+      </Code>
     </Snippet>
   </CodeSnippet>
 </CodeSnippets>


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
Fix interaction snippet: `=>` replaced with `{ get; } =`
Some minor final syntax adjustments



**What is the current behavior?**
Failed to find a registration for a Interaction.



**What is the new behavior?**
No exception. The property returns the registered Interaction instead of a new one.

