### PR TITLE
Fix IPlatformOperations to be public like other registrable interfaces

### DIFF
--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.net472.approved.txt
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.net472.approved.txt
@@ -225,6 +225,10 @@ namespace ReactiveUI
         TSender Sender { get; }
         TValue Value { get; }
     }
+    public interface IPlatformOperations
+    {
+        string? GetOrientation();
+    }
     public interface IPropertyBinderImplementation : Splat.IEnableLogger
     {
         [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {

--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.net5.0.approved.txt
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.net5.0.approved.txt
@@ -225,6 +225,10 @@ namespace ReactiveUI
         TSender Sender { get; }
         TValue Value { get; }
     }
+    public interface IPlatformOperations
+    {
+        string? GetOrientation();
+    }
     public interface IPropertyBinderImplementation : Splat.IEnableLogger
     {
         [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {

--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.netcoreapp3.1.approved.txt
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.netcoreapp3.1.approved.txt
@@ -223,6 +223,10 @@ namespace ReactiveUI
         TSender Sender { get; }
         TValue Value { get; }
     }
+    public interface IPlatformOperations
+    {
+        string? GetOrientation();
+    }
     public interface IPropertyBinderImplementation : Splat.IEnableLogger
     {
         [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {

--- a/src/ReactiveUI.Tests/Platforms/winforms/API/ApiApprovalTests.Winforms.net472.approved.txt
+++ b/src/ReactiveUI.Tests/Platforms/winforms/API/ApiApprovalTests.Winforms.net472.approved.txt
@@ -26,7 +26,7 @@ namespace ReactiveUI.Winforms
         public int GetAffinityForObjects(System.Type fromType, System.Type toType) { }
         public object PerformSet(object? toTarget, object? newValue, object?[]? arguments) { }
     }
-    public class PlatformOperations
+    public class PlatformOperations : ReactiveUI.IPlatformOperations
     {
         public PlatformOperations() { }
         public string? GetOrientation() { }

--- a/src/ReactiveUI.Tests/Platforms/winforms/API/ApiApprovalTests.Winforms.net5.0.approved.txt
+++ b/src/ReactiveUI.Tests/Platforms/winforms/API/ApiApprovalTests.Winforms.net5.0.approved.txt
@@ -28,7 +28,7 @@ namespace ReactiveUI.Winforms
         public int GetAffinityForObjects(System.Type fromType, System.Type toType) { }
         public object PerformSet(object? toTarget, object? newValue, object?[]? arguments) { }
     }
-    public class PlatformOperations
+    public class PlatformOperations : ReactiveUI.IPlatformOperations
     {
         public PlatformOperations() { }
         public string? GetOrientation() { }

--- a/src/ReactiveUI.Tests/Platforms/winforms/API/ApiApprovalTests.Winforms.netcoreapp3.1.approved.txt
+++ b/src/ReactiveUI.Tests/Platforms/winforms/API/ApiApprovalTests.Winforms.netcoreapp3.1.approved.txt
@@ -26,7 +26,7 @@ namespace ReactiveUI.Winforms
         public int GetAffinityForObjects(System.Type fromType, System.Type toType) { }
         public object PerformSet(object? toTarget, object? newValue, object?[]? arguments) { }
     }
-    public class PlatformOperations
+    public class PlatformOperations : ReactiveUI.IPlatformOperations
     {
         public PlatformOperations() { }
         public string? GetOrientation() { }

--- a/src/ReactiveUI/Interfaces/IPlatformOperations.cs
+++ b/src/ReactiveUI/Interfaces/IPlatformOperations.cs
@@ -8,7 +8,7 @@ namespace ReactiveUI
     /// <summary>
     /// Additional details implemented by the different ReactiveUI platform projects.
     /// </summary>
-    internal interface IPlatformOperations
+    public interface IPlatformOperations
     {
         /// <summary>
         /// Gets a descriptor that describes (if applicable) the orientation


### PR DESCRIPTION
It's super important that any interface we register in an `IWantsToRegisterStuff` is `public`, and ideally, the implementation too. This means that people can always extend ReactiveUI or support a new platform without having to fork the library