### PR TITLE
feature: Implement Interaction binding

### DIFF
--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.net472.approved.txt
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.net472.approved.txt
@@ -190,6 +190,17 @@ namespace ReactiveUI
     {
         System.IObservable<System.Exception> ThrownExceptions { get; }
     }
+    public interface IInteractionBinderImplementation : Splat.IEnableLogger
+    {
+        System.IDisposable BindInteraction<TViewModel, TView, TInput, TOutput>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, ReactiveUI.Interaction<TInput, TOutput>>> propertyName, System.Func<ReactiveUI.InteractionContext<TInput, TOutput>, System.Threading.Tasks.Task> handler)
+            where TViewModel :  class
+            where TView :  class, ReactiveUI.IViewFor
+        ;
+        System.IDisposable BindInteraction<TViewModel, TView, TInput, TOutput, TDontCare>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, ReactiveUI.Interaction<TInput, TOutput>>> propertyName, System.Func<ReactiveUI.InteractionContext<TInput, TOutput>, System.IObservable<TDontCare>> handler)
+            where TViewModel :  class
+            where TView :  class, ReactiveUI.IViewFor
+        ;
+    }
     public interface IMessageBus : Splat.IEnableLogger
     {
         bool IsRegistered(System.Type type, string? contract = null);
@@ -334,6 +345,25 @@ namespace ReactiveUI
     public interface IViewLocator : Splat.IEnableLogger
     {
         ReactiveUI.IViewFor? ResolveView<T>(T viewModel, string? contract = null);
+    }
+    public class InteractionBinderImplementation : ReactiveUI.IInteractionBinderImplementation, Splat.IEnableLogger
+    {
+        public InteractionBinderImplementation() { }
+        public System.IDisposable BindInteraction<TViewModel, TView, TInput, TOutput>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, ReactiveUI.Interaction<TInput, TOutput>>> propertyName, System.Func<ReactiveUI.InteractionContext<TInput, TOutput>, System.Threading.Tasks.Task> handler)
+            where TViewModel :  class
+            where TView :  class, ReactiveUI.IViewFor { }
+        public System.IDisposable BindInteraction<TViewModel, TView, TInput, TOutput, TDontCare>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, ReactiveUI.Interaction<TInput, TOutput>>> propertyName, System.Func<ReactiveUI.InteractionContext<TInput, TOutput>, System.IObservable<TDontCare>> handler)
+            where TViewModel :  class
+            where TView :  class, ReactiveUI.IViewFor { }
+    }
+    public static class InteractionBindingMixins
+    {
+        public static System.IDisposable BindInteraction<TViewModel, TView, TInput, TOutput>(this TView view, TViewModel? viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, ReactiveUI.Interaction<TInput, TOutput>>> propertyName, System.Func<ReactiveUI.InteractionContext<TInput, TOutput>, System.Threading.Tasks.Task> handler)
+            where TViewModel :  class
+            where TView :  class, ReactiveUI.IViewFor { }
+        public static System.IDisposable BindInteraction<TViewModel, TView, TInput, TOutput, TDontCare>(this TView view, TViewModel? viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, ReactiveUI.Interaction<TInput, TOutput>>> propertyName, System.Func<ReactiveUI.InteractionContext<TInput, TOutput>, System.IObservable<TDontCare>> handler)
+            where TViewModel :  class
+            where TView :  class, ReactiveUI.IViewFor { }
     }
     public sealed class InteractionContext<TInput, TOutput>
     {

--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.netcoreapp3.1.approved.txt
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.netcoreapp3.1.approved.txt
@@ -190,6 +190,17 @@ namespace ReactiveUI
     {
         System.IObservable<System.Exception> ThrownExceptions { get; }
     }
+    public interface IInteractionBinderImplementation : Splat.IEnableLogger
+    {
+        System.IDisposable BindInteraction<TViewModel, TView, TInput, TOutput>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, ReactiveUI.Interaction<TInput, TOutput>>> propertyName, System.Func<ReactiveUI.InteractionContext<TInput, TOutput>, System.Threading.Tasks.Task> handler)
+            where TViewModel :  class
+            where TView :  class, ReactiveUI.IViewFor
+        ;
+        System.IDisposable BindInteraction<TViewModel, TView, TInput, TOutput, TDontCare>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, ReactiveUI.Interaction<TInput, TOutput>>> propertyName, System.Func<ReactiveUI.InteractionContext<TInput, TOutput>, System.IObservable<TDontCare>> handler)
+            where TViewModel :  class
+            where TView :  class, ReactiveUI.IViewFor
+        ;
+    }
     public interface IMessageBus : Splat.IEnableLogger
     {
         bool IsRegistered(System.Type type, string? contract = null);
@@ -334,6 +345,25 @@ namespace ReactiveUI
     public interface IViewLocator : Splat.IEnableLogger
     {
         ReactiveUI.IViewFor? ResolveView<T>(T viewModel, string? contract = null);
+    }
+    public class InteractionBinderImplementation : ReactiveUI.IInteractionBinderImplementation, Splat.IEnableLogger
+    {
+        public InteractionBinderImplementation() { }
+        public System.IDisposable BindInteraction<TViewModel, TView, TInput, TOutput>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, ReactiveUI.Interaction<TInput, TOutput>>> propertyName, System.Func<ReactiveUI.InteractionContext<TInput, TOutput>, System.Threading.Tasks.Task> handler)
+            where TViewModel :  class
+            where TView :  class, ReactiveUI.IViewFor { }
+        public System.IDisposable BindInteraction<TViewModel, TView, TInput, TOutput, TDontCare>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, ReactiveUI.Interaction<TInput, TOutput>>> propertyName, System.Func<ReactiveUI.InteractionContext<TInput, TOutput>, System.IObservable<TDontCare>> handler)
+            where TViewModel :  class
+            where TView :  class, ReactiveUI.IViewFor { }
+    }
+    public static class InteractionBindingMixins
+    {
+        public static System.IDisposable BindInteraction<TViewModel, TView, TInput, TOutput>(this TView view, TViewModel? viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, ReactiveUI.Interaction<TInput, TOutput>>> propertyName, System.Func<ReactiveUI.InteractionContext<TInput, TOutput>, System.Threading.Tasks.Task> handler)
+            where TViewModel :  class
+            where TView :  class, ReactiveUI.IViewFor { }
+        public static System.IDisposable BindInteraction<TViewModel, TView, TInput, TOutput, TDontCare>(this TView view, TViewModel? viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, ReactiveUI.Interaction<TInput, TOutput>>> propertyName, System.Func<ReactiveUI.InteractionContext<TInput, TOutput>, System.IObservable<TDontCare>> handler)
+            where TViewModel :  class
+            where TView :  class, ReactiveUI.IViewFor { }
     }
     public sealed class InteractionContext<TInput, TOutput>
     {

--- a/src/ReactiveUI.Tests/InteractionBinding/InteractionBinderImplementationTests.cs
+++ b/src/ReactiveUI.Tests/InteractionBinding/InteractionBinderImplementationTests.cs
@@ -1,0 +1,456 @@
+﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using Shouldly;
+using Xunit;
+
+namespace ReactiveUI.Tests
+{
+    public class InteractionBinderImplementationTests
+    {
+        [Fact]
+        public async Task ShouldReceiveOutputFromTaskHandler()
+        {
+            var vm = new InteractionBindViewModel();
+            var view = new InteractionBindView { ViewModel = vm };
+
+            var disp = view.BindInteraction(
+                vm,
+                vm => vm.Interaction1,
+                input =>
+                    {
+                        input.SetOutput(true);
+                        return Task.CompletedTask;
+                    });
+
+            bool isDeletionConfirmed = await vm.Interaction1.Handle("123");
+
+            isDeletionConfirmed.ShouldBeTrue();
+        }
+
+        [Fact]
+        public async Task ShouldReceiveOutputFromObservableHandler()
+        {
+            var vm = new InteractionBindViewModel();
+            var view = new InteractionBindView { ViewModel = vm };
+
+            var disp = view.BindInteraction(
+                vm,
+                vm => vm.Interaction1,
+                input =>
+                {
+                    input.SetOutput(true);
+                    return Observable.Return(Unit.Default);
+                });
+
+            bool isDeletionConfirmed = await vm.Interaction1.Handle("123");
+
+            isDeletionConfirmed.ShouldBeTrue();
+        }
+
+        [Fact]
+        public async Task ShouldReceiveOutputFromTaskHandlerWhenViewModelWasInitiallyNull()
+        {
+            InteractionBindViewModel? vm = null;
+            var view = new InteractionBindView { ViewModel = vm };
+
+            var disp = view.BindInteraction(
+                vm,
+                vm => vm.Interaction1,
+                input =>
+                {
+                    input.SetOutput(true);
+                    return Task.CompletedTask;
+                });
+
+            view.ViewModel = new InteractionBindViewModel();
+
+            bool isDeletionConfirmed = await view.ViewModel.Interaction1.Handle("123");
+
+            isDeletionConfirmed.ShouldBeTrue();
+        }
+
+        [Fact]
+        public async Task ShouldReceiveOutputFromObservableHandlerWhenViewModelWasInitiallyNull()
+        {
+            InteractionBindViewModel? vm = null;
+            var view = new InteractionBindView { ViewModel = vm };
+
+            var disp = view.BindInteraction(
+                vm,
+                vm => vm.Interaction1,
+                input =>
+                {
+                    input.SetOutput(true);
+                    return Observable.Return(Unit.Default);
+                });
+
+            view.ViewModel = new InteractionBindViewModel();
+
+            bool isDeletionConfirmed = await view.ViewModel.Interaction1.Handle("123");
+
+            isDeletionConfirmed.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void ShouldUnregisterTaskHandlerWhenViewModelIsSetToNull()
+        {
+            var vm = new InteractionBindViewModel();
+            var view = new InteractionBindView { ViewModel = vm };
+
+            var disp = view.BindInteraction(
+                vm,
+                vm => vm.Interaction1,
+                input =>
+                {
+                    input.SetOutput(true);
+                    return Task.CompletedTask;
+                });
+
+            view.ViewModel = null;
+
+            _ = Assert.ThrowsAsync<UnhandledInteractionException<string, bool>>(() => vm.Interaction1.Handle("123").ToTask());
+        }
+
+        [Fact]
+        public void ShouldUnregisterObservableHandlerWhenViewModelIsSetToNull()
+        {
+            var vm = new InteractionBindViewModel();
+            var view = new InteractionBindView { ViewModel = vm };
+
+            var disp = view.BindInteraction(
+                vm,
+                vm => vm.Interaction1,
+                input =>
+                {
+                    input.SetOutput(true);
+                    return Observable.Return(Unit.Default);
+                });
+
+            view.ViewModel = null;
+
+            _ = Assert.ThrowsAsync<UnhandledInteractionException<string, bool>>(() => vm.Interaction1.Handle("123").ToTask());
+        }
+
+        [Fact]
+        public void ShouldUnregisterTaskHandlerFromOverwrittenViewModel()
+        {
+            var vm = new InteractionBindViewModel();
+            var view = new InteractionBindView { ViewModel = vm };
+
+            var disp = view.BindInteraction(
+                vm,
+                vm => vm.Interaction1,
+                input =>
+                {
+                    input.SetOutput(true);
+                    return Task.CompletedTask;
+                });
+
+            view.ViewModel = new InteractionBindViewModel();
+
+            _ = Assert.ThrowsAsync<UnhandledInteractionException<string, bool>>(() => vm.Interaction1.Handle("123").ToTask());
+        }
+
+        [Fact]
+        public void ShouldUnregisterObservableHandlerFromOverwrittenViewModel()
+        {
+            var vm = new InteractionBindViewModel();
+            var view = new InteractionBindView { ViewModel = vm };
+
+            var disp = view.BindInteraction(
+                vm,
+                vm => vm.Interaction1,
+                input =>
+                {
+                    input.SetOutput(true);
+                    return Observable.Return(Unit.Default);
+                });
+
+            view.ViewModel = new InteractionBindViewModel();
+
+            _ = Assert.ThrowsAsync<UnhandledInteractionException<string, bool>>(() => vm.Interaction1.Handle("123").ToTask());
+        }
+
+        [Fact]
+        public async Task ShouldRegisterTaskHandlerToNewlyAssignedViewModel()
+        {
+            var vm = new InteractionBindViewModel();
+            var view = new InteractionBindView { ViewModel = vm };
+
+            var disp = view.BindInteraction(
+                vm,
+                vm => vm.Interaction1,
+                input =>
+                {
+                    input.SetOutput(true);
+                    return Task.CompletedTask;
+                });
+
+            view.ViewModel = new InteractionBindViewModel();
+
+            bool isDeletionConfirmed = await view.ViewModel.Interaction1.Handle("123");
+
+            isDeletionConfirmed.ShouldBeTrue();
+        }
+
+        [Fact]
+        public async Task ShouldRegisterObservableHandlerToNewlyAssignedViewModel()
+        {
+            var vm = new InteractionBindViewModel();
+            var view = new InteractionBindView { ViewModel = vm };
+
+            var disp = view.BindInteraction(
+                vm,
+                vm => vm.Interaction1,
+                input =>
+                {
+                    input.SetOutput(true);
+                    return Observable.Return(Unit.Default);
+                });
+
+            view.ViewModel = new InteractionBindViewModel();
+
+            bool isDeletionConfirmed = await view.ViewModel.Interaction1.Handle("123");
+
+            isDeletionConfirmed.ShouldBeTrue();
+        }
+
+        [Fact]
+        public async Task NestedInteractionShouldReceiveOutputFromTaskHandler()
+        {
+            var vm = new InteractionAncestorViewModel();
+            var view = new InteractionAncestorView { ViewModel = vm };
+
+            var disp = view.BindInteraction(
+                vm,
+                vm => vm.InteractionViewModel.Interaction1,
+                input =>
+                {
+                    input.SetOutput(true);
+                    return Task.CompletedTask;
+                });
+
+            bool isDeletionConfirmed = await vm.InteractionViewModel.Interaction1.Handle("123");
+
+            isDeletionConfirmed.ShouldBeTrue();
+        }
+
+        [Fact]
+        public async Task NestedInteractionShouldReceiveOutputFromObservableHandler()
+        {
+            var vm = new InteractionAncestorViewModel();
+            var view = new InteractionAncestorView { ViewModel = vm };
+
+            var disp = view.BindInteraction(
+                vm,
+                vm => vm.InteractionViewModel.Interaction1,
+                input =>
+                {
+                    input.SetOutput(true);
+                    return Observable.Return(Unit.Default);
+                });
+
+            bool isDeletionConfirmed = await vm.InteractionViewModel.Interaction1.Handle("123");
+
+            isDeletionConfirmed.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void ShouldUnregisterTaskHandlerFromOverwrittenNestedViewModel()
+        {
+            var firstInteractionVm = new InteractionBindViewModel();
+            var vm = new InteractionAncestorViewModel();
+            var view = new InteractionAncestorView { ViewModel = vm };
+
+            var disp = view.BindInteraction(
+                vm,
+                vm => vm.InteractionViewModel.Interaction1,
+                input =>
+                {
+                    input.SetOutput(true);
+                    return Task.CompletedTask;
+                });
+
+            view.ViewModel.InteractionViewModel = new InteractionBindViewModel();
+
+            _ = Assert.ThrowsAsync<UnhandledInteractionException<string, bool>>(() => firstInteractionVm.Interaction1.Handle("123").ToTask());
+        }
+
+        [Fact]
+        public void ShouldUnregisterObservableHandlerFromOverwrittenNestedViewModel()
+        {
+            var firstInteractionVm = new InteractionBindViewModel();
+            var vm = new InteractionAncestorViewModel();
+            var view = new InteractionAncestorView { ViewModel = vm };
+
+            var disp = view.BindInteraction(
+                vm,
+                vm => vm.InteractionViewModel.Interaction1,
+                input =>
+                {
+                    input.SetOutput(true);
+                    return Observable.Return(Unit.Default);
+                });
+
+            view.ViewModel.InteractionViewModel = new InteractionBindViewModel();
+
+            _ = Assert.ThrowsAsync<UnhandledInteractionException<string, bool>>(() => firstInteractionVm.Interaction1.Handle("123").ToTask());
+        }
+
+        [Fact]
+        public async Task ShouldRegisterTaskHandlerToNewlyAssignedNestedViewModel()
+        {
+            var vm = new InteractionAncestorViewModel()
+            {
+                InteractionViewModel = new InteractionBindViewModel()
+            };
+            var view = new InteractionAncestorView { ViewModel = vm };
+
+            var disp = view.BindInteraction(
+                vm,
+                vm => vm.InteractionViewModel.Interaction1,
+                input =>
+                {
+                    input.SetOutput(true);
+                    return Observable.Return(Unit.Default);
+                });
+
+            vm.InteractionViewModel = new InteractionBindViewModel();
+
+            bool isDeletionConfirmed = await vm.InteractionViewModel.Interaction1.Handle("123");
+
+            isDeletionConfirmed.ShouldBeTrue();
+        }
+
+        [Fact]
+        public async Task ShouldRegisterObservableHandlerToNewlyAssignedNestedViewModel()
+        {
+            var vm = new InteractionAncestorViewModel()
+            {
+                InteractionViewModel = new InteractionBindViewModel()
+            };
+            var view = new InteractionAncestorView { ViewModel = vm };
+
+            var disp = view.BindInteraction(
+                vm,
+                vm => vm.InteractionViewModel.Interaction1,
+                input =>
+                {
+                    input.SetOutput(true);
+                    return Observable.Return(Unit.Default);
+                });
+
+            vm.InteractionViewModel = new InteractionBindViewModel();
+
+            bool isDeletionConfirmed = await vm.InteractionViewModel.Interaction1.Handle("123");
+
+            isDeletionConfirmed.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void ShouldUnregisterTaskHandlerWhenBindingIsDisposed()
+        {
+            var vm = new InteractionBindViewModel();
+            var view = new InteractionBindView { ViewModel = vm };
+
+            var disp = view.BindInteraction(
+                vm,
+                vm => vm.Interaction1,
+                input =>
+                {
+                    input.SetOutput(true);
+                    return Task.CompletedTask;
+                });
+
+            disp.Dispose();
+
+            _ = Assert.ThrowsAsync<UnhandledInteractionException<string, bool>>(() => vm.Interaction1.Handle("123").ToTask());
+        }
+
+        [Fact]
+        public void ShouldUnregisterObservableHandlerWhenBindingIsDisposed()
+        {
+            var vm = new InteractionBindViewModel();
+            var view = new InteractionBindView { ViewModel = vm };
+
+            var disp = view.BindInteraction(
+                vm,
+                vm => vm.Interaction1,
+                input =>
+                {
+                    input.SetOutput(true);
+                    return Observable.Return(Unit.Default);
+                });
+
+            disp.Dispose();
+
+            _ = Assert.ThrowsAsync<UnhandledInteractionException<string, bool>>(() => vm.Interaction1.Handle("123").ToTask());
+        }
+
+        [Fact]
+        public void ViewModelShouldBeGarbageCollectedWhenOverwritten()
+        {
+            static (IDisposable, WeakReference) GetWeakReference()
+            {
+                var vm = new InteractionBindViewModel();
+                var view = new InteractionBindView { ViewModel = vm };
+                var weakRef = new WeakReference(vm);
+                var disp = view.BindInteraction(
+                    vm,
+                    vm => vm.Interaction1,
+                    input =>
+                        {
+                            input.SetOutput(true);
+                            return Task.CompletedTask;
+                        });
+                view.ViewModel = new InteractionBindViewModel();
+
+                return (disp, weakRef);
+            }
+
+            var (disp, weakRef) = GetWeakReference();
+
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+
+            Assert.False(weakRef.IsAlive);
+        }
+
+        [Fact]
+        public void NestedViewModelShouldBeGarbageCollectedWhenOverwritten()
+        {
+            static (IDisposable, WeakReference) GetWeakReference()
+            {
+                var vm = new InteractionAncestorViewModel() { InteractionViewModel = new InteractionBindViewModel() };
+                var view = new InteractionAncestorView { ViewModel = vm };
+                var weakRef = new WeakReference(vm.InteractionViewModel);
+                var disp = view.BindInteraction(
+                    vm,
+                    vm => vm.InteractionViewModel.Interaction1,
+                    input =>
+                    {
+                        input.SetOutput(true);
+                        return Observable.Return(Unit.Default);
+                    });
+                vm.InteractionViewModel = new InteractionBindViewModel();
+
+                return (disp, weakRef);
+            }
+
+            var (disp, weakRef) = GetWeakReference();
+
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+
+            Assert.False(weakRef.IsAlive);
+        }
+    }
+}

--- a/src/ReactiveUI.Tests/Mocks/InteractionAncestorView.cs
+++ b/src/ReactiveUI.Tests/Mocks/InteractionAncestorView.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace ReactiveUI.Tests
+{
+    public class InteractionAncestorView : ReactiveObject, IViewFor<InteractionAncestorViewModel>
+    {
+        private InteractionAncestorViewModel? _viewModel;
+
+        object? IViewFor.ViewModel
+        {
+            get => ViewModel;
+            set => ViewModel = (InteractionAncestorViewModel?)value;
+        }
+
+        public InteractionAncestorViewModel? ViewModel
+        {
+            get => _viewModel;
+            set => this.RaiseAndSetIfChanged(ref _viewModel, value);
+        }
+    }
+}

--- a/src/ReactiveUI.Tests/Mocks/InteractionAncestorViewModel.cs
+++ b/src/ReactiveUI.Tests/Mocks/InteractionAncestorViewModel.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace ReactiveUI.Tests
+{
+    public class InteractionAncestorViewModel : ReactiveObject
+    {
+        private InteractionBindViewModel _interactionBindViewModel;
+
+#pragma warning disable CS8618 // Non-nullable field is uninitialized. Consider declaring as nullable.
+        public InteractionAncestorViewModel()
+#pragma warning restore CS8618 // Non-nullable field is uninitialized. Consider declaring as nullable.
+        {
+            InteractionViewModel = new InteractionBindViewModel();
+        }
+
+        public InteractionBindViewModel InteractionViewModel
+        {
+            get => _interactionBindViewModel;
+            set => this.RaiseAndSetIfChanged(ref _interactionBindViewModel, value);
+        }
+    }
+}

--- a/src/ReactiveUI.Tests/Mocks/InteractionBindView.cs
+++ b/src/ReactiveUI.Tests/Mocks/InteractionBindView.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace ReactiveUI.Tests
+{
+    public class InteractionBindView : ReactiveObject, IViewFor<InteractionBindViewModel>
+    {
+        private InteractionBindViewModel? _viewModel;
+
+        object? IViewFor.ViewModel
+        {
+            get => ViewModel;
+            set => ViewModel = (InteractionBindViewModel?)value;
+        }
+
+        public InteractionBindViewModel? ViewModel
+        {
+            get => _viewModel;
+            set => this.RaiseAndSetIfChanged(ref _viewModel, value);
+        }
+    }
+}

--- a/src/ReactiveUI.Tests/Mocks/InteractionBindViewModel.cs
+++ b/src/ReactiveUI.Tests/Mocks/InteractionBindViewModel.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace ReactiveUI.Tests
+{
+    public class InteractionBindViewModel : ReactiveObject
+    {
+        private Interaction<string, bool> _interaction1;
+
+#pragma warning disable CS8618 // Non-nullable field is uninitialized. Consider declaring as nullable.
+        public InteractionBindViewModel()
+#pragma warning restore CS8618 // Non-nullable field is uninitialized. Consider declaring as nullable.
+        {
+            Interaction1 = new Interaction<string, bool>();
+        }
+
+        public Interaction<string, bool> Interaction1
+        {
+            get => _interaction1;
+            set => this.RaiseAndSetIfChanged(ref _interaction1, value);
+        }
+    }
+}

--- a/src/ReactiveUI/Bindings/Interaction/IInteractionBinderImplementation.cs
+++ b/src/ReactiveUI/Bindings/Interaction/IInteractionBinderImplementation.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using Splat;
+
+namespace ReactiveUI
+{
+    /// <summary>
+    /// Implementation logic for <see cref="Interaction{TInput, TOutput}"/> binding.
+    /// </summary>
+    public interface IInteractionBinderImplementation : IEnableLogger
+    {
+        /// <summary>
+        /// Binds the <see cref="Interaction{TInput, TOutput}"/> on a ViewModel to the specified handler.
+        /// </summary>
+        /// <param name="viewModel">The view model to bind to.</param>
+        /// <param name="view">The view to bind to.</param>
+        /// <param name="propertyName">The name of the property on the View Model.</param>
+        /// <param name="handler">The handler.</param>
+        /// <typeparam name="TViewModel">The type of the view model.</typeparam>
+        /// <typeparam name="TView">The type of the view being bound.</typeparam>
+        /// <typeparam name="TInput">The interaction's input type.</typeparam>
+        /// <typeparam name="TOutput">The interaction's output type.</typeparam>
+        /// <returns>An object that when disposed, disconnects the binding.</returns>
+        IDisposable BindInteraction<TViewModel, TView, TInput, TOutput>(
+                TViewModel? viewModel,
+                TView view,
+                Expression<Func<TViewModel, Interaction<TInput, TOutput>>> propertyName,
+                Func<InteractionContext<TInput, TOutput>, Task> handler)
+            where TViewModel : class
+            where TView : class, IViewFor;
+
+        /// <summary>
+        /// Binds the <see cref="Interaction{TInput, TOutput}"/> on a ViewModel to the specified handler.
+        /// </summary>
+        /// <param name="viewModel">The view model to bind to.</param>
+        /// <param name="view">The view to bind to.</param>
+        /// <param name="propertyName">The name of the property on the View Model.</param>
+        /// <param name="handler">The handler.</param>
+        /// <typeparam name="TViewModel">The type of the view model.</typeparam>
+        /// <typeparam name="TView">The type of the view being bound.</typeparam>
+        /// <typeparam name="TInput">The interaction's input type.</typeparam>
+        /// <typeparam name="TOutput">The interaction's output type.</typeparam>
+        /// <typeparam name="TDontCare">The interaction's signal type.</typeparam>
+        /// <returns>An object that when disposed, disconnects the binding.</returns>
+        IDisposable BindInteraction<TViewModel, TView, TInput, TOutput, TDontCare>(
+                TViewModel? viewModel,
+                TView view,
+                Expression<Func<TViewModel, Interaction<TInput, TOutput>>> propertyName,
+                Func<InteractionContext<TInput, TOutput>, IObservable<TDontCare>> handler)
+            where TViewModel : class
+            where TView : class, IViewFor;
+    }
+}

--- a/src/ReactiveUI/Bindings/Interaction/InteractionBinderImplementation.cs
+++ b/src/ReactiveUI/Bindings/Interaction/InteractionBinderImplementation.cs
@@ -1,0 +1,85 @@
+﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using Splat;
+
+namespace ReactiveUI
+{
+    /// <summary>
+    /// Provides methods to bind <see cref="Interaction{TInput, TOutput}"/>s to handlers.
+    /// </summary>
+    public class InteractionBinderImplementation : IInteractionBinderImplementation
+    {
+        /// <inheritdoc />
+        public IDisposable BindInteraction<TViewModel, TView, TInput, TOutput>(
+                TViewModel? viewModel,
+                TView view,
+                Expression<Func<TViewModel, Interaction<TInput, TOutput>>> propertyName,
+                Func<InteractionContext<TInput, TOutput>, Task> handler)
+            where TViewModel : class
+            where TView : class, IViewFor
+        {
+            if (propertyName == null)
+            {
+                throw new ArgumentNullException(nameof(propertyName));
+            }
+
+            if (handler == null)
+            {
+                throw new ArgumentNullException(nameof(handler));
+            }
+
+            var vmExpression = Reflection.Rewrite(propertyName.Body);
+
+            var source = Reflection.ViewModelWhenAnyValue(viewModel, view, vmExpression).Cast<Interaction<TInput, TOutput>>();
+
+            var interactionDisposable = new SerialDisposable();
+
+            return source
+                .Where(x => x != null)
+                .Do(x => interactionDisposable.Disposable = x.RegisterHandler(handler))
+                .Finally(() => interactionDisposable?.Dispose())
+                .Subscribe(_ => { }, ex => this.Log().Error(ex, $"{vmExpression} Interaction Binding received an Exception!"));
+        }
+
+        /// <inheritdoc />
+        public IDisposable BindInteraction<TViewModel, TView, TInput, TOutput, TDontCare>(
+                TViewModel? viewModel,
+                TView view,
+                Expression<Func<TViewModel, Interaction<TInput, TOutput>>> propertyName,
+                Func<InteractionContext<TInput, TOutput>, IObservable<TDontCare>> handler)
+            where TViewModel : class
+            where TView : class, IViewFor
+        {
+            if (propertyName == null)
+            {
+                throw new ArgumentNullException(nameof(propertyName));
+            }
+
+            if (handler == null)
+            {
+                throw new ArgumentNullException(nameof(handler));
+            }
+
+            var vmExpression = Reflection.Rewrite(propertyName.Body);
+
+            var source = Reflection.ViewModelWhenAnyValue(viewModel, view, vmExpression).Cast<Interaction<TInput, TOutput>>();
+
+            var interactionDisposable = new SerialDisposable();
+
+            return source
+                .Where(x => x != null)
+                .Do(x => interactionDisposable.Disposable = x.RegisterHandler(handler))
+                .Finally(() => interactionDisposable?.Dispose())
+                .Subscribe(_ => { }, ex => this.Log().Error(ex, $"{vmExpression} Interaction Binding received an Exception!"));
+        }
+    }
+}

--- a/src/ReactiveUI/Bindings/Interaction/InteractionBindingMixins.cs
+++ b/src/ReactiveUI/Bindings/Interaction/InteractionBindingMixins.cs
@@ -1,0 +1,80 @@
+﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+
+namespace ReactiveUI
+{
+    /// <summary>
+    /// This class provides extension methods for the ReactiveUI view binding mechanism.
+    /// </summary>
+    public static class InteractionBindingMixins
+    {
+        private static readonly IInteractionBinderImplementation binderImplementation;
+
+        static InteractionBindingMixins()
+        {
+            RxApp.EnsureInitialized();
+            binderImplementation = new InteractionBinderImplementation();
+        }
+
+        /// <summary>
+        /// Binds the <see cref="Interaction{TInput, TOutput}"/> on a ViewModel to the specified handler.
+        /// </summary>
+        /// <param name="view">The view to bind to.</param>
+        /// <param name="viewModel">The view model to bind to.</param>
+        /// <param name="propertyName">The name of the property on the View Model.</param>
+        /// <param name="handler">The handler.</param>
+        /// <typeparam name="TViewModel">The type of the view model.</typeparam>
+        /// <typeparam name="TView">The type of the view being bound.</typeparam>
+        /// <typeparam name="TInput">The interaction's input type.</typeparam>
+        /// <typeparam name="TOutput">The interaction's output type.</typeparam>
+        /// <returns>An object that when disposed, disconnects the binding.</returns>
+        public static IDisposable BindInteraction<TViewModel, TView, TInput, TOutput>(
+                this TView view,
+                TViewModel? viewModel,
+                Expression<Func<TViewModel, Interaction<TInput, TOutput>>> propertyName,
+                Func<InteractionContext<TInput, TOutput>, Task> handler)
+            where TViewModel : class
+            where TView : class, IViewFor
+        {
+            return binderImplementation.BindInteraction(
+                viewModel,
+                view,
+                propertyName,
+                handler);
+        }
+
+        /// <summary>
+        /// Binds the <see cref="Interaction{TInput, TOutput}"/> on a ViewModel to the specified handler.
+        /// </summary>
+        /// <param name="view">The view to bind to.</param>
+        /// <param name="viewModel">The view model to bind to.</param>
+        /// <param name="propertyName">The name of the property on the View Model.</param>
+        /// <param name="handler">The handler.</param>
+        /// <typeparam name="TViewModel">The type of the view model.</typeparam>
+        /// <typeparam name="TView">The type of the view being bound.</typeparam>
+        /// <typeparam name="TInput">The interaction's input type.</typeparam>
+        /// <typeparam name="TOutput">The interaction's output type.</typeparam>
+        /// <typeparam name="TDontCare">The interaction's signal type.</typeparam>
+        /// <returns>An object that when disposed, disconnects the binding.</returns>
+        public static IDisposable BindInteraction<TViewModel, TView, TInput, TOutput, TDontCare>(
+                this TView view,
+                TViewModel? viewModel,
+                Expression<Func<TViewModel, Interaction<TInput, TOutput>>> propertyName,
+                Func<InteractionContext<TInput, TOutput>, IObservable<TDontCare>> handler)
+            where TViewModel : class
+            where TView : class, IViewFor
+        {
+            return binderImplementation.BindInteraction(
+                viewModel,
+                view,
+                propertyName,
+                handler);
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature.


**What is the current behavior?**
<!-- You can also link to an open issue here. -->
Resolves #2280 


**What is the new behavior?**
<!-- If this is a feature change -->
The user now has an elegant and familiar way to hook up interactions in the view, and hides the complexity of handling when an interaction or its view model changes.

Now it's as simple as:

```
this.BindInteraction(ViewModel, vm => vm.MyInteraction, input => /*Do Something*/);
```


**What might this PR break?**
Nothing


**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

