### PR TITLE
fix: NavigateBack wrong values on the NavigationStack

### DIFF
--- a/src/ReactiveUI.XamForms/RoutedViewHost.cs
+++ b/src/ReactiveUI.XamForms/RoutedViewHost.cs
@@ -135,6 +135,7 @@ namespace ReactiveUI.XamForms
                         popToRootPending = false;
                         return page;
                     })
+                    .Concat()
                     .Subscribe()
                     .DisposeWith(disposable);
 

--- a/src/ReactiveUI.XamForms/RoutedViewHost.cs
+++ b/src/ReactiveUI.XamForms/RoutedViewHost.cs
@@ -73,7 +73,7 @@ namespace ReactiveUI.XamForms
                     })
                     .Where(_ => !userInstigated)
                     .Where(x => x.Delta > 0)
-                    .SelectMany(
+                    .Select(
                         async x =>
                         {
                             // XF doesn't provide a means of navigating back more than one screen at a time apart from navigating right back to the root page
@@ -107,6 +107,7 @@ namespace ReactiveUI.XamForms
 
                             return Unit.Default;
                         })
+                    .Concat()
                     .Subscribe()
                     .DisposeWith(disposable);
 
@@ -135,7 +136,6 @@ namespace ReactiveUI.XamForms
                         popToRootPending = false;
                         return page;
                     })
-                    .Concat()
                     .Subscribe()
                     .DisposeWith(disposable);
 

--- a/src/ReactiveUI.XamForms/RoutedViewHost.cs
+++ b/src/ReactiveUI.XamForms/RoutedViewHost.cs
@@ -6,13 +6,13 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Reactive;
+using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
 using System.Reflection;
 using Splat;
 using Xamarin.Forms;
 
-#pragma warning disable RCS1090 // Call 'ConfigureAwait(false)'.
 namespace ReactiveUI.XamForms
 {
     /// <summary>
@@ -20,7 +20,8 @@ namespace ReactiveUI.XamForms
     /// </summary>
     /// <seealso cref="Xamarin.Forms.NavigationPage" />
     /// <seealso cref="ReactiveUI.IActivatableView" />
-    public class RoutedViewHost : NavigationPage, IActivatableView
+    [SuppressMessage("Readability", "RCS1090: Call 'ConfigureAwait(false)", Justification = "This class interacts with the UI thread.")]
+    public class RoutedViewHost : NavigationPage, IActivatableView, IEnableLogger
     {
         /// <summary>
         /// The router bindable property.
@@ -38,13 +39,13 @@ namespace ReactiveUI.XamForms
         /// <exception cref="Exception">You *must* register an IScreen class representing your App's main Screen.</exception>
         public RoutedViewHost()
         {
-            this.WhenActivated(new Action<Action<IDisposable>>(d =>
+            this.WhenActivated(disposable =>
             {
                 bool currentlyPopping = false;
                 bool popToRootPending = false;
                 bool userInstigated = false;
 
-                d(this.WhenAnyObservable(x => x.Router.NavigationChanged)
+                this.WhenAnyObservable(x => x.Router.NavigationChanged)
                     .Where(_ => Router.NavigationStack.Count == 0)
                     .Select(x =>
                     {
@@ -54,18 +55,22 @@ namespace ReactiveUI.XamForms
                         popToRootPending = true;
                         return x;
                     })
-                    .Subscribe());
+                    .Subscribe()
+                    .DisposeWith(disposable);
 
-                var previousCount =
-                    this.WhenAnyObservable(x => x.Router.NavigationChanged)
-                        .CountChanged()
-                        .ObserveOn(Router.Scheduler)
-                        .Select(_ => Router.NavigationStack.Count)
-                        .StartWith(Router.NavigationStack.Count);
+                Router.NavigationChanged
+                    .CountChanged()
+                    .Select(_ => Router.NavigationStack.Count)
+                    .StartWith(Router.NavigationStack.Count)
+                    .Buffer(2, 1)
+                    .Select(counts => new
+                    {
+                        Delta = counts[0] - counts[1],
+                        Current = counts[1],
 
-                var currentCount = previousCount.Skip(1);
-
-                d(Observable.Zip(previousCount, currentCount, (previous, current) => new { Delta = previous - current, Current = current })
+                        // cache current viewmodel as it might change if some other Navigation command is executed midway
+                        CurrentViewModel = Router.GetCurrentViewModel()
+                    })
                     .Where(_ => !userInstigated)
                     .Where(x => x.Delta > 0)
                     .SelectMany(
@@ -94,14 +99,19 @@ namespace ReactiveUI.XamForms
                             finally
                             {
                                 currentlyPopping = false;
-                                ((IViewFor)CurrentPage).ViewModel = Router.GetCurrentViewModel();
+                                if (CurrentPage is IViewFor page && x.CurrentViewModel != null)
+                                {
+                                    page.ViewModel = x.CurrentViewModel;
+                                }
                             }
 
                             return Unit.Default;
                         })
-                    .Subscribe());
+                    .Subscribe()
+                    .DisposeWith(disposable);
 
-                d(this.WhenAnyObservable(x => x.Router.Navigate)
+                Router
+                    .Navigate
                     .SelectMany(_ => PageForViewModel(Router.GetCurrentViewModel()))
                     .SelectMany(async page =>
                     {
@@ -125,20 +135,21 @@ namespace ReactiveUI.XamForms
                         popToRootPending = false;
                         return page;
                     })
-                    .Subscribe());
+                    .Subscribe()
+                    .DisposeWith(disposable);
 
                 var poppingEvent = Observable.FromEvent<EventHandler<NavigationEventArgs>, Unit>(
-                        eventHandler =>
-                        {
-                            void Handler(object sender, NavigationEventArgs e) => eventHandler(Unit.Default);
-                            return Handler;
-                        },
-                        x => Popped += x,
-                        x => Popped -= x);
+                    eventHandler =>
+                    {
+                        void Handler(object sender, NavigationEventArgs e) => eventHandler(Unit.Default);
+                        return Handler;
+                    },
+                    x => Popped += x,
+                    x => Popped -= x);
 
                 // NB: Catch when the user hit back as opposed to the application
                 // requesting Back via NavigateBack
-                d(poppingEvent
+                poppingEvent
                     .Where(_ => !currentlyPopping && Router != null)
                     .Subscribe(_ =>
                     {
@@ -146,19 +157,23 @@ namespace ReactiveUI.XamForms
 
                         try
                         {
-                            if (Router.NavigationStack.Count > 1)
-                            {
-                                Router.NavigationStack.RemoveAt(Router.NavigationStack.Count - 1);
-                            }
+                            Router.NavigationStack.RemoveAt(Router.NavigationStack.Count - 1);
                         }
                         finally
                         {
                             userInstigated = false;
                         }
 
-                        ((IViewFor)CurrentPage).ViewModel = Router.GetCurrentViewModel();
-                    }));
-            }));
+                        var vm = Router.GetCurrentViewModel();
+                        if (CurrentPage is IViewFor page && vm != null)
+                        {
+                            // don't replace view model if vm is null
+                            page.ViewModel = vm;
+                        }
+                    })
+                    .DisposeWith(disposable);
+            });
+
             var screen = Locator.Current.GetService<IScreen>();
             if (screen == null)
             {
@@ -169,8 +184,8 @@ namespace ReactiveUI.XamForms
 
             this.WhenAnyValue(x => x.Router)
                 .SelectMany(router =>
-                    router
-                        .NavigationStack
+                {
+                    return router.NavigationStack
                         .ToObservable()
                         .Select(x => (Page)ViewLocator.Current.ResolveView(x))
                         .SelectMany(x => PushAsync(x).ToObservable())
@@ -184,7 +199,8 @@ namespace ReactiveUI.XamForms
 
                             ((IViewFor)CurrentPage).ViewModel = vm;
                             CurrentPage.Title = vm.UrlPathSegment;
-                        }))
+                        });
+                })
                 .Subscribe();
         }
 
@@ -227,4 +243,3 @@ namespace ReactiveUI.XamForms
         }
     }
 }
-#pragma warning restore RCS1090 // Call 'ConfigureAwait(false)'.


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

@garyng provided a solution for fixing the `RoutedViewHost` Xamarin.Forms implementation.

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

fixes: #2317 

**What is the new behavior?**
<!-- If this is a feature change -->

The stack values do not get distorted after the navigation pattern provided.

**What might this PR break?**

Xamarin.Forms navigation

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
I tested this in a sample and saw that the `NavigationStack` seems to be correct.  I am going to look into creating some unit tests for this behavior so we can make sure it continues to function as expected.
