### PR TITLE
fix: ReactiveComponentBase creating unnecessary subscriptions

### DIFF
--- a/src/ReactiveUI.Blazor/ReactiveComponentBase.cs
+++ b/src/ReactiveUI.Blazor/ReactiveComponentBase.cs
@@ -85,6 +85,7 @@ namespace ReactiveUI.Blazor
         {
             if (firstRender)
             {
+                // The following subscriptions are here because if they are done in OnInitialized, they conflict with certain JavaScript frameworks.
                 var viewModelChanged =
                     this.WhenAnyValue(x => x.ViewModel)
                         .Publish()

--- a/src/ReactiveUI.Blazor/ReactiveComponentBase.cs
+++ b/src/ReactiveUI.Blazor/ReactiveComponentBase.cs
@@ -88,16 +88,14 @@ namespace ReactiveUI.Blazor
                 // The following subscriptions are here because if they are done in OnInitialized, they conflict with certain JavaScript frameworks.
                 var viewModelChanged =
                     this.WhenAnyValue(x => x.ViewModel)
+                        .Where(x => x != null)
                         .Publish()
                         .RefCount();
 
                 viewModelChanged
-                    .Skip(1)
-                    .Where(x => x != null)
                     .Subscribe(_ => InvokeAsync(StateHasChanged));
 
                 viewModelChanged
-                    .Where(x => x != null)
                     .Select(x =>
                         Observable
                             .FromEvent<PropertyChangedEventHandler, Unit>(


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Relates To: #2377 

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

The current implementation of the `ReactiveComponentBase` is potentially creating unnecessary subscriptions.  Currently, we are wiring up `this.WhenAnyValue` in the `OnAfterRender` outside the `firstRender` which causes additional subscriptions every render.

We currently have our logic checking for the first render, doing some subscriptions for state changes, and then doing others outside of that if block.  That code is potentially leaking subscriptions.  We also do not call that state change correctly in the observable pipeline.

**What is the new behavior?**
<!-- If this is a feature change -->

This change moves all subscription logic to inside the `firstRender` if statement.  This will reduce the number of subscriptions generated and should reduce leaks.

**What might this PR break?**

ReactiveUI.Blazor

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**: