### PR TITLE
Update OAPH to skip initial value when deferring subscription

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,10 @@ Install the following packages to start building your own ReactiveUI app. <b>Not
 | Xamarin.iOS       | [ReactiveUI][IosDoc]                | [![CoreBadge]][Core] | [ReactiveUI.Events][CoreEvents]         |
 | Xamarin.Mac       | [ReactiveUI][MacDoc]                | [![CoreBadge]][Core] | [ReactiveUI.Events][CoreEvents]         |
 | Tizen             | [ReactiveUI][CoreDoc]               | [![CoreBadge]][Core] | [ReactiveUI.Events][CoreEvents]         |
-| Platform Uno      | ReactiveUI.Uno                      | [![UnoBadge]][Uno]  | None                                     |
+| Blazor            | [ReactiveUI.Blazor][BlazDoc]        | [![BlazBadge]][Blaz] | None                                    |
+| Platform Uno      | ReactiveUI.Uno                      | [![UnoBadge]][Uno]   | None                                    |
 | Avalonia          | [Avalonia.ReactiveUI][AvaDoc]       | [![AvaBadge]][Ava]   | None                                    |
-| Any               | [ReactiveUI.Validation][ValidationsDocs]    | [![ValidationsBadge]][ValidationsCore] | None
+| Any               | [ReactiveUI.Validation][ValDocs]    | [![ValBadge]][ValCore] | None                                  |
 
 [Core]: https://www.nuget.org/packages/ReactiveUI/
 [CoreEvents]: https://www.nuget.org/packages/ReactiveUI.Events/
@@ -107,15 +108,18 @@ Install the following packages to start building your own ReactiveUI app. <b>Not
 [UnoBadge]: https://img.shields.io/nuget/v/ReactiveUI.Uno.svg
 [UnoDoc]: https://reactiveui.net/docs/getting-started/installation/uno-platform
 
+[Blaz]: https://www.nuget.org/packages/ReactiveUI.Blazor/
+[BlazBadge]: https://img.shields.io/nuget/v/ReactiveUI.Blazor.svg
+[BlazDoc]: https://www.reactiveui.net/blog/2020/07/article-blazor-compelling-example
 
 [Ava]: https://www.nuget.org/packages/Avalonia.ReactiveUI/
 [AvaBadge]: https://img.shields.io/nuget/v/Avalonia.ReactiveUI.svg
 [AvaDoc]: https://reactiveui.net/docs/getting-started/installation/avalonia
 [EventsDocs]: https://reactiveui.net/docs/handbook/events/
 
-[ValidationsCore]: https://www.nuget.org/packages/ReactiveUI.Validation/
-[ValidationsBadge]: https://img.shields.io/nuget/v/ReactiveUI.Validation.svg
-[ValidationsDocs]: https://reactiveui.net/docs/handbook/user-input-validation/
+[ValCore]: https://www.nuget.org/packages/ReactiveUI.Validation/
+[ValBadge]: https://img.shields.io/nuget/v/ReactiveUI.Validation.svg
+[ValDocs]: https://reactiveui.net/docs/handbook/user-input-validation/
 
 <h2>A Compelling Example</h2>
 

--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -69,7 +69,7 @@
   </ItemGroup>
 
   <ItemGroup>	
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.2.31" PrivateAssets="all" />	
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.3.37" PrivateAssets="all" />	
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.net472.approved.txt
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.net472.approved.txt
@@ -394,11 +394,19 @@ namespace ReactiveUI
     }
     public static class OAPHCreationHelperMixin
     {
+        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj source, System.Linq.Expressions.Expression<System.Func<TObj, TRet>> property, System.Func<TRet> getInitialValue, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
+            where TObj :  class, ReactiveUI.IReactiveObject { }
         public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj source, System.Linq.Expressions.Expression<System.Func<TObj, TRet>> property, TRet initialValue = default, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
+            where TObj :  class, ReactiveUI.IReactiveObject { }
+        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj source, string property, System.Func<TRet> getInitialValue, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
             where TObj :  class, ReactiveUI.IReactiveObject { }
         public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj source, string property, TRet initialValue = default, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
             where TObj :  class, ReactiveUI.IReactiveObject { }
+        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj source, System.Linq.Expressions.Expression<System.Func<TObj, TRet>> property, out ReactiveUI.ObservableAsPropertyHelper<TRet> result, System.Func<TRet> getInitialValue, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
+            where TObj :  class, ReactiveUI.IReactiveObject { }
         public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj source, System.Linq.Expressions.Expression<System.Func<TObj, TRet>> property, out ReactiveUI.ObservableAsPropertyHelper<TRet> result, TRet initialValue = default, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
+            where TObj :  class, ReactiveUI.IReactiveObject { }
+        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj source, string property, out ReactiveUI.ObservableAsPropertyHelper<TRet> result, System.Func<TRet> getInitialValue, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
             where TObj :  class, ReactiveUI.IReactiveObject { }
         public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj source, string property, out ReactiveUI.ObservableAsPropertyHelper<TRet> result, TRet initialValue = default, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
             where TObj :  class, ReactiveUI.IReactiveObject { }
@@ -406,6 +414,7 @@ namespace ReactiveUI
     public sealed class ObservableAsPropertyHelper<T> : ReactiveUI.IHandleObservableErrors, Splat.IEnableLogger, System.IDisposable
     {
         public ObservableAsPropertyHelper(System.IObservable<T> observable, System.Action<T> onChanged, T initialValue = default, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null) { }
+        public ObservableAsPropertyHelper(System.IObservable<T> observable, System.Action<T> onChanged, System.Action<T>? onChanging = null, System.Func<T>? getInitialValue = null, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null) { }
         public ObservableAsPropertyHelper(System.IObservable<T> observable, System.Action<T> onChanged, System.Action<T>? onChanging = null, T initialValue = default, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null) { }
         public bool IsSubscribed { get; }
         public System.IObservable<System.Exception> ThrownExceptions { get; }

--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.netcoreapp3.1.approved.txt
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.netcoreapp3.1.approved.txt
@@ -394,11 +394,19 @@ namespace ReactiveUI
     }
     public static class OAPHCreationHelperMixin
     {
+        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj source, System.Linq.Expressions.Expression<System.Func<TObj, TRet>> property, System.Func<TRet> getInitialValue, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
+            where TObj :  class, ReactiveUI.IReactiveObject { }
         public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj source, System.Linq.Expressions.Expression<System.Func<TObj, TRet>> property, TRet initialValue = default, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
+            where TObj :  class, ReactiveUI.IReactiveObject { }
+        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj source, string property, System.Func<TRet> getInitialValue, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
             where TObj :  class, ReactiveUI.IReactiveObject { }
         public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj source, string property, TRet initialValue = default, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
             where TObj :  class, ReactiveUI.IReactiveObject { }
+        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj source, System.Linq.Expressions.Expression<System.Func<TObj, TRet>> property, out ReactiveUI.ObservableAsPropertyHelper<TRet> result, System.Func<TRet> getInitialValue, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
+            where TObj :  class, ReactiveUI.IReactiveObject { }
         public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj source, System.Linq.Expressions.Expression<System.Func<TObj, TRet>> property, out ReactiveUI.ObservableAsPropertyHelper<TRet> result, TRet initialValue = default, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
+            where TObj :  class, ReactiveUI.IReactiveObject { }
+        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj source, string property, out ReactiveUI.ObservableAsPropertyHelper<TRet> result, System.Func<TRet> getInitialValue, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
             where TObj :  class, ReactiveUI.IReactiveObject { }
         public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj source, string property, out ReactiveUI.ObservableAsPropertyHelper<TRet> result, TRet initialValue = default, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
             where TObj :  class, ReactiveUI.IReactiveObject { }
@@ -406,6 +414,7 @@ namespace ReactiveUI
     public sealed class ObservableAsPropertyHelper<T> : ReactiveUI.IHandleObservableErrors, Splat.IEnableLogger, System.IDisposable
     {
         public ObservableAsPropertyHelper(System.IObservable<T> observable, System.Action<T> onChanged, T initialValue = default, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null) { }
+        public ObservableAsPropertyHelper(System.IObservable<T> observable, System.Action<T> onChanged, System.Action<T>? onChanging = null, System.Func<T>? getInitialValue = null, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null) { }
         public ObservableAsPropertyHelper(System.IObservable<T> observable, System.Action<T> onChanged, System.Action<T>? onChanging = null, T initialValue = default, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null) { }
         public bool IsSubscribed { get; }
         public System.IObservable<System.Exception> ThrownExceptions { get; }

--- a/src/ReactiveUI.Tests/ObservableAsPropertyHelper/ObservableAsPropertyHelperTest.cs
+++ b/src/ReactiveUI.Tests/ObservableAsPropertyHelper/ObservableAsPropertyHelperTest.cs
@@ -188,7 +188,23 @@ namespace ReactiveUI.Tests
         {
             var observable = Observable.Empty<int>();
 
-            var fixture = new ObservableAsPropertyHelper<int>(observable, _ => { }, initialValue, true);
+            var fixture = new ObservableAsPropertyHelper<int>(observable, _ => { }, initialValue, deferSubscription: true);
+
+            Assert.False(fixture.IsSubscribed);
+
+            int? emittedValue = null;
+            fixture.Source.Subscribe(val => emittedValue = val);
+            Assert.Null(emittedValue);
+            Assert.False(fixture.IsSubscribed);
+        }
+
+        [Fact]
+        public void OAPHDeferSubscriptionWithInitialFuncValueShouldNotEmitInitialValueNorAccessFunc()
+        {
+            var observable = Observable.Empty<int>();
+            Func<int> throwIfAccessed = () => throw new Exception();
+
+            var fixture = new ObservableAsPropertyHelper<int>(observable, _ => { }, getInitialValue: throwIfAccessed, deferSubscription: true);
 
             Assert.False(fixture.IsSubscribed);
 
@@ -205,13 +221,35 @@ namespace ReactiveUI.Tests
         {
             var observable = Observable.Empty<int>();
 
-            var fixture = new ObservableAsPropertyHelper<int>(observable, _ => { }, initialValue, true);
+            var fixture = new ObservableAsPropertyHelper<int>(observable, _ => { }, initialValue, deferSubscription: true);
 
             Assert.False(fixture.IsSubscribed);
 
             var result = fixture.Value;
             Assert.True(fixture.IsSubscribed);
             Assert.Equal(initialValue, result);
+        }
+
+        [Fact]
+        public void OAPHDeferSubscriptionWithInitialFuncValueEmitInitialValueWhenSubscribed()
+        {
+            var observable = Observable.Empty<int>();
+            bool wasAccessed = false;
+            Func<int> getInitialValue = () =>
+            {
+                wasAccessed = true;
+                return 42;
+            };
+
+            var fixture = new ObservableAsPropertyHelper<int>(observable, _ => { }, getInitialValue: getInitialValue, deferSubscription: true);
+
+            Assert.False(fixture.IsSubscribed);
+            Assert.False(wasAccessed);
+
+            var result = fixture.Value;
+            Assert.True(fixture.IsSubscribed);
+            Assert.True(wasAccessed);
+            Assert.Equal(42, result);
         }
 
         [Theory]
@@ -221,7 +259,7 @@ namespace ReactiveUI.Tests
         {
             var observable = Observable.Empty<int>();
 
-            var fixture = new ObservableAsPropertyHelper<int>(observable, _ => { }, initialValue, false);
+            var fixture = new ObservableAsPropertyHelper<int>(observable, _ => { }, initialValue, deferSubscription: false);
 
             Assert.True(fixture.IsSubscribed);
 

--- a/src/ReactiveUI.Tests/ObservableAsPropertyHelper/ObservableAsPropertyHelperTest.cs
+++ b/src/ReactiveUI.Tests/ObservableAsPropertyHelper/ObservableAsPropertyHelperTest.cs
@@ -182,6 +182,50 @@ namespace ReactiveUI.Tests
         }
 
         [Fact]
+        public void OAPHDeferSubscriptionWithDefaultValueShouldNotEmitInitialValue()
+        {
+            var observable = Observable.Empty<int>();
+
+            var fixture = new ObservableAsPropertyHelper<int>(observable, _ => { }, default, true);
+
+            Assert.False(fixture.IsSubscribed);
+
+            int? emittedValue = null;
+            fixture.Source.Subscribe(val => emittedValue = val);
+            Assert.Null(emittedValue);
+            Assert.False(fixture.IsSubscribed);
+        }
+
+        [Fact]
+        public void OAPHDeferSubscriptionWithInitialValueShouldEmitInitialValue()
+        {
+            var observable = Observable.Empty<int>();
+
+            var fixture = new ObservableAsPropertyHelper<int>(observable, _ => { }, 42, true);
+
+            Assert.False(fixture.IsSubscribed);
+
+            int? emittedValue = null;
+            fixture.Source.Subscribe(val => emittedValue = val);
+            Assert.Equal(42, emittedValue);
+            Assert.False(fixture.IsSubscribed);
+        }
+
+        [Fact]
+        public void OAPHWithDefaultValueShouldEmitInitialValue()
+        {
+            var observable = Observable.Empty<int>();
+
+            var fixture = new ObservableAsPropertyHelper<int>(observable, _ => { }, default, false);
+
+            Assert.True(fixture.IsSubscribed);
+
+            int? emittedValue = null;
+            fixture.Source.Subscribe(val => emittedValue = val);
+            Assert.Equal(default(int), emittedValue);
+        }
+
+        [Fact]
         public void OAPHShouldRethrowErrors()
         {
             var input = new Subject<int>();

--- a/src/ReactiveUI.Tests/ObservableAsPropertyHelper/ObservableAsPropertyHelperTest.cs
+++ b/src/ReactiveUI.Tests/ObservableAsPropertyHelper/ObservableAsPropertyHelperTest.cs
@@ -181,12 +181,14 @@ namespace ReactiveUI.Tests
             Assert.Null(ex);
         }
 
-        [Fact]
-        public void OAPHDeferSubscriptionWithDefaultValueShouldNotEmitInitialValue()
+        [Theory]
+        [InlineData(default(int))]
+        [InlineData(42)]
+        public void OAPHDeferSubscriptionWithInitialValueShouldNotEmitInitialValue(int initialValue)
         {
             var observable = Observable.Empty<int>();
 
-            var fixture = new ObservableAsPropertyHelper<int>(observable, _ => { }, default, true);
+            var fixture = new ObservableAsPropertyHelper<int>(observable, _ => { }, initialValue, true);
 
             Assert.False(fixture.IsSubscribed);
 
@@ -196,33 +198,36 @@ namespace ReactiveUI.Tests
             Assert.False(fixture.IsSubscribed);
         }
 
-        [Fact]
-        public void OAPHDeferSubscriptionWithInitialValueShouldEmitInitialValue()
+        [Theory]
+        [InlineData(default(int))]
+        [InlineData(42)]
+        public void OAPHDeferSubscriptionWithInitialValueEmitInitialValueWhenSubscribed(int initialValue)
         {
             var observable = Observable.Empty<int>();
 
-            var fixture = new ObservableAsPropertyHelper<int>(observable, _ => { }, 42, true);
+            var fixture = new ObservableAsPropertyHelper<int>(observable, _ => { }, initialValue, true);
 
             Assert.False(fixture.IsSubscribed);
 
-            int? emittedValue = null;
-            fixture.Source.Subscribe(val => emittedValue = val);
-            Assert.Equal(42, emittedValue);
-            Assert.False(fixture.IsSubscribed);
+            var result = fixture.Value;
+            Assert.True(fixture.IsSubscribed);
+            Assert.Equal(initialValue, result);
         }
 
-        [Fact]
-        public void OAPHWithDefaultValueShouldEmitInitialValue()
+        [Theory]
+        [InlineData(default(int))]
+        [InlineData(42)]
+        public void OAPHInitialValueShouldEmitInitialValue(int initialValue)
         {
             var observable = Observable.Empty<int>();
 
-            var fixture = new ObservableAsPropertyHelper<int>(observable, _ => { }, default, false);
+            var fixture = new ObservableAsPropertyHelper<int>(observable, _ => { }, initialValue, false);
 
             Assert.True(fixture.IsSubscribed);
 
             int? emittedValue = null;
             fixture.Source.Subscribe(val => emittedValue = val);
-            Assert.Equal(default(int), emittedValue);
+            Assert.Equal(initialValue, emittedValue);
         }
 
         [Fact]

--- a/src/ReactiveUI/ObservableForProperty/ObservableAsPropertyHelper.cs
+++ b/src/ReactiveUI/ObservableForProperty/ObservableAsPropertyHelper.cs
@@ -26,7 +26,6 @@ namespace ReactiveUI
     {
         private readonly Lazy<ISubject<Exception>> _thrownExceptions;
         private readonly ISubject<T> _subject;
-        private T _initialValue;
         private T _lastValue;
         private CompositeDisposable _disposable = new CompositeDisposable();
         private int _activated;
@@ -118,7 +117,7 @@ namespace ReactiveUI
 
             _thrownExceptions = new Lazy<ISubject<Exception>>(() => new ScheduledSubject<Exception>(CurrentThreadScheduler.Instance, RxApp.DefaultExceptionHandler));
 
-            _initialValue = initialValue;
+            _lastValue = initialValue;
 
             // Avoid the first notification only if the subscription is deferred and the initial value
             // is not set or is set to default.
@@ -128,7 +127,6 @@ namespace ReactiveUI
 
             if (!deferSubscription)
             {
-                _lastValue = initialValue;
                 Source.Subscribe(_subject).DisposeWith(_disposable);
                 _activated = 1;
             }
@@ -147,7 +145,7 @@ namespace ReactiveUI
                     var localReferenceInCaseDisposeIsCalled = _disposable;
                     if (localReferenceInCaseDisposeIsCalled != null)
                     {
-                        Source.StartWith(_initialValue).Subscribe(_subject).DisposeWith(localReferenceInCaseDisposeIsCalled);
+                        Source.StartWith(_lastValue).Subscribe(_subject).DisposeWith(localReferenceInCaseDisposeIsCalled);
                     }
                 }
 

--- a/src/ReactiveUI/ObservableForProperty/ObservableAsPropertyHelper.cs
+++ b/src/ReactiveUI/ObservableForProperty/ObservableAsPropertyHelper.cs
@@ -162,7 +162,9 @@ namespace ReactiveUI
 
             if (deferSubscription)
             {
+#pragma warning disable CS8601 // Possible null reference assignment.
                 _lastValue = default;
+#pragma warning restore CS8601 // Possible null reference assignment.
                 Source = observable.DistinctUntilChanged();
             }
             else


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Allow to not emit the initial value when deferring the subscription.

**What is the current behavior?**
If you subscribe to the property change it will emit a first default value.

**What is the new behavior?**
If you subscribe to the property change it will NOT emit a first default value.

**What might this PR break?**
As far as I can tell the biggest risk, and a risk I would be facing on some projects, is that to workaround this behavior I have used `Skip(1)` and if the first value is no longer emitted then the `Skip(1)` will skip the wrong value.

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
Fix #2124
