### PR TITLE
housekeeping: Updated FxCopAnalyzers to v3.0

### DIFF
--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -74,7 +74,7 @@
 
   <ItemGroup>
     <PackageReference Include="stylecop.analyzers" Version="1.1.118" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0" PrivateAssets="all" />
     <PackageReference Include="Roslynator.Analyzers" Version="2.3.0" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>

--- a/src/ReactiveUI.Tests/Platforms/winforms/CommandBindingTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/CommandBindingTests.cs
@@ -40,7 +40,7 @@ namespace ReactiveUI.Tests.Winforms
             }
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/reactiveui/ReactiveUI/issues/2279")]
         public void CommandBinderBindsToCustomControl()
         {
             var fixture = new CreatesWinformsCommandBinding();


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Updates Microsoft.CodeAnalysis.FxCopAnalyzers to version 3.0.0

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

Microsoft.CodeAnalysis.FxCopAnalyzers is on version 2.9.8

**What is the new behavior?**
<!-- If this is a feature change -->

Microsoft.CodeAnalysis.FxCopAnalyzers will be on version 3.0.0

**What might this PR break?**

Analyzers

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

