### PR TITLE
fix: Additional Subscriptions causing out of memory exception

### DIFF
--- a/src/ReactiveUI.Blazor/ReactiveComponentBase.cs
+++ b/src/ReactiveUI.Blazor/ReactiveComponentBase.cs
@@ -88,16 +88,16 @@ namespace ReactiveUI.Blazor
             {
                 // The following subscriptions are here because if they are done in OnInitialized, they conflict with certain JavaScript frameworks.
                 var viewModelChanged =
-                    this.WhenAnyValue(x => x.ViewModel);
+                    this.WhenAnyValue(x => x.ViewModel)
+                        .Where(x => x != null)
+                        .Publish()
+                        .RefCount(2);
 
                 viewModelChanged
-                    .Skip(1)
-                    .Where(x => x != null)
                     .Subscribe(_ => InvokeAsync(StateHasChanged))
                     .DisposeWith(_compositeDisposable);
 
                 viewModelChanged
-                    .Where(x => x != null)
                     .Select(x =>
                         Observable
                             .FromEvent<PropertyChangedEventHandler, Unit>(


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Resolves: #2377

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

When you run the sample provided in the report after a few updates, Blazor will throw an `OutOfMemoryException`.

**What is the new behavior?**
<!-- If this is a feature change -->

The sample no longer throw the exception.

**What might this PR break?**

`ReactiveComponentBase`

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

I tested my changes on a branch of the provided sample.  I will note that even though I am now disposing of the subscription with a composite disposable, I stopped seeing the issue as soon as I moved it into the `firstRender` check.

I let the app run for over an hour and did not experience the issue.  The most I did see logged on the memory footprint was a call to the GC that the nursery is full.

`GC_MINOR: (Nursery full) time 5.00ms, stw 5.00ms promoted 287K major size: 1152K in use: 409K los size: 1024K in use: 16K`

https://github.com/RLittlesII/BlazorReactiveUI/tree/fix/memory-leak