### PR TITLE
Mark deprecated fragment classes obsolete

### DIFF
--- a/src/ReactiveUI.AndroidSupport/ReactiveFragment.cs
+++ b/src/ReactiveUI.AndroidSupport/ReactiveFragment.cs
@@ -4,29 +4,11 @@
 // See the LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
-using System.Diagnostics.Contracts;
-using System.Linq;
 using System.Reactive;
-using System.Reactive.Concurrency;
-using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
-using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Runtime.Serialization;
-using System.Text;
-using System.Threading;
-using Android.App;
-using Android.Content;
-using Android.OS;
-using Android.Runtime;
-using Android.Util;
-using Android.Views;
-using Android.Widget;
-using Splat;
 
 namespace ReactiveUI.AndroidSupport
 {

--- a/src/ReactiveUI.AndroidSupport/ReactiveFragmentActivity.cs
+++ b/src/ReactiveUI.AndroidSupport/ReactiveFragmentActivity.cs
@@ -4,31 +4,17 @@
 // See the LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
-using System.Diagnostics.Contracts;
 using System.Linq;
 using System.Reactive;
-using System.Reactive.Concurrency;
-using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Reactive.Threading.Tasks;
-using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Runtime.Serialization;
-using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using Android.App;
 using Android.Content;
-using Android.OS;
-using Android.Runtime;
 using Android.Support.V4.App;
-using Android.Views;
-using Android.Widget;
-using Splat;
 
 namespace ReactiveUI.AndroidSupport
 {

--- a/src/ReactiveUI.AndroidSupport/ReactivePagerAdapter.cs
+++ b/src/ReactiveUI.AndroidSupport/ReactivePagerAdapter.cs
@@ -8,8 +8,6 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System.Reactive.Disposables;
-using System.Threading;
 using Android.Support.V4.View;
 using Android.Views;
 using DynamicData;
@@ -31,7 +29,7 @@ namespace ReactiveUI.AndroidSupport
         private readonly SourceList<TViewModel> _list;
         private readonly Func<TViewModel, ViewGroup, View> _viewCreator;
         private readonly Action<TViewModel, View> _viewInitializer;
-        private IDisposable _inner;
+        private readonly IDisposable _inner;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ReactivePagerAdapter{TViewModel}"/> class.

--- a/src/ReactiveUI.AndroidSupport/ReactivePreferenceFragment.cs
+++ b/src/ReactiveUI.AndroidSupport/ReactivePreferenceFragment.cs
@@ -1,0 +1,153 @@
+﻿// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using Android.Runtime;
+using Android.Support.V7.Preferences;
+
+namespace ReactiveUI.AndroidSupport
+{
+    /// <summary>
+    /// This is a PreferenceFragment that is both an Activity and has ReactiveObject powers
+    /// (i.e. you can call RaiseAndSetIfChanged).
+    /// </summary>
+    /// <typeparam name="TViewModel">The view model type.</typeparam>
+    [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleType", Justification = "Classes with the same class names within.")]
+    public abstract class ReactivePreferenceFragment<TViewModel> : ReactivePreferenceFragment, IViewFor<TViewModel>, ICanActivate
+        where TViewModel : class
+    {
+        private TViewModel _viewModel;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReactivePreferenceFragment{TViewModel}"/> class.
+        /// </summary>
+        protected ReactivePreferenceFragment()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReactivePreferenceFragment{TViewModel}"/> class.
+        /// </summary>
+        /// <param name="handle">The handle.</param>
+        /// <param name="ownership">The ownership.</param>
+        protected ReactivePreferenceFragment(IntPtr handle, JniHandleOwnership ownership)
+            : base(handle, ownership)
+        {
+        }
+
+        /// <inheritdoc/>
+        public TViewModel ViewModel
+        {
+            get => _viewModel;
+            set => this.RaiseAndSetIfChanged(ref _viewModel, value);
+        }
+
+        /// <inheritdoc/>
+        object IViewFor.ViewModel
+        {
+            get => _viewModel;
+            set => _viewModel = (TViewModel)value;
+        }
+    }
+
+    /// <summary>
+    /// This is a PreferenceFragment that is both an Activity and has ReactiveObject powers
+    /// (i.e. you can call RaiseAndSetIfChanged).
+    /// </summary>
+    [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleType", Justification = "Classes with the same class names within.")]
+    public abstract class ReactivePreferenceFragment : PreferenceFragmentCompat, IReactiveNotifyPropertyChanged<ReactivePreferenceFragment>, IReactiveObject, IHandleObservableErrors
+    {
+        private readonly Subject<Unit> _activated = new Subject<Unit>();
+        private readonly Subject<Unit> _deactivated = new Subject<Unit>();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReactivePreferenceFragment"/> class.
+        /// </summary>
+        protected ReactivePreferenceFragment()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReactivePreferenceFragment"/> class.
+        /// </summary>
+        /// <param name="handle">The handle.</param>
+        /// <param name="ownership">The ownership.</param>
+        protected ReactivePreferenceFragment(IntPtr handle, JniHandleOwnership ownership)
+            : base(handle, ownership)
+        {
+        }
+
+        /// <inheritdoc/>
+        public event PropertyChangingEventHandler PropertyChanging;
+
+        /// <inheritdoc/>
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        /// <inheritdoc />
+        public IObservable<IReactivePropertyChangedEventArgs<ReactivePreferenceFragment>> Changing => this.GetChangingObservable();
+
+        /// <inheritdoc />
+        public IObservable<IReactivePropertyChangedEventArgs<ReactivePreferenceFragment>> Changed => this.GetChangedObservable();
+
+        /// <inheritdoc/>
+        public IObservable<Exception> ThrownExceptions => this.GetThrownExceptionsObservable();
+
+        /// <summary>
+        /// Gets a signal when the fragment is activated.
+        /// </summary>
+        public IObservable<Unit> Activated => _activated.AsObservable();
+
+        /// <summary>
+        /// Gets a signal when the fragment is deactivated.
+        /// </summary>
+        public IObservable<Unit> Deactivated => _deactivated.AsObservable();
+
+        /// <inheritdoc/>
+        public IDisposable SuppressChangeNotifications() => IReactiveObjectExtensions.SuppressChangeNotifications(this);
+
+        /// <inheritdoc/>
+        void IReactiveObject.RaisePropertyChanged(PropertyChangedEventArgs args)
+        {
+            PropertyChanged?.Invoke(this, args);
+        }
+
+        /// <inheritdoc/>
+        void IReactiveObject.RaisePropertyChanging(PropertyChangingEventArgs args)
+        {
+            PropertyChanging?.Invoke(this, args);
+        }
+
+        /// <inheritdoc/>
+        public override void OnPause()
+        {
+            base.OnPause();
+            _deactivated.OnNext(Unit.Default);
+        }
+
+        /// <inheritdoc/>
+        public override void OnResume()
+        {
+            base.OnResume();
+            _activated.OnNext(Unit.Default);
+        }
+
+        /// <inheritdoc/>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _activated?.Dispose();
+                _deactivated?.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/src/ReactiveUI.AndroidSupport/ReactiveRecyclerViewAdapter.cs
+++ b/src/ReactiveUI.AndroidSupport/ReactiveRecyclerViewAdapter.cs
@@ -6,14 +6,9 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
-using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System.Reactive.Disposables;
 using System.Reactive.Linq;
-using System.Reflection;
-using System.Runtime.Serialization;
-using System.Threading;
 using Android.Support.V7.Widget;
 using Android.Views;
 using DynamicData;
@@ -33,7 +28,7 @@ namespace ReactiveUI.AndroidSupport
     {
         private readonly ISourceList<TViewModel> _list;
 
-        private IDisposable _inner;
+        private readonly IDisposable _inner;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ReactiveRecyclerViewAdapter{TViewModel}"/> class.

--- a/src/ReactiveUI.AndroidSupport/ReactiveUI.AndroidSupport.csproj
+++ b/src/ReactiveUI.AndroidSupport/ReactiveUI.AndroidSupport.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Xamarin.Android.Support.Animated.Vector.Drawable" Version="27.0.*" />
     <PackageReference Include="Xamarin.Android.Support.v4" Version="27.0.*" />
     <PackageReference Include="Xamarin.Android.Support.v7.AppCompat" Version="27.0.*" />
+    <PackageReference Include="Xamarin.Android.Support.v7.Preference" Version="27.0.*" />
     <PackageReference Include="Xamarin.Android.Support.v7.RecyclerView" Version="27.0.*" />
     <PackageReference Include="Xamarin.Android.Support.Vector.Drawable" Version="27.0.*" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />

--- a/src/ReactiveUI.AndroidX/ReactivePagerAdapter.cs
+++ b/src/ReactiveUI.AndroidX/ReactivePagerAdapter.cs
@@ -8,8 +8,6 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System.Reactive.Disposables;
-using System.Threading;
 using Android.Views;
 using AndroidX.ViewPager.Widget;
 using DynamicData;
@@ -31,7 +29,7 @@ namespace ReactiveUI.AndroidX
         private readonly SourceList<TViewModel> _list;
         private readonly Func<TViewModel, ViewGroup, View> _viewCreator;
         private readonly Action<TViewModel, View> _viewInitializer;
-        private IDisposable _inner;
+        private readonly IDisposable _inner;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ReactivePagerAdapter{TViewModel}"/> class.

--- a/src/ReactiveUI.AndroidX/ReactivePreferenceFragment.cs
+++ b/src/ReactiveUI.AndroidX/ReactivePreferenceFragment.cs
@@ -1,0 +1,153 @@
+﻿// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using Android.Runtime;
+using AndroidX.Preference;
+
+namespace ReactiveUI.AndroidX
+{
+    /// <summary>
+    /// This is a PreferenceFragment that is both an Activity and has ReactiveObject powers
+    /// (i.e. you can call RaiseAndSetIfChanged).
+    /// </summary>
+    /// <typeparam name="TViewModel">The view model type.</typeparam>
+    [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleType", Justification = "Classes with the same class names within.")]
+    public abstract class ReactivePreferenceFragment<TViewModel> : ReactivePreferenceFragment, IViewFor<TViewModel>, ICanActivate
+        where TViewModel : class
+    {
+        private TViewModel _viewModel;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReactivePreferenceFragment{TViewModel}"/> class.
+        /// </summary>
+        protected ReactivePreferenceFragment()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReactivePreferenceFragment{TViewModel}"/> class.
+        /// </summary>
+        /// <param name="handle">The handle.</param>
+        /// <param name="ownership">The ownership.</param>
+        protected ReactivePreferenceFragment(IntPtr handle, JniHandleOwnership ownership)
+            : base(handle, ownership)
+        {
+        }
+
+        /// <inheritdoc/>
+        public TViewModel ViewModel
+        {
+            get => _viewModel;
+            set => this.RaiseAndSetIfChanged(ref _viewModel, value);
+        }
+
+        /// <inheritdoc/>
+        object IViewFor.ViewModel
+        {
+            get => _viewModel;
+            set => _viewModel = (TViewModel)value;
+        }
+    }
+
+    /// <summary>
+    /// This is a PreferenceFragment that is both an Activity and has ReactiveObject powers
+    /// (i.e. you can call RaiseAndSetIfChanged).
+    /// </summary>
+    [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleType", Justification = "Classes with the same class names within.")]
+    public abstract class ReactivePreferenceFragment : PreferenceFragmentCompat, IReactiveNotifyPropertyChanged<ReactivePreferenceFragment>, IReactiveObject, IHandleObservableErrors
+    {
+        private readonly Subject<Unit> _activated = new Subject<Unit>();
+        private readonly Subject<Unit> _deactivated = new Subject<Unit>();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReactivePreferenceFragment"/> class.
+        /// </summary>
+        protected ReactivePreferenceFragment()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReactivePreferenceFragment"/> class.
+        /// </summary>
+        /// <param name="handle">The handle.</param>
+        /// <param name="ownership">The ownership.</param>
+        protected ReactivePreferenceFragment(IntPtr handle, JniHandleOwnership ownership)
+            : base(handle, ownership)
+        {
+        }
+
+        /// <inheritdoc/>
+        public event PropertyChangingEventHandler PropertyChanging;
+
+        /// <inheritdoc/>
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        /// <inheritdoc />
+        public IObservable<IReactivePropertyChangedEventArgs<ReactivePreferenceFragment>> Changing => this.GetChangingObservable();
+
+        /// <inheritdoc />
+        public IObservable<IReactivePropertyChangedEventArgs<ReactivePreferenceFragment>> Changed => this.GetChangedObservable();
+
+        /// <inheritdoc/>
+        public IObservable<Exception> ThrownExceptions => this.GetThrownExceptionsObservable();
+
+        /// <summary>
+        /// Gets a signal when the fragment is activated.
+        /// </summary>
+        public IObservable<Unit> Activated => _activated.AsObservable();
+
+        /// <summary>
+        /// Gets a signal when the fragment is deactivated.
+        /// </summary>
+        public IObservable<Unit> Deactivated => _deactivated.AsObservable();
+
+        /// <inheritdoc/>
+        public IDisposable SuppressChangeNotifications() => IReactiveObjectExtensions.SuppressChangeNotifications(this);
+
+        /// <inheritdoc/>
+        void IReactiveObject.RaisePropertyChanged(PropertyChangedEventArgs args)
+        {
+            PropertyChanged?.Invoke(this, args);
+        }
+
+        /// <inheritdoc/>
+        void IReactiveObject.RaisePropertyChanging(PropertyChangingEventArgs args)
+        {
+            PropertyChanging?.Invoke(this, args);
+        }
+
+        /// <inheritdoc/>
+        public override void OnPause()
+        {
+            base.OnPause();
+            _deactivated.OnNext(Unit.Default);
+        }
+
+        /// <inheritdoc/>
+        public override void OnResume()
+        {
+            base.OnResume();
+            _activated.OnNext(Unit.Default);
+        }
+
+        /// <inheritdoc/>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _activated?.Dispose();
+                _deactivated?.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/src/ReactiveUI.AndroidX/ReactiveRecyclerViewAdapter.cs
+++ b/src/ReactiveUI.AndroidX/ReactiveRecyclerViewAdapter.cs
@@ -8,8 +8,6 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System.Reactive.Disposables;
-using System.Threading;
 using AndroidX.RecyclerView.Widget;
 using DynamicData;
 using DynamicData.Binding;
@@ -26,7 +24,7 @@ namespace ReactiveUI.AndroidX
     {
         private readonly ISourceList<TViewModel> _list;
 
-        private IDisposable _inner;
+        private readonly IDisposable _inner;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ReactiveRecyclerViewAdapter{TViewModel}"/> class.

--- a/src/ReactiveUI.AndroidX/ReactiveUI.AndroidX.csproj
+++ b/src/ReactiveUI.AndroidX/ReactiveUI.AndroidX.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
     <PackageReference Include="Xamarin.AndroidX.AppCompat" Version="1.1.0" />
     <PackageReference Include="Xamarin.AndroidX.Fragment" Version="1.1.0" />
+    <PackageReference Include="Xamarin.AndroidX.Preference" Version="1.1.0" />
     <PackageReference Include="Xamarin.AndroidX.RecyclerView" Version="1.1.0" />
     <Reference Include="System.Runtime.Serialization" />
   </ItemGroup>

--- a/src/ReactiveUI/Platforms/android/ReactiveFragment.cs
+++ b/src/ReactiveUI/Platforms/android/ReactiveFragment.cs
@@ -20,6 +20,7 @@ namespace ReactiveUI
     /// </summary>
     /// <typeparam name="TViewModel">The view model type.</typeparam>
     [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleType", Justification = "Classes with the same class names within.")]
+    [Obsolete("This class was deprecated in API level 28. Use the ReactiveFragment in ReactiveUI.AndroidX (recommended) or ReactiveUI.AndroidSupport for consistent behavior across all devices and access to Lifecycle.", false)]
     public class ReactiveFragment<TViewModel> : ReactiveFragment, IViewFor<TViewModel>, ICanActivate
         where TViewModel : class
     {
@@ -62,6 +63,7 @@ namespace ReactiveUI
     /// (i.e. you can call RaiseAndSetIfChanged).
     /// </summary>
     [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleType", Justification = "Classes with the same class names within.")]
+    [Obsolete("This class was deprecated in API level 28. Use the ReactiveFragment in ReactiveUI.AndroidX (recommended) or ReactiveUI.AndroidSupport for consistent behavior across all devices and access to Lifecycle.", false)]
     public class ReactiveFragment : Fragment, IReactiveNotifyPropertyChanged<ReactiveFragment>, IReactiveObject, IHandleObservableErrors
     {
         private readonly Subject<Unit> _activated = new Subject<Unit>();

--- a/src/ReactiveUI/Platforms/android/ReactivePreferenceFragment.cs
+++ b/src/ReactiveUI/Platforms/android/ReactivePreferenceFragment.cs
@@ -20,6 +20,7 @@ namespace ReactiveUI
     /// </summary>
     /// <typeparam name="TViewModel">The view model type.</typeparam>
     [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleType", Justification = "Classes with the same class names within.")]
+    [Obsolete("This class was deprecated in API level 28. Use the ReactivePreferenceFragment in ReactiveUI.AndroidX (recommended) or ReactiveUI.AndroidSupport for consistent behavior across all devices and access to Lifecycle.", false)]
     public class ReactivePreferenceFragment<TViewModel> : ReactivePreferenceFragment, IViewFor<TViewModel>, ICanActivate
         where TViewModel : class
     {
@@ -62,6 +63,7 @@ namespace ReactiveUI
     /// (i.e. you can call RaiseAndSetIfChanged).
     /// </summary>
     [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleType", Justification = "Classes with the same class names within.")]
+    [Obsolete("This class was deprecated in API level 28. Use the ReactivePreferenceFragment in ReactiveUI.AndroidX (recommended) or ReactiveUI.AndroidSupport for consistent behavior across all devices and access to Lifecycle.", false)]
     public class ReactivePreferenceFragment : PreferenceFragment, IReactiveNotifyPropertyChanged<ReactivePreferenceFragment>, IReactiveObject, IHandleObservableErrors
     {
         private readonly Subject<Unit> _activated = new Subject<Unit>();


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
1) Mark ReactiveFragment and ReactivePreferenceFragment (core ReactiveUI project) as obsolete.

Fragment and PreferenceFragment were deprecated in API level 28:
https://developer.android.com/reference/android/preference/PreferenceFragment
https://developer.android.com/reference/android/app/Fragment

2) Adds a ReactivePreferenceFragment to ReactiveUI.AndroidX and ReactiveUI.AndroidSupport projects as alternatives to the obsolete one.


**What is the current behavior?**
<!-- You can also link to an open issue here. -->
Users can use these classes without warning.


**What is the new behavior?**
<!-- If this is a feature change -->
Users will be warned about these classes being obsolete, and encouraged to use the AndroidX or AndroidSupport equivalents.


**What might this PR break?**
Nothing.


**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

