### PR TITLE
Fix: BindTo and OneWayBind not working for null values

### DIFF
--- a/src/ReactiveUI.Tests/Platforms/windows-xaml/PropertyBindingTest.cs
+++ b/src/ReactiveUI.Tests/Platforms/windows-xaml/PropertyBindingTest.cs
@@ -235,7 +235,7 @@ namespace ReactiveUI.Tests.Xaml
         }
 
         [Fact]
-        public void BindToShouldntInitiallySetToNull()
+        public void OneWayBindShouldntInitiallySetToNull()
         {
             var vm = new PropertyBindViewModel();
             var view = new PropertyBindView { ViewModel = null };
@@ -352,6 +352,64 @@ namespace ReactiveUI.Tests.Xaml
             var fixture = new PropertyBinderImplementation();
             fixture.OneWayBind(vm, view, x => x.JustABoolean, x => x.SomeTextBox.IsEnabled, s => s);
             Assert.False(view.SomeTextBox.IsEnabled);
+        }
+
+        [Fact]
+        public void OneWayBindWithNullStartingValueToNonNullValue()
+        {
+            var vm = new PropertyBindViewModel();
+            var view = new PropertyBindView { ViewModel = vm };
+
+            view.OneWayBind(vm, x => x.Property1, x => x.SomeTextBox.Text);
+
+            vm.Property1 = "Baz";
+
+            Assert.Equal("Baz", view.SomeTextBox.Text);
+        }
+
+        [Fact]
+        public void OneWayBindWithNonNullStartingValueToNullValue()
+        {
+            var vm = new PropertyBindViewModel();
+            var view = new PropertyBindView { ViewModel = vm };
+
+            vm.Property1 = "Baz";
+
+            view.OneWayBind(vm, x => x.Property1, x => x.SomeTextBox.Text);
+
+            vm.Property1 = null;
+
+            Assert.True(string.IsNullOrEmpty(view.SomeTextBox.Text));
+        }
+
+        [Fact]
+        public void BindToWithNullStartingValueToNonNullValue()
+        {
+            var vm = new PropertyBindViewModel();
+            var view = new PropertyBindView { ViewModel = vm };
+
+            view.WhenAnyValue(x => x.ViewModel!.Property1)
+                .BindTo(view, x => x.SomeTextBox.Text);
+
+            vm.Property1 = "Baz";
+
+            Assert.Equal("Baz", view.SomeTextBox.Text);
+        }
+
+        [Fact]
+        public void BindToWithNonNullStartingValueToNullValue()
+        {
+            var vm = new PropertyBindViewModel();
+            var view = new PropertyBindView { ViewModel = vm };
+
+            vm.Property1 = "Baz";
+
+            view.WhenAnyValue(x => x.ViewModel!.Property1)
+                .BindTo(view, x => x.SomeTextBox.Text);
+
+            vm.Property1 = null;
+
+            Assert.True(string.IsNullOrEmpty(view.SomeTextBox.Text));
         }
 
         [Fact]

--- a/src/ReactiveUI.Tests/Platforms/windows-xaml/PropertyBindingTest.cs
+++ b/src/ReactiveUI.Tests/Platforms/windows-xaml/PropertyBindingTest.cs
@@ -383,6 +383,19 @@ namespace ReactiveUI.Tests.Xaml
         }
 
         [Fact]
+        public void OneWayBindWithSelectorAndNonNullStartingValueToNullValue()
+        {
+            var vm = new PropertyBindViewModel();
+            var view = new PropertyBindView { ViewModel = vm };
+
+            view.OneWayBind(vm, x => x.Model, x => x.SomeTextBox.Text, x => x?.AnotherThing);
+
+            vm.Model = null;
+
+            Assert.True(string.IsNullOrEmpty(view.SomeTextBox.Text));
+        }
+
+        [Fact]
         public void BindToWithNullStartingValueToNonNullValue()
         {
             var vm = new PropertyBindViewModel();

--- a/src/ReactiveUI/Bindings/Property/PropertyBinderImplementation.cs
+++ b/src/ReactiveUI/Bindings/Property/PropertyBinderImplementation.cs
@@ -319,7 +319,7 @@ namespace ReactiveUI
 
                 if (converter == null)
                 {
-                    defaultSetter?.Invoke(paramTarget, paramValue ?? throw new ArgumentNullException(nameof(paramValue)), paramParams);
+                    defaultSetter?.Invoke(paramTarget, paramValue, paramParams);
                     return defaultGetter(paramTarget, paramParams);
                 }
 


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Fixes #2474, Fixes #2476 


**What is the current behavior?**
<!-- You can also link to an open issue here. -->
BindTo and OneWayBind silently (but logged) stop working when attempting to assign null.


**What is the new behavior?**
<!-- If this is a feature change -->
Restores previous behavior, before regression: allows null to be assigned.


**What might this PR break?**
Nothing.


**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

