### PR TITLE
Remove System.ValueTuple package dependency from net472 target framew…

### DIFF
--- a/src/ReactiveUI/ReactiveUI.csproj
+++ b/src/ReactiveUI/ReactiveUI.csproj
@@ -37,10 +37,13 @@
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) ">
     <Compile Include="Platforms\net4\**\*.cs" />
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <Reference Include="System.Windows" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="WindowsBase" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('net46')) ">
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('net46')) or $(TargetFramework) == 'net5.0-windows' ">


### PR DESCRIPTION
This is a simple PR that removes the System.ValueTuple package dependency when targeting net472. This removes issues with binding redirects been required when your solution contains projects targeting both net472 and netstandard2.0 frameworks.