### PR TITLE
fix: Throw an informative registry exception in RegisterViewsForViewModels

### DIFF
--- a/src/ReactiveUI/Mixins/DependencyResolverMixins.cs
+++ b/src/ReactiveUI/Mixins/DependencyResolverMixins.cs
@@ -106,8 +106,13 @@ namespace ReactiveUI
         [SuppressMessage("Redundancy", "CA1801: Redundant parameter", Justification = "Used on some platforms")]
         private static Func<object> TypeFactory(TypeInfo typeInfo)
         {
-            return Expression.Lambda<Func<object>>(Expression.New(
-                typeInfo.DeclaredConstructors.First(ci => ci.IsPublic && !ci.GetParameters().Any()))).Compile();
+            var parameterlessConstructor = typeInfo.DeclaredConstructors.FirstOrDefault(ci => ci.IsPublic && !ci.GetParameters().Any());
+            if (parameterlessConstructor == null)
+            {
+                throw new Exception($"Failed to register type {typeInfo.FullName} because it's missing a parameterless constructor.");
+            }
+
+            return Expression.Lambda<Func<object>>(Expression.New(parameterlessConstructor)).Compile();
         }
 
         [SuppressMessage("Globalization", "CA1307: operator could change based on locale settings", Justification = "Replace() does not have third parameter on all platforms")]


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
developer usefulness 


**What is the current behavior?**
<!-- You can also link to an open issue here. -->
When using _RegisterViewsForViewModels_, it throws an InvalidOperationException with the unhelpful message, "Sequence contains no matching element," if any of the views are missing a parameterless constructor.


**What is the new behavior?**
<!-- If this is a feature change -->
Message is changed to "Failed to register type {typeInfo.FullName} because it's missing a parameterless constructor."


**What might this PR break?**
Nothing.


**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
Resolves #2437
