### PR TITLE
Fix Bug #2382 DelayChangeNotifications does not delay PropertyChanged events

### DIFF
--- a/src/ReactiveUI.Tests/ReactiveObject/ReactiveObjectTests.cs
+++ b/src/ReactiveUI.Tests/ReactiveObject/ReactiveObjectTests.cs
@@ -55,44 +55,62 @@ namespace ReactiveUI.Tests
         }
 
         [Fact]
-        public void DeferringNotificationsDontShowUpUntilUndeferred()
+        public void DeferredNotificationsDontShowUpUntilUndeferred()
         {
             var fixture = new TestFixture();
-            fixture.Changed.ToObservableChangeSet(ImmediateScheduler.Instance).Bind(out var output).Subscribe();
+            fixture.Changing.ToObservableChangeSet(ImmediateScheduler.Instance).Bind(out var changing).Subscribe();
+            fixture.Changed.ToObservableChangeSet(ImmediateScheduler.Instance).Bind(out var changed).Subscribe();
 
-            Assert.Equal(0, output.Count);
+            Assert.Equal(0, changing.Count);
+            Assert.Equal(0, changed.Count);
             fixture.NullableInt = 4;
-            Assert.Equal(1, output.Count);
+            Assert.Equal(1, changing.Count);
+            Assert.Equal(1, changed.Count);
 
             var stopDelaying = fixture.DelayChangeNotifications();
 
             fixture.NullableInt = 5;
-            Assert.Equal(1, output.Count);
+            Assert.Equal(1, changing.Count);
+            Assert.Equal(1, changed.Count);
 
             fixture.IsNotNullString = "Bar";
-            Assert.Equal(1, output.Count);
+            Assert.Equal(1, changing.Count);
+            Assert.Equal(1, changed.Count);
 
             fixture.NullableInt = 6;
-            Assert.Equal(1, output.Count);
+            Assert.Equal(1, changing.Count);
+            Assert.Equal(1, changed.Count);
 
             fixture.IsNotNullString = "Baz";
-            Assert.Equal(1, output.Count);
+            Assert.Equal(1, changing.Count);
+            Assert.Equal(1, changed.Count);
 
             var stopDelayingMore = fixture.DelayChangeNotifications();
 
             fixture.IsNotNullString = "Bamf";
-            Assert.Equal(1, output.Count);
+            Assert.Equal(1, changing.Count);
+            Assert.Equal(1, changed.Count);
 
             stopDelaying.Dispose();
 
             fixture.IsNotNullString = "Blargh";
-            Assert.Equal(1, output.Count);
+            Assert.Equal(1, changing.Count);
+            Assert.Equal(1, changed.Count);
 
             // NB: Because we debounce queued up notifications, we should only
             // see a notification from the latest NullableInt and the latest
             // IsNotNullableString
             stopDelayingMore.Dispose();
-            Assert.Equal(3, output.Count);
+
+            Assert.Equal(3, changing.Count);
+            Assert.Equal("NullableInt", changing[0].PropertyName);
+            Assert.Equal("NullableInt", changing[1].PropertyName);
+            Assert.Equal("IsNotNullString", changing[2].PropertyName);
+
+            Assert.Equal(3, changed.Count);
+            Assert.Equal("NullableInt", changed[0].PropertyName);
+            Assert.Equal("NullableInt", changed[1].PropertyName);
+            Assert.Equal("IsNotNullString", changed[2].PropertyName);
         }
 
         [Fact]

--- a/src/ReactiveUI.Tests/ReactiveObject/ReactiveObjectTests.cs
+++ b/src/ReactiveUI.Tests/ReactiveObject/ReactiveObjectTests.cs
@@ -4,7 +4,9 @@
 // See the LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Reactive.Concurrency;
 using System.Reactive.Linq;
@@ -60,57 +62,51 @@ namespace ReactiveUI.Tests
             var fixture = new TestFixture();
             fixture.Changing.ToObservableChangeSet(ImmediateScheduler.Instance).Bind(out var changing).Subscribe();
             fixture.Changed.ToObservableChangeSet(ImmediateScheduler.Instance).Bind(out var changed).Subscribe();
+            var propertyChangingEvents = new List<PropertyChangingEventArgs>();
+            fixture.PropertyChanging += (sender, args) => propertyChangingEvents.Add(args);
+            var propertyChangedEvents = new List<PropertyChangedEventArgs>();
+            fixture.PropertyChanged += (sender, args) => propertyChangedEvents.Add(args);
 
-            Assert.Equal(0, changing.Count);
-            Assert.Equal(0, changed.Count);
+            AssertCount(0, changing, changed, propertyChangingEvents, propertyChangedEvents);
             fixture.NullableInt = 4;
-            Assert.Equal(1, changing.Count);
-            Assert.Equal(1, changed.Count);
+            AssertCount(1, changing, changed, propertyChangingEvents, propertyChangedEvents);
 
             var stopDelaying = fixture.DelayChangeNotifications();
 
             fixture.NullableInt = 5;
-            Assert.Equal(1, changing.Count);
-            Assert.Equal(1, changed.Count);
+            AssertCount(1, changing, changed, propertyChangingEvents, propertyChangedEvents);
 
             fixture.IsNotNullString = "Bar";
-            Assert.Equal(1, changing.Count);
-            Assert.Equal(1, changed.Count);
+            AssertCount(1, changing, changed, propertyChangingEvents, propertyChangedEvents);
 
             fixture.NullableInt = 6;
-            Assert.Equal(1, changing.Count);
-            Assert.Equal(1, changed.Count);
+            AssertCount(1, changing, changed, propertyChangingEvents, propertyChangedEvents);
 
             fixture.IsNotNullString = "Baz";
-            Assert.Equal(1, changing.Count);
-            Assert.Equal(1, changed.Count);
+            AssertCount(1, changing, changed, propertyChangingEvents, propertyChangedEvents);
 
             var stopDelayingMore = fixture.DelayChangeNotifications();
 
             fixture.IsNotNullString = "Bamf";
-            Assert.Equal(1, changing.Count);
-            Assert.Equal(1, changed.Count);
+            AssertCount(1, changing, changed, propertyChangingEvents, propertyChangedEvents);
 
             stopDelaying.Dispose();
 
             fixture.IsNotNullString = "Blargh";
-            Assert.Equal(1, changing.Count);
-            Assert.Equal(1, changed.Count);
+            AssertCount(1, changing, changed, propertyChangingEvents, propertyChangedEvents);
 
             // NB: Because we debounce queued up notifications, we should only
             // see a notification from the latest NullableInt and the latest
             // IsNotNullableString
             stopDelayingMore.Dispose();
 
-            Assert.Equal(3, changing.Count);
-            Assert.Equal("NullableInt", changing[0].PropertyName);
-            Assert.Equal("NullableInt", changing[1].PropertyName);
-            Assert.Equal("IsNotNullString", changing[2].PropertyName);
+            AssertCount(3, changing, changed, propertyChangingEvents, propertyChangedEvents);
 
-            Assert.Equal(3, changed.Count);
-            Assert.Equal("NullableInt", changed[0].PropertyName);
-            Assert.Equal("NullableInt", changed[1].PropertyName);
-            Assert.Equal("IsNotNullString", changed[2].PropertyName);
+            var expectedEventProperties = new[] { "NullableInt", "NullableInt", "IsNotNullString" };
+            Assert.Equal(expectedEventProperties, changing.Select(e => e.PropertyName));
+            Assert.Equal(expectedEventProperties, changed.Select(e => e.PropertyName));
+            Assert.Equal(expectedEventProperties, propertyChangingEvents.Select(e => e.PropertyName));
+            Assert.Equal(expectedEventProperties, propertyChangedEvents.Select(e => e.PropertyName));
         }
 
         [Fact]
@@ -227,6 +223,14 @@ namespace ReactiveUI.Tests
 
             Assert.IsType<Exception>(result);
             Assert.Equal("This is a test.", result.Message);
+        }
+
+        private static void AssertCount(int expected, params ICollection[] collections)
+        {
+            foreach (var collection in collections)
+            {
+                Assert.Equal(expected, collection.Count);
+            }
         }
     }
 }

--- a/src/ReactiveUI/Interfaces/ReactivePropertyChangedEventArgs.cs
+++ b/src/ReactiveUI/Interfaces/ReactivePropertyChangedEventArgs.cs
@@ -28,7 +28,7 @@ namespace ReactiveUI
         /// <summary>
         /// Gets the sender which triggered the property changed event.
         /// </summary>
-/// <inheritdoc/>
+        /// <inheritdoc/>
         public TSender Sender { get; }
     }
 }

--- a/src/ReactiveUI/Interfaces/ReactivePropertyChangingEventArgs.cs
+++ b/src/ReactiveUI/Interfaces/ReactivePropertyChangingEventArgs.cs
@@ -27,7 +27,7 @@ namespace ReactiveUI
         /// <summary>
         /// Gets the sender which triggered the Reactive property changed event.
         /// </summary>
-/// <inheritdoc/>
+        /// <inheritdoc/>
         public TSender Sender { get; }
     }
 }

--- a/src/ReactiveUI/ReactiveObject/IReactiveObjectExtensions.cs
+++ b/src/ReactiveUI/ReactiveObject/IReactiveObjectExtensions.cs
@@ -44,12 +44,13 @@ namespace ReactiveUI
             IObservable<IReactivePropertyChangedEventArgs<TSender>> Changed { get; }
 
             /// <summary>
-            /// Gets a observable when a exception is thrown.
+            /// Gets a observable for when an exception is thrown.
             /// </summary>
             IObservable<Exception> ThrownExceptions { get; }
 
             /// <summary>
-            /// sdfsdg.
+            /// Subscribe raise property changing events to a property changing
+            /// observable. Must be called before raising property changing events.
             /// </summary>
             void SubscribePropertyChangingEvents();
 
@@ -60,7 +61,8 @@ namespace ReactiveUI
             void RaisePropertyChanging(string propertyName);
 
             /// <summary>
-            /// sdf sdfs fgdf.
+            /// Subscribe raise property changed events to a property changed
+            /// observable. Must be called before raising property changed events.
             /// </summary>
             void SubscribePropertyChangedEvents();
 

--- a/src/ReactiveUI/ReactiveObject/IReactiveObjectExtensions.cs
+++ b/src/ReactiveUI/ReactiveObject/IReactiveObjectExtensions.cs
@@ -5,8 +5,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Diagnostics.Contracts;
+using System.Linq;
 using System.Reactive;
 using System.Reactive.Concurrency;
 using System.Reactive.Disposables;
@@ -49,10 +49,20 @@ namespace ReactiveUI
             IObservable<Exception> ThrownExceptions { get; }
 
             /// <summary>
+            /// sdfsdg.
+            /// </summary>
+            void SubscribePropertyChangingEvents();
+
+            /// <summary>
             /// Raises a property changing event.
             /// </summary>
             /// <param name="propertyName">The name of the property that is changing.</param>
             void RaisePropertyChanging(string propertyName);
+
+            /// <summary>
+            /// sdf sdfs fgdf.
+            /// </summary>
+            void SubscribePropertyChangedEvents();
 
             /// <summary>
             /// Raises a property changed event.
@@ -172,6 +182,14 @@ namespace ReactiveUI
             return s.ThrownExceptions;
         }
 
+        internal static void SubscribePropertyChangingEvents<TSender>(this TSender reactiveObject)
+            where TSender : IReactiveObject
+        {
+            var s = state.GetValue(reactiveObject, _ => (IExtensionState<IReactiveObject>)new ExtensionState<TSender>(reactiveObject));
+
+            s.SubscribePropertyChangingEvents();
+        }
+
         internal static void RaisingPropertyChanging<TSender>(this TSender reactiveObject, string propertyName)
             where TSender : IReactiveObject
         {
@@ -180,6 +198,14 @@ namespace ReactiveUI
             var s = state.GetValue(reactiveObject, _ => (IExtensionState<IReactiveObject>)new ExtensionState<TSender>(reactiveObject));
 
             s.RaisePropertyChanging(propertyName);
+        }
+
+        internal static void SubscribePropertyChangedEvents<TSender>(this TSender reactiveObject)
+            where TSender : IReactiveObject
+        {
+            var s = state.GetValue(reactiveObject, _ => (IExtensionState<IReactiveObject>)new ExtensionState<TSender>(reactiveObject));
+
+            s.SubscribePropertyChangedEvents();
         }
 
         internal static void RaisingPropertyChanged<TSender>(this TSender reactiveObject, string propertyName)
@@ -216,38 +242,16 @@ namespace ReactiveUI
             return s.DelayChangeNotifications();
         }
 
-        /// <summary>
-        /// Filter a list of change notifications, returning the last change for each PropertyName in original order.
-        /// </summary>
-        private static IEnumerable<IReactivePropertyChangedEventArgs<TSender>> Dedup<TSender>(IList<IReactivePropertyChangedEventArgs<TSender>> batch)
-        {
-            if (batch.Count <= 1)
-            {
-                return batch;
-            }
-
-            var seen = new HashSet<string>();
-            var unique = new LinkedList<IReactivePropertyChangedEventArgs<TSender>>();
-
-            for (int i = batch.Count - 1; i >= 0; i--)
-            {
-                if (seen.Add(batch[i].PropertyName))
-                {
-                    unique.AddFirst(batch[i]);
-                }
-            }
-
-            return unique;
-        }
-
         private class ExtensionState<TSender> : IExtensionState<TSender>
             where TSender : IReactiveObject
         {
             private readonly Lazy<ISubject<Exception>> _thrownExceptions = new Lazy<ISubject<Exception>>(() => new ScheduledSubject<Exception>(Scheduler.Immediate, RxApp.DefaultExceptionHandler));
-            private readonly Lazy<Subject<Unit>> _startDelayNotifications = new Lazy<Subject<Unit>>();
+            private readonly Lazy<Subject<Unit>> _startOrStopDelayingChangeNotifications = new Lazy<Subject<Unit>>();
             private readonly TSender _sender;
             private readonly Lazy<(ISubject<IReactivePropertyChangedEventArgs<TSender>> subject, IObservable<IReactivePropertyChangedEventArgs<TSender>> observable)> _changing;
             private readonly Lazy<(ISubject<IReactivePropertyChangedEventArgs<TSender>> subject, IObservable<IReactivePropertyChangedEventArgs<TSender>> observable)> _changed;
+            private readonly Lazy<ISubject<ReactivePropertyChangingEventArgs<TSender>>> _propertyChanging;
+            private readonly Lazy<ISubject<ReactivePropertyChangedEventArgs<TSender>>> _propertyChanged;
 
             private long _changeNotificationsSuppressed;
             private long _changeNotificationsDelayed;
@@ -259,33 +263,10 @@ namespace ReactiveUI
             public ExtensionState(TSender sender)
             {
                 _sender = sender;
-                _changing = new Lazy<(ISubject<IReactivePropertyChangedEventArgs<TSender>>, IObservable<IReactivePropertyChangedEventArgs<TSender>>)>(() =>
-                {
-                    var changingSubject = new Subject<IReactivePropertyChangedEventArgs<TSender>>();
-                    var changedObs = changingSubject
-                        .Buffer(
-                            Observable.Merge(
-                                changingSubject.Where(_ => !AreChangeNotificationsDelayed()).Select(_ => Unit.Default), _startDelayNotifications.Value))
-                        .SelectMany(Dedup)
-                        .Publish()
-                        .RefCount();
-
-                    return (changingSubject, changedObs);
-                });
-
-                _changed = new Lazy<(ISubject<IReactivePropertyChangedEventArgs<TSender>> subject, IObservable<IReactivePropertyChangedEventArgs<TSender>> observable)>(() =>
-                {
-                    var changedSubject = new Subject<IReactivePropertyChangedEventArgs<TSender>>();
-                    var changedObs = changedSubject
-                        .Buffer(
-                            Observable.Merge(
-                                changedSubject.Where(_ => !AreChangeNotificationsDelayed()).Select(_ => Unit.Default), _startDelayNotifications.Value))
-                        .SelectMany(Dedup)
-                        .Publish()
-                        .RefCount();
-
-                    return (changedSubject, changedObs);
-                });
+                _changing = CreateLazyDelayableSubjectAndObservable();
+                _changed = CreateLazyDelayableSubjectAndObservable();
+                _propertyChanging = CreateLazyDelayableEventSubject<ReactivePropertyChangingEventArgs<TSender>>(_sender.RaisePropertyChanging);
+                _propertyChanged = CreateLazyDelayableEventSubject<ReactivePropertyChangedEventArgs<TSender>>(_sender.RaisePropertyChanged);
             }
 
             public IObservable<IReactivePropertyChangedEventArgs<TSender>> Changing => _changing.Value.observable;
@@ -329,9 +310,9 @@ namespace ReactiveUI
             {
                 if (Interlocked.Increment(ref _changeNotificationsDelayed) == 1)
                 {
-                    if (_startDelayNotifications.IsValueCreated)
+                    if (_startOrStopDelayingChangeNotifications.IsValueCreated)
                     {
-                        _startDelayNotifications.Value.OnNext(Unit.Default);
+                        _startOrStopDelayingChangeNotifications.Value.OnNext(Unit.Default);
                     }
                 }
 
@@ -339,12 +320,17 @@ namespace ReactiveUI
                 {
                     if (Interlocked.Decrement(ref _changeNotificationsDelayed) == 0)
                     {
-                        if (_startDelayNotifications.IsValueCreated)
+                        if (_startOrStopDelayingChangeNotifications.IsValueCreated)
                         {
-                            _startDelayNotifications.Value.OnNext(Unit.Default);
+                            _startOrStopDelayingChangeNotifications.Value.OnNext(Unit.Default);
                         }
                     }
                 });
+            }
+
+            public void SubscribePropertyChangingEvents()
+            {
+                _ = _propertyChanging.Value;
             }
 
             public void RaisePropertyChanging(string propertyName)
@@ -355,12 +341,21 @@ namespace ReactiveUI
                 }
 
                 var changing = new ReactivePropertyChangingEventArgs<TSender>(_sender, propertyName);
-                _sender.RaisePropertyChanging(changing);
+                if (_propertyChanging.IsValueCreated)
+                {
+                    // Do not use NotifyObservable because event exceptions shouldn't be put in ThrownExceptions
+                    _propertyChanging.Value.OnNext(changing);
+                }
 
                 if (_changing.IsValueCreated)
                 {
                     NotifyObservable(_sender, changing, _changing?.Value.subject);
                 }
+            }
+
+            public void SubscribePropertyChangedEvents()
+            {
+                _ = _propertyChanged.Value;
             }
 
             public void RaisePropertyChanged(string propertyName)
@@ -371,7 +366,11 @@ namespace ReactiveUI
                 }
 
                 var changed = new ReactivePropertyChangedEventArgs<TSender>(_sender, propertyName);
-                _sender.RaisePropertyChanged(changed);
+                if (_propertyChanged.IsValueCreated)
+                {
+                    // Do not use NotifyObservable because event exceptions shouldn't be put in ThrownExceptions
+                    _propertyChanged.Value.OnNext(changed);
+                }
 
                 if (_changed.IsValueCreated)
                 {
@@ -396,6 +395,64 @@ namespace ReactiveUI
 
                     throw;
                 }
+            }
+
+            /// <summary>
+            /// Filter a list of change notifications, returning the last change for each PropertyName in original order.
+            /// </summary>
+            private static IEnumerable<TEventArgs> DistinctEvents<TEventArgs>(IList<TEventArgs> events)
+                where TEventArgs : IReactivePropertyChangedEventArgs<TSender>
+            {
+                if (events.Count <= 1)
+                {
+                    return events;
+                }
+
+                var seen = new HashSet<string>();
+                var uniqueEvents = new Stack<TEventArgs>(events.Count);
+
+                for (int i = events.Count - 1; i >= 0; i--)
+                {
+                    if (seen.Add(events[i].PropertyName))
+                    {
+                        uniqueEvents.Push(events[i]);
+                    }
+                }
+
+                // Stack enumerates in LIFO order
+                return uniqueEvents;
+            }
+
+            private Lazy<(ISubject<IReactivePropertyChangedEventArgs<TSender>>, IObservable<IReactivePropertyChangedEventArgs<TSender>>)> CreateLazyDelayableSubjectAndObservable()
+            {
+                return new Lazy<(ISubject<IReactivePropertyChangedEventArgs<TSender>>, IObservable<IReactivePropertyChangedEventArgs<TSender>>)>(() =>
+              {
+                  var changeSubject = new Subject<IReactivePropertyChangedEventArgs<TSender>>();
+                  var changeObservable = changeSubject
+                      .Buffer(changeSubject.Where(_ => !AreChangeNotificationsDelayed()).Select(_ => Unit.Default)
+                                           .Merge(_startOrStopDelayingChangeNotifications.Value))
+                      .SelectMany(DistinctEvents)
+                      .Publish()
+                      .RefCount();
+
+                  return (changeSubject, changeObservable);
+              });
+            }
+
+            private Lazy<ISubject<TEventArgs>> CreateLazyDelayableEventSubject<TEventArgs>(Action<TEventArgs> raiseEvent)
+                where TEventArgs : IReactivePropertyChangedEventArgs<TSender>
+            {
+                return new Lazy<ISubject<TEventArgs>>(() =>
+                {
+                    var changeSubject = new Subject<TEventArgs>();
+                    changeSubject
+                        .Buffer(changeSubject.Where(_ => !AreChangeNotificationsDelayed()).Select(_ => Unit.Default)
+                                             .Merge(_startOrStopDelayingChangeNotifications.Value))
+                        .SelectMany(DistinctEvents)
+                        .Subscribe(raiseEvent);
+
+                    return changeSubject;
+                });
             }
         }
     }

--- a/src/ReactiveUI/ReactiveObject/ReactiveObject.cs
+++ b/src/ReactiveUI/ReactiveObject/ReactiveObject.cs
@@ -54,9 +54,9 @@ namespace ReactiveUI
             add
             {
                 _ = _propertyChangingEventsSubscribed.Value;
-                _propertyChanging += value;
+                PropertyChangingHandler += value;
             }
-            remove => _propertyChanging -= value;
+            remove => PropertyChangingHandler -= value;
         }
 
         /// <inheritdoc/>
@@ -65,22 +65,14 @@ namespace ReactiveUI
             add
             {
                 _ = _propertyChangedEventsSubscribed.Value;
-                _propertyChanged += value;
+                PropertyChangedHandler += value;
             }
-            remove => _propertyChanged -= value;
+            remove => PropertyChangedHandler -= value;
         }
 
-        [SuppressMessage(
-            "StyleCop.CSharp.NamingRules",
-            "SA1300:Element should begin with upper-case letter",
-            Justification = "Event is private backing field for PropertyChanging")]
-        private event PropertyChangingEventHandler _propertyChanging;
+        private event PropertyChangingEventHandler PropertyChangingHandler;
 
-        [SuppressMessage(
-            "StyleCop.CSharp.NamingRules",
-            "SA1300:Element should begin with upper-case letter",
-            Justification = "Event is private backing field for PropertyChanged")]
-        private event PropertyChangedEventHandler _propertyChanged;
+        private event PropertyChangedEventHandler PropertyChangedHandler;
 
         /// <inheritdoc />
         [IgnoreDataMember]
@@ -95,10 +87,10 @@ namespace ReactiveUI
         public IObservable<Exception> ThrownExceptions => _thrownExceptions.Value;
 
         /// <inheritdoc/>
-        void IReactiveObject.RaisePropertyChanging(PropertyChangingEventArgs args) => _propertyChanging?.Invoke(this, args);
+        void IReactiveObject.RaisePropertyChanging(PropertyChangingEventArgs args) => PropertyChangingHandler?.Invoke(this, args);
 
         /// <inheritdoc/>
-        void IReactiveObject.RaisePropertyChanged(PropertyChangedEventArgs args) => _propertyChanged?.Invoke(this, args);
+        void IReactiveObject.RaisePropertyChanged(PropertyChangedEventArgs args) => PropertyChangedHandler?.Invoke(this, args);
 
         /// <inheritdoc/>
         public IDisposable SuppressChangeNotifications() => IReactiveObjectExtensions.SuppressChangeNotifications(this);


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
Fixes #2382 DelayChangeNotifications does not delay PropertyChanged events

**What is the current behavior?**
Calling `DelayChangeNotifications()` on a `ReactiveObject` delays the `Changing` and `Changed` observable notifications, but not the actual `PropertyChanging` and `PropertyChanged` events.

**What is the new behavior?**
`DelayChangeNotifications()` now delays `PropertyChanging` and `PropertyChanged` events the same as the observables. Duplicate events are also removed the same as with the observables.

**What might this PR break?**
*Code relying on the current behavior of `PropertyChanging` and `PropertyChanged` events not being delayed.*

While I don't think this will break stuff, the most likely places for other bugs to be introduced:

* Exception handling for exceptions thrown from `PropertyChanging` and `PropertyChanged` events
* The ordering of change notifications in the `Changing` and `Changed` observables
* The raising of `PropertyChanging` and `PropertyChanged` events


**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
  * API docs for `DelayChangeNotifications()` was already not very specific, so didn't need to change.

**Other Information**:
The approach used here was discussed in issue #2382. See specifically [my comment](https://github.com/reactiveui/ReactiveUI/issues/2382#issuecomment-619299798) and those follow.
