### PR TITLE
Fix: RxApp scheduler logic makes unit tests unpredictable

### DIFF
--- a/src/ReactiveUI.Tests/Platforms/winforms/CommandBindingTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/CommandBindingTests.cs
@@ -14,7 +14,7 @@ namespace ReactiveUI.Tests.Winforms
 {
     public class CommandBindingTests
     {
-        [Fact(Skip = "https://github.com/reactiveui/ReactiveUI/issues/2279")]
+        [Fact]
         public void CommandBinderBindsToButton()
         {
             var fixture = new CreatesWinformsCommandBinding();
@@ -40,7 +40,7 @@ namespace ReactiveUI.Tests.Winforms
             }
         }
 
-        [Fact(Skip = "https://github.com/reactiveui/ReactiveUI/issues/2279")]
+        [Fact]
         public void CommandBinderBindsToCustomControl()
         {
             var fixture = new CreatesWinformsCommandBinding();
@@ -66,7 +66,7 @@ namespace ReactiveUI.Tests.Winforms
             }
         }
 
-        [Fact(Skip = "https://github.com/reactiveui/ReactiveUI/issues/2279")]
+        [Fact]
         public void CommandBinderBindsToCustomComponent()
         {
             var fixture = new CreatesWinformsCommandBinding();
@@ -92,7 +92,7 @@ namespace ReactiveUI.Tests.Winforms
             }
         }
 
-        [Fact(Skip = "https://github.com/reactiveui/ReactiveUI/issues/2279")]
+        [Fact]
         public void CommandBinderAffectsEnabledState()
         {
             var fixture = new CreatesWinformsCommandBinding();
@@ -112,7 +112,7 @@ namespace ReactiveUI.Tests.Winforms
             }
         }
 
-        [Fact(Skip = "https://github.com/reactiveui/ReactiveUI/issues/2279")]
+        [Fact]
         public void CommandBinderAffectsEnabledStateForComponents()
         {
             var fixture = new CreatesWinformsCommandBinding();

--- a/src/ReactiveUI.Tests/Platforms/winforms/DefaultPropertyBindingTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/DefaultPropertyBindingTests.cs
@@ -18,7 +18,7 @@ namespace ReactiveUI.Tests.Winforms
 {
     public class DefaultPropertyBindingTests
     {
-        [Fact(Skip = "https://github.com/reactiveui/ReactiveUI/issues/2279")]
+        [Fact]
         public void WinformsCreatesObservableForPropertyWorksForTextboxes()
         {
             var input = new TextBox();
@@ -42,7 +42,7 @@ namespace ReactiveUI.Tests.Winforms
             Assert.Equal(1, output.Count);
         }
 
-        [Fact(Skip = "https://github.com/reactiveui/ReactiveUI/issues/2279")]
+        [Fact]
         public void WinformsCreatesObservableForPropertyWorksForComponents()
         {
             var input = new ToolStripButton(); // ToolStripButton is a Component, not a Control
@@ -67,7 +67,7 @@ namespace ReactiveUI.Tests.Winforms
             Assert.Equal(1, output.Count);
         }
 
-        [Fact(Skip = "https://github.com/reactiveui/ReactiveUI/issues/2279")]
+        [Fact]
         public void WinformsCreatesObservableForPropertyWorksForThirdPartyControls()
         {
             var input = new AThirdPartyNamespace.ThirdPartyControl();
@@ -91,7 +91,7 @@ namespace ReactiveUI.Tests.Winforms
             Assert.Equal(1, output.Count);
         }
 
-        [Fact(Skip = "https://github.com/reactiveui/ReactiveUI/issues/2279")]
+        [Fact]
         public void CanBindViewModelToWinformControls()
         {
             var vm = new FakeWinformViewModel();
@@ -113,7 +113,7 @@ namespace ReactiveUI.Tests.Winforms
             Assert.Equal(vm.SomeDouble.ToString(), view.Property3.Text);
         }
 
-        [Fact(Skip = "https://github.com/reactiveui/ReactiveUI/issues/2279")]
+        [Fact]
         public void SmokeTestWinformControls()
         {
             var vm = new FakeWinformViewModel();

--- a/src/ReactiveUI.Tests/RxAppTest.cs
+++ b/src/ReactiveUI.Tests/RxAppTest.cs
@@ -13,7 +13,7 @@ namespace ReactiveUI.Tests
 {
     public class RxAppTest
     {
-        [Fact(Skip = "Requires initialize to run on seperate thread")]
+        [Fact]
         public void SchedulerShouldBeCurrentThreadInTestRunner()
         {
             Debug.WriteLine(RxApp.MainThreadScheduler.GetType().FullName);

--- a/src/ReactiveUI.Wpf/Registrations.cs
+++ b/src/ReactiveUI.Wpf/Registrations.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.Reactive.Concurrency;
-using ReactiveUI;
 using Splat;
 
 namespace ReactiveUI.Wpf
@@ -31,12 +30,11 @@ namespace ReactiveUI.Wpf
             registerFunction(() => new AutoDataTemplateBindingHook(), typeof(IPropertyBindingHook));
             registerFunction(() => new ComponentModelTypeConverter(), typeof(IBindingTypeConverter));
 
-            RxApp.TaskpoolScheduler = TaskPoolScheduler.Default;
-
             if (!ModeDetector.InUnitTestRunner())
             {
                 // NB: On .NET Core, trying to touch DispatcherScheduler blows up :cry:
                 RxApp.MainThreadScheduler = new WaitForDispatcherScheduler(() => DispatcherScheduler.Current);
+                RxApp.TaskpoolScheduler = TaskPoolScheduler.Default;
             }
 
             RxApp.SuppressViewCommandBindingMessage = true;

--- a/src/ReactiveUI/Bindings/Property/PropertyBinderImplementation.cs
+++ b/src/ReactiveUI/Bindings/Property/PropertyBinderImplementation.cs
@@ -44,6 +44,11 @@ namespace ReactiveUI
                     }).currentBinding;
             }, RxApp.SmallCacheLimit);
 
+        static PropertyBinderImplementation()
+        {
+            RxApp.EnsureInitialized();
+        }
+
         private delegate bool OutFunc<in T1, T2>(T1 t1, out T2 t2);
 
         /// <inheritdoc />

--- a/src/ReactiveUI/Platforms/android/PlatformRegistrations.cs
+++ b/src/ReactiveUI/Platforms/android/PlatformRegistrations.cs
@@ -27,8 +27,13 @@ namespace ReactiveUI
             registerFunction(() => new ComponentModelTypeConverter(), typeof(IBindingTypeConverter));
             registerFunction(() => new AndroidObservableForWidgets(), typeof(ICreatesObservableForProperty));
             registerFunction(() => new AndroidCommandBinders(), typeof(ICreatesCommandBinding));
-            RxApp.TaskpoolScheduler = TaskPoolScheduler.Default;
-            RxApp.MainThreadScheduler = HandlerScheduler.MainThreadScheduler;
+
+            if (!ModeDetector.InUnitTestRunner())
+            {
+                RxApp.TaskpoolScheduler = TaskPoolScheduler.Default;
+                RxApp.MainThreadScheduler = HandlerScheduler.MainThreadScheduler;
+            }
+
             registerFunction(() => new BundleSuspensionDriver(), typeof(ISuspensionDriver));
         }
     }

--- a/src/ReactiveUI/Platforms/mac/PlatformRegistrations.cs
+++ b/src/ReactiveUI/Platforms/mac/PlatformRegistrations.cs
@@ -29,8 +29,13 @@ namespace ReactiveUI
             registerFunction(() => new TargetActionCommandBinder(), typeof(ICreatesCommandBinding));
             registerFunction(() => new DateTimeNSDateConverter(), typeof(IBindingTypeConverter));
             registerFunction(() => new KVOObservableForProperty(), typeof(ICreatesObservableForProperty));
-            RxApp.TaskpoolScheduler = TaskPoolScheduler.Default;
-            RxApp.MainThreadScheduler = new WaitForDispatcherScheduler(() => new NSRunloopScheduler());
+
+            if (!ModeDetector.InUnitTestRunner())
+            {
+                RxApp.TaskpoolScheduler = TaskPoolScheduler.Default;
+                RxApp.MainThreadScheduler = new WaitForDispatcherScheduler(() => new NSRunloopScheduler());
+            }
+
             registerFunction(() => new AppSupportJsonSuspensionDriver(), typeof(ISuspensionDriver));
        }
     }

--- a/src/ReactiveUI/Platforms/net4/PlatformRegistrations.cs
+++ b/src/ReactiveUI/Platforms/net4/PlatformRegistrations.cs
@@ -24,8 +24,12 @@ namespace ReactiveUI
             }
 
             registerFunction(() => new ComponentModelTypeConverter(), typeof(IBindingTypeConverter));
-            RxApp.TaskpoolScheduler = TaskPoolScheduler.Default;
-            RxApp.MainThreadScheduler = DefaultScheduler.Instance;
+
+            if (!ModeDetector.InUnitTestRunner())
+            {
+                RxApp.TaskpoolScheduler = TaskPoolScheduler.Default;
+                RxApp.MainThreadScheduler = DefaultScheduler.Instance;
+            }
         }
     }
 }

--- a/src/ReactiveUI/Platforms/netcoreapp2/PlatformRegistrations.cs
+++ b/src/ReactiveUI/Platforms/netcoreapp2/PlatformRegistrations.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Reactive.Concurrency;
+using Splat;
 
 namespace ReactiveUI
 {
@@ -16,8 +17,11 @@ namespace ReactiveUI
         /// <inheritdoc/>
         public void Register(Action<Func<object>, Type> registerFunction)
         {
-            RxApp.TaskpoolScheduler = TaskPoolScheduler.Default;
-            RxApp.MainThreadScheduler = DefaultScheduler.Instance;
+            if (!ModeDetector.InUnitTestRunner())
+            {
+                RxApp.TaskpoolScheduler = TaskPoolScheduler.Default;
+                RxApp.MainThreadScheduler = DefaultScheduler.Instance;
+            }
         }
     }
 }

--- a/src/ReactiveUI/Platforms/netcoreapp3/PlatformRegistrations.cs
+++ b/src/ReactiveUI/Platforms/netcoreapp3/PlatformRegistrations.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Reactive.Concurrency;
+using Splat;
 
 namespace ReactiveUI
 {
@@ -22,8 +23,12 @@ namespace ReactiveUI
             }
 
             registerFunction(() => new ComponentModelTypeConverter(), typeof(IBindingTypeConverter));
-            RxApp.TaskpoolScheduler = TaskPoolScheduler.Default;
-            RxApp.MainThreadScheduler = DefaultScheduler.Instance;
+
+            if (!ModeDetector.InUnitTestRunner())
+            {
+                RxApp.TaskpoolScheduler = TaskPoolScheduler.Default;
+                RxApp.MainThreadScheduler = DefaultScheduler.Instance;
+            }
         }
     }
 }

--- a/src/ReactiveUI/Platforms/netstandard2.0/PlatformRegistrations.cs
+++ b/src/ReactiveUI/Platforms/netstandard2.0/PlatformRegistrations.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Reactive.Concurrency;
+using Splat;
 
 namespace ReactiveUI
 {
@@ -22,8 +23,11 @@ namespace ReactiveUI
                 throw new ArgumentNullException(nameof(registerFunction));
             }
 
-            RxApp.TaskpoolScheduler = TaskPoolScheduler.Default;
-            RxApp.MainThreadScheduler = DefaultScheduler.Instance;
+            if (!ModeDetector.InUnitTestRunner())
+            {
+                RxApp.TaskpoolScheduler = TaskPoolScheduler.Default;
+                RxApp.MainThreadScheduler = DefaultScheduler.Instance;
+            }
         }
     }
 }

--- a/src/ReactiveUI/Platforms/tizen/PlatformRegistrations.cs
+++ b/src/ReactiveUI/Platforms/tizen/PlatformRegistrations.cs
@@ -25,8 +25,12 @@ namespace ReactiveUI
 
             registerFunction(() => new PlatformOperations(), typeof(IPlatformOperations));
             registerFunction(() => new ComponentModelTypeConverter(), typeof(IBindingTypeConverter));
-            RxApp.TaskpoolScheduler = TaskPoolScheduler.Default;
-            RxApp.MainThreadScheduler = EcoreMainloopScheduler.MainThreadScheduler;
+
+            if (!ModeDetector.InUnitTestRunner())
+            {
+                RxApp.TaskpoolScheduler = TaskPoolScheduler.Default;
+                RxApp.MainThreadScheduler = EcoreMainloopScheduler.MainThreadScheduler;
+            }
         }
     }
 }

--- a/src/ReactiveUI/Platforms/uap/PlatformRegistrations.cs
+++ b/src/ReactiveUI/Platforms/uap/PlatformRegistrations.cs
@@ -28,8 +28,13 @@ namespace ReactiveUI
             registerFunction(() => new DependencyObjectObservableForProperty(), typeof(ICreatesObservableForProperty));
             registerFunction(() => new BooleanToVisibilityTypeConverter(), typeof(IBindingTypeConverter));
             registerFunction(() => new AutoDataTemplateBindingHook(), typeof(IPropertyBindingHook));
-            RxApp.TaskpoolScheduler = TaskPoolScheduler.Default;
-            RxApp.MainThreadScheduler = new SingleWindowDispatcherScheduler();
+
+            if (!ModeDetector.InUnitTestRunner())
+            {
+                RxApp.TaskpoolScheduler = TaskPoolScheduler.Default;
+                RxApp.MainThreadScheduler = new SingleWindowDispatcherScheduler();
+            }
+
             registerFunction(() => new WinRTAppDataDriver(), typeof(ISuspensionDriver));
         }
     }

--- a/src/ReactiveUI/Platforms/uikit-common/PlatformRegistrations.cs
+++ b/src/ReactiveUI/Platforms/uikit-common/PlatformRegistrations.cs
@@ -29,8 +29,13 @@ namespace ReactiveUI
             registerFunction(() => new UIKitCommandBinders(), typeof(ICreatesCommandBinding));
             registerFunction(() => new DateTimeNSDateConverter(), typeof(IBindingTypeConverter));
             registerFunction(() => new KVOObservableForProperty(), typeof(ICreatesObservableForProperty));
-            RxApp.TaskpoolScheduler = TaskPoolScheduler.Default;
-            RxApp.MainThreadScheduler = new WaitForDispatcherScheduler(() => new NSRunloopScheduler());
+
+            if (!ModeDetector.InUnitTestRunner())
+            {
+                RxApp.TaskpoolScheduler = TaskPoolScheduler.Default;
+                RxApp.MainThreadScheduler = new WaitForDispatcherScheduler(() => new NSRunloopScheduler());
+            }
+
             registerFunction(() => new AppSupportJsonSuspensionDriver(), typeof(ISuspensionDriver));
         }
     }

--- a/src/ReactiveUI/RxApp.cs
+++ b/src/ReactiveUI/RxApp.cs
@@ -118,7 +118,7 @@ namespace ReactiveUI
                 LogHost.Default.Warn("ReactiveUI acts differently under a test runner, see the docs\n");
                 LogHost.Default.Warn("for more info about what to expect");
 
-                _mainThreadScheduler = CurrentThreadScheduler.Instance;
+                UnitTestMainThreadScheduler = CurrentThreadScheduler.Instance;
                 return;
             }
 
@@ -140,9 +140,9 @@ namespace ReactiveUI
         {
             get
             {
-                if (_unitTestMainThreadScheduler != null)
+                if (ModeDetector.InUnitTestRunner())
                 {
-                    return _unitTestMainThreadScheduler;
+                    return UnitTestMainThreadScheduler;
                 }
 
                 // If Scheduler is DefaultScheduler, user is likely using .NET Standard
@@ -166,7 +166,7 @@ namespace ReactiveUI
                 // then pass when you rerun them.
                 if (ModeDetector.InUnitTestRunner())
                 {
-                    _unitTestMainThreadScheduler = value;
+                    UnitTestMainThreadScheduler = value;
                     _mainThreadScheduler ??= value;
                 }
                 else
@@ -234,6 +234,24 @@ namespace ReactiveUI
                 {
                     _suspensionHost = value;
                 }
+            }
+        }
+
+        private static IScheduler UnitTestMainThreadScheduler
+        {
+            get
+            {
+                if (_unitTestMainThreadScheduler is null)
+                {
+                    _unitTestMainThreadScheduler = CurrentThreadScheduler.Instance;
+                }
+
+                return _unitTestMainThreadScheduler;
+            }
+
+            set
+            {
+                _unitTestMainThreadScheduler = value;
             }
         }
 


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Fix


**What is the current behavior?**
<!-- You can also link to an open issue here. -->
All the current (non-skipped) unit tests in the ReactiveUI solution pass when run together. However, some of them (particularly a handful of the xaml binding tests), fail when run in isolation or small groups. Which means some tests are dependent on others. An unfortunate consequence of having the RxApp ambient context, leaking state.

![rxui test failures](https://user-images.githubusercontent.com/6819362/90228166-b7c34880-de50-11ea-9847-eaba2b227bc5.png)

**The main issues I found:**

1) The current code [assigns `CurrentThreadScheduler.Instance` to `_mainThreadScheduler`](https://github.com/reactiveui/ReactiveUI/blob/68596de514622ecf5961c1587f47ad6d702da76e/src/ReactiveUI/RxApp.cs#L121) instead of `_unitTestMainThreadScheduler`, so `_unitTestMainThreadScheduler` is left with whatever the platform registration assigned. For netcore and net4x it's `DefaultScheduler.Instance` which schedules work on other threads (not good for "RxApp.MainThreadScheduler").
2) After addressing the point above, the next issue that came up was us not correctly handling the `ThreadStatic` field, `_unitTestMainThreadScheduler`. From [the documentation](https://docs.microsoft.com/en-us/dotnet/api/system.threadstaticattribute?view=netcore-3.1#remarks):

> Do not specify initial values for fields marked with ThreadStaticAttribute, because such initialization occurs only once, when the class constructor executes, and therefore affects only one thread. If you do not specify an initial value, you can rely on the field being initialized to its default value if it is a value type, or to null if it is a reference type.

We currently initialize `_unitTestMainThreadScheduler` in the RxApp static constructor. So the moment another thread takes over, it gets set back to null, and we have to depend on some outside source to set the `RxApp.MainThreadScheduler` property back to `CurrentThreadScheduler.Instance`. To address this issue I added a lazy property so it gets initialized correctly whenever it's null.

3) After that, I noticed whenever PlatformRegistrations executes more than once, it overwrites RxApp.MainThreadScheduler (CurrentThreadScheduler) with the DefaultScheduler, and we end up with the threading problem again. Depending on the call to `EnsureInitialized()` is ideal because it ensures PlatformRegistrations is only executed once. The problem arises when `InitializeReactiveUI` is called manually by a unit test (common in the ViewLocator tests). So to get around that, while still allowing the `IScheduler.With` extension to assign-and-restore the main thread scheduler, we now tell PlatformRegistrations to only assign the RxApp schedulers when `!ModeDetector.InUnitTestRunner()`.

I also re-enabled the WinForms tests that were skipped because of #2279. It's hard to _guarantee_ these are fixed, because of how intermittent they would fail, but I'm fairly confident these fixes do the trick because I haven't had a failure since the fix.

I also added a static constructor to PropertyBinderImplementation.cs that calls `RxApp.EnsureInitialized()` [just like PropertyBindingMixins has](https://github.com/reactiveui/ReactiveUI/blob/a6c5dcf4f0ce82a9c0c8b05d7c78f80cd57028d1/src/ReactiveUI/Bindings/Property/PropertyBindingMixins.cs#L19), because I noticed TwoWayBindSmokeTest and TypeConvertedTwoWayBindSmokeTest (visible in the screenshot above) were failing with [a type converter exception](https://github.com/reactiveui/ReactiveUI/blob/a6c5dcf4f0ce82a9c0c8b05d7c78f80cd57028d1/src/ReactiveUI/Bindings/Property/PropertyBinderImplementation.cs#L68). In other words it was dependent on other tests to call `RxApp.EnsureInitialized()`.


**What is the new behavior?**
<!-- If this is a feature change -->
Both ReactiveUI unit tests _and_ user unit tests will be more predictable and stable. 


**What might this PR break?**
Shouldn't break anything, unless someone has tests that were tightly coupled to the incorrect/inconsistent scheduler behavior.


**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
I was even able to unskip the `RxAppTest.SchedulerShouldBeCurrentThreadInTestRunner` test
