### PR TITLE
housekeeping: Upgraded Xamarin.Forms to v4.5

### DIFF
--- a/integrationtests/IntegrationTests.XamarinForms/IntegrationTests.XamarinForms.csproj
+++ b/integrationtests/IntegrationTests.XamarinForms/IntegrationTests.XamarinForms.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Acr.UserDialogs" Version="7.0.30" />
     <PackageReference Include="ReactiveUI.XamForms" Version="*" />
-    <PackageReference Include="Xamarin.Forms" Version="4.4.*" />
+    <PackageReference Include="Xamarin.Forms" Version="4.5.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ReactiveUI.Events.XamForms/ReactiveUI.Events.XamForms.csproj
+++ b/src/ReactiveUI.Events.XamForms/ReactiveUI.Events.XamForms.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.4.*" />
+    <PackageReference Include="Xamarin.Forms" Version="4.5.*" />
     <PackageReference Include="Pharmacist.MsBuild" Version="1.*" PrivateAssets="all" />
     <PackageReference Include="Pharmacist.Common" Version="1.*" />
    </ItemGroup>

--- a/src/ReactiveUI.XamForms/ReactiveUI.XamForms.csproj
+++ b/src/ReactiveUI.XamForms/ReactiveUI.XamForms.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.4.*" />
+    <PackageReference Include="Xamarin.Forms" Version="4.5.*" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

General housekeeping.  Xamarin.Forms 4.6 is coming out in the next cycle based on their current release cadence, moving this change in now because of consumer reported issues.

Resolves: #2386 

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

Xamarin 4.4.* is the minimum required version.

**What is the new behavior?**
<!-- If this is a feature change -->

Xamarin 4.5.* is the minimum required version.

**What might this PR break?**

ReactiveUI.XamForms

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

