### PR TITLE
Fix: ReactiveUI.Fody "long" property breaks build

### DIFF
--- a/src/ReactiveUI.Fody.Tests/Issues/Issue47Tests.cs
+++ b/src/ReactiveUI.Fody.Tests/Issues/Issue47Tests.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+using ReactiveUI.Fody.Helpers;
+
+namespace ReactiveUI.Fody.Tests.Issues
+{
+    public static class Issue47Tests
+    {
+        /// <summary>
+        /// The "test" here is simply for these to compile
+        /// Tests ObservableAsPropertyWeaver.EmitDefaultValue.
+        /// </summary>
+        [SuppressMessage("Microsoft.Performance", "CA1812: Avoid uninstantiated internal classes", Justification = "Purpose is just to be compiled.")]
+        private class TestModel : ReactiveObject
+        {
+            [ObservableAsProperty]
+            public int IntProperty { get; }
+
+            [ObservableAsProperty]
+            public double DoubleProperty { get; }
+
+            [ObservableAsProperty]
+            public float FloatProperty { get; }
+
+            [ObservableAsProperty]
+            public long LongProperty { get; }
+        }
+    }
+}

--- a/src/ReactiveUI.Fody/ObservableAsPropertyWeaver.cs
+++ b/src/ReactiveUI.Fody/ObservableAsPropertyWeaver.cs
@@ -155,7 +155,7 @@ namespace ReactiveUI.Fody
                 }
                 else if (type.CompareTo(ModuleDefinition.TypeSystem.Int64))
                 {
-                    il.Emit(OpCodes.Ldc_I8);
+                    il.Emit(OpCodes.Ldc_I8, 0L);
                 }
                 else if (type.CompareTo(ModuleDefinition.TypeSystem.Double))
                 {


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix: resolves #2243 


**What is the current behavior?**
<!-- You can also link to an open issue here. -->
Breaks project if using a long property with the `ObservableAsProperty` attribute


**What is the new behavior?**
<!-- If this is a feature change -->
Doesn't break.


**What might this PR break?**
Nothing


**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
Fix was just migrated from the old repo, as referenced in the comments in the linked issue.
