### PR TITLE
housekeeping: Fix CodeCov Paths

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -27,22 +27,17 @@ jobs:
       with:
         dotnet-version: 3.1.x
 
-    - name: Use Node.js
-      uses: actions/setup-node@v1
+    - name: NBGV
+      id: nbgv
+      uses: dotnet/nbgv@master
       with:
-        node-version: '12.x'
+        setAllVars: true
 
     - name: NuGet restore
       run: | 
         dotnet restore ReactiveUI.sln
         dotnet restore ReactiveUI.Events.sln
       working-directory: src
-
-    - name: NBGV
-      id: nbgv
-      uses: dotnet/nbgv@master
-      with:
-        setAllVars: true
 
     - name: Add MSBuild to PATH
       uses: microsoft/setup-msbuild@v1

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -68,23 +68,15 @@ jobs:
         exclude-filter: '[${{env.productNamespacePrefix}}*Tests.*]*'
         include-filter: '[${{env.productNamespacePrefix}}*]*'
         output-format: cobertura
-        output: '../../artifacts/coverage/'
+        output: '../../artifacts/'
         configuration: ${{ env.configuration }}
-        skip-auto-props: false
-        use-sourcelink: false
         working-directory: src
 
-    - name: Combine Coverage Reports
+    - name: Upload Code Coverage
       shell: bash
       run: |
-        dotnet tool install --global dotnet-reportgenerator-globaltool
-        reportgenerator -reports:artifacts/coverage/*.xml -targetdir:artifacts/finalcoverage  -reporttypes:Cobertura
-
-    - name: Upload Code Coverage
-      run: |
-        npm install -g codecov
-        codecov
-      working-directory: artifacts/finalcoverage
+        echo $PWD
+        bash <(curl -s https://codecov.io/bash) -X gcov -X coveragepy -t ${{ env.CODECOV_TOKEN }} -s '$PWD/artifacts' -f '*.xml'
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -60,12 +60,11 @@ jobs:
       with:
         project-files: 'src/**/*Tests*.csproj'
         no-build: true
-        exclude-filter: '[${{env.productNamespacePrefix}}*Tests.*]*'
+        exclude-filter: '[${{env.productNamespacePrefix}}.*.Tests.*]*'
         include-filter: '[${{env.productNamespacePrefix}}*]*'
         output-format: cobertura
         output: '../../artifacts/'
         configuration: ${{ env.configuration }}
-        working-directory: src
 
     - name: Upload Code Coverage
       shell: bash


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

This PR updates the `ci-build.yml` file with the new parameters coming from https://github.com/reactiveui/ReactiveUI.Validation/pull/156 With this PR, we are getting rid of `node`, `dotnet-reportgenerator` and `npm`, we are invoking codecov bash script now. This PR also updates the `codecov` paths from the old format `a/ReactiveUI/ReactiveUI/src/ReactiveUI/VariadicTemplates.cs` to the new format `src/ReactiveUI/VariadicTemplates.cs`, this should fix potential issues with paths.