### PR TITLE
fix:  TransitionContentControl throwing exception on control height zero

### DIFF
--- a/src/ReactiveUI.Wpf/TransitioningContentControl.cs
+++ b/src/ReactiveUI.Wpf/TransitioningContentControl.cs
@@ -224,6 +224,11 @@ namespace ReactiveUI
 
         private static RenderTargetBitmap GetRenderTargetBitmapFromUiElement(UIElement uiElement)
         {
+            if (uiElement.RenderSize.Height == 0)
+            {
+                return default!;
+            }
+
             DpiScale dpiScale = VisualTreeHelper.GetDpi(uiElement);
 
             var renderTargetBitmap = new RenderTargetBitmap(
@@ -288,6 +293,7 @@ namespace ReactiveUI
             }
 
             _previousImageSite.Source = GetRenderTargetBitmapFromUiElement(_currentContentPresentationSite);
+
             _currentContentPresentationSite.Content = newContent;
             string startingTransitionName;
 


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

resolves: #2565 

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

`GetRenderTargetBitmapFromUiElement` throws an exception when `ui.Element.RenderSize.Height` is zero

**What is the new behavior?**
<!-- If this is a feature change -->

return a default value in the `Height == 0` case

**What might this PR break?**

`TransitionContentControl `

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

