### PR TITLE
fix: windows-common ViewModelViewHost creating the old view again whe…

### DIFF
--- a/src/ReactiveUI/Platforms/windows-common/ViewModelViewHost.cs
+++ b/src/ReactiveUI/Platforms/windows-common/ViewModelViewHost.cs
@@ -52,15 +52,16 @@ namespace ReactiveUI
         /// The view model dependency property.
         /// </summary>
         public static readonly DependencyProperty ViewModelProperty =
-            DependencyProperty.Register(nameof(ViewModel), typeof(object), typeof(ViewModelViewHost), new PropertyMetadata(null, SomethingChanged));
+            DependencyProperty.Register(nameof(ViewModel), typeof(object), typeof(ViewModelViewHost), new PropertyMetadata(null, ViewModelChanged));
 
         /// <summary>
         /// The view contract observable dependency property.
         /// </summary>
         public static readonly DependencyProperty ViewContractObservableProperty =
-            DependencyProperty.Register(nameof(ViewContractObservable), typeof(IObservable<string>), typeof(ViewModelViewHost), new PropertyMetadata(Observable<string>.Default, SomethingChanged));
+            DependencyProperty.Register(nameof(ViewContractObservable), typeof(IObservable<string>), typeof(ViewModelViewHost), new PropertyMetadata(Observable<string>.Default, ViewContractChanged));
 
         private readonly Subject<Unit> _updateViewModel = new Subject<Unit>();
+        private readonly Subject<Unit> _updateViewContract = new Subject<Unit>();
         private string _viewContract;
         private bool _isDisposed;
 
@@ -106,7 +107,7 @@ namespace ReactiveUI
                 .StartWith(platformGetter())
                 .DistinctUntilChanged();
 
-            var contractChanged = _updateViewModel.Select(_ => ViewContractObservable).Switch();
+            var contractChanged = _updateViewContract.Select(_ => ViewContractObservable).Switch();
             var viewModelChanged = _updateViewModel.Select(_ => ViewModel);
 
             var vmAndContract = contractChanged.CombineLatest(viewModelChanged, (contract, vm) => new { ViewModel = vm, Contract = contract });
@@ -179,14 +180,20 @@ namespace ReactiveUI
             if (isDisposing)
             {
                 _updateViewModel?.Dispose();
+                _updateViewContract?.Dispose();
             }
 
             _isDisposed = true;
         }
 
-        private static void SomethingChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
+        private static void ViewModelChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
         {
             ((ViewModelViewHost)dependencyObject)._updateViewModel.OnNext(Unit.Default);
+        }
+
+        private static void ViewContractChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
+        {
+            ((ViewModelViewHost)dependencyObject)._updateViewContract.OnNext(Unit.Default);
         }
 
         private void ResolveViewForViewModel(object viewModel, string contract)

--- a/src/ReactiveUI/Platforms/windows-common/ViewModelViewHost.cs
+++ b/src/ReactiveUI/Platforms/windows-common/ViewModelViewHost.cs
@@ -52,15 +52,14 @@ namespace ReactiveUI
         /// The view model dependency property.
         /// </summary>
         public static readonly DependencyProperty ViewModelProperty =
-            DependencyProperty.Register(nameof(ViewModel), typeof(object), typeof(ViewModelViewHost), new PropertyMetadata(null, SomethingChanged));
+            DependencyProperty.Register(nameof(ViewModel), typeof(object), typeof(ViewModelViewHost), new PropertyMetadata(default(object)));
 
         /// <summary>
         /// The view contract observable dependency property.
         /// </summary>
         public static readonly DependencyProperty ViewContractObservableProperty =
-            DependencyProperty.Register(nameof(ViewContractObservable), typeof(IObservable<string>), typeof(ViewModelViewHost), new PropertyMetadata(Observable<string>.Default, SomethingChanged));
+            DependencyProperty.Register(nameof(ViewContractObservable), typeof(IObservable<string>), typeof(ViewModelViewHost), new PropertyMetadata(Observable<string>.Default));
 
-        private readonly Subject<Unit> _updateViewModel = new Subject<Unit>();
         private string _viewContract;
         private bool _isDisposed;
 
@@ -106,15 +105,17 @@ namespace ReactiveUI
                 .StartWith(platformGetter())
                 .DistinctUntilChanged();
 
-            var contractChanged = _updateViewModel.Select(_ => ViewContractObservable).Switch();
-            var viewModelChanged = _updateViewModel.Select(_ => ViewModel);
+            // Observable that fires when ViewModel or ViewContractObservable change, or ViewContractObservable fires
+            var vmAndContract = Observable.CombineLatest(
+                this.WhenAnyValue(x => x.ViewModel),
+                this.WhenAnyObservable(x => x.ViewContractObservable),
+                (vm, contract) => new { ViewModel = vm, Contract = contract });
 
-            var vmAndContract = contractChanged.CombineLatest(viewModelChanged, (contract, vm) => new { ViewModel = vm, Contract = contract });
-
-            vmAndContract.Subscribe(x => ResolveViewForViewModel(x.ViewModel, x.Contract));
-            contractChanged
-                .ObserveOn(RxApp.MainThreadScheduler)
-                .Subscribe(x => _viewContract = x);
+            vmAndContract.Subscribe(x =>
+            {
+                _viewContract = x.Contract;
+                ResolveViewForViewModel(x.ViewModel, x.Contract);
+            });
         }
 
         /// <summary>
@@ -176,17 +177,7 @@ namespace ReactiveUI
                 return;
             }
 
-            if (isDisposing)
-            {
-                _updateViewModel?.Dispose();
-            }
-
             _isDisposed = true;
-        }
-
-        private static void SomethingChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
-        {
-            ((ViewModelViewHost)dependencyObject)._updateViewModel.OnNext(Unit.Default);
         }
 
         private void ResolveViewForViewModel(object viewModel, string contract)


### PR DESCRIPTION
fix: windows-common ViewModelViewHost creating the old view again when switching to a new view model (#2258)

<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here. -->
fixes https://github.com/reactiveui/ReactiveUI/issues/2258
[windows-common ViewModelViewHost](https://github.com/reactiveui/ReactiveUI/blob/main/src/ReactiveUI/Platforms/windows-common/ViewModelViewHost.cs) creates the old view again when switching to a new view model:
The way it was written before, a change of either ViewModelProperty or ViewContractObservableProperty resulted in both firing their corresponding Observables. Because of CombineLatest this resulted in the old ViewModel being run through ResolveViewForViewModel again, when the ViewModelProperty was changed. This created the old View for a moment again, which is a waste of resources, and it results in animation flickering (and other issues with DI lifetime management which I use).

**What is the new behavior?**
<!-- If this is a feature change -->
Now each Dependency property only fires their own Observable, instead of both at the same time.
The implementation has been mostly copied from [XamForms ViewModelViewHost](https://github.com/reactiveui/ReactiveUI/blob/main/src/ReactiveUI.XamForms/ViewModelViewHost.cs)

**What might this PR break?**
It's a simple change, that has been taken from another part of ReactiveUI, so I find it unlikely to break anything.


**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
I cannot run the ReactiveUI.Tests, because I am missing build tools for all the multitude of test targets. I do not think this class even has any tests anyhow.
- [ ] Docs have been added / updated (for bug fixes / features)
I would not know, where to look for that. Besides, this bug fix makes ViewModelViewHost ViewModelProperty follow expected behavior, so no documentation changes should be necessary.

**Other information**:
I suggest ReactiveUI's team to do an audit of the 3 ViewModelViewHost implementations, with the goal of putting shared code in a common class. Currently, there is a lot of repetition and a showcase, how to write the same thing in 3 different ways (ViewLocator part of the code being the biggest offender).
