### PR TITLE
fix: Add RegistrationNamespace.Avalonia

### DIFF
--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.net472.approved.txt
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.net472.approved.txt
@@ -655,6 +655,7 @@ namespace ReactiveUI
         Uno = 3,
         Blazor = 4,
         Drawing = 5,
+        Avalonia = 6,
     }
     public class Registrations
     {

--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.net5.0.approved.txt
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.net5.0.approved.txt
@@ -650,6 +650,7 @@ namespace ReactiveUI
         Uno = 3,
         Blazor = 4,
         Drawing = 5,
+        Avalonia = 6,
     }
     public class Registrations
     {

--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.netcoreapp3.1.approved.txt
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.netcoreapp3.1.approved.txt
@@ -648,6 +648,7 @@ namespace ReactiveUI
         Uno = 3,
         Blazor = 4,
         Drawing = 5,
+        Avalonia = 6,
     }
     public class Registrations
     {

--- a/src/ReactiveUI/Mixins/DependencyResolverMixins.cs
+++ b/src/ReactiveUI/Mixins/DependencyResolverMixins.cs
@@ -41,7 +41,7 @@ namespace ReactiveUI
 
             if (registrationNamespaces.Length == 0)
             {
-                registrationNamespaces = PlatformRegistrationManager.NamespacesToRegister;
+                registrationNamespaces = PlatformRegistrationManager.DefaultRegistrationNamespaces;
             }
 
             var extraNs =

--- a/src/ReactiveUI/Mixins/DependencyResolverMixins.cs
+++ b/src/ReactiveUI/Mixins/DependencyResolverMixins.cs
@@ -41,7 +41,7 @@ namespace ReactiveUI
 
             if (registrationNamespaces.Length == 0)
             {
-                registrationNamespaces = PlatformRegistrationManager.DefaultRegistrationNamespaces;
+                registrationNamespaces = PlatformRegistrationManager.NamespacesToRegister;
             }
 
             var extraNs =

--- a/src/ReactiveUI/RegistrationNamespace.cs
+++ b/src/ReactiveUI/RegistrationNamespace.cs
@@ -38,6 +38,11 @@ namespace ReactiveUI
         /// <summary>
         /// Drawing.
         /// </summary>
-        Drawing
+        Drawing,
+
+        /// <summary>
+        /// Avalonia.
+        /// </summary>
+        Avalonia
     }
 }


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

With this PR, the `InitializeReactiveUI` extension method is now falling back to `PlatformRegistrationManager.NamespacesToRegister` if there are no registration namespaces provided via `params` of the `InitializeReactiveUI` method. The `NamespacesToRegister` property is mutable as opposed to `DefaultRegistrationNamespaces` — if we prefer `NamespacesToRegister` over the read only `DefaultRegistrationNamespaces` as the default value [here](https://github.com/reactiveui/ReactiveUI/blob/15f542b01da300d350b8ddb49855155c45531e8b/src/ReactiveUI/Mixins/DependencyResolverMixins.cs#L44), our users will be able to disable implicit dependency discovery if they'd like to via a call to `PlatformRegistrationManager.SetRegistrationNamespaces()`.

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

Currently, folks with the "Break on all exceptions" feature enabled in their IDE are confused by exceptions during app initialization:
`System.IO.FileNotFoundException: Could not load file or assembly 'ReactiveUI.XamForms, Version=13.1.0.0, Culture=neutral, PublicKeyToken=null'. The system cannot find the file specified.`

We know, that this is ordinary ReactiveUI dependency registration behavior — ReactiveUI tries to load assemblies in order to register the required services, and if the framework fails to load an assembly, then a `FileNotFoundException` is thrown, which is immediately caught by the `MemoizingMRUCache` implementation:

https://github.com/reactiveui/ReactiveUI/blob/0518c2bc9e03328712bf1fb2e35bca3dfe5f9885/src/ReactiveUI/Expression/Reflection.cs#L41-L48

This behavior is OK on most platforms, but there are folks who'd like to register the required dependencies manually and explicitly. That's why the [`SetRegistrationNamespaces`](https://github.com/reactiveui/ReactiveUI/blob/15f542b01da300d350b8ddb49855155c45531e8b/src/ReactiveUI/PlatformRegistrationManager.cs#L25) method currently exists. At the moment we allow _setting_ the registration namespaces, but don't allow _turning off_ the auto dependency registration via assembly loading completely. Turning off this feature might be useful in such environments as [Avalonia.ReactiveUI](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.ReactiveUI/AppBuilderExtensions.cs). Avalonia folks tend to use a `IAppBuilder` and the `.UseReactiveUI()` extension method for Avalonia-specific dependency registrations. That's why they might want to turn off the implicit ReactiveUI default dependency registration behavior.

**What is the new behavior?**
<!-- If this is a feature change -->

With the proposed change, one can disable implicit assembly loading by doing this:
```cs
PlatformRegistrationManager.SetRegistrationNamespaces(new RegistrationNamespace[0]);
```
This change would allow adding this statement to [Avalonia.ReactiveUI](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.ReactiveUI/AppBuilderExtensions.cs) in order to avoid performing unnecessary assembly loading in their environment. Also, this feature might be useful for folks who tend to use the "Break on all exceptions" feature in Microsoft Visual Studio or JetBrains Rider, and who might want to register the dependencies manually. In case if one disables platform registrations this way, the `InitializeReactiveUI` extension method will only register [default registrations](https://github.com/reactiveui/ReactiveUI/blob/4289c99dad570e4556e8ceacdd2ddda7eb7b183b/src/ReactiveUI/Registration/Registrations.cs#L18) and [.NET Standard](https://github.com/reactiveui/ReactiveUI/blob/4289c99dad570e4556e8ceacdd2ddda7eb7b183b/src/ReactiveUI/Platforms/netstandard2.0/PlatformRegistrations.cs#L16)/.NET Core etc. platform registrations.

**What might this PR break?**

Hopefully nothing, but let's wait for the CI?
