### PR TITLE
Add AutoSuspendHelper to ReactiveUI.XamForms

### DIFF
--- a/src/ReactiveUI.XamForms/AutoSuspendHelper.cs
+++ b/src/ReactiveUI.XamForms/AutoSuspendHelper.cs
@@ -3,11 +3,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using Splat;
 using System;
 using System.Reactive;
 using System.Reactive.Disposables;
 using System.Reactive.Subjects;
+using Splat;
 
 namespace ReactiveUI.XamForms
 {
@@ -23,7 +23,7 @@ namespace ReactiveUI.XamForms
     /// public partial class App : Application
     /// {
     ///   private readonly AutoSuspendHelper _autoSuspendHelper;
-    /// 
+    ///
     ///   public App()
     ///   {
     ///     _autoSuspendHelper = new AutoSuspendHelper();
@@ -102,6 +102,14 @@ namespace ReactiveUI.XamForms
         /// </summary>
         public void OnResume() => _onResume.OnNext(Unit.Default);
 
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in Dispose(bool disposing).
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
         /// <summary>
         /// Disposes of the items inside the class.
         /// </summary>
@@ -122,14 +130,6 @@ namespace ReactiveUI.XamForms
             }
 
             _disposedValue = true;
-        }
-
-        /// <inheritdoc />
-        public void Dispose()
-        {
-            // Do not change this code. Put cleanup code in Dispose(bool disposing).
-            Dispose(true);
-            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/ReactiveUI.XamForms/AutoSuspendHelper.cs
+++ b/src/ReactiveUI.XamForms/AutoSuspendHelper.cs
@@ -1,0 +1,135 @@
+// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Splat;
+using System;
+using System.Reactive;
+using System.Reactive.Disposables;
+using System.Reactive.Subjects;
+
+namespace ReactiveUI.XamForms
+{
+    /// <summary>
+    /// Helps manage Xamarin.Forms application lifecycle events.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Instantiate this class in order to setup ReactiveUI suspension hooks. Sample
+    /// usage of <see cref="AutoSuspendHelper" /> is given by the code snippet below.
+    /// <code>
+    /// <![CDATA[
+    /// public partial class App : Application
+    /// {
+    ///   private readonly AutoSuspendHelper _autoSuspendHelper;
+    /// 
+    ///   public App()
+    ///   {
+    ///     _autoSuspendHelper = new AutoSuspendHelper();
+    ///     RxApp.SuspensionHost.CreateNewAppState = () => new MainState();
+    ///     RxApp.SuspensionHost.SetupDefaultSuspendResume(new CustomSuspensionDriver());
+    ///     _autoSuspendHelper.OnCreate();
+    ///
+    ///     InitializeComponent();
+    ///     MainPage = new MainView();
+    ///   }
+    ///
+    ///   protected override void OnStart() => _autoSuspendHelper.OnStart();
+    ///
+    ///   protected override void OnResume() => _autoSuspendHelper.OnResume();
+    ///
+    ///   protected override void OnSleep() => _autoSuspendHelper.OnSleep();
+    /// }
+    /// ]]>
+    /// </code>
+    /// </para>
+    /// </remarks>
+    public class AutoSuspendHelper : IEnableLogger, IDisposable
+    {
+        private readonly Subject<IDisposable> _onSleep = new Subject<IDisposable>();
+        private readonly Subject<Unit> _onLaunchingNew = new Subject<Unit>();
+        private readonly Subject<Unit> _onResume = new Subject<Unit>();
+        private readonly Subject<Unit> _onStart = new Subject<Unit>();
+        private bool _disposedValue; // To detect redundant calls
+
+        /// <summary>
+        /// Initializes static members of the <see cref="AutoSuspendHelper"/> class.
+        /// </summary>
+        static AutoSuspendHelper()
+        {
+            AppDomain.CurrentDomain.UnhandledException += (o, e) => UntimelyDemise.OnNext(Unit.Default);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AutoSuspendHelper"/> class.
+        /// </summary>
+        public AutoSuspendHelper()
+        {
+            RxApp.SuspensionHost.IsLaunchingNew = _onLaunchingNew;
+            RxApp.SuspensionHost.IsResuming = _onResume;
+            RxApp.SuspensionHost.IsUnpausing = _onStart;
+            RxApp.SuspensionHost.ShouldPersistState = _onSleep;
+            RxApp.SuspensionHost.ShouldInvalidateState = UntimelyDemise;
+        }
+
+        /// <summary>
+        /// Gets a subject to indicate whether the application has crashed.
+        /// </summary>
+        public static Subject<Unit> UntimelyDemise { get; } = new Subject<Unit>();
+
+        /// <summary>
+        /// Call this method in the constructor of your Xamarin.Forms
+        /// <see cref="Xamarin.Forms.Application" />.
+        /// </summary>
+        public void OnCreate() => _onLaunchingNew.OnNext(Unit.Default);
+
+        /// <summary>
+        /// Call this method in <see cref="Xamarin.Forms.Application.OnStart" /> method
+        /// override in your Xamarin.Forms <see cref="Xamarin.Forms.Application" />.
+        /// </summary>
+        public void OnStart() => _onStart.OnNext(Unit.Default);
+
+        /// <summary>
+        /// Call this method in <see cref="Xamarin.Forms.Application.OnSleep" /> method
+        /// override in your Xamarin.Forms <see cref="Xamarin.Forms.Application" />.
+        /// </summary>
+        public void OnSleep() => _onSleep.OnNext(Disposable.Empty);
+
+        /// <summary>
+        /// Call this method in <see cref="Xamarin.Forms.Application.OnResume" /> method
+        /// override in your Xamarin.Forms <see cref="Xamarin.Forms.Application" />.
+        /// </summary>
+        public void OnResume() => _onResume.OnNext(Unit.Default);
+
+        /// <summary>
+        /// Disposes of the items inside the class.
+        /// </summary>
+        /// <param name="disposing">If we are disposing of managed objects or not.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposedValue)
+            {
+                return;
+            }
+
+            if (disposing)
+            {
+                _onLaunchingNew?.Dispose();
+                _onResume?.Dispose();
+                _onStart?.Dispose();
+                _onSleep?.Dispose();
+            }
+
+            _disposedValue = true;
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in Dispose(bool disposing).
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

This PR adds a new `AutoSuspendHelper` utility class to the `ReactiveUI.XamForms` package. In the proposed implementation we rely on Xamarin.Forms app lifecycle events https://docs.microsoft.com/en-us/xamarin/xamarin-forms/app-fundamentals/app-lifecycle

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

Currently, `AutoSuspendHelper` implementations exist for iOS and Android as separate classes. An implementation targeting Xamarin.Forms could help to reduce the amount of platform-specific code as stated in https://github.com/reactiveui/ReactiveUI/issues/1429 and also this way we can support other platforms supported by XF.

**What is the new behavior?**
<!-- If this is a feature change -->

Now, there is an implementation of `AutoSuspendHelper` that works with Xamarin.Forms. Expected usage:

```cs
public partial class App : Application
{
    private readonly AutoSuspendHelper _autoSuspendHelper;

    public App()
    {
        _autoSuspendHelper = new AutoSuspendHelper();
        RxApp.SuspensionHost.CreateNewAppState = () => new MainState();
        RxApp.SuspensionHost.SetupDefaultSuspendResume(new CustomSuspensionDriver());
        _autoSuspendHelper.OnCreate();
    
        InitializeComponent();
        var state = RxApp.SuspensionHost.GetAppState<AppState>();
        MainPage = new MainView(new MainViewModel(state));
    }
    
    protected override void OnStart() => _autoSuspendHelper.OnStart();
    
    protected override void OnResume() => _autoSuspendHelper.OnResume();
    
    protected override void OnSleep() => _autoSuspendHelper.OnSleep();
}
```

**What might this PR break?**

Nothing.

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)