### PR TITLE
Fix: StateHasChanged firing before render being available in Blazor

### DIFF
--- a/src/ReactiveUI.Blazor/ReactiveComponentBase.cs
+++ b/src/ReactiveUI.Blazor/ReactiveComponentBase.cs
@@ -35,7 +35,7 @@ namespace ReactiveUI.Blazor
         /// </summary>
         public ReactiveComponentBase()
         {
-            this.WhenAnyValue(x => x.ViewModel).Where(x => x != null).Subscribe(_ => StateHasChanged());
+            this.WhenAnyValue(x => x.ViewModel).Where(x => x != null).Subscribe(_ => InvokeAsync(StateHasChanged));
             var viewModelsPropertyChanged = this.WhenAnyValue(x => x.ViewModel)
                 .Where(x => x != null)
                 .Select(x => Observable.FromEvent<PropertyChangedEventHandler, Unit>(
@@ -49,7 +49,7 @@ namespace ReactiveUI.Blazor
                     eh => x.PropertyChanged -= eh))
                 .Switch();
 
-            viewModelsPropertyChanged.Do(_ => StateHasChanged()).Subscribe();
+            viewModelsPropertyChanged.Do(_ => InvokeAsync(StateHasChanged)).Subscribe();
         }
 
         /// <inheritdoc />

--- a/src/ReactiveUI.Blazor/ReactiveLayoutComponentBase.cs
+++ b/src/ReactiveUI.Blazor/ReactiveLayoutComponentBase.cs
@@ -33,7 +33,7 @@ namespace ReactiveUI.Blazor
         /// </summary>
         public ReactiveLayoutComponentBase()
         {
-            this.WhenAnyValue(x => x.ViewModel).Where(x => x != null).Subscribe(_ => StateHasChanged());
+            this.WhenAnyValue(x => x.ViewModel).Where(x => x != null).Subscribe(_ => InvokeAsync(StateHasChanged));
             var viewModelsPropertyChanged = this.WhenAnyValue(x => x.ViewModel)
                 .Where(x => x != null)
                 .Select(x => Observable.FromEvent<PropertyChangedEventHandler, Unit>(
@@ -47,7 +47,7 @@ namespace ReactiveUI.Blazor
                     eh => x.PropertyChanged -= eh))
                 .Switch();
 
-            viewModelsPropertyChanged.Do(_ => StateHasChanged()).Subscribe();
+            viewModelsPropertyChanged.Do(_ => InvokeAsync(StateHasChanged)).Subscribe();
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

fix

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

There is a exception that happens when the ViewModel is changed, because the render hasn't happened yet.

**What is the new behavior?**
<!-- If this is a feature change -->

We fire the StateHasChanged in a InvokeAsync, which will dispatch it after the render.

**What might this PR break?**
Hopefully no-one.


**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

