### PR TITLE
Fix: Make Bind() ViewModel parameters nullable.

### DIFF
--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.net472.approved.txt
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.net472.approved.txt
@@ -216,32 +216,32 @@ namespace ReactiveUI
         [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {
                 "view",
                 "isViewModel"})]
-        ReactiveUI.IReactiveBinding<TView, TViewModel, System.ValueTuple<object?, bool>>? Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(TViewModel viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, System.IObservable<TDontCare>? signalViewUpdate, System.Func<TVMProp, TVProp> vmToViewConverter, System.Func<TVProp, TVMProp> viewToVmConverter)
+        ReactiveUI.IReactiveBinding<TView, TViewModel, System.ValueTuple<object?, bool>>? Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, System.IObservable<TDontCare>? signalViewUpdate, System.Func<TVMProp, TVProp> vmToViewConverter, System.Func<TVProp, TVMProp> viewToVmConverter)
             where TViewModel :  class
             where TView :  class, ReactiveUI.IViewFor
         ;
-        [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {
+        [return: System.Runtime.CompilerServices.TupleElementNames(new string?[]?[] {
                 "view",
                 "isViewModel"})]
-        ReactiveUI.IReactiveBinding<TView, TViewModel, System.ValueTuple<object?, bool>>? Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(TViewModel viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, System.IObservable<TDontCare>? signalViewUpdate, object? conversionHint, ReactiveUI.IBindingTypeConverter? vmToViewConverterOverride = null, ReactiveUI.IBindingTypeConverter? viewToVMConverterOverride = null)
+        ReactiveUI.IReactiveBinding<TView, TViewModel, System.ValueTuple<object?, bool>>? Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, System.IObservable<TDontCare>? signalViewUpdate, object? conversionHint, ReactiveUI.IBindingTypeConverter? vmToViewConverterOverride = null, ReactiveUI.IBindingTypeConverter? viewToVMConverterOverride = null)
             where TViewModel :  class
             where TView :  class, ReactiveUI.IViewFor
         ;
         System.IDisposable BindTo<TValue, TTarget, TTValue>(System.IObservable<TValue> observedChange, TTarget target, System.Linq.Expressions.Expression<System.Func<TTarget, TTValue>> propertyExpression, object? conversionHint, ReactiveUI.IBindingTypeConverter? vmToViewConverterOverride = null)
             where TTarget :  class
         ;
-        ReactiveUI.IReactiveBinding<TView, TViewModel, TOut>? OneWayBind<TViewModel, TView, TProp, TOut>(TViewModel viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TOut>> viewProperty, System.Func<TProp, TOut> selector)
+        ReactiveUI.IReactiveBinding<TView, TViewModel, TOut>? OneWayBind<TViewModel, TView, TProp, TOut>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TOut>> viewProperty, System.Func<TProp, TOut> selector)
             where TViewModel :  class
             where TView :  class, ReactiveUI.IViewFor
         ;
-        ReactiveUI.IReactiveBinding<TView, TViewModel, TVProp>? OneWayBind<TViewModel, TView, TVMProp, TVProp>(TViewModel viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, object? conversionHint, ReactiveUI.IBindingTypeConverter? vmToViewConverterOverride = null)
+        ReactiveUI.IReactiveBinding<TView, TViewModel, TVProp>? OneWayBind<TViewModel, TView, TVMProp, TVProp>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, object? conversionHint, ReactiveUI.IBindingTypeConverter? vmToViewConverterOverride = null)
             where TViewModel :  class
             where TView :  class, ReactiveUI.IViewFor
         ;
     }
     public interface IPropertyBindingHook
     {
-        bool ExecuteHook(object source, object target, System.Func<ReactiveUI.IObservedChange<, >[]> getCurrentViewModelProperties, System.Func<ReactiveUI.IObservedChange<, >[]> getCurrentViewProperties, ReactiveUI.BindingDirection direction);
+        bool ExecuteHook(object? source, object target, System.Func<ReactiveUI.IObservedChange<, >[]> getCurrentViewModelProperties, System.Func<ReactiveUI.IObservedChange<, >[]> getCurrentViewProperties, ReactiveUI.BindingDirection direction);
     }
     public class IROObservableForProperty : ReactiveUI.ICreatesObservableForProperty, Splat.IEnableLogger
     {
@@ -433,21 +433,21 @@ namespace ReactiveUI
         [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {
                 "view",
                 "isViewModel"})]
-        public ReactiveUI.IReactiveBinding<TView, TViewModel, System.ValueTuple<object?, bool>>? Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(TViewModel viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, System.IObservable<TDontCare>? signalViewUpdate, System.Func<TVMProp, TVProp> vmToViewConverter, System.Func<TVProp, TVMProp> viewToVmConverter)
+        public ReactiveUI.IReactiveBinding<TView, TViewModel, System.ValueTuple<object?, bool>>? Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, System.IObservable<TDontCare>? signalViewUpdate, System.Func<TVMProp, TVProp> vmToViewConverter, System.Func<TVProp, TVMProp> viewToVmConverter)
             where TViewModel :  class
             where TView :  class, ReactiveUI.IViewFor { }
-        [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {
+        [return: System.Runtime.CompilerServices.TupleElementNames(new string?[]?[] {
                 "view",
                 "isViewModel"})]
-        public ReactiveUI.IReactiveBinding<TView, TViewModel, System.ValueTuple<object?, bool>> Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(TViewModel viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, System.IObservable<TDontCare>? signalViewUpdate, object? conversionHint, ReactiveUI.IBindingTypeConverter? vmToViewConverterOverride = null, ReactiveUI.IBindingTypeConverter? viewToVMConverterOverride = null)
+        public ReactiveUI.IReactiveBinding<TView, TViewModel, System.ValueTuple<object?, bool>> Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, System.IObservable<TDontCare>? signalViewUpdate, object? conversionHint, ReactiveUI.IBindingTypeConverter? vmToViewConverterOverride = null, ReactiveUI.IBindingTypeConverter? viewToVMConverterOverride = null)
             where TViewModel :  class
             where TView :  class, ReactiveUI.IViewFor { }
         public System.IDisposable BindTo<TValue, TTarget, TTValue>(System.IObservable<TValue> observedChange, TTarget target, System.Linq.Expressions.Expression<System.Func<TTarget, TTValue>> propertyExpression, object? conversionHint = null, ReactiveUI.IBindingTypeConverter? vmToViewConverterOverride = null)
             where TTarget :  class { }
-        public ReactiveUI.IReactiveBinding<TView, TViewModel, TOut>? OneWayBind<TViewModel, TView, TProp, TOut>(TViewModel viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TOut>> viewProperty, System.Func<TProp, TOut> selector)
+        public ReactiveUI.IReactiveBinding<TView, TViewModel, TOut>? OneWayBind<TViewModel, TView, TProp, TOut>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TOut>> viewProperty, System.Func<TProp, TOut> selector)
             where TViewModel :  class
             where TView :  class, ReactiveUI.IViewFor { }
-        public ReactiveUI.IReactiveBinding<TView, TViewModel, TVProp>? OneWayBind<TViewModel, TView, TVMProp, TVProp>(TViewModel viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, object? conversionHint = null, ReactiveUI.IBindingTypeConverter? vmToViewConverterOverride = null)
+        public ReactiveUI.IReactiveBinding<TView, TViewModel, TVProp>? OneWayBind<TViewModel, TView, TVMProp, TVProp>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, object? conversionHint = null, ReactiveUI.IBindingTypeConverter? vmToViewConverterOverride = null)
             where TViewModel :  class
             where TView :  class, ReactiveUI.IViewFor { }
     }
@@ -456,33 +456,33 @@ namespace ReactiveUI
         [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {
                 "view",
                 "isViewModel"})]
-        public static ReactiveUI.IReactiveBinding<TView, TViewModel, System.ValueTuple<object?, bool>>? Bind<TViewModel, TView, TVMProp, TVProp>(this TView view, TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, System.Func<TVMProp, TVProp> vmToViewConverter, System.Func<TVProp, TVMProp> viewToVmConverter)
+        public static ReactiveUI.IReactiveBinding<TView, TViewModel, System.ValueTuple<object?, bool>>? Bind<TViewModel, TView, TVMProp, TVProp>(this TView view, TViewModel? viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, System.Func<TVMProp, TVProp> vmToViewConverter, System.Func<TVProp, TVMProp> viewToVmConverter)
             where TViewModel :  class
             where TView :  class, ReactiveUI.IViewFor { }
         [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {
                 "view",
                 "isViewModel"})]
-        public static ReactiveUI.IReactiveBinding<TView, TViewModel, System.ValueTuple<object?, bool>>? Bind<TViewModel, TView, TVMProp, TVProp>(this TView view, TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, object? conversionHint = null, ReactiveUI.IBindingTypeConverter? vmToViewConverterOverride = null, ReactiveUI.IBindingTypeConverter? viewToVMConverterOverride = null)
+        public static ReactiveUI.IReactiveBinding<TView, TViewModel, System.ValueTuple<object?, bool>>? Bind<TViewModel, TView, TVMProp, TVProp>(this TView view, TViewModel? viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, object? conversionHint = null, ReactiveUI.IBindingTypeConverter? vmToViewConverterOverride = null, ReactiveUI.IBindingTypeConverter? viewToVMConverterOverride = null)
             where TViewModel :  class
             where TView :  class, ReactiveUI.IViewFor { }
         [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {
                 "view",
                 "isViewModel"})]
-        public static ReactiveUI.IReactiveBinding<TView, TViewModel, System.ValueTuple<object?, bool>>? Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(this TView view, TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, System.IObservable<TDontCare>? signalViewUpdate, System.Func<TVMProp, TVProp> vmToViewConverter, System.Func<TVProp, TVMProp> viewToVmConverter)
+        public static ReactiveUI.IReactiveBinding<TView, TViewModel, System.ValueTuple<object?, bool>>? Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(this TView view, TViewModel? viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, System.IObservable<TDontCare>? signalViewUpdate, System.Func<TVMProp, TVProp> vmToViewConverter, System.Func<TVProp, TVMProp> viewToVmConverter)
             where TViewModel :  class
             where TView :  class, ReactiveUI.IViewFor { }
-        [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {
+        [return: System.Runtime.CompilerServices.TupleElementNames(new string?[]?[] {
                 "view",
                 "isViewModel"})]
-        public static ReactiveUI.IReactiveBinding<TView, TViewModel, System.ValueTuple<object?, bool>>? Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(this TView view, TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, System.IObservable<TDontCare>? signalViewUpdate, object? conversionHint = null, ReactiveUI.IBindingTypeConverter? vmToViewConverterOverride = null, ReactiveUI.IBindingTypeConverter? viewToVMConverterOverride = null)
+        public static ReactiveUI.IReactiveBinding<TView, TViewModel, System.ValueTuple<object?, bool>>? Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(this TView view, TViewModel? viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, System.IObservable<TDontCare>? signalViewUpdate, object? conversionHint = null, ReactiveUI.IBindingTypeConverter? vmToViewConverterOverride = null, ReactiveUI.IBindingTypeConverter? viewToVMConverterOverride = null)
             where TViewModel :  class
             where TView :  class, ReactiveUI.IViewFor { }
         public static System.IDisposable BindTo<TValue, TTarget, TTValue>(this System.IObservable<TValue> @this, TTarget target, System.Linq.Expressions.Expression<System.Func<TTarget, TTValue>> property, object? conversionHint = null, ReactiveUI.IBindingTypeConverter? vmToViewConverterOverride = null)
             where TTarget :  class { }
-        public static ReactiveUI.IReactiveBinding<TView, TViewModel, TOut>? OneWayBind<TViewModel, TView, TProp, TOut>(this TView view, TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TOut>> viewProperty, System.Func<TProp, TOut> selector)
+        public static ReactiveUI.IReactiveBinding<TView, TViewModel, TOut>? OneWayBind<TViewModel, TView, TProp, TOut>(this TView view, TViewModel? viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TOut>> viewProperty, System.Func<TProp, TOut> selector)
             where TViewModel :  class
             where TView :  class, ReactiveUI.IViewFor { }
-        public static ReactiveUI.IReactiveBinding<TView, TViewModel, TVProp>? OneWayBind<TViewModel, TView, TVMProp, TVProp>(this TView view, TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, object? conversionHint = null, ReactiveUI.IBindingTypeConverter? vmToViewConverterOverride = null)
+        public static ReactiveUI.IReactiveBinding<TView, TViewModel, TVProp>? OneWayBind<TViewModel, TView, TVMProp, TVProp>(this TView view, TViewModel? viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, object? conversionHint = null, ReactiveUI.IBindingTypeConverter? vmToViewConverterOverride = null)
             where TViewModel :  class
             where TView :  class, ReactiveUI.IViewFor { }
     }

--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.netcoreapp3.1.approved.txt
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.netcoreapp3.1.approved.txt
@@ -216,32 +216,32 @@ namespace ReactiveUI
         [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {
                 "view",
                 "isViewModel"})]
-        ReactiveUI.IReactiveBinding<TView, TViewModel, System.ValueTuple<object?, bool>>? Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(TViewModel viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, System.IObservable<TDontCare>? signalViewUpdate, System.Func<TVMProp, TVProp> vmToViewConverter, System.Func<TVProp, TVMProp> viewToVmConverter)
+        ReactiveUI.IReactiveBinding<TView, TViewModel, System.ValueTuple<object?, bool>>? Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, System.IObservable<TDontCare>? signalViewUpdate, System.Func<TVMProp, TVProp> vmToViewConverter, System.Func<TVProp, TVMProp> viewToVmConverter)
             where TViewModel :  class
             where TView :  class, ReactiveUI.IViewFor
         ;
-        [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {
+        [return: System.Runtime.CompilerServices.TupleElementNames(new string?[]?[] {
                 "view",
                 "isViewModel"})]
-        ReactiveUI.IReactiveBinding<TView, TViewModel, System.ValueTuple<object?, bool>>? Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(TViewModel viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, System.IObservable<TDontCare>? signalViewUpdate, object? conversionHint, ReactiveUI.IBindingTypeConverter? vmToViewConverterOverride = null, ReactiveUI.IBindingTypeConverter? viewToVMConverterOverride = null)
+        ReactiveUI.IReactiveBinding<TView, TViewModel, System.ValueTuple<object?, bool>>? Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, System.IObservable<TDontCare>? signalViewUpdate, object? conversionHint, ReactiveUI.IBindingTypeConverter? vmToViewConverterOverride = null, ReactiveUI.IBindingTypeConverter? viewToVMConverterOverride = null)
             where TViewModel :  class
             where TView :  class, ReactiveUI.IViewFor
         ;
         System.IDisposable BindTo<TValue, TTarget, TTValue>(System.IObservable<TValue> observedChange, TTarget target, System.Linq.Expressions.Expression<System.Func<TTarget, TTValue>> propertyExpression, object? conversionHint, ReactiveUI.IBindingTypeConverter? vmToViewConverterOverride = null)
             where TTarget :  class
         ;
-        ReactiveUI.IReactiveBinding<TView, TViewModel, TOut>? OneWayBind<TViewModel, TView, TProp, TOut>(TViewModel viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TOut>> viewProperty, System.Func<TProp, TOut> selector)
+        ReactiveUI.IReactiveBinding<TView, TViewModel, TOut>? OneWayBind<TViewModel, TView, TProp, TOut>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TOut>> viewProperty, System.Func<TProp, TOut> selector)
             where TViewModel :  class
             where TView :  class, ReactiveUI.IViewFor
         ;
-        ReactiveUI.IReactiveBinding<TView, TViewModel, TVProp>? OneWayBind<TViewModel, TView, TVMProp, TVProp>(TViewModel viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, object? conversionHint, ReactiveUI.IBindingTypeConverter? vmToViewConverterOverride = null)
+        ReactiveUI.IReactiveBinding<TView, TViewModel, TVProp>? OneWayBind<TViewModel, TView, TVMProp, TVProp>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, object? conversionHint, ReactiveUI.IBindingTypeConverter? vmToViewConverterOverride = null)
             where TViewModel :  class
             where TView :  class, ReactiveUI.IViewFor
         ;
     }
     public interface IPropertyBindingHook
     {
-        bool ExecuteHook(object source, object target, System.Func<ReactiveUI.IObservedChange<, >[]> getCurrentViewModelProperties, System.Func<ReactiveUI.IObservedChange<, >[]> getCurrentViewProperties, ReactiveUI.BindingDirection direction);
+        bool ExecuteHook(object? source, object target, System.Func<ReactiveUI.IObservedChange<, >[]> getCurrentViewModelProperties, System.Func<ReactiveUI.IObservedChange<, >[]> getCurrentViewProperties, ReactiveUI.BindingDirection direction);
     }
     public class IROObservableForProperty : ReactiveUI.ICreatesObservableForProperty, Splat.IEnableLogger
     {
@@ -433,21 +433,21 @@ namespace ReactiveUI
         [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {
                 "view",
                 "isViewModel"})]
-        public ReactiveUI.IReactiveBinding<TView, TViewModel, System.ValueTuple<object?, bool>>? Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(TViewModel viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, System.IObservable<TDontCare>? signalViewUpdate, System.Func<TVMProp, TVProp> vmToViewConverter, System.Func<TVProp, TVMProp> viewToVmConverter)
+        public ReactiveUI.IReactiveBinding<TView, TViewModel, System.ValueTuple<object?, bool>>? Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, System.IObservable<TDontCare>? signalViewUpdate, System.Func<TVMProp, TVProp> vmToViewConverter, System.Func<TVProp, TVMProp> viewToVmConverter)
             where TViewModel :  class
             where TView :  class, ReactiveUI.IViewFor { }
-        [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {
+        [return: System.Runtime.CompilerServices.TupleElementNames(new string?[]?[] {
                 "view",
                 "isViewModel"})]
-        public ReactiveUI.IReactiveBinding<TView, TViewModel, System.ValueTuple<object?, bool>> Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(TViewModel viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, System.IObservable<TDontCare>? signalViewUpdate, object? conversionHint, ReactiveUI.IBindingTypeConverter? vmToViewConverterOverride = null, ReactiveUI.IBindingTypeConverter? viewToVMConverterOverride = null)
+        public ReactiveUI.IReactiveBinding<TView, TViewModel, System.ValueTuple<object?, bool>> Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, System.IObservable<TDontCare>? signalViewUpdate, object? conversionHint, ReactiveUI.IBindingTypeConverter? vmToViewConverterOverride = null, ReactiveUI.IBindingTypeConverter? viewToVMConverterOverride = null)
             where TViewModel :  class
             where TView :  class, ReactiveUI.IViewFor { }
         public System.IDisposable BindTo<TValue, TTarget, TTValue>(System.IObservable<TValue> observedChange, TTarget target, System.Linq.Expressions.Expression<System.Func<TTarget, TTValue>> propertyExpression, object? conversionHint = null, ReactiveUI.IBindingTypeConverter? vmToViewConverterOverride = null)
             where TTarget :  class { }
-        public ReactiveUI.IReactiveBinding<TView, TViewModel, TOut>? OneWayBind<TViewModel, TView, TProp, TOut>(TViewModel viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TOut>> viewProperty, System.Func<TProp, TOut> selector)
+        public ReactiveUI.IReactiveBinding<TView, TViewModel, TOut>? OneWayBind<TViewModel, TView, TProp, TOut>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TOut>> viewProperty, System.Func<TProp, TOut> selector)
             where TViewModel :  class
             where TView :  class, ReactiveUI.IViewFor { }
-        public ReactiveUI.IReactiveBinding<TView, TViewModel, TVProp>? OneWayBind<TViewModel, TView, TVMProp, TVProp>(TViewModel viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, object? conversionHint = null, ReactiveUI.IBindingTypeConverter? vmToViewConverterOverride = null)
+        public ReactiveUI.IReactiveBinding<TView, TViewModel, TVProp>? OneWayBind<TViewModel, TView, TVMProp, TVProp>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, object? conversionHint = null, ReactiveUI.IBindingTypeConverter? vmToViewConverterOverride = null)
             where TViewModel :  class
             where TView :  class, ReactiveUI.IViewFor { }
     }
@@ -456,33 +456,33 @@ namespace ReactiveUI
         [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {
                 "view",
                 "isViewModel"})]
-        public static ReactiveUI.IReactiveBinding<TView, TViewModel, System.ValueTuple<object?, bool>>? Bind<TViewModel, TView, TVMProp, TVProp>(this TView view, TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, System.Func<TVMProp, TVProp> vmToViewConverter, System.Func<TVProp, TVMProp> viewToVmConverter)
+        public static ReactiveUI.IReactiveBinding<TView, TViewModel, System.ValueTuple<object?, bool>>? Bind<TViewModel, TView, TVMProp, TVProp>(this TView view, TViewModel? viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, System.Func<TVMProp, TVProp> vmToViewConverter, System.Func<TVProp, TVMProp> viewToVmConverter)
             where TViewModel :  class
             where TView :  class, ReactiveUI.IViewFor { }
         [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {
                 "view",
                 "isViewModel"})]
-        public static ReactiveUI.IReactiveBinding<TView, TViewModel, System.ValueTuple<object?, bool>>? Bind<TViewModel, TView, TVMProp, TVProp>(this TView view, TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, object? conversionHint = null, ReactiveUI.IBindingTypeConverter? vmToViewConverterOverride = null, ReactiveUI.IBindingTypeConverter? viewToVMConverterOverride = null)
+        public static ReactiveUI.IReactiveBinding<TView, TViewModel, System.ValueTuple<object?, bool>>? Bind<TViewModel, TView, TVMProp, TVProp>(this TView view, TViewModel? viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, object? conversionHint = null, ReactiveUI.IBindingTypeConverter? vmToViewConverterOverride = null, ReactiveUI.IBindingTypeConverter? viewToVMConverterOverride = null)
             where TViewModel :  class
             where TView :  class, ReactiveUI.IViewFor { }
         [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {
                 "view",
                 "isViewModel"})]
-        public static ReactiveUI.IReactiveBinding<TView, TViewModel, System.ValueTuple<object?, bool>>? Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(this TView view, TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, System.IObservable<TDontCare>? signalViewUpdate, System.Func<TVMProp, TVProp> vmToViewConverter, System.Func<TVProp, TVMProp> viewToVmConverter)
+        public static ReactiveUI.IReactiveBinding<TView, TViewModel, System.ValueTuple<object?, bool>>? Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(this TView view, TViewModel? viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, System.IObservable<TDontCare>? signalViewUpdate, System.Func<TVMProp, TVProp> vmToViewConverter, System.Func<TVProp, TVMProp> viewToVmConverter)
             where TViewModel :  class
             where TView :  class, ReactiveUI.IViewFor { }
-        [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {
+        [return: System.Runtime.CompilerServices.TupleElementNames(new string?[]?[] {
                 "view",
                 "isViewModel"})]
-        public static ReactiveUI.IReactiveBinding<TView, TViewModel, System.ValueTuple<object?, bool>>? Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(this TView view, TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, System.IObservable<TDontCare>? signalViewUpdate, object? conversionHint = null, ReactiveUI.IBindingTypeConverter? vmToViewConverterOverride = null, ReactiveUI.IBindingTypeConverter? viewToVMConverterOverride = null)
+        public static ReactiveUI.IReactiveBinding<TView, TViewModel, System.ValueTuple<object?, bool>>? Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(this TView view, TViewModel? viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, System.IObservable<TDontCare>? signalViewUpdate, object? conversionHint = null, ReactiveUI.IBindingTypeConverter? vmToViewConverterOverride = null, ReactiveUI.IBindingTypeConverter? viewToVMConverterOverride = null)
             where TViewModel :  class
             where TView :  class, ReactiveUI.IViewFor { }
         public static System.IDisposable BindTo<TValue, TTarget, TTValue>(this System.IObservable<TValue> @this, TTarget target, System.Linq.Expressions.Expression<System.Func<TTarget, TTValue>> property, object? conversionHint = null, ReactiveUI.IBindingTypeConverter? vmToViewConverterOverride = null)
             where TTarget :  class { }
-        public static ReactiveUI.IReactiveBinding<TView, TViewModel, TOut>? OneWayBind<TViewModel, TView, TProp, TOut>(this TView view, TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TOut>> viewProperty, System.Func<TProp, TOut> selector)
+        public static ReactiveUI.IReactiveBinding<TView, TViewModel, TOut>? OneWayBind<TViewModel, TView, TProp, TOut>(this TView view, TViewModel? viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TOut>> viewProperty, System.Func<TProp, TOut> selector)
             where TViewModel :  class
             where TView :  class, ReactiveUI.IViewFor { }
-        public static ReactiveUI.IReactiveBinding<TView, TViewModel, TVProp>? OneWayBind<TViewModel, TView, TVMProp, TVProp>(this TView view, TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, object? conversionHint = null, ReactiveUI.IBindingTypeConverter? vmToViewConverterOverride = null)
+        public static ReactiveUI.IReactiveBinding<TView, TViewModel, TVProp>? OneWayBind<TViewModel, TView, TVMProp, TVProp>(this TView view, TViewModel? viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, object? conversionHint = null, ReactiveUI.IBindingTypeConverter? vmToViewConverterOverride = null)
             where TViewModel :  class
             where TView :  class, ReactiveUI.IViewFor { }
     }

--- a/src/ReactiveUI.Tests/Platforms/winforms/API/ApiApprovalTests.Winforms.net472.approved.txt
+++ b/src/ReactiveUI.Tests/Platforms/winforms/API/ApiApprovalTests.Winforms.net472.approved.txt
@@ -10,7 +10,7 @@ namespace ReactiveUI.Winforms
     public class ContentControlBindingHook : ReactiveUI.IPropertyBindingHook
     {
         public ContentControlBindingHook() { }
-        public bool ExecuteHook(object source, object target, System.Func<ReactiveUI.IObservedChange<, >[]> getCurrentViewModelProperties, System.Func<ReactiveUI.IObservedChange<, >[]> getCurrentViewProperties, ReactiveUI.BindingDirection direction) { }
+        public bool ExecuteHook(object? source, object target, System.Func<ReactiveUI.IObservedChange<, >[]> getCurrentViewModelProperties, System.Func<ReactiveUI.IObservedChange<, >[]> getCurrentViewProperties, ReactiveUI.BindingDirection direction) { }
     }
     public class CreatesWinformsCommandBinding : ReactiveUI.ICreatesCommandBinding
     {

--- a/src/ReactiveUI.Tests/Platforms/winforms/API/ApiApprovalTests.Winforms.netcoreapp3.1.approved.txt
+++ b/src/ReactiveUI.Tests/Platforms/winforms/API/ApiApprovalTests.Winforms.netcoreapp3.1.approved.txt
@@ -10,7 +10,7 @@ namespace ReactiveUI.Winforms
     public class ContentControlBindingHook : ReactiveUI.IPropertyBindingHook
     {
         public ContentControlBindingHook() { }
-        public bool ExecuteHook(object source, object target, System.Func<ReactiveUI.IObservedChange<, >[]> getCurrentViewModelProperties, System.Func<ReactiveUI.IObservedChange<, >[]> getCurrentViewProperties, ReactiveUI.BindingDirection direction) { }
+        public bool ExecuteHook(object? source, object target, System.Func<ReactiveUI.IObservedChange<, >[]> getCurrentViewModelProperties, System.Func<ReactiveUI.IObservedChange<, >[]> getCurrentViewProperties, ReactiveUI.BindingDirection direction) { }
     }
     public class CreatesWinformsCommandBinding : ReactiveUI.ICreatesCommandBinding
     {

--- a/src/ReactiveUI.Winforms/ContentControlBindingHook.cs
+++ b/src/ReactiveUI.Winforms/ContentControlBindingHook.cs
@@ -17,7 +17,7 @@ namespace ReactiveUI.Winforms
     public class ContentControlBindingHook : IPropertyBindingHook
     {
         /// <inheritdoc/>
-        public bool ExecuteHook(object source, object target, Func<IObservedChange<object, object>[]> getCurrentViewModelProperties, Func<IObservedChange<object, object>[]> getCurrentViewProperties, BindingDirection direction)
+        public bool ExecuteHook(object? source, object target, Func<IObservedChange<object, object>[]> getCurrentViewModelProperties, Func<IObservedChange<object, object>[]> getCurrentViewProperties, BindingDirection direction)
         {
             if (getCurrentViewProperties == null)
             {

--- a/src/ReactiveUI.Winforms/ContentControlBindingHook.cs
+++ b/src/ReactiveUI.Winforms/ContentControlBindingHook.cs
@@ -17,7 +17,7 @@ namespace ReactiveUI.Winforms
     public class ContentControlBindingHook : IPropertyBindingHook
     {
         /// <inheritdoc/>
-        public bool ExecuteHook(object target, Func<IObservedChange<object, object>[]> getCurrentViewModelProperties, Func<IObservedChange<object, object>[]> getCurrentViewProperties, BindingDirection direction)
+        public bool ExecuteHook(object source, object target, Func<IObservedChange<object, object>[]> getCurrentViewModelProperties, Func<IObservedChange<object, object>[]> getCurrentViewProperties, BindingDirection direction)
         {
             if (getCurrentViewProperties == null)
             {

--- a/src/ReactiveUI.Winforms/ContentControlBindingHook.cs
+++ b/src/ReactiveUI.Winforms/ContentControlBindingHook.cs
@@ -17,7 +17,7 @@ namespace ReactiveUI.Winforms
     public class ContentControlBindingHook : IPropertyBindingHook
     {
         /// <inheritdoc/>
-        public bool ExecuteHook(object source, object target, Func<IObservedChange<object, object>[]> getCurrentViewModelProperties, Func<IObservedChange<object, object>[]> getCurrentViewProperties, BindingDirection direction)
+        public bool ExecuteHook(object target, Func<IObservedChange<object, object>[]> getCurrentViewModelProperties, Func<IObservedChange<object, object>[]> getCurrentViewProperties, BindingDirection direction)
         {
             if (getCurrentViewProperties == null)
             {

--- a/src/ReactiveUI/Bindings/Property/IPropertyBinderImplementation.cs
+++ b/src/ReactiveUI/Bindings/Property/IPropertyBinderImplementation.cs
@@ -65,7 +65,7 @@ namespace ReactiveUI
         /// disconnects the binding.
         /// </returns>
         IReactiveBinding<TView, TViewModel, (object? view, bool isViewModel)>? Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(
-                TViewModel viewModel,
+                TViewModel? viewModel,
                 TView view,
                 Expression<Func<TViewModel, TVMProp>> vmProperty,
                 Expression<Func<TView, TVProp>> viewProperty,
@@ -122,7 +122,7 @@ namespace ReactiveUI
         /// disconnects the binding.
         /// </returns>
         IReactiveBinding<TView, TViewModel, (object? view, bool isViewModel)>? Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(
-                TViewModel viewModel,
+                TViewModel? viewModel,
                 TView view,
                 Expression<Func<TViewModel, TVMProp>> vmProperty,
                 Expression<Func<TView, TVProp>> viewProperty,
@@ -172,7 +172,7 @@ namespace ReactiveUI
         /// There is no registered converter from <typeparamref name="TVMProp"/> to <typeparamref name="TVProp"/>.
         /// </exception>
         IReactiveBinding<TView, TViewModel, TVProp>? OneWayBind<TViewModel, TView, TVMProp, TVProp>(
-                TViewModel viewModel,
+                TViewModel? viewModel,
                 TView view,
                 Expression<Func<TViewModel, TVMProp>> vmProperty,
                 Expression<Func<TView, TVProp>> viewProperty,
@@ -213,7 +213,7 @@ namespace ReactiveUI
         /// disconnects the binding.
         /// </returns>
         IReactiveBinding<TView, TViewModel, TOut>? OneWayBind<TViewModel, TView, TProp, TOut>(
-            TViewModel viewModel,
+            TViewModel? viewModel,
             TView view,
             Expression<Func<TViewModel, TProp>> vmProperty,
             Expression<Func<TView, TOut>> viewProperty,

--- a/src/ReactiveUI/Bindings/Property/PropertyBinderImplementation.cs
+++ b/src/ReactiveUI/Bindings/Property/PropertyBinderImplementation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
@@ -157,11 +157,6 @@ namespace ReactiveUI
                 throw new ArgumentNullException(nameof(viewProperty));
             }
 
-            if (viewModel == null)
-            {
-                throw new ArgumentNullException(nameof(viewModel));
-            }
-
             var vmExpression = Reflection.Rewrite(vmProperty.Body);
             var viewExpression = Reflection.Rewrite(viewProperty.Body);
             var viewType = viewExpression.Type;
@@ -212,11 +207,6 @@ namespace ReactiveUI
             if (viewProperty == null)
             {
                 throw new ArgumentNullException(nameof(viewProperty));
-            }
-
-            if (viewModel == null)
-            {
-                throw new ArgumentNullException(nameof(viewModel));
             }
 
             var vmExpression = Reflection.Rewrite(vmProperty.Body);
@@ -363,7 +353,7 @@ namespace ReactiveUI
             return (setObservable.Subscribe(_ => { }, ex => this.Log().Error(ex, $"{viewExpression} Binding received an Exception!")), setObservable);
         }
 
-        private bool EvalBindingHooks<TViewModel, TView>(TViewModel viewModel, TView view, Expression vmExpression, Expression viewExpression, BindingDirection direction)
+        private bool EvalBindingHooks<TViewModel, TView>(TViewModel? viewModel, TView view, Expression vmExpression, Expression viewExpression, BindingDirection direction)
             where TViewModel : class
         {
             var hooks = Locator.Current.GetServices<IPropertyBindingHook>();
@@ -428,11 +418,6 @@ namespace ReactiveUI
             if (viewProperty == null)
             {
                 throw new ArgumentNullException(nameof(viewProperty));
-            }
-
-            if (viewModel == null)
-            {
-                throw new ArgumentNullException(nameof(viewModel));
             }
 
             var signalInitialUpdate = new Subject<bool>();

--- a/src/ReactiveUI/Bindings/Property/PropertyBinderImplementation.cs
+++ b/src/ReactiveUI/Bindings/Property/PropertyBinderImplementation.cs
@@ -48,7 +48,7 @@ namespace ReactiveUI
 
         /// <inheritdoc />
         public IReactiveBinding<TView, TViewModel, (object? view, bool isViewModel)> Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(
-                TViewModel viewModel,
+                TViewModel? viewModel,
                 TView view,
                 Expression<Func<TViewModel, TVMProp>> vmProperty,
                 Expression<Func<TView, TVProp>> viewProperty,
@@ -91,7 +91,7 @@ namespace ReactiveUI
 
         /// <inheritdoc />
         public IReactiveBinding<TView, TViewModel, (object? view, bool isViewModel)>? Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(
-                TViewModel viewModel,
+                TViewModel? viewModel,
                 TView view,
                 Expression<Func<TViewModel, TVMProp>> vmProperty,
                 Expression<Func<TView, TVProp>> viewProperty,
@@ -138,7 +138,7 @@ namespace ReactiveUI
 
         /// <inheritdoc />
         public IReactiveBinding<TView, TViewModel, TVProp>? OneWayBind<TViewModel, TView, TVMProp, TVProp>(
-                TViewModel viewModel,
+                TViewModel? viewModel,
                 TView view,
                 Expression<Func<TViewModel, TVMProp>> vmProperty,
                 Expression<Func<TView, TVProp>> viewProperty,
@@ -155,6 +155,11 @@ namespace ReactiveUI
             if (viewProperty == null)
             {
                 throw new ArgumentNullException(nameof(viewProperty));
+            }
+
+            if (viewModel == null)
+            {
+                throw new ArgumentNullException(nameof(viewModel));
             }
 
             var vmExpression = Reflection.Rewrite(vmProperty.Body);
@@ -191,7 +196,7 @@ namespace ReactiveUI
 
         /// <inheritdoc />
         public IReactiveBinding<TView, TViewModel, TOut>? OneWayBind<TViewModel, TView, TProp, TOut>(
-            TViewModel viewModel,
+            TViewModel? viewModel,
             TView view,
             Expression<Func<TViewModel, TProp>> vmProperty,
             Expression<Func<TView, TOut>> viewProperty,
@@ -207,6 +212,11 @@ namespace ReactiveUI
             if (viewProperty == null)
             {
                 throw new ArgumentNullException(nameof(viewProperty));
+            }
+
+            if (viewModel == null)
+            {
+                throw new ArgumentNullException(nameof(viewModel));
             }
 
             var vmExpression = Reflection.Rewrite(vmProperty.Body);
@@ -353,7 +363,7 @@ namespace ReactiveUI
             return (setObservable.Subscribe(_ => { }, ex => this.Log().Error(ex, $"{viewExpression} Binding received an Exception!")), setObservable);
         }
 
-        private bool EvalBindingHooks<TViewModel, TView>(TViewModel viewModel, TView view, Expression vmExpression, Expression viewExpression, BindingDirection direction)
+        private bool EvalBindingHooks<TViewModel, TView>(TViewModel? viewModel, TView view, Expression vmExpression, Expression viewExpression, BindingDirection direction)
             where TViewModel : class
         {
             var hooks = Locator.Current.GetServices<IPropertyBindingHook>();
@@ -376,7 +386,7 @@ namespace ReactiveUI
             {
                 vmFetcher = () => new IObservedChange<object, object?>[]
                 {
-                    new ObservedChange<object, object>(null!, null!, viewModel)
+                    new ObservedChange<object, object?>(null!, null!, viewModel)
                 };
             }
 
@@ -387,7 +397,7 @@ namespace ReactiveUI
             });
 
             var shouldBind = hooks.Aggregate(true, (acc, x) =>
-                acc && x.ExecuteHook(viewModel, view, vmFetcher!, vFetcher!, direction));
+                acc && x.ExecuteHook(view, vmFetcher!, vFetcher!, direction));
 
             if (!shouldBind)
             {
@@ -400,7 +410,7 @@ namespace ReactiveUI
         }
 
         private IReactiveBinding<TView, TViewModel, (object? view, bool isViewModel)> BindImpl<TViewModel, TView, TVMProp, TVProp, TDontCare>(
-            TViewModel viewModel,
+            TViewModel? viewModel,
             TView view,
             Expression<Func<TViewModel, TVMProp>> vmProperty,
             Expression<Func<TView, TVProp>> viewProperty,
@@ -418,6 +428,11 @@ namespace ReactiveUI
             if (viewProperty == null)
             {
                 throw new ArgumentNullException(nameof(viewProperty));
+            }
+
+            if (viewModel == null)
+            {
+                throw new ArgumentNullException(nameof(viewModel));
             }
 
             var signalInitialUpdate = new Subject<bool>();

--- a/src/ReactiveUI/Bindings/Property/PropertyBinderImplementation.cs
+++ b/src/ReactiveUI/Bindings/Property/PropertyBinderImplementation.cs
@@ -363,7 +363,7 @@ namespace ReactiveUI
             return (setObservable.Subscribe(_ => { }, ex => this.Log().Error(ex, $"{viewExpression} Binding received an Exception!")), setObservable);
         }
 
-        private bool EvalBindingHooks<TViewModel, TView>(TViewModel? viewModel, TView view, Expression vmExpression, Expression viewExpression, BindingDirection direction)
+        private bool EvalBindingHooks<TViewModel, TView>(TViewModel viewModel, TView view, Expression vmExpression, Expression viewExpression, BindingDirection direction)
             where TViewModel : class
         {
             var hooks = Locator.Current.GetServices<IPropertyBindingHook>();
@@ -397,7 +397,7 @@ namespace ReactiveUI
             });
 
             var shouldBind = hooks.Aggregate(true, (acc, x) =>
-                acc && x.ExecuteHook(view, vmFetcher!, vFetcher!, direction));
+                acc && x.ExecuteHook(viewModel, view, vmFetcher!, vFetcher!, direction));
 
             if (!shouldBind)
             {

--- a/src/ReactiveUI/Bindings/Property/PropertyBindingMixins.cs
+++ b/src/ReactiveUI/Bindings/Property/PropertyBindingMixins.cs
@@ -59,7 +59,7 @@ namespace ReactiveUI
         /// </returns>
         public static IReactiveBinding<TView, TViewModel, (object? view, bool isViewModel)>? Bind<TViewModel, TView, TVMProp, TVProp>(
                 this TView view,
-                TViewModel viewModel,
+                TViewModel? viewModel,
                 Expression<Func<TViewModel, TVMProp>> vmProperty,
                 Expression<Func<TView, TVProp>> viewProperty,
                 object? conversionHint = null,
@@ -126,7 +126,7 @@ namespace ReactiveUI
         /// </returns>
         public static IReactiveBinding<TView, TViewModel, (object? view, bool isViewModel)>? Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(
                 this TView view,
-                TViewModel viewModel,
+                TViewModel? viewModel,
                 Expression<Func<TViewModel, TVMProp>> vmProperty,
                 Expression<Func<TView, TVProp>> viewProperty,
                 IObservable<TDontCare>? signalViewUpdate,
@@ -170,7 +170,7 @@ namespace ReactiveUI
         /// </returns>
         public static IReactiveBinding<TView, TViewModel, (object? view, bool isViewModel)>? Bind<TViewModel, TView, TVMProp, TVProp>(
             this TView view,
-            TViewModel viewModel,
+            TViewModel? viewModel,
             Expression<Func<TViewModel, TVMProp>> vmProperty,
             Expression<Func<TView, TVProp>> viewProperty,
             Func<TVMProp, TVProp> vmToViewConverter,
@@ -220,7 +220,7 @@ namespace ReactiveUI
         /// </returns>
         public static IReactiveBinding<TView, TViewModel, (object? view, bool isViewModel)>? Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(
             this TView view,
-            TViewModel viewModel,
+            TViewModel? viewModel,
             Expression<Func<TViewModel, TVMProp>> vmProperty,
             Expression<Func<TView, TVProp>> viewProperty,
             IObservable<TDontCare>? signalViewUpdate,
@@ -270,7 +270,7 @@ namespace ReactiveUI
         /// </returns>
         public static IReactiveBinding<TView, TViewModel, TVProp>? OneWayBind<TViewModel, TView, TVMProp, TVProp>(
                 this TView view,
-                TViewModel viewModel,
+                TViewModel? viewModel,
                 Expression<Func<TViewModel, TVMProp>> vmProperty,
                 Expression<Func<TView, TVProp>> viewProperty,
                 object? conversionHint = null,
@@ -319,7 +319,7 @@ namespace ReactiveUI
         /// </returns>
         public static IReactiveBinding<TView, TViewModel, TOut>? OneWayBind<TViewModel, TView, TProp, TOut>(
                 this TView view,
-                TViewModel viewModel,
+                TViewModel? viewModel,
                 Expression<Func<TViewModel, TProp>> vmProperty,
                 Expression<Func<TView, TOut>> viewProperty,
                 Func<TProp, TOut> selector)

--- a/src/ReactiveUI/Bindings/Reactive/IReactiveBinding.cs
+++ b/src/ReactiveUI/Bindings/Reactive/IReactiveBinding.cs
@@ -24,7 +24,7 @@ namespace ReactiveUI
         /// <summary>
         /// Gets the instance of the view model this binding is applied to.
         /// </summary>
-        TViewModel ViewModel { get; }
+        TViewModel? ViewModel { get; }
 
         /// <summary>
         /// Gets an expression representing the propertyon the viewmodel bound to the view.

--- a/src/ReactiveUI/Bindings/Reactive/ReactiveBinding.cs
+++ b/src/ReactiveUI/Bindings/Reactive/ReactiveBinding.cs
@@ -16,7 +16,7 @@ namespace ReactiveUI
 
         public ReactiveBinding(
             TView view,
-            TViewModel viewModel,
+            TViewModel? viewModel,
             Expression viewExpression,
             Expression viewModelExpression,
             IObservable<TValue> changed,
@@ -34,7 +34,7 @@ namespace ReactiveUI
         }
 
         /// <inheritdoc />
-        public TViewModel ViewModel { get; }
+        public TViewModel? ViewModel { get; }
 
         /// <inheritdoc />
         public Expression ViewModelExpression { get; }

--- a/src/ReactiveUI/Expression/Reflection.cs
+++ b/src/ReactiveUI/Expression/Reflection.cs
@@ -433,7 +433,7 @@ namespace ReactiveUI
         }
 
         [SuppressMessage("Microsoft.Performance", "CA1801", Justification = "TViewModel used to help generic calling.")]
-        internal static IObservable<object> ViewModelWhenAnyValue<TView, TViewModel>(TViewModel viewModel, TView view, Expression expression)
+        internal static IObservable<object> ViewModelWhenAnyValue<TView, TViewModel>(TViewModel? viewModel, TView view, Expression expression)
             where TView : class, IViewFor
             where TViewModel : class
         {

--- a/src/ReactiveUI/Interfaces/IPropertyBindingHook.cs
+++ b/src/ReactiveUI/Interfaces/IPropertyBindingHook.cs
@@ -23,7 +23,7 @@ namespace ReactiveUI
         /// <param name="getCurrentViewProperties">Get current view properties.</param>
         /// <param name="direction">The Binding direction.</param>
         bool ExecuteHook(
-            object source,
+            object? source,
             object target,
             Func<IObservedChange<object, object>[]> getCurrentViewModelProperties,
             Func<IObservedChange<object, object>[]> getCurrentViewProperties,

--- a/src/ReactiveUI/Interfaces/IPropertyBindingHook.cs
+++ b/src/ReactiveUI/Interfaces/IPropertyBindingHook.cs
@@ -17,13 +17,11 @@ namespace ReactiveUI
         /// Called when any binding is set up.
         /// </summary>
         /// <returns>If false, the binding is cancelled.</returns>
-        /// <param name="source">The source ViewModel.</param>
         /// <param name="target">The target View (not the actual control).</param>
         /// <param name="getCurrentViewModelProperties">Get current view model properties.</param>
         /// <param name="getCurrentViewProperties">Get current view properties.</param>
         /// <param name="direction">The Binding direction.</param>
         bool ExecuteHook(
-            object source,
             object target,
             Func<IObservedChange<object, object>[]> getCurrentViewModelProperties,
             Func<IObservedChange<object, object>[]> getCurrentViewProperties,

--- a/src/ReactiveUI/Interfaces/IPropertyBindingHook.cs
+++ b/src/ReactiveUI/Interfaces/IPropertyBindingHook.cs
@@ -17,11 +17,13 @@ namespace ReactiveUI
         /// Called when any binding is set up.
         /// </summary>
         /// <returns>If false, the binding is cancelled.</returns>
+        /// <param name="source">The source ViewModel.</param>
         /// <param name="target">The target View (not the actual control).</param>
         /// <param name="getCurrentViewModelProperties">Get current view model properties.</param>
         /// <param name="getCurrentViewProperties">Get current view properties.</param>
         /// <param name="direction">The Binding direction.</param>
         bool ExecuteHook(
+            object source,
             object target,
             Func<IObservedChange<object, object>[]> getCurrentViewModelProperties,
             Func<IObservedChange<object, object>[]> getCurrentViewProperties,

--- a/src/ReactiveUI/Platforms/windows-common/AutoDataTemplateBindingHook.cs
+++ b/src/ReactiveUI/Platforms/windows-common/AutoDataTemplateBindingHook.cs
@@ -56,7 +56,7 @@ namespace ReactiveUI
         });
 
         /// <inheritdoc/>
-        public bool ExecuteHook(object source, object target, Func<IObservedChange<object, object>[]> getCurrentViewModelProperties, Func<IObservedChange<object, object>[]> getCurrentViewProperties, BindingDirection direction)
+        public bool ExecuteHook(object? source, object target, Func<IObservedChange<object, object>[]> getCurrentViewModelProperties, Func<IObservedChange<object, object>[]> getCurrentViewProperties, BindingDirection direction)
         {
             if (getCurrentViewProperties == null)
             {

--- a/src/ReactiveUI/Platforms/windows-common/AutoDataTemplateBindingHook.cs
+++ b/src/ReactiveUI/Platforms/windows-common/AutoDataTemplateBindingHook.cs
@@ -56,7 +56,7 @@ namespace ReactiveUI
         });
 
         /// <inheritdoc/>
-        public bool ExecuteHook(object target, Func<IObservedChange<object, object>[]> getCurrentViewModelProperties, Func<IObservedChange<object, object>[]> getCurrentViewProperties, BindingDirection direction)
+        public bool ExecuteHook(object source, object target, Func<IObservedChange<object, object>[]> getCurrentViewModelProperties, Func<IObservedChange<object, object>[]> getCurrentViewProperties, BindingDirection direction)
         {
             if (getCurrentViewProperties == null)
             {

--- a/src/ReactiveUI/Platforms/windows-common/AutoDataTemplateBindingHook.cs
+++ b/src/ReactiveUI/Platforms/windows-common/AutoDataTemplateBindingHook.cs
@@ -56,7 +56,7 @@ namespace ReactiveUI
         });
 
         /// <inheritdoc/>
-        public bool ExecuteHook(object source, object target, Func<IObservedChange<object, object>[]> getCurrentViewModelProperties, Func<IObservedChange<object, object>[]> getCurrentViewProperties, BindingDirection direction)
+        public bool ExecuteHook(object target, Func<IObservedChange<object, object>[]> getCurrentViewModelProperties, Func<IObservedChange<object, object>[]> getCurrentViewProperties, BindingDirection direction)
         {
             if (getCurrentViewProperties == null)
             {


### PR DESCRIPTION
## What kind of change does this PR introduce?
This PR modifies the `PropertyBindingMixins` used mainly within `ReactiveUserControl` codebehind `WhenActivated` blocks.
It changes the `viewModel` members to be nullable.


**What is the current behavior?**
Bit of contextual overview:
The ViewModel parameter in `Bind` is mostly unused.  The reason it exists is to simplify generic specification of the call.  By passing the ViewModel in, the generics can be implied, whereas if the parameter was omitted, the user would have to type out the verbose generic args themselves for every call.  Otherwise, the parameter is mostly unneeded, and theoretically could be removed.

99% of the time `Bind` is used, `ReactiveUserControl.ViewModel` member is what is passed in.  The current misalignment in nullability, though, means the user has to pass in the ViewModel with the override operator:

`this.Bind(this.ViewModel!, ...`



## What is the new behavior?
Since the ViewModel is unused, and just there for typing, it doesn't actually matter if the parameter nullable or not.  

**So why make it nullable?**  
By shifting the parameter to be nullable, it aligns with the `ReactiveUserControl.ViewModel` member, meaning the call is cleaner for the end user:

`this.Bind(this.ViewModel, ...`

This is much cleaner for the user, and is less confusing, as requiring a `!` operator makes the user question if they're doing something wrong, and/or tempts them to need to check that `ViewModel` is not null first.. which we know is an unnecessary step.

This API shift takes the burden/questions off the user on if they're doing something wrong, and lets them use `Bind` more as they would expect.



## What might this PR break?
I added ArgumentNullExceptions to check that the viewmodel is not null.   We know in typical usage it will not be null, as WhenActivated will never be called with null ViewModels, which is where Bind is being invoked from.   Still, it is good to check that it is not null internally anyway, as it definitely means something is in an error state, as this should never happen.

One reason to do so, is that the ViewModel parameter IS used in one spot:  It's given to the ReactiveBinding class that is returned, which has a ViewModel member, which is not nullable.  It is good to check that the VM is not null, just as it's an error state if that was to ever happen, and it means we safely fill this member with a viewmodel object that is not null, as it expects.

One note is that the current methodology of passing in `this.ViewModel!` is no safer, we're still potentially "lying" and setting a null view model object to ReactiveBinding's non-null member.  The ArgumentNullException is actually a bit safer on that front, nipping an odd situation in the bud early.


## Summary
I think this change gives the user an experience they're expecting, while retaining the safety of the system overall.

I had some remaining errors related to some missing SDKs for some of the more obscure platform targets.  I think everything is okay.  We'll let the build system double check, though.