### PR TITLE
Fix misleading interface documentation

### DIFF
--- a/src/ReactiveUI/Interfaces/IViewLocator.cs
+++ b/src/ReactiveUI/Interfaces/IViewLocator.cs
@@ -17,10 +17,9 @@ namespace ReactiveUI
         /// Determines the view for an associated ViewModel.
         /// </summary>
         /// <typeparam name="T">The view model type.</typeparam>
-        /// <returns>The view, with the ViewModel property assigned to
-        /// viewModel.</returns>
         /// <param name="viewModel">View model.</param>
         /// <param name="contract">Contract.</param>
+        /// <returns>The view associated with the given view model.</returns>
         IViewFor? ResolveView<T>(T viewModel, string? contract = null);
     }
 }


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Docs


**What is the current behavior?**
<!-- You can also link to an open issue here. -->
Resolves #2451


**What is the new behavior?**
<!-- If this is a feature change -->
Doesn't claim to assign the `ViewModel` property of `IViewFor`


**What might this PR break?**
Nothing


**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
Whether or not we want to change the default view locator implementation to populate the `ViewModel` property can be discussed and implemented in a separate PR.
