### PR TITLE
Fix: WhenNavigatedToObservable completion

### DIFF
--- a/src/ReactiveUI.Tests/Routing/RoutableViewModelMixinTests.cs
+++ b/src/ReactiveUI.Tests/Routing/RoutableViewModelMixinTests.cs
@@ -78,6 +78,29 @@ namespace ReactiveUI.Tests
         }
 
         [Fact]
+        public void WhenNavigatedToCallsDisposeWhenNavigationStackIsReset()
+        {
+            var count = 0;
+
+            var screen = new TestScreen();
+            var vm1 = new RoutableViewModel(screen);
+            var vm2 = new RoutableViewModel(screen);
+
+            vm1.WhenNavigatedTo(() =>
+            {
+                return Disposable.Create(() => count++);
+            });
+
+            screen.Router.Navigate.Execute(vm1);
+
+            Assert.Equal(0, count);
+
+            screen.Router.NavigateAndReset.Execute(vm2);
+
+            Assert.Equal(1, count);
+        }
+
+        [Fact]
         public void WhenNavigatedToObservableFiresWhenViewModelAddedToNavigationStack()
         {
             var count = 0;
@@ -130,6 +153,25 @@ namespace ReactiveUI.Tests
 
             screen.Router.Navigate.Execute(vm);
             screen.Router.NavigateBack.Execute();
+
+            Assert.Equal(1, count);
+        }
+
+        [Fact]
+        public void WhenNavigatedToObservableCompletesWhenNavigationStackIsReset()
+        {
+            var count = 0;
+
+            var screen = new TestScreen();
+            var vm1 = new RoutableViewModel(screen);
+            var vm2 = new RoutableViewModel(screen);
+
+            vm1.WhenNavigatedToObservable().Subscribe(
+                _ => { },
+                () => { count++; });
+
+            screen.Router.Navigate.Execute(vm1);
+            screen.Router.NavigateAndReset.Execute(vm2);
 
             Assert.Equal(1, count);
         }

--- a/src/ReactiveUI/Routing/RoutableViewModelMixin.cs
+++ b/src/ReactiveUI/Routing/RoutableViewModelMixin.cs
@@ -81,9 +81,7 @@ namespace ReactiveUI
 
             var router = item.HostScreen.Router;
             var navigationStackChanged = router.NavigationChanged?.CountChanged();
-
-            var itemRemoved = navigationStackChanged
-                .Where(x => x.Any(change => change.Reason == ListChangeReason.Remove && change.Item.Current == item));
+            var itemRemoved = navigationStackChanged.Where(x => WasItemRemoved(x, item));
 
             return navigationStackChanged
                 .Where(_ => router?.GetCurrentViewModel() == item)
@@ -115,14 +113,21 @@ namespace ReactiveUI
 
             var router = item.HostScreen.Router;
             var navigationStackChanged = router.NavigationChanged?.CountChanged();
-            bool StackIsCleared(Change<IRoutableViewModel> change) => change.Reason == ListChangeReason.Clear;
-            bool ThisViewModelIsRemoved(Change<IRoutableViewModel> change) => NavigationStackRemovalOperations.Contains(change.Reason) && change.Item.Current == item;
-            var itemRemoved = navigationStackChanged.Where(x => x.Any(change => StackIsCleared(change) || ThisViewModelIsRemoved(change)));
+            var itemRemoved = navigationStackChanged.Where(x => WasItemRemoved(x, item));
             var viewModelsChanged = navigationStackChanged.Scan(new IRoutableViewModel[2], (previous, current) => new[] { previous[1], router.GetCurrentViewModel() });
+
             return viewModelsChanged
                 .Where(x => x[0] == item)
                 .Select(_ => Unit.Default)
                 .TakeUntil(itemRemoved);
+        }
+
+        private static bool WasItemRemoved(IChangeSet<IRoutableViewModel> changeSet, IRoutableViewModel item)
+        {
+            bool StackIsCleared(Change<IRoutableViewModel> change) => change.Reason == ListChangeReason.Clear;
+            bool ThisViewModelIsRemoved(Change<IRoutableViewModel> change) => NavigationStackRemovalOperations.Contains(change.Reason) && change.Item.Current == item;
+
+            return changeSet.Any(change => StackIsCleared(change) || ThisViewModelIsRemoved(change));
         }
     }
 }

--- a/src/ReactiveUI/Routing/RoutableViewModelMixin.cs
+++ b/src/ReactiveUI/Routing/RoutableViewModelMixin.cs
@@ -124,10 +124,14 @@ namespace ReactiveUI
 
         private static bool WasItemRemoved(IChangeSet<IRoutableViewModel> changeSet, IRoutableViewModel item)
         {
-            bool StackIsCleared(Change<IRoutableViewModel> change) => change.Reason == ListChangeReason.Clear;
-            bool ThisViewModelIsRemoved(Change<IRoutableViewModel> change) => NavigationStackRemovalOperations.Contains(change.Reason) && change.Item.Current == item;
-
-            return changeSet.Any(change => StackIsCleared(change) || ThisViewModelIsRemoved(change));
+            return changeSet
+                .Any(
+                    change =>
+                    {
+                        return
+                            change.Reason == ListChangeReason.Clear ||
+                            (NavigationStackRemovalOperations.Contains(change.Reason) && change.Item.Current == item);
+                    });
         }
     }
 }


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug


**What is the current behavior?**
<!-- You can also link to an open issue here. -->
Calling `NavigateAndReset` doesn't complete the observable returned by `WhenNavigatedToObservable`.
This happens because `WhenNavigatedToObservable` only checks for `ListChangeReason.Remove`, and not `ListChangeReason.Clear`.


**What is the new behavior?**
<!-- If this is a feature change -->
Calling `NavigateAndReset` completes the observable. This PR reuses the fix that was applied to `WhenNavigatingFromObservable`.


**What might this PR break?**
Nothing


**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

