### PR TITLE
housekeeping: Update nullability operator spacing

### DIFF
--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -20,9 +20,6 @@
     <RepositoryUrl>https://github.com/reactiveui/reactiveui</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
 
-    <!-- disable sourcelink on mono, to workaround https://github.com/dotnet/sourcelink/issues/155 -->
-    <EnableSourceLink Condition=" '$(OS)' != 'Windows_NT' AND '$(MSBuildRuntimeType)' != 'Core' ">false</EnableSourceLink>
-    <EnableSourceControlManagerQueries>$(EnableSourceLink)</EnableSourceControlManagerQueries>    
     <!-- Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->
     <PublishRepositoryUrl>true</PublishRepositoryUrl> 
     <!-- Embed source files that are not tracked by the source control manager in the PDB -->
@@ -59,7 +56,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)ApiGeneratorGlobalSuppressions.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(IsTestProject)' != 'true' and '$(SourceLinkEnabled)' != 'false'">
+  <ItemGroup Condition="'$(IsTestProject)' != 'true'">
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" /> 
   </ItemGroup>
   
@@ -76,9 +73,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="stylecop.analyzers" Version="1.1.118" PrivateAssets="all" />
+    <PackageReference Include="stylecop.analyzers" Version="1.2.0-beta.205" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0" PrivateAssets="all" />
-    <PackageReference Include="Roslynator.Analyzers" Version="2.3.0" PrivateAssets="All" />
+    <PackageReference Include="Roslynator.Analyzers" Version="3.0.0-rc" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)stylecop.json" Link="stylecop.json" />

--- a/src/ReactiveUI.Fody.Tests/FodyWeavers.xsd
+++ b/src/ReactiveUI.Fody.Tests/FodyWeavers.xsd
@@ -4,7 +4,6 @@
   <xs:element name="Weavers">
     <xs:complexType>
       <xs:all>
-        <xs:element name="ReactiveUI.Fody.deps" minOccurs="0" maxOccurs="1" type="xs:anyType" />
         <xs:element name="ReactiveUI" minOccurs="0" maxOccurs="1" type="xs:anyType" />
       </xs:all>
       <xs:attribute name="VerifyAssembly" type="xs:boolean">

--- a/src/ReactiveUI.Tests/ObservedChanged/ObservedChangedMixinTest.cs
+++ b/src/ReactiveUI.Tests/ObservedChanged/ObservedChangedMixinTest.cs
@@ -28,7 +28,7 @@ namespace ReactiveUI.Tests
                 // ...whereas ObservableForProperty *is* guaranteed to.
                 fixture.ObservableForProperty(x => x.IsOnlyOneWord).Subscribe(x =>
                 {
-                    output.Add(x.GetValue() !);
+                    output.Add(x.GetValue()!);
                 });
 
                 foreach (var v in input)

--- a/src/ReactiveUI.XamForms/RoutedViewHost.cs
+++ b/src/ReactiveUI.XamForms/RoutedViewHost.cs
@@ -189,7 +189,7 @@ namespace ReactiveUI.XamForms
                 {
                     return router.NavigationStack
                         .ToObservable()
-                        .Select(x => (Page)ViewLocator.Current.ResolveView(x) !)
+                        .Select(x => (Page)ViewLocator.Current.ResolveView(x)!)
                         .SelectMany(x => PushAsync(x).ToObservable())
                         .Finally(() =>
                         {

--- a/src/ReactiveUI/Bindings/Command/CommandBinderImplementation.cs
+++ b/src/ReactiveUI/Bindings/Command/CommandBinderImplementation.cs
@@ -78,7 +78,6 @@ namespace ReactiveUI
 
             return new ReactiveBinding<TView, TViewModel, TProp>(
                 view,
-                viewModel,
                 controlExpression,
                 vmExpression,
                 source,
@@ -136,7 +135,6 @@ namespace ReactiveUI
 
             return new ReactiveBinding<TView, TViewModel, TProp>(
                  view,
-                 viewModel,
                  controlExpression,
                  vmExpression,
                  source,

--- a/src/ReactiveUI/Bindings/Command/CreatesCommandBinding.cs
+++ b/src/ReactiveUI/Bindings/Command/CreatesCommandBinding.cs
@@ -73,7 +73,7 @@ namespace ReactiveUI
             var mi = binder.GetType().GetTypeInfo().DeclaredMethods.First(x => x.Name == "BindCommandToObject" && x.IsGenericMethod);
             mi = mi.MakeGenericMethod(new[] { eventArgsType });
 
-            var ret = (IDisposable)mi.Invoke(binder, new[] { command, target, commandParameter, eventName }) !;
+            var ret = (IDisposable)mi.Invoke(binder, new[] { command, target, commandParameter, eventName })!;
             if (ret == null)
             {
                 throw new Exception($"Couldn't bind Command Binder for {type.FullName} and event {eventName}");

--- a/src/ReactiveUI/Bindings/Property/PropertyBinderImplementation.cs
+++ b/src/ReactiveUI/Bindings/Property/PropertyBinderImplementation.cs
@@ -179,7 +179,7 @@ namespace ReactiveUI
             var ret = EvalBindingHooks(viewModel, view, vmExpression, viewExpression, BindingDirection.OneWay);
             if (!ret)
             {
-                return new ReactiveBinding<TView, TViewModel, TVProp>(view, viewModel, viewExpression, vmExpression, Observable.Empty<TVProp>(), BindingDirection.OneWay, Disposable.Empty);
+                return new ReactiveBinding<TView, TViewModel, TVProp>(view, viewExpression, vmExpression, Observable.Empty<TVProp>(), BindingDirection.OneWay, Disposable.Empty);
             }
 
             var source = Reflection.ViewModelWhenAnyValue(viewModel, view, vmExpression)
@@ -195,7 +195,7 @@ namespace ReactiveUI
 
             var (disposable, obs) = BindToDirect<TView, TVProp, object?>(source, view, viewExpression);
 
-            return new ReactiveBinding<TView, TViewModel, TVProp>(view, viewModel, viewExpression, vmExpression, obs, BindingDirection.OneWay, disposable);
+            return new ReactiveBinding<TView, TViewModel, TVProp>(view, viewExpression, vmExpression, obs, BindingDirection.OneWay, disposable);
         }
 
         /// <inheritdoc />
@@ -223,14 +223,14 @@ namespace ReactiveUI
             var ret = EvalBindingHooks(viewModel, view, vmExpression, viewExpression, BindingDirection.OneWay);
             if (!ret)
             {
-                return new ReactiveBinding<TView, TViewModel, TOut>(view, viewModel, viewExpression, vmExpression, Observable.Empty<TOut>(), BindingDirection.OneWay, Disposable.Empty);
+                return new ReactiveBinding<TView, TViewModel, TOut>(view, viewExpression, vmExpression, Observable.Empty<TOut>(), BindingDirection.OneWay, Disposable.Empty);
             }
 
             var source = Reflection.ViewModelWhenAnyValue(viewModel, view, vmExpression).Cast<TProp>().Select(selector);
 
             var (disposable, obs) = BindToDirect<TView, TOut, TOut>(source, view, viewExpression);
 
-            return new ReactiveBinding<TView, TViewModel, TOut>(view, viewModel, viewExpression, vmExpression, obs, BindingDirection.OneWay, disposable);
+            return new ReactiveBinding<TView, TViewModel, TOut>(view, viewExpression, vmExpression, obs, BindingDirection.OneWay, disposable);
         }
 
         /// <inheritdoc />
@@ -336,7 +336,7 @@ namespace ReactiveUI
 
             if (viewExpression.GetParent().NodeType == ExpressionType.Parameter)
             {
-                setObservable = changeObservable.Select(x => (TValue)SetThenGet(target, x, viewExpression.GetArgumentsArray()) !);
+                setObservable = changeObservable.Select(x => (TValue)SetThenGet(target, x, viewExpression.GetArgumentsArray())!);
             }
             else
             {
@@ -498,7 +498,6 @@ namespace ReactiveUI
 
             return new ReactiveBinding<TView, TViewModel, (object? view, bool isViewModel)>(
                    view,
-                   viewModel,
                    viewExpression,
                    vmExpression,
                    changes,

--- a/src/ReactiveUI/Bindings/Reactive/ReactiveBinding.cs
+++ b/src/ReactiveUI/Bindings/Reactive/ReactiveBinding.cs
@@ -14,9 +14,27 @@ namespace ReactiveUI
     {
         private readonly IDisposable _bindingDisposable;
 
+        [Obsolete("This constructor will be removed in the future.")]
         public ReactiveBinding(
             TView view,
             TViewModel? viewModel,
+            Expression viewExpression,
+            Expression viewModelExpression,
+            IObservable<TValue> changed,
+            BindingDirection direction,
+            IDisposable bindingDisposable)
+        {
+            View = view;
+            ViewExpression = viewExpression;
+            ViewModelExpression = viewModelExpression;
+            Direction = direction;
+            Changed = changed;
+
+            _bindingDisposable = bindingDisposable;
+        }
+
+        public ReactiveBinding(
+            TView view,
             Expression viewExpression,
             Expression viewModelExpression,
             IObservable<TValue> changed,

--- a/src/ReactiveUI/Expression/Reflection.cs
+++ b/src/ReactiveUI/Expression/Reflection.cs
@@ -430,7 +430,7 @@ namespace ReactiveUI
                 throw new ArgumentNullException(nameof(item));
             }
 
-            var method = (item.GetMethod ?? item.SetMethod) !;
+            var method = (item.GetMethod ?? item.SetMethod)!;
             return method.IsStatic;
         }
 

--- a/src/ReactiveUI/Interactions/Interaction.cs
+++ b/src/ReactiveUI/Interactions/Interaction.cs
@@ -180,7 +180,7 @@ namespace ReactiveUI
                 .Concat()
                 .TakeWhile(_ => !context.IsHandled)
                 .IgnoreElements()
-                .Select(_ => default(TOutput) !)
+                .Select(_ => default(TOutput)!)
                 .Concat(
                     Observable.Defer(
                         () => context.IsHandled

--- a/src/ReactiveUI/Interactions/UnhandledInteractionException.cs
+++ b/src/ReactiveUI/Interactions/UnhandledInteractionException.cs
@@ -70,7 +70,7 @@ namespace ReactiveUI
         protected UnhandledInteractionException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
-            _input = (TInput)info.GetValue(nameof(Input), typeof(TInput)) !;
+            _input = (TInput)info.GetValue(nameof(Input), typeof(TInput))!;
         }
 
         /// <summary>

--- a/src/ReactiveUI/Mixins/DependencyResolverMixins.cs
+++ b/src/ReactiveUI/Mixins/DependencyResolverMixins.cs
@@ -44,7 +44,7 @@ namespace ReactiveUI
 
             var fdr = typeof(DependencyResolverMixins);
 
-            var assemblyName = new AssemblyName(fdr?.AssemblyQualifiedName?.Replace(fdr?.FullName + ", ", string.Empty) !);
+            var assemblyName = new AssemblyName(fdr?.AssemblyQualifiedName?.Replace(fdr?.FullName + ", ", string.Empty)!);
 
             foreach (var ns in extraNs)
             {
@@ -126,7 +126,7 @@ namespace ReactiveUI
                 var registerTypeClass = Reflection.ReallyFindType(fullName, false);
                 if (registerTypeClass != null)
                 {
-                    var registerer = (IWantsToRegisterStuff)Activator.CreateInstance(registerTypeClass) !;
+                    var registerer = (IWantsToRegisterStuff)Activator.CreateInstance(registerTypeClass)!;
                     registerer?.Register((f, t) => resolver.RegisterConstant(f(), t));
                 }
             }

--- a/src/ReactiveUI/Observable.cs
+++ b/src/ReactiveUI/Observable.cs
@@ -26,6 +26,6 @@ namespace System.Reactive.Linq
         /// <summary>
         /// An observable of type <typeparamref name="T"/> that ticks a single, default value.
         /// </summary>
-        public static readonly IObservable<T> Default = Observable.Return(default(T) !);
+        public static readonly IObservable<T> Default = Observable.Return(default(T)!);
     }
 }

--- a/src/ReactiveUI/Platforms/windows-common/ViewModelViewHost.cs
+++ b/src/ReactiveUI/Platforms/windows-common/ViewModelViewHost.cs
@@ -110,7 +110,7 @@ namespace ReactiveUI
             ViewContractObservable = Observable.FromEvent<SizeChangedEventHandler, string>(
                 eventHandler =>
                 {
-                    void Handler(object sender, SizeChangedEventArgs e) => eventHandler(platformGetter() !);
+                    void Handler(object sender, SizeChangedEventArgs e) => eventHandler(platformGetter()!);
                     return Handler;
                 },
                 x => SizeChanged += x,

--- a/src/ReactiveUI/ReactiveCommand/ReactiveCommandMixins.cs
+++ b/src/ReactiveUI/ReactiveCommand/ReactiveCommandMixins.cs
@@ -119,7 +119,7 @@ namespace ReactiveUI
             var invocationInfo = command
                 .Select(cmd => cmd == null ? Observable<InvokeCommandInfo<ReactiveCommandBase<T, TResult>, T>>.Empty : cmd
                     .CanExecute
-                    .Select(canExecute => InvokeCommandInfo.From(cmd, canExecute, default(T) !)))
+                    .Select(canExecute => InvokeCommandInfo.From(cmd, canExecute, default(T)!)))
                 .Switch();
 
             return WithLatestFromFixed(item, invocationInfo, (value, ii) => ii.WithValue(value))

--- a/src/ReactiveUI/ReactiveObject/IReactiveObjectExtensions.cs
+++ b/src/ReactiveUI/ReactiveObject/IReactiveObjectExtensions.cs
@@ -440,7 +440,7 @@ namespace ReactiveUI
                 return uniqueEvents;
             }
 
-            private Lazy<(ISubject<IReactivePropertyChangedEventArgs<TSender>>, IObservable<IReactivePropertyChangedEventArgs<TSender>>)> CreateLazyDelayableSubjectAndObservable()
+            private Lazy<(ISubject<IReactivePropertyChangedEventArgs<TSender>> changeSubject, IObservable<IReactivePropertyChangedEventArgs<TSender>> changeObservable)> CreateLazyDelayableSubjectAndObservable()
             {
                 return new Lazy<(ISubject<IReactivePropertyChangedEventArgs<TSender>>, IObservable<IReactivePropertyChangedEventArgs<TSender>>)>(() =>
               {

--- a/src/ReactiveUI/Routing/MessageBus.cs
+++ b/src/ReactiveUI/Routing/MessageBus.cs
@@ -123,7 +123,7 @@ namespace ReactiveUI
                 throw new ArgumentNullException(nameof(source));
             }
 
-            return source.Subscribe(SetupSubjectIfNecessary<T>(contract) !);
+            return source.Subscribe(SetupSubjectIfNecessary<T>(contract)!);
         }
 
         /// <summary>

--- a/src/analyzers.ruleset
+++ b/src/analyzers.ruleset
@@ -225,6 +225,7 @@
     <Rule Id="SA1312" Action="Error" />
     <Rule Id="SA1313" Action="Error" />
     <Rule Id="SA1314" Action="Error" />
+    <Rule Id="SA1316" Action="None" />
     <Rule Id="SA1401" Action="Error" />
     <Rule Id="SA1403" Action="Error" />
     <Rule Id="SA1404" Action="Error" />

--- a/src/analyzers.tests.ruleset
+++ b/src/analyzers.tests.ruleset
@@ -229,6 +229,7 @@
     <Rule Id="SA1312" Action="Error" />
     <Rule Id="SA1313" Action="Error" />
     <Rule Id="SA1314" Action="Error" />
+    <Rule Id="SA1316" Action="None" />    
     <Rule Id="SA1401" Action="Error" />
     <Rule Id="SA1403" Action="Error" />
     <Rule Id="SA1404" Action="Error" />


### PR DESCRIPTION
Older versions of StyleCop analyzers forced a space before the `!` character when confirming nullability. This new version doesn't require that.

Also removed old SourceLink csproj settings and not requiring SA1316 (Tuple's requiring upper space first letters). 

SA1316 wasn't turned on due to it being a breaking API change.