### PR TITLE
Improve ability of RegisterViewsForViewModels to find the correct interface

### DIFF
--- a/src/ReactiveUI/Mixins/DependencyResolverMixins.cs
+++ b/src/ReactiveUI/Mixins/DependencyResolverMixins.cs
@@ -75,8 +75,8 @@ namespace ReactiveUI
             foreach (var ti in assembly.DefinedTypes
                 .Where(ti => ti.ImplementedInterfaces.Contains(typeof(IViewFor)) && !ti.IsAbstract))
             {
-                // grab the first _implemented_ interface that also implements IViewFor, this should be the expected IViewFor<>
-                var ivf = ti.ImplementedInterfaces.FirstOrDefault(t => t.GetTypeInfo().ImplementedInterfaces.Contains(typeof(IViewFor)));
+                // grab the first _implemented_ interface that matches IViewFor<T>
+                var ivf = ti.ImplementedInterfaces.FirstOrDefault(t => t.IsGenericType && t.GetGenericTypeDefinition() == typeof(IViewFor<>));
 
                 // need to check for null because some classes may implement IViewFor but not IViewFor<T> - we don't care about those
                 if (ivf != null)


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix



**What is the current behavior?**
<!-- You can also link to an open issue here. -->
If you create an interface ```IMoreSpecificViewFor<T> : IViewFor<T>``` and have a view that implements that interface instead of ```IViewFor<T>```, calling ```RegisterViewsForViewModels``` registers the view using the wrong interface, and ReactiveUI fails to find the proper view at runtime.

**What is the new behavior?**
<!-- If this is a feature change -->
```RegisterViewsForViewModels``` will register the proper interface and allow views to be created properly.

**What might this PR break?**
Realistically, should not break anyone.  However, I suppose it could break somebody who has a class that directly implements ```IViewFor<T>```, as well as one or more other classes that implement an extended version of the interface, and is specifically relying on only the first class being registered.

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
I did not add any additional tests for the scenario.  The existing DependencyResolverTests should still pass.  No additional documentation should be necessary.
