### PR TITLE
Fix/memory leaks

### DIFF
--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.net472.approved.txt
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.net472.approved.txt
@@ -257,6 +257,8 @@ namespace ReactiveUI
         ReactiveUI.BindingDirection Direction { get; }
         TView View { get; }
         System.Linq.Expressions.Expression ViewExpression { get; }
+        [System.Obsolete("This property has been deprecated. Refer to ViewModelExpression for a representat" +
+            "ion of the bound view model.")]
         TViewModel ViewModel { get; }
         System.Linq.Expressions.Expression ViewModelExpression { get; }
     }

--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.netcoreapp3.1.approved.txt
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.netcoreapp3.1.approved.txt
@@ -257,6 +257,8 @@ namespace ReactiveUI
         ReactiveUI.BindingDirection Direction { get; }
         TView View { get; }
         System.Linq.Expressions.Expression ViewExpression { get; }
+        [System.Obsolete("This property has been deprecated. Refer to ViewModelExpression for a representat" +
+            "ion of the bound view model.")]
         TViewModel ViewModel { get; }
         System.Linq.Expressions.Expression ViewModelExpression { get; }
     }

--- a/src/ReactiveUI.Tests/Platforms/windows-xaml/PropertyBindingTest.cs
+++ b/src/ReactiveUI.Tests/Platforms/windows-xaml/PropertyBindingTest.cs
@@ -396,6 +396,28 @@ namespace ReactiveUI.Tests.Xaml
         }
 
         [Fact]
+        public void OneWayBindInitialViewModelShouldBeGarbageCollectedWhenOverwritten()
+        {
+            static (IDisposable?, WeakReference) GetWeakReference()
+            {
+                var vm = new PropertyBindViewModel();
+                var view = new PropertyBindView { ViewModel = vm };
+                var weakRef = new WeakReference(vm);
+                var disp = view.OneWayBind(vm, x => x.Property1, x => x.SomeTextBox.Text);
+                view.ViewModel = new PropertyBindViewModel();
+
+                return (disp, weakRef);
+            }
+
+            var (disp, weakRef) = GetWeakReference();
+
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+
+            Assert.False(weakRef.IsAlive);
+        }
+
+        [Fact]
         public void BindToWithNullStartingValueToNonNullValue()
         {
             var vm = new PropertyBindViewModel();
@@ -445,6 +467,28 @@ namespace ReactiveUI.Tests.Xaml
             var view = new PropertyBindView { ViewModel = vm };
 
             view.Bind(vm, x => x.JustADecimal, x => x.SomeTextBox.Text, d => d.ToString(), decimal.Parse);
+        }
+
+        [Fact]
+        public void BindInitialViewModelShouldBeGarbageCollectedWhenOverwritten()
+        {
+            static (IDisposable?, WeakReference) GetWeakReference()
+            {
+                var vm = new PropertyBindViewModel();
+                var view = new PropertyBindView { ViewModel = vm };
+                var weakRef = new WeakReference(vm);
+                var disp = view.Bind(vm, x => x.Property1, x => x.SomeTextBox.Text);
+                view.ViewModel = new PropertyBindViewModel();
+
+                return (disp, weakRef);
+            }
+
+            var (disp, weakRef) = GetWeakReference();
+
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+
+            Assert.False(weakRef.IsAlive);
         }
     }
 }

--- a/src/ReactiveUI.Tests/Platforms/wpf/Mocks/CommandBindingView.cs
+++ b/src/ReactiveUI.Tests/Platforms/wpf/Mocks/CommandBindingView.cs
@@ -13,8 +13,10 @@ using ReactiveUI.Tests.Xaml;
 
 namespace ReactiveUI.Tests.Wpf
 {
-    public class CommandBindingView : IViewFor<CommandBindingViewModel>
+    public class CommandBindingView : ReactiveObject, IViewFor<CommandBindingViewModel>
     {
+        private CommandBindingViewModel? _viewModel;
+
         public CommandBindingView()
         {
             Command1 = new CustomClickButton();
@@ -27,7 +29,11 @@ namespace ReactiveUI.Tests.Wpf
             set => ViewModel = (CommandBindingViewModel?)value;
         }
 
-        public CommandBindingViewModel? ViewModel { get; set; }
+        public CommandBindingViewModel? ViewModel
+        {
+            get => _viewModel;
+            set => this.RaiseAndSetIfChanged(ref _viewModel, value);
+        }
 
         public CustomClickButton Command1 { get; protected set; }
 

--- a/src/ReactiveUI.Tests/Platforms/wpf/WpfCommandBindingImplementationTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/wpf/WpfCommandBindingImplementationTests.cs
@@ -51,5 +51,27 @@ namespace ReactiveUI.Tests.Wpf
 
             testLogger.Messages.ShouldNotContain(t => t.message.Contains(nameof(POCOObservableForProperty)) && t.message.Contains(view.NameOfButtonDeclaredInXaml) && t.logLevel == LogLevel.Warn);
         }
+
+        [Fact]
+        public void ViewModelShouldBeGarbageCollectedWhenOverwritten()
+        {
+            static (IDisposable, WeakReference) GetWeakReference()
+            {
+                var vm = new CommandBindingViewModel();
+                var view = new CommandBindingView { ViewModel = vm };
+                var weakRef = new WeakReference(vm);
+                var disp = view.BindCommand(vm, x => x.Command2, x => x.Command2, "MouseUp");
+                view.ViewModel = new CommandBindingViewModel();
+
+                return (disp, weakRef);
+            }
+
+            var (disp, weakRef) = GetWeakReference();
+
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+
+            Assert.False(weakRef.IsAlive);
+        }
     }
 }

--- a/src/ReactiveUI.Tests/WhenAny/ReactiveNotifyPropertyChangedMixinTest.cs
+++ b/src/ReactiveUI.Tests/WhenAny/ReactiveNotifyPropertyChangedMixinTest.cs
@@ -706,5 +706,50 @@ namespace ReactiveUI.Tests
                                          Assert.Equal("Bar", output2[2]);
                                      });
         }
+
+        [Fact]
+        public void ObjectShouldBeGarbageCollectedWhenPropertyValueChanges()
+        {
+            static (ObjChain1, WeakReference) GetWeakReference1()
+            {
+                var obj = new ObjChain1();
+                var weakRef = new WeakReference(obj.Model);
+                obj.ObservableForProperty(x => x.Model.Model.Model.SomeOtherParam).Subscribe();
+                obj.Model = new ObjChain2();
+
+                return (obj, weakRef);
+            }
+
+            static (ObjChain1, WeakReference) GetWeakReference2()
+            {
+                var obj = new ObjChain1();
+                var weakRef = new WeakReference(obj.Model.Model);
+                obj.ObservableForProperty(x => x.Model.Model.Model.SomeOtherParam).Subscribe();
+                obj.Model.Model = new ObjChain3();
+
+                return (obj, weakRef);
+            }
+
+            static (ObjChain1, WeakReference) GetWeakReference3()
+            {
+                var obj = new ObjChain1();
+                var weakRef = new WeakReference(obj.Model.Model.Model);
+                obj.ObservableForProperty(x => x.Model.Model.Model.SomeOtherParam).Subscribe();
+                obj.Model.Model.Model = new HostTestFixture();
+
+                return (obj, weakRef);
+            }
+
+            var (obj1, weakRef1) = GetWeakReference1();
+            var (obj2, weakRef2) = GetWeakReference2();
+            var (obj3, weakRef3) = GetWeakReference3();
+
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+
+            Assert.False(weakRef1.IsAlive);
+            Assert.False(weakRef2.IsAlive);
+            Assert.False(weakRef3.IsAlive);
+        }
     }
 }

--- a/src/ReactiveUI/Bindings/Reactive/IReactiveBinding.cs
+++ b/src/ReactiveUI/Bindings/Reactive/IReactiveBinding.cs
@@ -24,6 +24,7 @@ namespace ReactiveUI
         /// <summary>
         /// Gets the instance of the view model this binding is applied to.
         /// </summary>
+        [Obsolete("This property has been deprecated. Refer to ViewModelExpression for a representation of the bound view model.")]
         TViewModel? ViewModel { get; }
 
         /// <summary>

--- a/src/ReactiveUI/Bindings/Reactive/ReactiveBinding.cs
+++ b/src/ReactiveUI/Bindings/Reactive/ReactiveBinding.cs
@@ -24,7 +24,6 @@ namespace ReactiveUI
             IDisposable bindingDisposable)
         {
             View = view;
-            ViewModel = viewModel;
             ViewExpression = viewExpression;
             ViewModelExpression = viewModelExpression;
             Direction = direction;
@@ -34,6 +33,7 @@ namespace ReactiveUI
         }
 
         /// <inheritdoc />
+        [Obsolete("This property has been deprecated. Refer to ViewModelExpression for a representation of the bound view model.")]
         public TViewModel? ViewModel { get; }
 
         /// <inheritdoc />


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix. Resolves #2384


**What is the current behavior?**
<!-- You can also link to an open issue here. -->
If the initial view model is assigned _before_ the binding is set up, that view model gets tied to the lifetime of the binding. This means even if the view model gets swapped out for a different one, it never gets garbage collected. This includes Bind, OneWayBind, and BindCommand. The linked issue above includes a WPF reproduction project that I based my findings and fixes off of. I also tried with a Xamarin Forms Android project and experienced the same issue, so I assume this hidden memory leak affects most, if not all, platforms.


**What is the new behavior?**
<!-- If this is a feature change -->
The initial view model is not tied to the lifetime of the binding.


**What might this PR break?**
Nothing


**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

There ended up being two different memory leak sources.

1) The ReactiveBinding object returned by the Bind family, because of storing the initial view model in a property.

![ReactiveBindingLeak](https://user-images.githubusercontent.com/6819362/91390987-809f5f00-e874-11ea-94b6-fe8641b79fdb.PNG)

As you can see, that binding object is usually kept alive because of storing it in the CompositeDisposable of `WhenActivated`. So this fix was simple; just remove the ViewModel property assignment and deprecate the ViewModel property.

<br />

2) Passing the [_calculated_ `ObservedChange<TSender, TValue>.Value`](https://github.com/reactiveui/ReactiveUI/blob/2251609d377e03b7c1f2e760edd4ac4847979241/src/ReactiveUI/Mixins/ReactiveNotifyPropertyChangedMixin.cs#L188)  to [`StartWith`](https://github.com/reactiveui/ReactiveUI/blob/2251609d377e03b7c1f2e760edd4ac4847979241/src/ReactiveUI/Mixins/ReactiveNotifyPropertyChangedMixin.cs#L207). 

![StartWithLeak](https://user-images.githubusercontent.com/6819362/91398341-e0970500-e876-11ea-8fc0-174cefe72dc4.PNG)

StartWith is implemented via [`ToObservable().Concat`](https://github.com/dotnet/reactive/blob/7ad606b3dcd4bb2c6ae9622f8a59db7f8f52aa85/Rx.NET/Source/src/System.Reactive/Linq/QueryLanguage.Single.cs#L330), and [`Concat` keeps a reference](https://github.com/dotnet/reactive/blob/7ad606b3dcd4bb2c6ae9622f8a59db7f8f52aa85/Rx.NET/Source/src/System.Reactive/Linq/Observable/Concat.cs#L11) to that object until the pipeline is disposed of.

So the solution is to not calculate the kicker value _outside_ of the pipeline, and instead take advantage of the [existing `Select` statement](https://github.com/reactiveui/ReactiveUI/blob/2251609d377e03b7c1f2e760edd4ac4847979241/src/ReactiveUI/Mixins/ReactiveNotifyPropertyChangedMixin.cs#L206) which uses the `GetValue` method to calculate it lazily _within_ the pipeline.

<br />

**Memory Leak Tests**

You may notice my use of local functions in the unit tests I added. This is necessary, at least for the netcoreapp unit tests, and it's the reason why the old memory leak tests failed. Quoted from a [JetBrains blog](https://blog.jetbrains.com/dotnet/2018/10/04/unit-testing-memory-leaks-using-dotmemory-unit/):

> Since all of our logic is being run in one method (our test method), the garbage collector will not clean up local variables that are still available in the context of our function. We will have to re-write our test a little bit, so that the local variables used are considered out of scope when validating memory usage. This can be done by creating a separate method to run the code being tested, or inline using a local function or an Action.