### PR TITLE
Fixes UITextField linker setter override

### DIFF
--- a/src/ReactiveUI/Platforms/ios/LinkerOverrides.cs
+++ b/src/ReactiveUI/Platforms/ios/LinkerOverrides.cs
@@ -33,7 +33,7 @@ namespace ReactiveUI.Cocoa
 
             // UITextField
             var tf = new UITextField();
-            tv.Text = tf.Text;
+            tf.Text = tf.Text;
 
             // var UIImageView
             var iv = new UIImageView();


### PR DESCRIPTION
In the linker override for iOS, the UITextField setter was not trickered (probably because a little too much use of copy/paste).