### PR TITLE
fix: Parameter tag on ReactiveComponentBase, moved WhenAny

### DIFF
--- a/src/ReactiveUI.Blazor/ReactiveComponentBase.cs
+++ b/src/ReactiveUI.Blazor/ReactiveComponentBase.cs
@@ -11,6 +11,7 @@ using System.Reactive;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 
 namespace ReactiveUI.Blazor
@@ -35,7 +36,6 @@ namespace ReactiveUI.Blazor
         /// </summary>
         public ReactiveComponentBase()
         {
-            this.WhenAnyValue(x => x.ViewModel).Where(x => x != null).Subscribe(_ => InvokeAsync(StateHasChanged));
             var viewModelsPropertyChanged = this.WhenAnyValue(x => x.ViewModel)
                 .Where(x => x != null)
                 .Select(x => Observable.FromEvent<PropertyChangedEventHandler, Unit>(
@@ -56,6 +56,7 @@ namespace ReactiveUI.Blazor
         public event PropertyChangedEventHandler PropertyChanged;
 
         /// <inheritdoc />
+        [Parameter]
         public T ViewModel
         {
             get => _viewModel;
@@ -97,6 +98,15 @@ namespace ReactiveUI.Blazor
         {
             _initSubject.OnNext(Unit.Default);
             base.OnInitialized();
+        }
+
+        /// <inheritdoc />
+        protected override void OnAfterRender(bool isFirstRender)
+        {
+            if (isFirstRender)
+            {
+                this.WhenAnyValue(x => x.ViewModel).Where(x => x != null).Subscribe(_ => InvokeAsync(StateHasChanged));
+            }
         }
 
         /// <summary>

--- a/src/ReactiveUI.Blazor/ReactiveLayoutComponentBase.cs
+++ b/src/ReactiveUI.Blazor/ReactiveLayoutComponentBase.cs
@@ -11,6 +11,7 @@ using System.Reactive;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 
 namespace ReactiveUI.Blazor
@@ -33,7 +34,6 @@ namespace ReactiveUI.Blazor
         /// </summary>
         public ReactiveLayoutComponentBase()
         {
-            this.WhenAnyValue(x => x.ViewModel).Where(x => x != null).Subscribe(_ => InvokeAsync(StateHasChanged));
             var viewModelsPropertyChanged = this.WhenAnyValue(x => x.ViewModel)
                 .Where(x => x != null)
                 .Select(x => Observable.FromEvent<PropertyChangedEventHandler, Unit>(
@@ -95,6 +95,15 @@ namespace ReactiveUI.Blazor
         {
             _initSubject.OnNext(Unit.Default);
             base.OnInitialized();
+        }
+
+        /// <inheritdoc />
+        protected override void OnAfterRender(bool isFirstRender)
+        {
+            if (isFirstRender)
+            {
+                this.WhenAnyValue(x => x.ViewModel).Where(x => x != null).Subscribe(_ => InvokeAsync(StateHasChanged));
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**

Bug fix - moves WhenAny that was throwing errors in constructor to OnAfterRender.

Functionality - Adds `[Parameter]` tag to ViewModel property in component base to allow allow users to compose ViewModel in Razor syntax.


**What is the current behavior?**

```
System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation. ---> System.InvalidOperationException: The render handle is not yet assigned.
```

**kaboom** basically.  

**What is the new behavior?**

Hopefully not **kaboom**, although I've thought that before.

**What might this PR break?**

Nothing that ain't already broke.

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

