### PR TITLE
Fix: Allow IReactiveObject to access subscription extensions

### DIFF
--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.net472.approved.txt
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.net472.approved.txt
@@ -300,6 +300,10 @@ namespace ReactiveUI
             where TSender : ReactiveUI.IReactiveObject { }
         public static void RaisePropertyChanging<TSender>(this TSender reactiveObject, [System.Runtime.CompilerServices.CallerMemberName] string? propertyName = null)
             where TSender : ReactiveUI.IReactiveObject { }
+        public static void SubscribePropertyChangedEvents<TSender>(this TSender reactiveObject)
+            where TSender : ReactiveUI.IReactiveObject { }
+        public static void SubscribePropertyChangingEvents<TSender>(this TSender reactiveObject)
+            where TSender : ReactiveUI.IReactiveObject { }
     }
     public interface IReactivePropertyChangedEventArgs<out TSender>
     {

--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.net472.approved.txt
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.net472.approved.txt
@@ -662,8 +662,8 @@ namespace ReactiveUI
         protected virtual bool PrintMembers(System.Text.StringBuilder builder) { }
         public System.IDisposable SuppressChangeNotifications() { }
         public override string ToString() { }
-        public static bool operator !=(ReactiveUI.ReactiveRecord? r1, ReactiveUI.ReactiveRecord? r2) { }
-        public static bool operator ==(ReactiveUI.ReactiveRecord? r1, ReactiveUI.ReactiveRecord? r2) { }
+        public static bool operator !=(ReactiveUI.ReactiveRecord? left, ReactiveUI.ReactiveRecord? right) { }
+        public static bool operator ==(ReactiveUI.ReactiveRecord? left, ReactiveUI.ReactiveRecord? right) { }
     }
     public static class Reflection
     {

--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.net5.0.approved.txt
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.net5.0.approved.txt
@@ -657,8 +657,8 @@ namespace ReactiveUI
         protected virtual bool PrintMembers(System.Text.StringBuilder builder) { }
         public System.IDisposable SuppressChangeNotifications() { }
         public override string ToString() { }
-        public static bool operator !=(ReactiveUI.ReactiveRecord? r1, ReactiveUI.ReactiveRecord? r2) { }
-        public static bool operator ==(ReactiveUI.ReactiveRecord? r1, ReactiveUI.ReactiveRecord? r2) { }
+        public static bool operator !=(ReactiveUI.ReactiveRecord? left, ReactiveUI.ReactiveRecord? right) { }
+        public static bool operator ==(ReactiveUI.ReactiveRecord? left, ReactiveUI.ReactiveRecord? right) { }
     }
     public static class Reflection
     {

--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.net5.0.approved.txt
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.net5.0.approved.txt
@@ -295,6 +295,10 @@ namespace ReactiveUI
             where TSender : ReactiveUI.IReactiveObject { }
         public static void RaisePropertyChanging<TSender>(this TSender reactiveObject, [System.Runtime.CompilerServices.CallerMemberName] string? propertyName = null)
             where TSender : ReactiveUI.IReactiveObject { }
+        public static void SubscribePropertyChangedEvents<TSender>(this TSender reactiveObject)
+            where TSender : ReactiveUI.IReactiveObject { }
+        public static void SubscribePropertyChangingEvents<TSender>(this TSender reactiveObject)
+            where TSender : ReactiveUI.IReactiveObject { }
     }
     public interface IReactivePropertyChangedEventArgs<out TSender>
     {

--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.netcoreapp3.1.approved.txt
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.netcoreapp3.1.approved.txt
@@ -655,8 +655,8 @@ namespace ReactiveUI
         protected virtual bool PrintMembers(System.Text.StringBuilder builder) { }
         public System.IDisposable SuppressChangeNotifications() { }
         public override string ToString() { }
-        public static bool operator !=(ReactiveUI.ReactiveRecord? r1, ReactiveUI.ReactiveRecord? r2) { }
-        public static bool operator ==(ReactiveUI.ReactiveRecord? r1, ReactiveUI.ReactiveRecord? r2) { }
+        public static bool operator !=(ReactiveUI.ReactiveRecord? left, ReactiveUI.ReactiveRecord? right) { }
+        public static bool operator ==(ReactiveUI.ReactiveRecord? left, ReactiveUI.ReactiveRecord? right) { }
     }
     public static class Reflection
     {

--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.netcoreapp3.1.approved.txt
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.netcoreapp3.1.approved.txt
@@ -293,6 +293,10 @@ namespace ReactiveUI
             where TSender : ReactiveUI.IReactiveObject { }
         public static void RaisePropertyChanging<TSender>(this TSender reactiveObject, [System.Runtime.CompilerServices.CallerMemberName] string? propertyName = null)
             where TSender : ReactiveUI.IReactiveObject { }
+        public static void SubscribePropertyChangedEvents<TSender>(this TSender reactiveObject)
+            where TSender : ReactiveUI.IReactiveObject { }
+        public static void SubscribePropertyChangingEvents<TSender>(this TSender reactiveObject)
+            where TSender : ReactiveUI.IReactiveObject { }
     }
     public interface IReactivePropertyChangedEventArgs<out TSender>
     {

--- a/src/ReactiveUI.Tests/Platforms/windows-xaml/PropertyBindingTest.cs
+++ b/src/ReactiveUI.Tests/Platforms/windows-xaml/PropertyBindingTest.cs
@@ -114,10 +114,10 @@ namespace ReactiveUI.Tests.Xaml
             vm.JustADecimal = 17.2m;
             var disp1 = fixture.Bind(vm, view, x => x.JustADecimal, x => x.SomeTextBox.Text, (IObservable<Unit>?)null, null);
 
-            Assert.Equal(vm.JustADecimal.ToString(CultureInfo.InvariantCulture), view.SomeTextBox.Text);
+            Assert.Equal(vm.JustADecimal.ToString(CultureInfo.CurrentCulture), view.SomeTextBox.Text);
             Assert.Equal(17.2m, vm.JustADecimal);
 
-            view.SomeTextBox.Text = 42.3m.ToString(CultureInfo.InvariantCulture);
+            view.SomeTextBox.Text = 42.3m.ToString(CultureInfo.CurrentCulture);
             Assert.Equal(42.3m, vm.JustADecimal);
 
             // Bad formatting.

--- a/src/ReactiveUI.Tests/Platforms/winforms/DefaultPropertyBindingTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/DefaultPropertyBindingTests.cs
@@ -143,7 +143,7 @@ namespace ReactiveUI.Tests.Winforms
             var disp2 = view.Bind(vm, x => x.SomeDouble, x => x.Property3.Text);
             vm.SomeDouble = 123.4;
 
-            Assert.Equal(vm.SomeDouble.ToString(CultureInfo.InvariantCulture), view.Property3.Text);
+            Assert.Equal(vm.SomeDouble.ToString(CultureInfo.CurrentCulture), view.Property3.Text);
         }
 
         /// <summary>

--- a/src/ReactiveUI.Tests/Utilities/ApiApprovalBase.cs
+++ b/src/ReactiveUI.Tests/Utilities/ApiApprovalBase.cs
@@ -83,7 +83,7 @@ namespace ReactiveUI.Tests
                 }
             }
 
-            Assert.Equal(approvedPublicApi, receivedPublicApi);
+            Assert.Equal(approvedPublicApi.Trim(), receivedPublicApi);
         }
 
         private static string Filter(string text)

--- a/src/ReactiveUI/ReactiveObject/IReactiveObjectExtensions.cs
+++ b/src/ReactiveUI/ReactiveObject/IReactiveObjectExtensions.cs
@@ -170,6 +170,34 @@ namespace ReactiveUI
             }
         }
 
+        /// <summary>
+        /// Use this method for enabling classic PropertyChanging events when you
+        /// are implementing IReactiveObject manually.
+        /// </summary>
+        /// <typeparam name="TSender">The sender type.</typeparam>
+        /// <param name="reactiveObject">The instance of IReactiveObject which should propagate property changes.</param>
+        public static void SubscribePropertyChangingEvents<TSender>(this TSender reactiveObject)
+            where TSender : IReactiveObject
+        {
+            var s = state.GetValue(reactiveObject, _ => (IExtensionState<IReactiveObject>)new ExtensionState<TSender>(reactiveObject));
+
+            s.SubscribePropertyChangingEvents();
+        }
+
+        /// <summary>
+        /// Use this method for enabling classic PropertyChanged events when you
+        /// are implementing IReactiveObject manually.
+        /// </summary>
+        /// <typeparam name="TSender">The sender type.</typeparam>
+        /// <param name="reactiveObject">The instance of IReactiveObject which should propagate property changes.</param>
+        public static void SubscribePropertyChangedEvents<TSender>(this TSender reactiveObject)
+            where TSender : IReactiveObject
+        {
+            var s = state.GetValue(reactiveObject, _ => (IExtensionState<IReactiveObject>)new ExtensionState<TSender>(reactiveObject));
+
+            s.SubscribePropertyChangedEvents();
+        }
+
         internal static IObservable<IReactivePropertyChangedEventArgs<TSender>> GetChangedObservable<TSender>(this TSender reactiveObject)
             where TSender : IReactiveObject
         {
@@ -191,14 +219,6 @@ namespace ReactiveUI
             return s.ThrownExceptions;
         }
 
-        internal static void SubscribePropertyChangingEvents<TSender>(this TSender reactiveObject)
-            where TSender : IReactiveObject
-        {
-            var s = state.GetValue(reactiveObject, _ => (IExtensionState<IReactiveObject>)new ExtensionState<TSender>(reactiveObject));
-
-            s.SubscribePropertyChangingEvents();
-        }
-
         internal static void RaisingPropertyChanging<TSender>(this TSender reactiveObject, string propertyName)
             where TSender : IReactiveObject
         {
@@ -210,14 +230,6 @@ namespace ReactiveUI
             var s = state.GetValue(reactiveObject, _ => (IExtensionState<IReactiveObject>)new ExtensionState<TSender>(reactiveObject));
 
             s.RaisePropertyChanging(propertyName);
-        }
-
-        internal static void SubscribePropertyChangedEvents<TSender>(this TSender reactiveObject)
-            where TSender : IReactiveObject
-        {
-            var s = state.GetValue(reactiveObject, _ => (IExtensionState<IReactiveObject>)new ExtensionState<TSender>(reactiveObject));
-
-            s.SubscribePropertyChangedEvents();
         }
 
         internal static void RaisingPropertyChanged<TSender>(this TSender reactiveObject, string propertyName)


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here. -->
Custom implementation of `IReactiveObject` does not fire PropertyChanging and PropertyChanged events.
See #2594 


**What is the new behavior?**
<!-- If this is a feature change -->
`IReactiveObjectExtensions.SubscribePropertyChangedEvents` and `IReactiveObjectExtensions.SubscribePropertyChangingEvents are` now public


**What might this PR break?**
This PR breaks the public API by adding two new public extension methods `IReactiveObjectExtensions.SubscribePropertyChangedEvents` and `IReactiveObjectExtensions.SubscribePropertyChangingEvents are`


**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features) -> API tests have been updated
- [x] Docs have been added / updated (for bug fixes / features) -> Added XML docs

**Other information**:

