### PR TITLE
build(deps): Use Shouldly 4.0.0-beta0003

### DIFF
--- a/integrationtests/IntegrationTests.Shared.Tests/IntegrationTests.Shared.Tests.csproj
+++ b/integrationtests/IntegrationTests.Shared.Tests/IntegrationTests.Shared.Tests.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="Shouldly" Version="4.0.0-beta0002" />
+    <PackageReference Include="Shouldly" Version="4.0.0-beta0003" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -47,7 +47,7 @@
     <PackageReference Include="xunit.runner.console" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <PackageReference Include="Xunit.StaFact" Version="1.0.37" />
-    <PackageReference Include="Shouldly" Version="4.0.0-beta0002" />
+    <PackageReference Include="Shouldly" Version="4.0.0-beta0003" />
     <PackageReference Include="Microsoft.Reactive.Testing" Version="4.4.1" />
     <PackageReference Include="PublicApiGenerator" Version="10.2.0" />
   </ItemGroup>

--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -48,6 +48,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <PackageReference Include="Xunit.StaFact" Version="1.0.37" />
     <PackageReference Include="Shouldly" Version="4.0.0-beta0003" />
+    <PackageReference Include="DiffEngine" Version="6.1.1" />
     <PackageReference Include="Microsoft.Reactive.Testing" Version="4.4.1" />
     <PackageReference Include="PublicApiGenerator" Version="10.2.0" />
   </ItemGroup>

--- a/src/ReactiveUI.Fody.Tests/ApiApprovalBase.cs
+++ b/src/ReactiveUI.Fody.Tests/ApiApprovalBase.cs
@@ -13,6 +13,7 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using DiffEngine;
 using PublicApiGenerator;
 using Shouldly;
 using Splat;
@@ -48,7 +49,7 @@ namespace ReactiveUI.Fody.Tests
                 if (!string.Equals(receivedPublicApi, approvedPublicApi, StringComparison.InvariantCulture))
                 {
                     File.WriteAllText(receivedFileName, receivedPublicApi);
-                    ShouldlyConfiguration.DiffTools.GetDiffTool().Open(receivedFileName, approvedFileName, true);
+                    DiffEngine.DiffRunner.Launch(receivedFileName, approvedFileName);
                 }
 
                 Assert.Equal(approvedPublicApi, receivedPublicApi);

--- a/src/ReactiveUI.Tests/Utilities/ApiApprovalBase.cs
+++ b/src/ReactiveUI.Tests/Utilities/ApiApprovalBase.cs
@@ -15,6 +15,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using DiffEngine;
 using PublicApiGenerator;
 using Shouldly;
 using Splat;
@@ -56,7 +57,7 @@ namespace ReactiveUI.Tests
                 File.WriteAllText(receivedFileName, receivedPublicApi);
                 try
                 {
-                    ShouldlyConfiguration.DiffTools.GetDiffTool().Open(receivedFileName, approvedFileName, true);
+                    DiffEngine.DiffRunner.Launch(receivedFileName, approvedFileName);
                 }
                 catch (ShouldAssertException)
                 {


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

The breaking change in Shouldly `4.0.0-beta0003` https://github.com/reactiveui/ReactiveUI/pull/2538 fails our build, so here is a fix.

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

Currently, we are using Shouldly `4.0.0-beta0002`, and dependabot is unable to upgrade the package due to a breaking change. 

**What is the new behavior?**
<!-- If this is a feature change -->

Now, the package is upgraded and we are using the new `DiffEngine` API.

The new `DiffEngine` library lives here: https://github.com/VerifyTests/DiffEngine

**What might this PR break?**

Nothing, as this is just a minor dependency upgrade.