### PR TITLE
housekeeping: Update Copyright Year

### DIFF
--- a/integrationtests/IntegrationTests.Android/MainActivity.cs
+++ b/integrationtests/IntegrationTests.Android/MainActivity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/integrationtests/IntegrationTests.Android/Properties/AssemblyInfo.cs
+++ b/integrationtests/IntegrationTests.Android/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/integrationtests/IntegrationTests.Mac/AppDelegate.cs
+++ b/integrationtests/IntegrationTests.Mac/AppDelegate.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/integrationtests/IntegrationTests.Mac/LoginViewController.cs
+++ b/integrationtests/IntegrationTests.Mac/LoginViewController.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/integrationtests/IntegrationTests.Mac/MainClass.cs
+++ b/integrationtests/IntegrationTests.Mac/MainClass.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/integrationtests/IntegrationTests.Mac/Properties/AssemblyInfo.cs
+++ b/integrationtests/IntegrationTests.Mac/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/integrationtests/IntegrationTests.Shared.Tests/BuilderExtensions.cs
+++ b/integrationtests/IntegrationTests.Shared.Tests/BuilderExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/integrationtests/IntegrationTests.Shared.Tests/Features/Login/LoginViewModelBuilder.cs
+++ b/integrationtests/IntegrationTests.Shared.Tests/Features/Login/LoginViewModelBuilder.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/integrationtests/IntegrationTests.Shared.Tests/Features/Login/LoginViewModelTests.cs
+++ b/integrationtests/IntegrationTests.Shared.Tests/Features/Login/LoginViewModelTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/integrationtests/IntegrationTests.Shared.Tests/IBuilder.cs
+++ b/integrationtests/IntegrationTests.Shared.Tests/IBuilder.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/integrationtests/IntegrationTests.Shared/LoginViewModel.cs
+++ b/integrationtests/IntegrationTests.Shared/LoginViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/integrationtests/IntegrationTests.UWP/App.xaml.cs
+++ b/integrationtests/IntegrationTests.UWP/App.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/integrationtests/IntegrationTests.UWP/LoginControl.xaml.cs
+++ b/integrationtests/IntegrationTests.UWP/LoginControl.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/integrationtests/IntegrationTests.UWP/LoginControlBase.cs
+++ b/integrationtests/IntegrationTests.UWP/LoginControlBase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/integrationtests/IntegrationTests.UWP/MainPage.xaml.cs
+++ b/integrationtests/IntegrationTests.UWP/MainPage.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/integrationtests/IntegrationTests.UWP/Properties/AssemblyInfo.cs
+++ b/integrationtests/IntegrationTests.UWP/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/integrationtests/IntegrationTests.WPF/App.xaml.cs
+++ b/integrationtests/IntegrationTests.WPF/App.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/integrationtests/IntegrationTests.WPF/LoginControl.xaml.cs
+++ b/integrationtests/IntegrationTests.WPF/LoginControl.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/integrationtests/IntegrationTests.WPF/MainWindow.xaml.cs
+++ b/integrationtests/IntegrationTests.WPF/MainWindow.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/integrationtests/IntegrationTests.WPF/Properties/AssemblyInfo.cs
+++ b/integrationtests/IntegrationTests.WPF/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/integrationtests/IntegrationTests.WPF/UserControlExtensions.cs
+++ b/integrationtests/IntegrationTests.WPF/UserControlExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/integrationtests/IntegrationTests.WinForms/LoginControl.cs
+++ b/integrationtests/IntegrationTests.WinForms/LoginControl.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/integrationtests/IntegrationTests.WinForms/MainForm.cs
+++ b/integrationtests/IntegrationTests.WinForms/MainForm.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/integrationtests/IntegrationTests.WinForms/Program.cs
+++ b/integrationtests/IntegrationTests.WinForms/Program.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/integrationtests/IntegrationTests.WinForms/Properties/AssemblyInfo.cs
+++ b/integrationtests/IntegrationTests.WinForms/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/integrationtests/IntegrationTests.XamarinForms.Android/MainActivity.cs
+++ b/integrationtests/IntegrationTests.XamarinForms.Android/MainActivity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/integrationtests/IntegrationTests.XamarinForms.Android/Properties/AssemblyInfo.cs
+++ b/integrationtests/IntegrationTests.XamarinForms.Android/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/integrationtests/IntegrationTests.XamarinForms.UWP/App.xaml.cs
+++ b/integrationtests/IntegrationTests.XamarinForms.UWP/App.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/integrationtests/IntegrationTests.XamarinForms.UWP/MainPage.xaml.cs
+++ b/integrationtests/IntegrationTests.XamarinForms.UWP/MainPage.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/integrationtests/IntegrationTests.XamarinForms.UWP/Properties/AssemblyInfo.cs
+++ b/integrationtests/IntegrationTests.XamarinForms.UWP/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/integrationtests/IntegrationTests.XamarinForms.iOS/AppDelegate.cs
+++ b/integrationtests/IntegrationTests.XamarinForms.iOS/AppDelegate.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/integrationtests/IntegrationTests.XamarinForms.iOS/AppLaunch.cs
+++ b/integrationtests/IntegrationTests.XamarinForms.iOS/AppLaunch.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/integrationtests/IntegrationTests.XamarinForms.iOS/Properties/AssemblyInfo.cs
+++ b/integrationtests/IntegrationTests.XamarinForms.iOS/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/integrationtests/IntegrationTests.XamarinForms/App.xaml.cs
+++ b/integrationtests/IntegrationTests.XamarinForms/App.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/integrationtests/IntegrationTests.XamarinForms/MainPage.xaml.cs
+++ b/integrationtests/IntegrationTests.XamarinForms/MainPage.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/integrationtests/IntegrationTests.iOS/AppDelegate.cs
+++ b/integrationtests/IntegrationTests.iOS/AppDelegate.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/integrationtests/IntegrationTests.iOS/Application.cs
+++ b/integrationtests/IntegrationTests.iOS/Application.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/integrationtests/IntegrationTests.iOS/LoginViewController.cs
+++ b/integrationtests/IntegrationTests.iOS/LoginViewController.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ApiGeneratorGlobalSuppressions.cs
+++ b/src/ApiGeneratorGlobalSuppressions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/Benchmarks/AutoPersistBenchmark.cs
+++ b/src/Benchmarks/AutoPersistBenchmark.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/Benchmarks/CreateReactiveListBenchmark.cs
+++ b/src/Benchmarks/CreateReactiveListBenchmark.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/Benchmarks/INPCObservableForPropertyBenchmarks.cs
+++ b/src/Benchmarks/INPCObservableForPropertyBenchmarks.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/Benchmarks/Mocks/MockHostScreen.cs
+++ b/src/Benchmarks/Mocks/MockHostScreen.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/Benchmarks/Mocks/MockViewModel.cs
+++ b/src/Benchmarks/Mocks/MockViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/Benchmarks/NavigationStackBenchmark.cs
+++ b/src/Benchmarks/NavigationStackBenchmark.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/Benchmarks/Program.cs
+++ b/src/Benchmarks/Program.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/Benchmarks/ReactiveCommandCreateBenchmark.cs
+++ b/src/Benchmarks/ReactiveCommandCreateBenchmark.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/Benchmarks/ReactiveListOperationBenchmark.cs
+++ b/src/Benchmarks/ReactiveListOperationBenchmark.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/Benchmarks/RoutableViewModelMixinsBenchmarks.cs
+++ b/src/Benchmarks/RoutableViewModelMixinsBenchmarks.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.AndroidSupport/ControlFetcherMixin.cs
+++ b/src/ReactiveUI.AndroidSupport/ControlFetcherMixin.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.AndroidSupport/ReactiveAppCompatActivity.cs
+++ b/src/ReactiveUI.AndroidSupport/ReactiveAppCompatActivity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.AndroidSupport/ReactiveDialogFragment.cs
+++ b/src/ReactiveUI.AndroidSupport/ReactiveDialogFragment.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.AndroidSupport/ReactiveFragment.cs
+++ b/src/ReactiveUI.AndroidSupport/ReactiveFragment.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.AndroidSupport/ReactiveFragmentActivity.cs
+++ b/src/ReactiveUI.AndroidSupport/ReactiveFragmentActivity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.AndroidSupport/ReactivePagerAdapter.cs
+++ b/src/ReactiveUI.AndroidSupport/ReactivePagerAdapter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.AndroidSupport/ReactivePreferenceFragment.cs
+++ b/src/ReactiveUI.AndroidSupport/ReactivePreferenceFragment.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.AndroidSupport/ReactiveRecyclerViewAdapter.cs
+++ b/src/ReactiveUI.AndroidSupport/ReactiveRecyclerViewAdapter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.AndroidSupport/ReactiveRecyclerViewViewHolder.cs
+++ b/src/ReactiveUI.AndroidSupport/ReactiveRecyclerViewViewHolder.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.AndroidX/ControlFetcherMixin.cs
+++ b/src/ReactiveUI.AndroidX/ControlFetcherMixin.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.AndroidX/ReactiveAppCompatActivity.cs
+++ b/src/ReactiveUI.AndroidX/ReactiveAppCompatActivity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.AndroidX/ReactiveDialogFragment.cs
+++ b/src/ReactiveUI.AndroidX/ReactiveDialogFragment.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.AndroidX/ReactiveFragment.cs
+++ b/src/ReactiveUI.AndroidX/ReactiveFragment.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.AndroidX/ReactiveFragmentActivity.cs
+++ b/src/ReactiveUI.AndroidX/ReactiveFragmentActivity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.AndroidX/ReactivePagerAdapter.cs
+++ b/src/ReactiveUI.AndroidX/ReactivePagerAdapter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.AndroidX/ReactivePreferenceFragment.cs
+++ b/src/ReactiveUI.AndroidX/ReactivePreferenceFragment.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.AndroidX/ReactiveRecyclerViewAdapter.cs
+++ b/src/ReactiveUI.AndroidX/ReactiveRecyclerViewAdapter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.AndroidX/ReactiveRecyclerViewViewHolder.cs
+++ b/src/ReactiveUI.AndroidX/ReactiveRecyclerViewViewHolder.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Blazor/PlatformOperations.cs
+++ b/src/ReactiveUI.Blazor/PlatformOperations.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Blazor/ReactiveComponentBase.cs
+++ b/src/ReactiveUI.Blazor/ReactiveComponentBase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Blazor/ReactiveInjectableComponentBase.cs
+++ b/src/ReactiveUI.Blazor/ReactiveInjectableComponentBase.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Blazor/ReactiveLayoutComponentBase.cs
+++ b/src/ReactiveUI.Blazor/ReactiveLayoutComponentBase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Blazor/Registrations.cs
+++ b/src/ReactiveUI.Blazor/Registrations.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Blend/FollowObservableStateBehavior.cs
+++ b/src/ReactiveUI.Blend/FollowObservableStateBehavior.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Blend/Platforms/net4/ObservableTrigger.cs
+++ b/src/ReactiveUI.Blend/Platforms/net4/ObservableTrigger.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Blend/Platforms/uap/Behavior.cs
+++ b/src/ReactiveUI.Blend/Platforms/uap/Behavior.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Blend/Platforms/uap/ObservableTriggerBehavior.cs
+++ b/src/ReactiveUI.Blend/Platforms/uap/ObservableTriggerBehavior.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Drawing/Registrations.cs
+++ b/src/ReactiveUI.Drawing/Registrations.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Fody.Analyzer.Test/Helpers/CodeFixVerifier.Helper.cs
+++ b/src/ReactiveUI.Fody.Analyzer.Test/Helpers/CodeFixVerifier.Helper.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Fody.Analyzer.Test/Helpers/DiagnosticResult.cs
+++ b/src/ReactiveUI.Fody.Analyzer.Test/Helpers/DiagnosticResult.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Fody.Analyzer.Test/Helpers/DiagnosticResultLocation.cs
+++ b/src/ReactiveUI.Fody.Analyzer.Test/Helpers/DiagnosticResultLocation.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Fody.Analyzer.Test/Helpers/DiagnosticVerifier.Helper.cs
+++ b/src/ReactiveUI.Fody.Analyzer.Test/Helpers/DiagnosticVerifier.Helper.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Fody.Analyzer.Test/ReactiveObjectAnalyzerTest.cs
+++ b/src/ReactiveUI.Fody.Analyzer.Test/ReactiveObjectAnalyzerTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Fody.Analyzer.Test/Verifiers/DiagnosticVerifier.cs
+++ b/src/ReactiveUI.Fody.Analyzer.Test/Verifiers/DiagnosticVerifier.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Fody.Analyzer/ReactiveObjectAnalyzer.cs
+++ b/src/ReactiveUI.Fody.Analyzer/ReactiveObjectAnalyzer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Fody.Helpers/ObservableAsPropertyAttribute.cs
+++ b/src/ReactiveUI.Fody.Helpers/ObservableAsPropertyAttribute.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Fody.Helpers/ObservableAsPropertyExtensions.cs
+++ b/src/ReactiveUI.Fody.Helpers/ObservableAsPropertyExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Fody.Helpers/Properties/AssemblyInfo.cs
+++ b/src/ReactiveUI.Fody.Helpers/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Fody.Helpers/ReactiveAttribute.cs
+++ b/src/ReactiveUI.Fody.Helpers/ReactiveAttribute.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Fody.Helpers/ReactiveDependencyAttribute.cs
+++ b/src/ReactiveUI.Fody.Helpers/ReactiveDependencyAttribute.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Fody.Tests/API/ApiApprovalTests.cs
+++ b/src/ReactiveUI.Fody.Tests/API/ApiApprovalTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Fody.Tests/ApiApprovalBase.cs
+++ b/src/ReactiveUI.Fody.Tests/ApiApprovalBase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Fody.Tests/Issues/Issue10Tests.cs
+++ b/src/ReactiveUI.Fody.Tests/Issues/Issue10Tests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Fody.Tests/Issues/Issue11Tests.cs
+++ b/src/ReactiveUI.Fody.Tests/Issues/Issue11Tests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Fody.Tests/Issues/Issue13Tests.cs
+++ b/src/ReactiveUI.Fody.Tests/Issues/Issue13Tests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Fody.Tests/Issues/Mocks/Issue11TestModel.cs
+++ b/src/ReactiveUI.Fody.Tests/Issues/Mocks/Issue11TestModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Fody.Tests/Mocks/BaseModel.cs
+++ b/src/ReactiveUI.Fody.Tests/Mocks/BaseModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Fody.Tests/Mocks/DecoratorModel.cs
+++ b/src/ReactiveUI.Fody.Tests/Mocks/DecoratorModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Fody.Tests/Mocks/FacadeModel.cs
+++ b/src/ReactiveUI.Fody.Tests/Mocks/FacadeModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Fody.Tests/Mocks/ObservableAsTestModel.cs
+++ b/src/ReactiveUI.Fody.Tests/Mocks/ObservableAsTestModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Fody.Tests/ObservableAsPropertyTests.cs
+++ b/src/ReactiveUI.Fody.Tests/ObservableAsPropertyTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Fody.Tests/ReactiveDependencyTests.cs
+++ b/src/ReactiveUI.Fody.Tests/ReactiveDependencyTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Fody/CecilExtensions.cs
+++ b/src/ReactiveUI.Fody/CecilExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Fody/ModuleWeaver.cs
+++ b/src/ReactiveUI.Fody/ModuleWeaver.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Fody/ObservableAsPropertyWeaver.cs
+++ b/src/ReactiveUI.Fody/ObservableAsPropertyWeaver.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Fody/Properties/AssemblyInfo.cs
+++ b/src/ReactiveUI.Fody/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Fody/ReactiveDependencyPropertyWeaver.cs
+++ b/src/ReactiveUI.Fody/ReactiveDependencyPropertyWeaver.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Fody/ReactiveUIPropertyWeaver.cs
+++ b/src/ReactiveUI.Fody/ReactiveUIPropertyWeaver.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Splat.Tests/SplatAdapterTests.cs
+++ b/src/ReactiveUI.Splat.Tests/SplatAdapterTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.TestRunner.Android/MainActivity.cs
+++ b/src/ReactiveUI.TestRunner.Android/MainActivity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.TestRunner.Android/Properties/AssemblyInfo.cs
+++ b/src/ReactiveUI.TestRunner.Android/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Testing.Tests/TestFixture.cs
+++ b/src/ReactiveUI.Testing.Tests/TestFixture.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Testing.Tests/TestFixtureBuilder.cs
+++ b/src/ReactiveUI.Testing.Tests/TestFixtureBuilder.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Testing.Tests/TestFixtureBuilderExtensionTests.cs
+++ b/src/ReactiveUI.Testing.Tests/TestFixtureBuilderExtensionTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Testing/IBuilderExtensions.cs
+++ b/src/ReactiveUI.Testing/IBuilderExtensions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Testing/MessageBusExtensions.cs
+++ b/src/ReactiveUI.Testing/MessageBusExtensions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Testing/SchedulerExtensions.cs
+++ b/src/ReactiveUI.Testing/SchedulerExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.cs
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Activation/ActivatingView.cs
+++ b/src/ReactiveUI.Tests/Activation/ActivatingView.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Activation/ActivatingViewFetcher.cs
+++ b/src/ReactiveUI.Tests/Activation/ActivatingViewFetcher.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Activation/ActivatingViewModel.cs
+++ b/src/ReactiveUI.Tests/Activation/ActivatingViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Activation/ActivatingViewModelTests.cs
+++ b/src/ReactiveUI.Tests/Activation/ActivatingViewModelTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Activation/ActivatingViewTests.cs
+++ b/src/ReactiveUI.Tests/Activation/ActivatingViewTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Activation/CanActivateViewFetcherTests.cs
+++ b/src/ReactiveUI.Tests/Activation/CanActivateViewFetcherTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Activation/DerivedActivatingViewModel.cs
+++ b/src/ReactiveUI.Tests/Activation/DerivedActivatingViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Activation/ViewModelActivatorTests.cs
+++ b/src/ReactiveUI.Tests/Activation/ViewModelActivatorTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/AutoPersist/AutoPersistCollectionTests.cs
+++ b/src/ReactiveUI.Tests/AutoPersist/AutoPersistCollectionTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/AutoPersist/AutoPersistHelperTest.cs
+++ b/src/ReactiveUI.Tests/AutoPersist/AutoPersistHelperTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/AwaiterTest.cs
+++ b/src/ReactiveUI.Tests/AwaiterTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/BindingTypeConvertersTest.cs
+++ b/src/ReactiveUI.Tests/BindingTypeConvertersTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Commands/CombinedReactiveCommandTest.cs
+++ b/src/ReactiveUI.Tests/Commands/CombinedReactiveCommandTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Commands/CreatesCommandBindingTests.cs
+++ b/src/ReactiveUI.Tests/Commands/CreatesCommandBindingTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Commands/Mocks/FakeCommand.cs
+++ b/src/ReactiveUI.Tests/Commands/Mocks/FakeCommand.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Commands/Mocks/ICommandHolder.cs
+++ b/src/ReactiveUI.Tests/Commands/Mocks/ICommandHolder.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Commands/Mocks/ReactiveCommandHolder.cs
+++ b/src/ReactiveUI.Tests/Commands/Mocks/ReactiveCommandHolder.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Commands/ReactiveCommandTest.cs
+++ b/src/ReactiveUI.Tests/Commands/ReactiveCommandTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Comparers/OrderedComparerTests.cs
+++ b/src/ReactiveUI.Tests/Comparers/OrderedComparerTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/InteractionBinding/InteractionBinderImplementationTests.cs
+++ b/src/ReactiveUI.Tests/InteractionBinding/InteractionBinderImplementationTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/InteractionsTest.cs
+++ b/src/ReactiveUI.Tests/InteractionsTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Locator/DefaultViewLocatorTests.cs
+++ b/src/ReactiveUI.Tests/Locator/DefaultViewLocatorTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Locator/Mocks/BarView.cs
+++ b/src/ReactiveUI.Tests/Locator/Mocks/BarView.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Locator/Mocks/BarViewModel.cs
+++ b/src/ReactiveUI.Tests/Locator/Mocks/BarViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Locator/Mocks/FooThatThrowsView.cs
+++ b/src/ReactiveUI.Tests/Locator/Mocks/FooThatThrowsView.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Locator/Mocks/FooView.cs
+++ b/src/ReactiveUI.Tests/Locator/Mocks/FooView.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Locator/Mocks/FooViewModel.cs
+++ b/src/ReactiveUI.Tests/Locator/Mocks/FooViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Locator/Mocks/FooViewModelWithWeirdName.cs
+++ b/src/ReactiveUI.Tests/Locator/Mocks/FooViewModelWithWeirdName.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Locator/Mocks/FooWithWeirdConvention.cs
+++ b/src/ReactiveUI.Tests/Locator/Mocks/FooWithWeirdConvention.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Locator/Mocks/IBarViewModel.cs
+++ b/src/ReactiveUI.Tests/Locator/Mocks/IBarViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Locator/Mocks/IFooView.cs
+++ b/src/ReactiveUI.Tests/Locator/Mocks/IFooView.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Locator/Mocks/IFooViewModel.cs
+++ b/src/ReactiveUI.Tests/Locator/Mocks/IFooViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Locator/Mocks/IRoutableFooViewModel.cs
+++ b/src/ReactiveUI.Tests/Locator/Mocks/IRoutableFooViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Locator/Mocks/IStrangeInterfaceNotFollowingConvention.cs
+++ b/src/ReactiveUI.Tests/Locator/Mocks/IStrangeInterfaceNotFollowingConvention.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Locator/Mocks/RoutableFooCustomView.cs
+++ b/src/ReactiveUI.Tests/Locator/Mocks/RoutableFooCustomView.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Locator/Mocks/RoutableFooView.cs
+++ b/src/ReactiveUI.Tests/Locator/Mocks/RoutableFooView.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Locator/Mocks/RoutableFooViewModel.cs
+++ b/src/ReactiveUI.Tests/Locator/Mocks/RoutableFooViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Locator/Mocks/StrangeClassNotFollowingConvention.cs
+++ b/src/ReactiveUI.Tests/Locator/Mocks/StrangeClassNotFollowingConvention.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/MessageBusTest.cs
+++ b/src/ReactiveUI.Tests/MessageBusTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Mocks/AnotherViewModel.cs
+++ b/src/ReactiveUI.Tests/Mocks/AnotherViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Mocks/CommandBindViewModel.cs
+++ b/src/ReactiveUI.Tests/Mocks/CommandBindViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Mocks/ExampleViewModel.cs
+++ b/src/ReactiveUI.Tests/Mocks/ExampleViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Mocks/ExampleWindowViewModel.cs
+++ b/src/ReactiveUI.Tests/Mocks/ExampleWindowViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Mocks/FakeCollectionModel.cs
+++ b/src/ReactiveUI.Tests/Mocks/FakeCollectionModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Mocks/FakeCollectionViewModel.cs
+++ b/src/ReactiveUI.Tests/Mocks/FakeCollectionViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Mocks/FakeNestedViewModel.cs
+++ b/src/ReactiveUI.Tests/Mocks/FakeNestedViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Mocks/FakeViewModel.cs
+++ b/src/ReactiveUI.Tests/Mocks/FakeViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Mocks/InteractionAncestorView.cs
+++ b/src/ReactiveUI.Tests/Mocks/InteractionAncestorView.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Mocks/InteractionAncestorViewModel.cs
+++ b/src/ReactiveUI.Tests/Mocks/InteractionAncestorViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Mocks/InteractionBindView.cs
+++ b/src/ReactiveUI.Tests/Mocks/InteractionBindView.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Mocks/InteractionBindViewModel.cs
+++ b/src/ReactiveUI.Tests/Mocks/InteractionBindViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Mocks/NeverUsedViewModel.cs
+++ b/src/ReactiveUI.Tests/Mocks/NeverUsedViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Mocks/PropertyBindModel.cs
+++ b/src/ReactiveUI.Tests/Mocks/PropertyBindModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Mocks/PropertyBindViewModel.cs
+++ b/src/ReactiveUI.Tests/Mocks/PropertyBindViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Mocks/SingleInstanceExampleViewModel.cs
+++ b/src/ReactiveUI.Tests/Mocks/SingleInstanceExampleViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Mocks/ViewModelWithWeirdName.cs
+++ b/src/ReactiveUI.Tests/Mocks/ViewModelWithWeirdName.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/ObservableAsPropertyHelper/Mocks/OAPHIndexerTestFixture.cs
+++ b/src/ReactiveUI.Tests/ObservableAsPropertyHelper/Mocks/OAPHIndexerTestFixture.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/ObservableAsPropertyHelper/ObservableAsPropertyHelperTest.cs
+++ b/src/ReactiveUI.Tests/ObservableAsPropertyHelper/ObservableAsPropertyHelperTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/ObservedChanged/Mocks/NewGameViewModel.cs
+++ b/src/ReactiveUI.Tests/ObservedChanged/Mocks/NewGameViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/ObservedChanged/NewGameViewModelTests.cs
+++ b/src/ReactiveUI.Tests/ObservedChanged/NewGameViewModelTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/ObservedChanged/ObservedChangedMixinTest.cs
+++ b/src/ReactiveUI.Tests/ObservedChanged/ObservedChangedMixinTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Platforms/android/MainActivity.cs
+++ b/src/ReactiveUI.Tests/Platforms/android/MainActivity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Platforms/android/PropertyBindingTestViews.cs
+++ b/src/ReactiveUI.Tests/Platforms/android/PropertyBindingTestViews.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Platforms/cocoa/AppDelegate.cs
+++ b/src/ReactiveUI.Tests/Platforms/cocoa/AppDelegate.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Platforms/cocoa/IndexNormalizerTest.cs
+++ b/src/ReactiveUI.Tests/Platforms/cocoa/IndexNormalizerTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Platforms/cocoa/KVOBindingTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/cocoa/KVOBindingTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Platforms/cocoa/Main.cs
+++ b/src/ReactiveUI.Tests/Platforms/cocoa/Main.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Platforms/cocoa/PropertyBindingTestViews.cs
+++ b/src/ReactiveUI.Tests/Platforms/cocoa/PropertyBindingTestViews.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Platforms/cocoa/UnitTestAppDelegate.cs
+++ b/src/ReactiveUI.Tests/Platforms/cocoa/UnitTestAppDelegate.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Platforms/common-gui/Mocks/RaceConditionFixture.cs
+++ b/src/ReactiveUI.Tests/Platforms/common-gui/Mocks/RaceConditionFixture.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Platforms/common-gui/Mocks/RaceConditionNameOfFixture.cs
+++ b/src/ReactiveUI.Tests/Platforms/common-gui/Mocks/RaceConditionNameOfFixture.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Platforms/common-gui/ObservableAsPropertyHelperModeTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/common-gui/ObservableAsPropertyHelperModeTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Platforms/common-gui/ProductionMode.cs
+++ b/src/ReactiveUI.Tests/Platforms/common-gui/ProductionMode.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Platforms/uwp/API/UwpApiApprovalTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/uwp/API/UwpApiApprovalTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Platforms/windows-xaml/Api/XamlApiApprovalTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/windows-xaml/Api/XamlApiApprovalTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Platforms/windows-xaml/CommandBindingImplementationTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/windows-xaml/CommandBindingImplementationTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Platforms/windows-xaml/DependencyObjectObservableForPropertyTest.cs
+++ b/src/ReactiveUI.Tests/Platforms/windows-xaml/DependencyObjectObservableForPropertyTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Platforms/windows-xaml/Mocks/CommandBindView.cs
+++ b/src/ReactiveUI.Tests/Platforms/windows-xaml/Mocks/CommandBindView.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Platforms/windows-xaml/Mocks/CustomClickButton.cs
+++ b/src/ReactiveUI.Tests/Platforms/windows-xaml/Mocks/CustomClickButton.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Platforms/windows-xaml/Mocks/DepObjFixture.cs
+++ b/src/ReactiveUI.Tests/Platforms/windows-xaml/Mocks/DepObjFixture.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Platforms/windows-xaml/Mocks/DerivedDepObjFixture.cs
+++ b/src/ReactiveUI.Tests/Platforms/windows-xaml/Mocks/DerivedDepObjFixture.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Platforms/windows-xaml/Mocks/FakeView.cs
+++ b/src/ReactiveUI.Tests/Platforms/windows-xaml/Mocks/FakeView.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Platforms/windows-xaml/Mocks/HostTestView.cs
+++ b/src/ReactiveUI.Tests/Platforms/windows-xaml/Mocks/HostTestView.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Platforms/windows-xaml/Mocks/PropertyBindFakeControl.cs
+++ b/src/ReactiveUI.Tests/Platforms/windows-xaml/Mocks/PropertyBindFakeControl.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Platforms/windows-xaml/Mocks/PropertyBindView.cs
+++ b/src/ReactiveUI.Tests/Platforms/windows-xaml/Mocks/PropertyBindView.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Platforms/windows-xaml/Mocks/ReactiveObjectCommandBindView.cs
+++ b/src/ReactiveUI.Tests/Platforms/windows-xaml/Mocks/ReactiveObjectCommandBindView.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Platforms/windows-xaml/PropertyBindingTest.cs
+++ b/src/ReactiveUI.Tests/Platforms/windows-xaml/PropertyBindingTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Platforms/windows-xaml/RxAppDependencyObjectTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/windows-xaml/RxAppDependencyObjectTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Platforms/windows-xaml/Utilities/DispatcherUtilities.cs
+++ b/src/ReactiveUI.Tests/Platforms/windows-xaml/Utilities/DispatcherUtilities.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Platforms/windows-xaml/WhenAnyThroughDependencyObjectTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/windows-xaml/WhenAnyThroughDependencyObjectTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Platforms/windows-xaml/XamlViewCommandTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/windows-xaml/XamlViewCommandTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Platforms/windows-xaml/XamlViewDependencyResolverTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/windows-xaml/XamlViewDependencyResolverTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Platforms/winforms/API/WinformsApiApprovalTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/API/WinformsApiApprovalTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Platforms/winforms/ActivationTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/ActivationTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Platforms/winforms/CommandBindingImplementationTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/CommandBindingImplementationTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Platforms/winforms/CommandBindingTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/CommandBindingTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Platforms/winforms/DefaultPropertyBindingTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/DefaultPropertyBindingTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Platforms/winforms/Mocks/AnotherView.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/Mocks/AnotherView.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Platforms/winforms/Mocks/ContractExampleView.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/Mocks/ContractExampleView.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Platforms/winforms/Mocks/CustomClickableComponent.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/Mocks/CustomClickableComponent.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Platforms/winforms/Mocks/CustomClickableControl.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/Mocks/CustomClickableControl.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Platforms/winforms/Mocks/ExampleView.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/Mocks/ExampleView.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Platforms/winforms/Mocks/FakeView.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/Mocks/FakeView.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Platforms/winforms/Mocks/FakeViewLocator.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/Mocks/FakeViewLocator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Platforms/winforms/Mocks/FakeViewModel.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/Mocks/FakeViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Platforms/winforms/Mocks/FakeWinformViewModel.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/Mocks/FakeWinformViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Platforms/winforms/Mocks/FakeWinformsView.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/Mocks/FakeWinformsView.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Platforms/winforms/Mocks/NeverUsedView.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/Mocks/NeverUsedView.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Platforms/winforms/Mocks/SingleInstanceExampleView.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/Mocks/SingleInstanceExampleView.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Platforms/winforms/Mocks/SingleInstanceWithContractExampleView.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/Mocks/SingleInstanceWithContractExampleView.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Platforms/winforms/Mocks/TestControl.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/Mocks/TestControl.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Platforms/winforms/Mocks/TestForm.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/Mocks/TestForm.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Platforms/winforms/Mocks/ThirdPartyControl.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/Mocks/ThirdPartyControl.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Platforms/winforms/Mocks/ViewWithoutMatchingName.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/Mocks/ViewWithoutMatchingName.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Platforms/winforms/Mocks/WinformCommandBindView.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/Mocks/WinformCommandBindView.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Platforms/winforms/Mocks/WinformCommandBindViewModel.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/Mocks/WinformCommandBindViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Platforms/winforms/WinFormsRoutedViewHostTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/WinFormsRoutedViewHostTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Platforms/winforms/WinFormsViewDependencyResolverTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/WinFormsViewDependencyResolverTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Platforms/winforms/WinFormsViewModelViewHostTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/WinFormsViewModelViewHostTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Platforms/wpf/API/WpfApiApprovalTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/wpf/API/WpfApiApprovalTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Platforms/wpf/Mocks/CommandBindingView.cs
+++ b/src/ReactiveUI.Tests/Platforms/wpf/Mocks/CommandBindingView.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Platforms/wpf/Mocks/CommandBindingViewModel.cs
+++ b/src/ReactiveUI.Tests/Platforms/wpf/Mocks/CommandBindingViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Platforms/wpf/Mocks/ExampleWindowView.cs
+++ b/src/ReactiveUI.Tests/Platforms/wpf/Mocks/ExampleWindowView.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Platforms/wpf/Mocks/WpfTestUserControl.cs
+++ b/src/ReactiveUI.Tests/Platforms/wpf/Mocks/WpfTestUserControl.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Platforms/wpf/WpfActivationForViewFetcherTest.cs
+++ b/src/ReactiveUI.Tests/Platforms/wpf/WpfActivationForViewFetcherTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Platforms/wpf/WpfCommandBindingImplementationTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/wpf/WpfCommandBindingImplementationTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Platforms/wpf/WpfViewDependencyResolverTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/wpf/WpfViewDependencyResolverTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/ReactiveObject/Mocks/OaphNameOfTestFixture.cs
+++ b/src/ReactiveUI.Tests/ReactiveObject/Mocks/OaphNameOfTestFixture.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/ReactiveObject/Mocks/OaphTestFixture.cs
+++ b/src/ReactiveUI.Tests/ReactiveObject/Mocks/OaphTestFixture.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/ReactiveObject/Mocks/TestFixture.cs
+++ b/src/ReactiveUI.Tests/ReactiveObject/Mocks/TestFixture.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/ReactiveObject/ReactiveObjectTests.cs
+++ b/src/ReactiveUI.Tests/ReactiveObject/ReactiveObjectTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Resolvers/DependencyResolverTests.cs
+++ b/src/ReactiveUI.Tests/Resolvers/DependencyResolverTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Resolvers/INPCObservableForPropertyTests.cs
+++ b/src/ReactiveUI.Tests/Resolvers/INPCObservableForPropertyTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Resolvers/PocoObservableForPropertyTests.cs
+++ b/src/ReactiveUI.Tests/Resolvers/PocoObservableForPropertyTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Routing/Mocks/TestScreen.cs
+++ b/src/ReactiveUI.Tests/Routing/Mocks/TestScreen.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Routing/Mocks/TestViewModel.cs
+++ b/src/ReactiveUI.Tests/Routing/Mocks/TestViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Routing/RoutableViewModelMixinTests.cs
+++ b/src/ReactiveUI.Tests/Routing/RoutableViewModelMixinTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Routing/RoutingStateTests.cs
+++ b/src/ReactiveUI.Tests/Routing/RoutingStateTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/RxAppTest.cs
+++ b/src/ReactiveUI.Tests/RxAppTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Suspension/DummyAppState.cs
+++ b/src/ReactiveUI.Tests/Suspension/DummyAppState.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Suspension/SuspensionHostExtensionsTests.cs
+++ b/src/ReactiveUI.Tests/Suspension/SuspensionHostExtensionsTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/TestConfiguration.cs
+++ b/src/ReactiveUI.Tests/TestConfiguration.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Utilities/ApiApprovalBase.cs
+++ b/src/ReactiveUI.Tests/Utilities/ApiApprovalBase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Utilities/CompatMixins.cs
+++ b/src/ReactiveUI.Tests/Utilities/CompatMixins.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Utilities/CountingTestScheduler.cs
+++ b/src/ReactiveUI.Tests/Utilities/CountingTestScheduler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Utilities/EnumerableTestMixin.cs
+++ b/src/ReactiveUI.Tests/Utilities/EnumerableTestMixin.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Utilities/JsonHelper.cs
+++ b/src/ReactiveUI.Tests/Utilities/JsonHelper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Utilities/TestLogger.cs
+++ b/src/ReactiveUI.Tests/Utilities/TestLogger.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/Utilities/UseInvariantCulture.cs
+++ b/src/ReactiveUI.Tests/Utilities/UseInvariantCulture.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/WaitForDispatcherSchedulerTests.cs
+++ b/src/ReactiveUI.Tests/WaitForDispatcherSchedulerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/WhenAny/Mockups/HostTestFixture.cs
+++ b/src/ReactiveUI.Tests/WhenAny/Mockups/HostTestFixture.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/WhenAny/Mockups/NonObservableTestFixture.cs
+++ b/src/ReactiveUI.Tests/WhenAny/Mockups/NonObservableTestFixture.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/WhenAny/Mockups/NonReactiveINPCObject.cs
+++ b/src/ReactiveUI.Tests/WhenAny/Mockups/NonReactiveINPCObject.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/WhenAny/Mockups/ObjChain1.cs
+++ b/src/ReactiveUI.Tests/WhenAny/Mockups/ObjChain1.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/WhenAny/Mockups/ObjChain2.cs
+++ b/src/ReactiveUI.Tests/WhenAny/Mockups/ObjChain2.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/WhenAny/Mockups/ObjChain3.cs
+++ b/src/ReactiveUI.Tests/WhenAny/Mockups/ObjChain3.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/WhenAny/ReactiveNotifyPropertyChangedMixinTest.cs
+++ b/src/ReactiveUI.Tests/WhenAny/ReactiveNotifyPropertyChangedMixinTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/WhenAny/TestWhenAnyObsViewModel.cs
+++ b/src/ReactiveUI.Tests/WhenAny/TestWhenAnyObsViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Tests/WhenAny/WhenAnyObservableTests.cs
+++ b/src/ReactiveUI.Tests/WhenAny/WhenAnyObservableTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Uno/ActivationForViewFetcher.cs
+++ b/src/ReactiveUI.Uno/ActivationForViewFetcher.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Uno/CoreDispatcherScheduler.cs
+++ b/src/ReactiveUI.Uno/CoreDispatcherScheduler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Uno/Registrations.cs
+++ b/src/ReactiveUI.Uno/Registrations.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Winforms/ActivationForViewFetcher.cs
+++ b/src/ReactiveUI.Winforms/ActivationForViewFetcher.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Winforms/ContentControlBindingHook.cs
+++ b/src/ReactiveUI.Winforms/ContentControlBindingHook.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Winforms/CreatesWinformsCommandBinding.cs
+++ b/src/ReactiveUI.Winforms/CreatesWinformsCommandBinding.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Winforms/ObservableCollectionChangedToListChangedTransformer.cs
+++ b/src/ReactiveUI.Winforms/ObservableCollectionChangedToListChangedTransformer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Winforms/PanelSetMethodBindingConverter.cs
+++ b/src/ReactiveUI.Winforms/PanelSetMethodBindingConverter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Winforms/PlatformOperations.cs
+++ b/src/ReactiveUI.Winforms/PlatformOperations.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Winforms/ReactiveUserControl.cs
+++ b/src/ReactiveUI.Winforms/ReactiveUserControl.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Winforms/Registrations.cs
+++ b/src/ReactiveUI.Winforms/Registrations.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Winforms/RoutedViewHost.cs
+++ b/src/ReactiveUI.Winforms/RoutedViewHost.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Winforms/TableContentSetMethodBindingConverter.cs
+++ b/src/ReactiveUI.Winforms/TableContentSetMethodBindingConverter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Winforms/ViewModelViewHost.cs
+++ b/src/ReactiveUI.Winforms/ViewModelViewHost.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Winforms/WinformsCreatesObservableForProperty.cs
+++ b/src/ReactiveUI.Winforms/WinformsCreatesObservableForProperty.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Wpf/ActivationForViewFetcher.cs
+++ b/src/ReactiveUI.Wpf/ActivationForViewFetcher.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Wpf/Attributes.cs
+++ b/src/ReactiveUI.Wpf/Attributes.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Wpf/AutoSuspendHelper.cs
+++ b/src/ReactiveUI.Wpf/AutoSuspendHelper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Wpf/DependencyObjectObservableForProperty.cs
+++ b/src/ReactiveUI.Wpf/DependencyObjectObservableForProperty.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Wpf/ReactiveWindow.cs
+++ b/src/ReactiveUI.Wpf/ReactiveWindow.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Wpf/Registrations.cs
+++ b/src/ReactiveUI.Wpf/Registrations.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Wpf/TransitioningContentControl.cs
+++ b/src/ReactiveUI.Wpf/TransitioningContentControl.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.XamForms/ActivationForViewFetcher.cs
+++ b/src/ReactiveUI.XamForms/ActivationForViewFetcher.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.XamForms/AutoSuspendHelper.cs
+++ b/src/ReactiveUI.XamForms/AutoSuspendHelper.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.XamForms/DisableAnimationAttribute.cs
+++ b/src/ReactiveUI.XamForms/DisableAnimationAttribute.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.XamForms/ReactiveCarouselPage.cs
+++ b/src/ReactiveUI.XamForms/ReactiveCarouselPage.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.XamForms/ReactiveContentPage.cs
+++ b/src/ReactiveUI.XamForms/ReactiveContentPage.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.XamForms/ReactiveContentView.cs
+++ b/src/ReactiveUI.XamForms/ReactiveContentView.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.XamForms/ReactiveEntryCell.cs
+++ b/src/ReactiveUI.XamForms/ReactiveEntryCell.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.XamForms/ReactiveImageCell.cs
+++ b/src/ReactiveUI.XamForms/ReactiveImageCell.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.XamForms/ReactiveMasterDetailPage.cs
+++ b/src/ReactiveUI.XamForms/ReactiveMasterDetailPage.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.XamForms/ReactiveMultiPage.cs
+++ b/src/ReactiveUI.XamForms/ReactiveMultiPage.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.XamForms/ReactiveNavigationPage.cs
+++ b/src/ReactiveUI.XamForms/ReactiveNavigationPage.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.XamForms/ReactiveSwitchCell.cs
+++ b/src/ReactiveUI.XamForms/ReactiveSwitchCell.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.XamForms/ReactiveTabbedPage.cs
+++ b/src/ReactiveUI.XamForms/ReactiveTabbedPage.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.XamForms/ReactiveTextCell.cs
+++ b/src/ReactiveUI.XamForms/ReactiveTextCell.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.XamForms/ReactiveViewCell.cs
+++ b/src/ReactiveUI.XamForms/ReactiveViewCell.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.XamForms/Registrations.cs
+++ b/src/ReactiveUI.XamForms/Registrations.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.XamForms/RoutedViewHost.cs
+++ b/src/ReactiveUI.XamForms/RoutedViewHost.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.XamForms/ViewModelViewHost.cs
+++ b/src/ReactiveUI.XamForms/ViewModelViewHost.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Activation/CanActivateViewFetcher.cs
+++ b/src/ReactiveUI/Activation/CanActivateViewFetcher.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Activation/IActivationForViewFetcher.cs
+++ b/src/ReactiveUI/Activation/IActivationForViewFetcher.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Activation/ViewForMixins.cs
+++ b/src/ReactiveUI/Activation/ViewForMixins.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Activation/ViewModelActivator.cs
+++ b/src/ReactiveUI/Activation/ViewModelActivator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Bindings/BindingDirection.cs
+++ b/src/ReactiveUI/Bindings/BindingDirection.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Bindings/Command/CommandBinder.cs
+++ b/src/ReactiveUI/Bindings/Command/CommandBinder.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Bindings/Command/CommandBinderImplementation.cs
+++ b/src/ReactiveUI/Bindings/Command/CommandBinderImplementation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Bindings/Command/CommandBinderImplementationMixins.cs
+++ b/src/ReactiveUI/Bindings/Command/CommandBinderImplementationMixins.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Bindings/Command/CreatesCommandBinding.cs
+++ b/src/ReactiveUI/Bindings/Command/CreatesCommandBinding.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Bindings/Command/CreatesCommandBindingViaCommandParameter.cs
+++ b/src/ReactiveUI/Bindings/Command/CreatesCommandBindingViaCommandParameter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Bindings/Command/CreatesCommandBindingViaEvent.cs
+++ b/src/ReactiveUI/Bindings/Command/CreatesCommandBindingViaEvent.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Bindings/Command/ICommandBinderImplementation.cs
+++ b/src/ReactiveUI/Bindings/Command/ICommandBinderImplementation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Bindings/Command/RelayCommand.cs
+++ b/src/ReactiveUI/Bindings/Command/RelayCommand.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Bindings/Converter/EqualityTypeConverter.cs
+++ b/src/ReactiveUI/Bindings/Converter/EqualityTypeConverter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Bindings/Converter/StringConverter.cs
+++ b/src/ReactiveUI/Bindings/Converter/StringConverter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Bindings/IBindingTypeConverter.cs
+++ b/src/ReactiveUI/Bindings/IBindingTypeConverter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Bindings/ISetMethodBindingConverter.cs
+++ b/src/ReactiveUI/Bindings/ISetMethodBindingConverter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Bindings/Interaction/IInteractionBinderImplementation.cs
+++ b/src/ReactiveUI/Bindings/Interaction/IInteractionBinderImplementation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Bindings/Interaction/InteractionBinderImplementation.cs
+++ b/src/ReactiveUI/Bindings/Interaction/InteractionBinderImplementation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Bindings/Interaction/InteractionBindingMixins.cs
+++ b/src/ReactiveUI/Bindings/Interaction/InteractionBindingMixins.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Bindings/Property/IPropertyBinderImplementation.cs
+++ b/src/ReactiveUI/Bindings/Property/IPropertyBinderImplementation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Bindings/Property/PropertyBinderImplementation.cs
+++ b/src/ReactiveUI/Bindings/Property/PropertyBinderImplementation.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Bindings/Property/PropertyBindingMixins.cs
+++ b/src/ReactiveUI/Bindings/Property/PropertyBindingMixins.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Bindings/Reactive/IReactiveBinding.cs
+++ b/src/ReactiveUI/Bindings/Reactive/IReactiveBinding.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Bindings/Reactive/ReactiveBinding.cs
+++ b/src/ReactiveUI/Bindings/Reactive/ReactiveBinding.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Comparers/ChainedComparer.cs
+++ b/src/ReactiveUI/Comparers/ChainedComparer.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Comparers/ComparerChainingExtensions.cs
+++ b/src/ReactiveUI/Comparers/ComparerChainingExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Comparers/IComparerBuilder.cs
+++ b/src/ReactiveUI/Comparers/IComparerBuilder.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Comparers/OrderedComparer.cs
+++ b/src/ReactiveUI/Comparers/OrderedComparer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/EventHandlers/LocalizableAttribute.cs
+++ b/src/ReactiveUI/EventHandlers/LocalizableAttribute.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Expression/ExpressionRewriter.cs
+++ b/src/ReactiveUI/Expression/ExpressionRewriter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Expression/Reflection.cs
+++ b/src/ReactiveUI/Expression/Reflection.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Interactions/Interaction.cs
+++ b/src/ReactiveUI/Interactions/Interaction.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Interactions/InteractionContext.cs
+++ b/src/ReactiveUI/Interactions/InteractionContext.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Interactions/UnhandledInteractionException.cs
+++ b/src/ReactiveUI/Interactions/UnhandledInteractionException.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Interfaces/IActivatableView.cs
+++ b/src/ReactiveUI/Interfaces/IActivatableView.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Interfaces/IActivatableViewModel.cs
+++ b/src/ReactiveUI/Interfaces/IActivatableViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Interfaces/ICanActivate.cs
+++ b/src/ReactiveUI/Interfaces/ICanActivate.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Interfaces/ICanForceManualActivation.cs
+++ b/src/ReactiveUI/Interfaces/ICanForceManualActivation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Interfaces/ICreatesCommandBinding.cs
+++ b/src/ReactiveUI/Interfaces/ICreatesCommandBinding.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Interfaces/ICreatesObservableForProperty.cs
+++ b/src/ReactiveUI/Interfaces/ICreatesObservableForProperty.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Interfaces/IHandleObservableErrors.cs
+++ b/src/ReactiveUI/Interfaces/IHandleObservableErrors.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Interfaces/IMessageBus.cs
+++ b/src/ReactiveUI/Interfaces/IMessageBus.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Interfaces/IObservedChange.cs
+++ b/src/ReactiveUI/Interfaces/IObservedChange.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Interfaces/IPlatformOperations.cs
+++ b/src/ReactiveUI/Interfaces/IPlatformOperations.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Interfaces/IPropertyBindingHook.cs
+++ b/src/ReactiveUI/Interfaces/IPropertyBindingHook.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Interfaces/IReactiveNotifyPropertyChanged.cs
+++ b/src/ReactiveUI/Interfaces/IReactiveNotifyPropertyChanged.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Interfaces/IReactivePropertyChangedEventArgs.cs
+++ b/src/ReactiveUI/Interfaces/IReactivePropertyChangedEventArgs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Interfaces/IRoutableViewModel.cs
+++ b/src/ReactiveUI/Interfaces/IRoutableViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Interfaces/IScreen.cs
+++ b/src/ReactiveUI/Interfaces/IScreen.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Interfaces/ISuspensionDriver.cs
+++ b/src/ReactiveUI/Interfaces/ISuspensionDriver.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Interfaces/ISuspensionHost.cs
+++ b/src/ReactiveUI/Interfaces/ISuspensionHost.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Interfaces/IViewFor.cs
+++ b/src/ReactiveUI/Interfaces/IViewFor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Interfaces/IViewLocator.cs
+++ b/src/ReactiveUI/Interfaces/IViewLocator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Interfaces/IWantsToRegisterStuff.cs
+++ b/src/ReactiveUI/Interfaces/IWantsToRegisterStuff.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Interfaces/ObservedChange.cs
+++ b/src/ReactiveUI/Interfaces/ObservedChange.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Interfaces/ReactivePropertyChangedEventArgs.cs
+++ b/src/ReactiveUI/Interfaces/ReactivePropertyChangedEventArgs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Interfaces/ReactivePropertyChangingEventArgs.cs
+++ b/src/ReactiveUI/Interfaces/ReactivePropertyChangingEventArgs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Legacy/CollectionDebugView.cs
+++ b/src/ReactiveUI/Legacy/CollectionDebugView.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Legacy/RefcountDisposeWrapper.cs
+++ b/src/ReactiveUI/Legacy/RefcountDisposeWrapper.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Mixins/AutoPersistHelper.cs
+++ b/src/ReactiveUI/Mixins/AutoPersistHelper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Mixins/ChangeSetMixin.cs
+++ b/src/ReactiveUI/Mixins/ChangeSetMixin.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Mixins/CompatMixins.cs
+++ b/src/ReactiveUI/Mixins/CompatMixins.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Mixins/DependencyResolverMixins.cs
+++ b/src/ReactiveUI/Mixins/DependencyResolverMixins.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Mixins/DisposableMixins.cs
+++ b/src/ReactiveUI/Mixins/DisposableMixins.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Mixins/ExpressionMixins.cs
+++ b/src/ReactiveUI/Mixins/ExpressionMixins.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Mixins/ObservableLoggingMixin.cs
+++ b/src/ReactiveUI/Mixins/ObservableLoggingMixin.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Mixins/ObservableMixins.cs
+++ b/src/ReactiveUI/Mixins/ObservableMixins.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Mixins/ObservedChangedMixin.cs
+++ b/src/ReactiveUI/Mixins/ObservedChangedMixin.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Mixins/PreserveAttribute.cs
+++ b/src/ReactiveUI/Mixins/PreserveAttribute.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Mixins/ReactiveNotifyPropertyChangedMixin.cs
+++ b/src/ReactiveUI/Mixins/ReactiveNotifyPropertyChangedMixin.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Observable.cs
+++ b/src/ReactiveUI/Observable.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/ObservableForProperty/INPCObservableForProperty.cs
+++ b/src/ReactiveUI/ObservableForProperty/INPCObservableForProperty.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/ObservableForProperty/IROObservableForProperty.cs
+++ b/src/ReactiveUI/ObservableForProperty/IROObservableForProperty.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/ObservableForProperty/OAPHCreationHelperMixin.cs
+++ b/src/ReactiveUI/ObservableForProperty/OAPHCreationHelperMixin.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/ObservableForProperty/ObservableAsPropertyHelper.cs
+++ b/src/ReactiveUI/ObservableForProperty/ObservableAsPropertyHelper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/ObservableForProperty/POCOObservableForProperty.cs
+++ b/src/ReactiveUI/ObservableForProperty/POCOObservableForProperty.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Observables.cs
+++ b/src/ReactiveUI/Observables.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/PlatformRegistrationManager.cs
+++ b/src/ReactiveUI/PlatformRegistrationManager.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/android/AndroidCommandBinders.cs
+++ b/src/ReactiveUI/Platforms/android/AndroidCommandBinders.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/android/AndroidObservableForWidgets.cs
+++ b/src/ReactiveUI/Platforms/android/AndroidObservableForWidgets.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/android/AutoSuspendHelper.cs
+++ b/src/ReactiveUI/Platforms/android/AutoSuspendHelper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/android/BundleSuspensionDriver.cs
+++ b/src/ReactiveUI/Platforms/android/BundleSuspensionDriver.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/android/ContextExtensions.cs
+++ b/src/ReactiveUI/Platforms/android/ContextExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/android/ControlFetcherMixin.cs
+++ b/src/ReactiveUI/Platforms/android/ControlFetcherMixin.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/android/FlexibleCommandBinder.cs
+++ b/src/ReactiveUI/Platforms/android/FlexibleCommandBinder.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/android/HandlerScheduler.cs
+++ b/src/ReactiveUI/Platforms/android/HandlerScheduler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/android/ILayoutViewHost.cs
+++ b/src/ReactiveUI/Platforms/android/ILayoutViewHost.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/android/IgnoreResourceAttribute.cs
+++ b/src/ReactiveUI/Platforms/android/IgnoreResourceAttribute.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/android/JavaHolder.cs
+++ b/src/ReactiveUI/Platforms/android/JavaHolder.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/android/LayoutViewHost.cs
+++ b/src/ReactiveUI/Platforms/android/LayoutViewHost.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/android/LinkerOverrides.cs
+++ b/src/ReactiveUI/Platforms/android/LinkerOverrides.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/android/ObjectExtension.cs
+++ b/src/ReactiveUI/Platforms/android/ObjectExtension.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/android/PlatformOperations.cs
+++ b/src/ReactiveUI/Platforms/android/PlatformOperations.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/android/PlatformRegistrations.cs
+++ b/src/ReactiveUI/Platforms/android/PlatformRegistrations.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/android/ReactiveActivity.cs
+++ b/src/ReactiveUI/Platforms/android/ReactiveActivity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/android/ReactiveFragment.cs
+++ b/src/ReactiveUI/Platforms/android/ReactiveFragment.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/android/ReactivePreferenceActivity.cs
+++ b/src/ReactiveUI/Platforms/android/ReactivePreferenceActivity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/android/ReactivePreferenceFragment.cs
+++ b/src/ReactiveUI/Platforms/android/ReactivePreferenceFragment.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/android/ReactiveViewHost.cs
+++ b/src/ReactiveUI/Platforms/android/ReactiveViewHost.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/android/ResolveStrategy.cs
+++ b/src/ReactiveUI/Platforms/android/ResolveStrategy.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/android/SharedPreferencesExtensions.cs
+++ b/src/ReactiveUI/Platforms/android/SharedPreferencesExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/android/UsbManagerExtensions.cs
+++ b/src/ReactiveUI/Platforms/android/UsbManagerExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/android/ViewCommandExtensions.cs
+++ b/src/ReactiveUI/Platforms/android/ViewCommandExtensions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/android/ViewMixins.cs
+++ b/src/ReactiveUI/Platforms/android/ViewMixins.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/android/WireUpResourceAttribute.cs
+++ b/src/ReactiveUI/Platforms/android/WireUpResourceAttribute.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/apple-common/AppSupportJsonSuspensionDriver.cs
+++ b/src/ReactiveUI/Platforms/apple-common/AppSupportJsonSuspensionDriver.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/apple-common/BlockObserveValueDelegate.cs
+++ b/src/ReactiveUI/Platforms/apple-common/BlockObserveValueDelegate.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/apple-common/Converters/DateTimeNSDateConverter.cs
+++ b/src/ReactiveUI/Platforms/apple-common/Converters/DateTimeNSDateConverter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/apple-common/IndexNormalizer.cs
+++ b/src/ReactiveUI/Platforms/apple-common/IndexNormalizer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/apple-common/KVOObservableForProperty.cs
+++ b/src/ReactiveUI/Platforms/apple-common/KVOObservableForProperty.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/apple-common/NSRunloopScheduler.cs
+++ b/src/ReactiveUI/Platforms/apple-common/NSRunloopScheduler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/apple-common/ObservableForPropertyBase.cs
+++ b/src/ReactiveUI/Platforms/apple-common/ObservableForPropertyBase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/apple-common/PlatformOperations.cs
+++ b/src/ReactiveUI/Platforms/apple-common/PlatformOperations.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/apple-common/ReactiveControl.cs
+++ b/src/ReactiveUI/Platforms/apple-common/ReactiveControl.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/apple-common/ReactiveImageView.cs
+++ b/src/ReactiveUI/Platforms/apple-common/ReactiveImageView.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/apple-common/ReactiveSplitViewController.cs
+++ b/src/ReactiveUI/Platforms/apple-common/ReactiveSplitViewController.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/apple-common/ReactiveView.cs
+++ b/src/ReactiveUI/Platforms/apple-common/ReactiveView.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/apple-common/ReactiveViewController.cs
+++ b/src/ReactiveUI/Platforms/apple-common/ReactiveViewController.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/apple-common/TargetActionCommandBinder.cs
+++ b/src/ReactiveUI/Platforms/apple-common/TargetActionCommandBinder.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/apple-common/UIViewControllerMixins.cs
+++ b/src/ReactiveUI/Platforms/apple-common/UIViewControllerMixins.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/apple-common/Update.cs
+++ b/src/ReactiveUI/Platforms/apple-common/Update.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/apple-common/UpdateType.cs
+++ b/src/ReactiveUI/Platforms/apple-common/UpdateType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/apple-common/ViewModelViewHost.cs
+++ b/src/ReactiveUI/Platforms/apple-common/ViewModelViewHost.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/ios/LinkerOverrides.cs
+++ b/src/ReactiveUI/Platforms/ios/LinkerOverrides.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/ios/UIKitCommandBinders.cs
+++ b/src/ReactiveUI/Platforms/ios/UIKitCommandBinders.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/ios/UIKitObservableForProperty.cs
+++ b/src/ReactiveUI/Platforms/ios/UIKitObservableForProperty.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/mac/AppKitObservableForProperty.cs
+++ b/src/ReactiveUI/Platforms/mac/AppKitObservableForProperty.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/mac/AutoSuspendHelper.cs
+++ b/src/ReactiveUI/Platforms/mac/AutoSuspendHelper.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/mac/PlatformRegistrations.cs
+++ b/src/ReactiveUI/Platforms/mac/PlatformRegistrations.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/mac/ReactiveWindowController.cs
+++ b/src/ReactiveUI/Platforms/mac/ReactiveWindowController.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/net4/ComponentModelTypeConverter.cs
+++ b/src/ReactiveUI/Platforms/net4/ComponentModelTypeConverter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/net4/PlatformRegistrations.cs
+++ b/src/ReactiveUI/Platforms/net4/PlatformRegistrations.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/net5/ComponentModelTypeConverter.cs
+++ b/src/ReactiveUI/Platforms/net5/ComponentModelTypeConverter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/net5/PlatformRegistrations.cs
+++ b/src/ReactiveUI/Platforms/net5/PlatformRegistrations.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/netcoreapp3/ComponentModelTypeConverter.cs
+++ b/src/ReactiveUI/Platforms/netcoreapp3/ComponentModelTypeConverter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/netcoreapp3/PlatformRegistrations.cs
+++ b/src/ReactiveUI/Platforms/netcoreapp3/PlatformRegistrations.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/netstandard2.0/PlatformRegistrations.cs
+++ b/src/ReactiveUI/Platforms/netstandard2.0/PlatformRegistrations.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/tizen/EcoreMainloopScheduler.cs
+++ b/src/ReactiveUI/Platforms/tizen/EcoreMainloopScheduler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/tizen/PlatformOperations.cs
+++ b/src/ReactiveUI/Platforms/tizen/PlatformOperations.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/tizen/PlatformRegistrations.cs
+++ b/src/ReactiveUI/Platforms/tizen/PlatformRegistrations.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/tvos/LinkerOverrides.cs
+++ b/src/ReactiveUI/Platforms/tvos/LinkerOverrides.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/tvos/UIKitCommandBinders.cs
+++ b/src/ReactiveUI/Platforms/tvos/UIKitCommandBinders.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/tvos/UIKitObservableForProperty.cs
+++ b/src/ReactiveUI/Platforms/tvos/UIKitObservableForProperty.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/uap/ActivationForViewFetcher.cs
+++ b/src/ReactiveUI/Platforms/uap/ActivationForViewFetcher.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/uap/AutoSuspendHelper.cs
+++ b/src/ReactiveUI/Platforms/uap/AutoSuspendHelper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/uap/DependencyObjectObservableForProperty.cs
+++ b/src/ReactiveUI/Platforms/uap/DependencyObjectObservableForProperty.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/uap/PlatformRegistrations.cs
+++ b/src/ReactiveUI/Platforms/uap/PlatformRegistrations.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/uap/SingleWindowDispatcherScheduler.cs
+++ b/src/ReactiveUI/Platforms/uap/SingleWindowDispatcherScheduler.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/uap/TransitioningContentControl.Empty.cs
+++ b/src/ReactiveUI/Platforms/uap/TransitioningContentControl.Empty.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/uap/WinRTAppDataDriver.cs
+++ b/src/ReactiveUI/Platforms/uap/WinRTAppDataDriver.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/uikit-common/AutoSuspendHelper.cs
+++ b/src/ReactiveUI/Platforms/uikit-common/AutoSuspendHelper.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/uikit-common/CollectionViewSectionInformation.cs
+++ b/src/ReactiveUI/Platforms/uikit-common/CollectionViewSectionInformation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/uikit-common/CommonReactiveSource.cs
+++ b/src/ReactiveUI/Platforms/uikit-common/CommonReactiveSource.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/uikit-common/FlexibleCommandBinder.cs
+++ b/src/ReactiveUI/Platforms/uikit-common/FlexibleCommandBinder.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/uikit-common/ISectionInformation.cs
+++ b/src/ReactiveUI/Platforms/uikit-common/ISectionInformation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/uikit-common/IUICollViewAdapter.cs
+++ b/src/ReactiveUI/Platforms/uikit-common/IUICollViewAdapter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/uikit-common/PlatformRegistrations.cs
+++ b/src/ReactiveUI/Platforms/uikit-common/PlatformRegistrations.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/uikit-common/ReactiveCollectionReusableView.cs
+++ b/src/ReactiveUI/Platforms/uikit-common/ReactiveCollectionReusableView.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/uikit-common/ReactiveCollectionView.cs
+++ b/src/ReactiveUI/Platforms/uikit-common/ReactiveCollectionView.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/uikit-common/ReactiveCollectionViewCell.cs
+++ b/src/ReactiveUI/Platforms/uikit-common/ReactiveCollectionViewCell.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/uikit-common/ReactiveCollectionViewController.cs
+++ b/src/ReactiveUI/Platforms/uikit-common/ReactiveCollectionViewController.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/uikit-common/ReactiveCollectionViewSource.cs
+++ b/src/ReactiveUI/Platforms/uikit-common/ReactiveCollectionViewSource.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/uikit-common/ReactiveCollectionViewSourceExtensions.cs
+++ b/src/ReactiveUI/Platforms/uikit-common/ReactiveCollectionViewSourceExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/uikit-common/ReactiveNavigationController.cs
+++ b/src/ReactiveUI/Platforms/uikit-common/ReactiveNavigationController.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/uikit-common/ReactivePageViewController.cs
+++ b/src/ReactiveUI/Platforms/uikit-common/ReactivePageViewController.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/uikit-common/ReactiveTabBarController.cs
+++ b/src/ReactiveUI/Platforms/uikit-common/ReactiveTabBarController.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/uikit-common/ReactiveTableView.cs
+++ b/src/ReactiveUI/Platforms/uikit-common/ReactiveTableView.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/uikit-common/ReactiveTableViewCell.cs
+++ b/src/ReactiveUI/Platforms/uikit-common/ReactiveTableViewCell.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/uikit-common/ReactiveTableViewController.cs
+++ b/src/ReactiveUI/Platforms/uikit-common/ReactiveTableViewController.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/uikit-common/ReactiveTableViewSource.cs
+++ b/src/ReactiveUI/Platforms/uikit-common/ReactiveTableViewSource.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/uikit-common/ReactiveTableViewSourceExtensions.cs
+++ b/src/ReactiveUI/Platforms/uikit-common/ReactiveTableViewSourceExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/uikit-common/RoutedViewHost.cs
+++ b/src/ReactiveUI/Platforms/uikit-common/RoutedViewHost.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/uikit-common/SectionInfoIdGenerator.cs
+++ b/src/ReactiveUI/Platforms/uikit-common/SectionInfoIdGenerator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/uikit-common/TableSectionHeader.cs
+++ b/src/ReactiveUI/Platforms/uikit-common/TableSectionHeader.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/uikit-common/TableSectionInformation.cs
+++ b/src/ReactiveUI/Platforms/uikit-common/TableSectionInformation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/uikit-common/UICollectionViewAdapter.cs
+++ b/src/ReactiveUI/Platforms/uikit-common/UICollectionViewAdapter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/uikit-common/UIControlCommandExtensions.cs
+++ b/src/ReactiveUI/Platforms/uikit-common/UIControlCommandExtensions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/uikit-common/UITableViewAdapter.cs
+++ b/src/ReactiveUI/Platforms/uikit-common/UITableViewAdapter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/windows-common/AutoDataTemplateBindingHook.cs
+++ b/src/ReactiveUI/Platforms/windows-common/AutoDataTemplateBindingHook.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/windows-common/BooleanToVisibilityHint.cs
+++ b/src/ReactiveUI/Platforms/windows-common/BooleanToVisibilityHint.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/windows-common/BooleanToVisibilityTypeConverter.cs
+++ b/src/ReactiveUI/Platforms/windows-common/BooleanToVisibilityTypeConverter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/windows-common/PlatformOperations.cs
+++ b/src/ReactiveUI/Platforms/windows-common/PlatformOperations.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/windows-common/ReactivePage.cs
+++ b/src/ReactiveUI/Platforms/windows-common/ReactivePage.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/windows-common/ReactiveUserControl.cs
+++ b/src/ReactiveUI/Platforms/windows-common/ReactiveUserControl.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/windows-common/RoutedViewHost.cs
+++ b/src/ReactiveUI/Platforms/windows-common/RoutedViewHost.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/windows-common/ViewModelViewHost.cs
+++ b/src/ReactiveUI/Platforms/windows-common/ViewModelViewHost.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Platforms/xamarin-common/ComponentModelTypeConverter.cs
+++ b/src/ReactiveUI/Platforms/xamarin-common/ComponentModelTypeConverter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Properties/AssemblyInfo.cs
+++ b/src/ReactiveUI/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/ReactiveCommand/CombinedReactiveCommand.cs
+++ b/src/ReactiveUI/ReactiveCommand/CombinedReactiveCommand.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/ReactiveCommand/IReactiveCommand.cs
+++ b/src/ReactiveUI/ReactiveCommand/IReactiveCommand.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/ReactiveCommand/ReactiveCommand.cs
+++ b/src/ReactiveUI/ReactiveCommand/ReactiveCommand.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/ReactiveCommand/ReactiveCommandBase.cs
+++ b/src/ReactiveUI/ReactiveCommand/ReactiveCommandBase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/ReactiveCommand/ReactiveCommandMixins.cs
+++ b/src/ReactiveUI/ReactiveCommand/ReactiveCommandMixins.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/ReactiveObject/IReactiveObject.cs
+++ b/src/ReactiveUI/ReactiveObject/IReactiveObject.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/ReactiveObject/IReactiveObjectExtensions.cs
+++ b/src/ReactiveUI/ReactiveObject/IReactiveObjectExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/ReactiveObject/ReactiveObject.cs
+++ b/src/ReactiveUI/ReactiveObject/ReactiveObject.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Registration/Registrations.cs
+++ b/src/ReactiveUI/Registration/Registrations.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/RegistrationNamespace.cs
+++ b/src/ReactiveUI/RegistrationNamespace.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Routing/MessageBus.cs
+++ b/src/ReactiveUI/Routing/MessageBus.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Routing/NotAWeakReference.cs
+++ b/src/ReactiveUI/Routing/NotAWeakReference.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Routing/RoutableViewModelMixin.cs
+++ b/src/ReactiveUI/Routing/RoutableViewModelMixin.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Routing/RoutingState.cs
+++ b/src/ReactiveUI/Routing/RoutingState.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Routing/RoutingStateMixins.cs
+++ b/src/ReactiveUI/Routing/RoutingStateMixins.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/RxApp.cs
+++ b/src/ReactiveUI/RxApp.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Scheduler/ScheduledSubject.cs
+++ b/src/ReactiveUI/Scheduler/ScheduledSubject.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Scheduler/WaitForDispatcherScheduler.cs
+++ b/src/ReactiveUI/Scheduler/WaitForDispatcherScheduler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Suspension/DummySuspensionDriver.cs
+++ b/src/ReactiveUI/Suspension/DummySuspensionDriver.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Suspension/SuspensionHost.cs
+++ b/src/ReactiveUI/Suspension/SuspensionHost.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/Suspension/SuspensionHostExtensions.cs
+++ b/src/ReactiveUI/Suspension/SuspensionHostExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/UnhandledErrorException.cs
+++ b/src/ReactiveUI/UnhandledErrorException.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/View/DefaultViewLocator.cs
+++ b/src/ReactiveUI/View/DefaultViewLocator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/View/SingleInstanceViewAttribute.cs
+++ b/src/ReactiveUI/View/SingleInstanceViewAttribute.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/View/ViewContractAttribute.cs
+++ b/src/ReactiveUI/View/ViewContractAttribute.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/View/ViewLocator.cs
+++ b/src/ReactiveUI/View/ViewLocator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI/View/ViewLocatorNotFoundException.cs
+++ b/src/ReactiveUI/View/ViewLocatorNotFoundException.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/stylecop.json
+++ b/src/stylecop.json
@@ -13,7 +13,7 @@
             "documentPrivateFields": false,
             "documentationCulture": "en-US",
             "companyName": ".NET Foundation and Contributors",
-            "copyrightText": "Copyright (c) 2020 {companyName}. All rights reserved.\nLicensed to the .NET Foundation under one or more agreements.\nThe .NET Foundation licenses this file to you under the {licenseName} license.\nSee the {licenseFile} file in the project root for full license information.",
+            "copyrightText": "Copyright (c) 2021 {companyName}. All rights reserved.\nLicensed to the .NET Foundation under one or more agreements.\nThe .NET Foundation licenses this file to you under the {licenseName} license.\nSee the {licenseFile} file in the project root for full license information.",
             "variables": {
                 "licenseName": "MIT",
                 "licenseFile": "LICENSE"


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

This PR updates ReactiveUI copyright year in the license header. Used a basic shell script and a manual `json` file update:
`find -type f -exec ex -sc '%s/Copyright (c) 2020 .NET Foundation and Contributors/Copyright (c) 2021 .NET Foundation and Contributors/g' -cx {} ';'`