### PR TITLE
feature RoutingState NavigateBack Result Type To IRoutableViewModel closes #2743

### DIFF
--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.net472.approved.txt
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.net472.approved.txt
@@ -706,7 +706,7 @@ namespace ReactiveUI
         [System.Runtime.Serialization.IgnoreDataMember]
         public ReactiveUI.ReactiveCommand<ReactiveUI.IRoutableViewModel, ReactiveUI.IRoutableViewModel> NavigateAndReset { get; set; }
         [System.Runtime.Serialization.IgnoreDataMember]
-        public ReactiveUI.ReactiveCommand<System.Reactive.Unit, System.Reactive.Unit> NavigateBack { get; set; }
+        public ReactiveUI.ReactiveCommand<System.Reactive.Unit, ReactiveUI.IRoutableViewModel?> NavigateBack { get; set; }
         [System.Runtime.Serialization.IgnoreDataMember]
         public System.IObservable<DynamicData.IChangeSet<ReactiveUI.IRoutableViewModel>> NavigationChanged { get; set; }
         [System.Runtime.Serialization.IgnoreDataMember]

--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.net5.0.approved.txt
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.net5.0.approved.txt
@@ -701,7 +701,7 @@ namespace ReactiveUI
         [System.Runtime.Serialization.IgnoreDataMember]
         public ReactiveUI.ReactiveCommand<ReactiveUI.IRoutableViewModel, ReactiveUI.IRoutableViewModel> NavigateAndReset { get; set; }
         [System.Runtime.Serialization.IgnoreDataMember]
-        public ReactiveUI.ReactiveCommand<System.Reactive.Unit, System.Reactive.Unit> NavigateBack { get; set; }
+        public ReactiveUI.ReactiveCommand<System.Reactive.Unit, ReactiveUI.IRoutableViewModel?> NavigateBack { get; set; }
         [System.Runtime.Serialization.IgnoreDataMember]
         public System.IObservable<DynamicData.IChangeSet<ReactiveUI.IRoutableViewModel>> NavigationChanged { get; set; }
         [System.Runtime.Serialization.IgnoreDataMember]

--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.netcoreapp3.1.approved.txt
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.netcoreapp3.1.approved.txt
@@ -699,7 +699,7 @@ namespace ReactiveUI
         [System.Runtime.Serialization.IgnoreDataMember]
         public ReactiveUI.ReactiveCommand<ReactiveUI.IRoutableViewModel, ReactiveUI.IRoutableViewModel> NavigateAndReset { get; set; }
         [System.Runtime.Serialization.IgnoreDataMember]
-        public ReactiveUI.ReactiveCommand<System.Reactive.Unit, System.Reactive.Unit> NavigateBack { get; set; }
+        public ReactiveUI.ReactiveCommand<System.Reactive.Unit, ReactiveUI.IRoutableViewModel?> NavigateBack { get; set; }
         [System.Runtime.Serialization.IgnoreDataMember]
         public System.IObservable<DynamicData.IChangeSet<ReactiveUI.IRoutableViewModel>> NavigationChanged { get; set; }
         [System.Runtime.Serialization.IgnoreDataMember]

--- a/src/ReactiveUI.Tests/Routing/RoutingStateTests.cs
+++ b/src/ReactiveUI.Tests/Routing/RoutingStateTests.cs
@@ -34,29 +34,57 @@ namespace ReactiveUI.Tests
             Assert.Equal(2, fixture.NavigationStack.Count);
             Assert.True(await fixture.NavigateBack.CanExecute.FirstAsync());
 
-            await fixture.NavigateBack.Execute();
-
+            var navigatedTo = await fixture.NavigateBack.Execute();
+            Assert.Equal(navigatedTo.GetType(), input.GetType());
             Assert.Equal(1, fixture.NavigationStack.Count);
         }
 
         [Fact]
-        public void CurrentViewModelObservableIsAccurate()
+        public async Task CurrentViewModelObservableIsAccurate()
         {
             var fixture = new RoutingState();
             fixture.CurrentViewModel.ToObservableChangeSet(ImmediateScheduler.Instance).Bind(out var output).Subscribe();
 
             Assert.Equal(1, output.Count);
 
-            fixture.Navigate.Execute(new TestViewModel { SomeProp = "A" });
+            await fixture.Navigate.Execute(new TestViewModel { SomeProp = "A" });
             Assert.Equal(2, output.Count);
 
-            fixture.Navigate.Execute(new TestViewModel { SomeProp = "B" });
+            await fixture.Navigate.Execute(new TestViewModel { SomeProp = "B" });
             Assert.Equal(3, output.Count);
             Assert.Equal("B", (output.Last() as TestViewModel)?.SomeProp);
 
-            fixture.NavigateBack.Execute();
+            var navigatedTo = await fixture.NavigateBack.Execute();
+            Assert.Equal(navigatedTo?.GetType(), output.Last()?.GetType());
             Assert.Equal(4, output.Count);
             Assert.Equal("A", (output.Last() as TestViewModel)?.SomeProp);
+            Assert.Equal((navigatedTo as TestViewModel)?.SomeProp, (output.Last() as TestViewModel)?.SomeProp);
+
+            await fixture.Navigate.Execute(new TestViewModel { SomeProp = "B" });
+            Assert.Equal(5, output.Count);
+            Assert.Equal("B", (output.Last() as TestViewModel)?.SomeProp);
+
+            await fixture.Navigate.Execute(new TestViewModel { SomeProp = "C" });
+            Assert.Equal(6, output.Count);
+            Assert.Equal("C", (output.Last() as TestViewModel)?.SomeProp);
+
+            navigatedTo = await fixture.NavigateBack.Execute();
+            Assert.Equal(navigatedTo?.GetType(), output.Last()?.GetType());
+            Assert.Equal(7, output.Count);
+            Assert.Equal("B", (output.Last() as TestViewModel)?.SomeProp);
+            Assert.Equal((navigatedTo as TestViewModel)?.SomeProp, (output.Last() as TestViewModel)?.SomeProp);
+
+            navigatedTo = await fixture.NavigateBack.Execute();
+            Assert.Equal(navigatedTo?.GetType(), output.Last()?.GetType());
+            Assert.Equal(8, output.Count);
+            Assert.Equal("A", (output.Last() as TestViewModel)?.SomeProp);
+            Assert.Equal((navigatedTo as TestViewModel)?.SomeProp, (output.Last() as TestViewModel)?.SomeProp);
+
+            navigatedTo = await fixture.NavigateBack.Execute();
+            Assert.Equal(navigatedTo?.GetType(), output.Last()?.GetType());
+            Assert.Equal(9, output.Count);
+            Assert.Equal(null, (output.Last() as TestViewModel)?.SomeProp);
+            Assert.Equal(null, (navigatedTo as TestViewModel)?.SomeProp);
         }
 
         [Fact]

--- a/src/ReactiveUI.XamForms.Tests/Mocks/NavigationViewModel.cs
+++ b/src/ReactiveUI.XamForms.Tests/Mocks/NavigationViewModel.cs
@@ -62,6 +62,6 @@ namespace ReactiveUI.XamForms.Tests.Mocks
         /// Navigates back.
         /// </summary>
         /// <returns>An observable.</returns>
-        public IObservable<Unit> NavigateBack() => Router.NavigateBack.Execute();
+        public IObservable<IRoutableViewModel?> NavigateBack() => Router.NavigateBack.Execute();
     }
 }

--- a/src/ReactiveUI/Routing/RoutingState.cs
+++ b/src/ReactiveUI/Routing/RoutingState.cs
@@ -81,7 +81,7 @@ namespace ReactiveUI
         /// Gets or sets a command which will navigate back to the previous element in the stack.
         /// </summary>
         [IgnoreDataMember]
-        public ReactiveCommand<Unit, Unit> NavigateBack { get; protected set; }
+        public ReactiveCommand<Unit, IRoutableViewModel?> NavigateBack { get; protected set; }
 
         /// <summary>
         /// Gets or sets a command that navigates to the a new element in the stack - the Execute parameter
@@ -122,11 +122,11 @@ namespace ReactiveUI
 
             var countAsBehavior = Observable.Defer(() => Observable.Return(NavigationStack.Count)).Concat(NavigationChanged.CountChanged().Select(_ => NavigationStack.Count));
             NavigateBack =
-                ReactiveCommand.CreateFromObservable(
+                ReactiveCommand.CreateFromObservable<IRoutableViewModel?>(
                     () =>
                     {
                         _navigationStack.RemoveAt(NavigationStack.Count - 1);
-                        return Observables.Unit;
+                        return Observable.Return(NavigationStack.Count > 0 ? _navigationStack[NavigationStack.Count - 1] : default);
                     },
                     countAsBehavior.Select(x => x > 1),
                     navigateScheduler);


### PR DESCRIPTION
Changed Routing state to provide the nullable ViewModel upon navigating or Null if the stack is empty
closes #2743

<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

feature

**What is the current behaviour?**
<!-- You can also link to an open issue here. -->

NavigateBack returns a Unit

**What is the new behaviour?**
<!-- If this is a feature change -->

NavigateBack returns a nullable IRoutableViewModel

**What might this PR break?**

may produce compile errors if there is currently a usage of the NavigateBack provided Unit

**Please check if the PR fulfils these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

