### PR TITLE
Update unsupported expression error messages

### DIFF
--- a/src/ReactiveUI.Tests/WhenAny/ReactiveNotifyPropertyChangedMixinTest.cs
+++ b/src/ReactiveUI.Tests/WhenAny/ReactiveNotifyPropertyChangedMixinTest.cs
@@ -24,6 +24,8 @@ namespace ReactiveUI.Tests
 {
     public class ReactiveNotifyPropertyChangedMixinTest
     {
+        public string? Dummy { get; set; }
+
         [Fact]
         public void AnyChangeInExpressionListTriggersUpdate()
         {
@@ -750,6 +752,26 @@ namespace ReactiveUI.Tests
             Assert.False(weakRef1.IsAlive);
             Assert.False(weakRef2.IsAlive);
             Assert.False(weakRef3.IsAlive);
+        }
+
+        [Fact]
+        public void WhenAnyValueUnsupportedExpressionType_Equal()
+        {
+            var fixture = new TestFixture();
+            var exception = Assert.Throws<NotSupportedException>(
+                () => fixture.WhenAnyValue(x => x.IsNotNullString == x.IsOnlyOneWord).Subscribe());
+
+            Assert.Equal("Unsupported expression of type 'Equal' (x.IsNotNullString == x.IsOnlyOneWord). Did you meant to use expressions 'x.IsNotNullString' and 'x.IsOnlyOneWord'?", exception.Message);
+        }
+
+        [Fact]
+        public void WhenAnyValueUnsupportedExpressionType_Constant()
+        {
+            var fixture = new TestFixture();
+            var exception = Assert.Throws<NotSupportedException>(
+                () => fixture.WhenAnyValue(x => Dummy).Subscribe());
+
+            Assert.Equal("Unsupported expression of type 'Constant'. Did you miss the member access prefix in the expression?", exception.Message);
         }
     }
 }

--- a/src/ReactiveUI/Expression/ExpressionRewriter.cs
+++ b/src/ReactiveUI/Expression/ExpressionRewriter.cs
@@ -39,7 +39,18 @@ namespace ReactiveUI
             case ExpressionType.Convert:
                 return VisitUnary((UnaryExpression)node);
             default:
-                throw new NotSupportedException($"Unsupported expression type: '{node.NodeType}'");
+                var errorMessageBuilder = new StringBuilder($"Unsupported expression of type '{node.NodeType}' {node}.");
+
+                if (node is BinaryExpression binaryExpression)
+                {
+                    errorMessageBuilder.Append(" Did you meant to use expressions '")
+                        .Append(binaryExpression.Left)
+                        .Append("' and '")
+                        .Append(binaryExpression.Right)
+                        .Append("'?");
+                }
+
+                throw new NotSupportedException(errorMessageBuilder.ToString());
             }
         }
 

--- a/src/ReactiveUI/Mixins/ExpressionMixins.cs
+++ b/src/ReactiveUI/Mixins/ExpressionMixins.cs
@@ -61,7 +61,14 @@ namespace ReactiveUI
                     node = memberExpr.Expression;
                     break;
                 default:
-                    throw new NotSupportedException($"Unsupported expression type: '{node.NodeType}'");
+                    var errorMessageBuilder = new StringBuilder($"Unsupported expression of type '{node.NodeType}'.");
+
+                    if (node is ConstantExpression)
+                    {
+                        errorMessageBuilder.Append(" Did you miss the member access prefix in the expression?");
+                    }
+
+                    throw new NotSupportedException(errorMessageBuilder.ToString());
                 }
             }
 


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

This PR intends to improve the error message when providing an unsupported expression type in the `WhenAny` calls.

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

Fix #1209

**What is the new behavior?**
<!-- If this is a feature change -->



**What might this PR break?**



**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**: