### PR TITLE
Fix WPF View deactivation

### DIFF
--- a/src/ReactiveUI.Tests/Platforms/wpf/Mocks/WpfTestWindow.cs
+++ b/src/ReactiveUI.Tests/Platforms/wpf/Mocks/WpfTestWindow.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Windows;
+
+namespace ReactiveUI.Tests.Wpf
+{
+    public class WpfTestWindow : Window, IActivatableView
+    {
+    }
+}

--- a/src/ReactiveUI.Tests/Platforms/wpf/Mocks/WpfTestWindow.cs
+++ b/src/ReactiveUI.Tests/Platforms/wpf/Mocks/WpfTestWindow.cs
@@ -4,10 +4,19 @@
 // See the LICENSE file in the project root for full license information.
 
 using System.Windows;
+using System.Windows.Controls;
 
 namespace ReactiveUI.Tests.Wpf
 {
     public class WpfTestWindow : Window, IActivatableView
     {
+        public WpfTestWindow()
+        {
+            RootGrid = new Grid();
+
+            AddChild(RootGrid);
+        }
+
+        public Grid RootGrid { get; }
     }
 }

--- a/src/ReactiveUI.Tests/Platforms/wpf/WpfActivationForViewFetcherTest.cs
+++ b/src/ReactiveUI.Tests/Platforms/wpf/WpfActivationForViewFetcherTest.cs
@@ -41,6 +41,27 @@ namespace ReactiveUI.Tests.Wpf
         }
 
         [Fact]
+        public void WindowIsActivatedAndDeactivated()
+        {
+            var window = new WpfTestWindow();
+            var activation = new ActivationForViewFetcher();
+
+            var obs = activation.GetActivationForView(window);
+            obs.ToObservableChangeSet(scheduler: ImmediateScheduler.Instance).Bind(out var activated).Subscribe();
+
+            var loaded = new RoutedEventArgs();
+            loaded.RoutedEvent = FrameworkElement.LoadedEvent;
+
+            window.RaiseEvent(loaded);
+
+            new[] { true }.AssertAreEqual(activated);
+
+            window.Close();
+
+            new[] { true, false }.AssertAreEqual(activated);
+        }
+
+        [Fact]
         public void IsHitTestVisibleActivatesFrameworkElement()
         {
             var uc = new WpfTestUserControl();

--- a/src/ReactiveUI.Tests/Platforms/wpf/WpfActivationForViewFetcherTest.cs
+++ b/src/ReactiveUI.Tests/Platforms/wpf/WpfActivationForViewFetcherTest.cs
@@ -1,17 +1,17 @@
-﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
-
+​
 using System;
 using System.Reactive.Concurrency;
 using System.Windows;
-
+​
 using DynamicData;
 using Xunit;
-
+​
 using FactAttribute = Xunit.WpfFactAttribute;
-
+​
 namespace ReactiveUI.Tests.Wpf
 {
     public class WpfActivationForViewFetcherTest
@@ -21,161 +21,161 @@ namespace ReactiveUI.Tests.Wpf
         {
             var uc = new WpfTestUserControl();
             var activation = new ActivationForViewFetcher();
-
+​
             var obs = activation.GetActivationForView(uc);
             obs.ToObservableChangeSet(scheduler: ImmediateScheduler.Instance).Bind(out var activated).Subscribe();
-
+​
             var loaded = new RoutedEventArgs();
             loaded.RoutedEvent = FrameworkElement.LoadedEvent;
-
+​
             uc.RaiseEvent(loaded);
-
+​
             new[] { true }.AssertAreEqual(activated);
-
+​
             var unloaded = new RoutedEventArgs();
             unloaded.RoutedEvent = FrameworkElement.UnloadedEvent;
-
+​
             uc.RaiseEvent(unloaded);
-
+​
             new[] { true, false }.AssertAreEqual(activated);
         }
-
+​
         [Fact]
         public void WindowIsActivatedAndDeactivated()
         {
             var window = new WpfTestWindow();
             var activation = new ActivationForViewFetcher();
-
+​
             var obs = activation.GetActivationForView(window);
             obs.ToObservableChangeSet(scheduler: ImmediateScheduler.Instance).Bind(out var activated).Subscribe();
-
+​
             var loaded = new RoutedEventArgs();
             loaded.RoutedEvent = FrameworkElement.LoadedEvent;
-
+​
             window.RaiseEvent(loaded);
-
+​
             new[] { true }.AssertAreEqual(activated);
-
+​
             window.Close();
-
+​
             new[] { true, false }.AssertAreEqual(activated);
         }
-
-        [Fact]
+​
+        [StaFact]
         public void WindowAndFrameworkElementAreActivatedAndDeactivated()
         {
             var window = new WpfTestWindow();
             var uc = new WpfTestUserControl();
-
+​
             window.RootGrid.Children.Add(uc);
-
+​
             var activation = new ActivationForViewFetcher();
-
+​
             var windowObs = activation.GetActivationForView(window);
             windowObs.ToObservableChangeSet(scheduler: ImmediateScheduler.Instance).Bind(out var windowActivated).Subscribe();
-
+​
             var ucObs = activation.GetActivationForView(uc);
             ucObs.ToObservableChangeSet(scheduler: ImmediateScheduler.Instance).Bind(out var controlActivated).Subscribe();
-
+​
             var loaded = new RoutedEventArgs();
             loaded.RoutedEvent = FrameworkElement.LoadedEvent;
-
+​
             window.RaiseEvent(loaded);
             uc.RaiseEvent(loaded);
-
+​
             new[] { true }.AssertAreEqual(windowActivated);
             new[] { true }.AssertAreEqual(controlActivated);
-
+​
             window.Dispatcher.InvokeShutdown();
-
+​
             new[] { true, false }.AssertAreEqual(windowActivated);
             new[] { true, false }.AssertAreEqual(controlActivated);
         }
-
+​
         [Fact]
         public void IsHitTestVisibleActivatesFrameworkElement()
         {
             var uc = new WpfTestUserControl();
             uc.IsHitTestVisible = false;
             var activation = new ActivationForViewFetcher();
-
+​
             var obs = activation.GetActivationForView(uc);
             obs.ToObservableChangeSet(scheduler: ImmediateScheduler.Instance).Bind(out var activated).Subscribe();
-
+​
             var loaded = new RoutedEventArgs();
             loaded.RoutedEvent = FrameworkElement.LoadedEvent;
-
+​
             uc.RaiseEvent(loaded);
-
+​
             // Loaded has happened.
             new[] { true }.AssertAreEqual(activated);
-
+​
             uc.IsHitTestVisible = true;
-
+​
             // IsHitTestVisible true, we don't want the event to repeat unnecessarily.
             new[] { true }.AssertAreEqual(activated);
-
+​
             var unloaded = new RoutedEventArgs();
             unloaded.RoutedEvent = FrameworkElement.UnloadedEvent;
-
+​
             uc.RaiseEvent(unloaded);
-
+​
             // We had both a loaded/hit test visible change/unloaded happen.
             new[] { true, false }.AssertAreEqual(activated);
         }
-
+​
         [Fact]
         public void IsHitTestVisibleDeactivatesFrameworkElement()
         {
             var uc = new WpfTestUserControl();
             var activation = new ActivationForViewFetcher();
-
+​
             var obs = activation.GetActivationForView(uc);
             obs.ToObservableChangeSet(scheduler: ImmediateScheduler.Instance).Bind(out var activated).Subscribe();
-
+​
             var loaded = new RoutedEventArgs();
             loaded.RoutedEvent = FrameworkElement.LoadedEvent;
-
+​
             uc.RaiseEvent(loaded);
-
+​
             new[] { true }.AssertAreEqual(activated);
-
+​
             uc.IsHitTestVisible = false;
-
+​
             new[] { true, false }.AssertAreEqual(activated);
         }
-
+​
         [Fact]
         public void FrameworkElementIsActivatedAndDeactivatedWithHitTest()
         {
             var uc = new WpfTestUserControl();
             var activation = new ActivationForViewFetcher();
-
+​
             var obs = activation.GetActivationForView(uc);
             obs.ToObservableChangeSet(scheduler: ImmediateScheduler.Instance).Bind(out var activated).Subscribe();
-
+​
             var loaded = new RoutedEventArgs();
             loaded.RoutedEvent = FrameworkElement.LoadedEvent;
-
+​
             uc.RaiseEvent(loaded);
-
+​
             new[] { true }.AssertAreEqual(activated);
-
+​
             // this should deactivate it
             uc.IsHitTestVisible = false;
-
+​
             new[] { true, false }.AssertAreEqual(activated);
-
+​
             // this should activate it
             uc.IsHitTestVisible = true;
-
+​
             new[] { true, false, true }.AssertAreEqual(activated);
-
+​
             var unloaded = new RoutedEventArgs();
             unloaded.RoutedEvent = FrameworkElement.UnloadedEvent;
-
+​
             uc.RaiseEvent(unloaded);
-
+​
             new[] { true, false, true, false }.AssertAreEqual(activated);
         }
     }

--- a/src/ReactiveUI.Tests/Platforms/wpf/WpfActivationForViewFetcherTest.cs
+++ b/src/ReactiveUI.Tests/Platforms/wpf/WpfActivationForViewFetcherTest.cs
@@ -62,6 +62,37 @@ namespace ReactiveUI.Tests.Wpf
         }
 
         [Fact]
+        public void WindowAndFrameworkElementAreActivatedAndDeactivated()
+        {
+            var window = new WpfTestWindow();
+            var uc = new WpfTestUserControl();
+
+            window.RootGrid.Children.Add(uc);
+
+            var activation = new ActivationForViewFetcher();
+
+            var windowObs = activation.GetActivationForView(window);
+            windowObs.ToObservableChangeSet(scheduler: ImmediateScheduler.Instance).Bind(out var windowActivated).Subscribe();
+
+            var ucObs = activation.GetActivationForView(uc);
+            ucObs.ToObservableChangeSet(scheduler: ImmediateScheduler.Instance).Bind(out var controlActivated).Subscribe();
+
+            var loaded = new RoutedEventArgs();
+            loaded.RoutedEvent = FrameworkElement.LoadedEvent;
+
+            window.RaiseEvent(loaded);
+            uc.RaiseEvent(loaded);
+
+            new[] { true }.AssertAreEqual(windowActivated);
+            new[] { true }.AssertAreEqual(controlActivated);
+
+            window.Dispatcher.InvokeShutdown();
+
+            new[] { true, false }.AssertAreEqual(windowActivated);
+            new[] { true, false }.AssertAreEqual(controlActivated);
+        }
+
+        [Fact]
         public void IsHitTestVisibleActivatesFrameworkElement()
         {
             var uc = new WpfTestUserControl();

--- a/src/ReactiveUI.Tests/Platforms/wpf/WpfActivationForViewFetcherTest.cs
+++ b/src/ReactiveUI.Tests/Platforms/wpf/WpfActivationForViewFetcherTest.cs
@@ -2,16 +2,16 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
-​
+
 using System;
 using System.Reactive.Concurrency;
 using System.Windows;
-​
+
 using DynamicData;
 using Xunit;
-​
+
 using FactAttribute = Xunit.WpfFactAttribute;
-​
+
 namespace ReactiveUI.Tests.Wpf
 {
     public class WpfActivationForViewFetcherTest
@@ -21,161 +21,161 @@ namespace ReactiveUI.Tests.Wpf
         {
             var uc = new WpfTestUserControl();
             var activation = new ActivationForViewFetcher();
-​
+
             var obs = activation.GetActivationForView(uc);
             obs.ToObservableChangeSet(scheduler: ImmediateScheduler.Instance).Bind(out var activated).Subscribe();
-​
+
             var loaded = new RoutedEventArgs();
             loaded.RoutedEvent = FrameworkElement.LoadedEvent;
-​
+
             uc.RaiseEvent(loaded);
-​
+
             new[] { true }.AssertAreEqual(activated);
-​
+
             var unloaded = new RoutedEventArgs();
             unloaded.RoutedEvent = FrameworkElement.UnloadedEvent;
-​
+
             uc.RaiseEvent(unloaded);
-​
+
             new[] { true, false }.AssertAreEqual(activated);
         }
-​
+
         [Fact]
         public void WindowIsActivatedAndDeactivated()
         {
             var window = new WpfTestWindow();
             var activation = new ActivationForViewFetcher();
-​
+
             var obs = activation.GetActivationForView(window);
             obs.ToObservableChangeSet(scheduler: ImmediateScheduler.Instance).Bind(out var activated).Subscribe();
-​
+
             var loaded = new RoutedEventArgs();
             loaded.RoutedEvent = FrameworkElement.LoadedEvent;
-​
+
             window.RaiseEvent(loaded);
-​
+
             new[] { true }.AssertAreEqual(activated);
-​
+
             window.Close();
-​
+
             new[] { true, false }.AssertAreEqual(activated);
         }
-​
+
         [StaFact]
         public void WindowAndFrameworkElementAreActivatedAndDeactivated()
         {
             var window = new WpfTestWindow();
             var uc = new WpfTestUserControl();
-​
+
             window.RootGrid.Children.Add(uc);
-​
+
             var activation = new ActivationForViewFetcher();
-​
+
             var windowObs = activation.GetActivationForView(window);
             windowObs.ToObservableChangeSet(scheduler: ImmediateScheduler.Instance).Bind(out var windowActivated).Subscribe();
-​
+
             var ucObs = activation.GetActivationForView(uc);
             ucObs.ToObservableChangeSet(scheduler: ImmediateScheduler.Instance).Bind(out var controlActivated).Subscribe();
-​
+
             var loaded = new RoutedEventArgs();
             loaded.RoutedEvent = FrameworkElement.LoadedEvent;
-​
+
             window.RaiseEvent(loaded);
             uc.RaiseEvent(loaded);
-​
+
             new[] { true }.AssertAreEqual(windowActivated);
             new[] { true }.AssertAreEqual(controlActivated);
-​
+
             window.Dispatcher.InvokeShutdown();
-​
+
             new[] { true, false }.AssertAreEqual(windowActivated);
             new[] { true, false }.AssertAreEqual(controlActivated);
         }
-​
+
         [Fact]
         public void IsHitTestVisibleActivatesFrameworkElement()
         {
             var uc = new WpfTestUserControl();
             uc.IsHitTestVisible = false;
             var activation = new ActivationForViewFetcher();
-​
+
             var obs = activation.GetActivationForView(uc);
             obs.ToObservableChangeSet(scheduler: ImmediateScheduler.Instance).Bind(out var activated).Subscribe();
-​
+
             var loaded = new RoutedEventArgs();
             loaded.RoutedEvent = FrameworkElement.LoadedEvent;
-​
+
             uc.RaiseEvent(loaded);
-​
+
             // Loaded has happened.
             new[] { true }.AssertAreEqual(activated);
-​
+
             uc.IsHitTestVisible = true;
-​
+
             // IsHitTestVisible true, we don't want the event to repeat unnecessarily.
             new[] { true }.AssertAreEqual(activated);
-​
+
             var unloaded = new RoutedEventArgs();
             unloaded.RoutedEvent = FrameworkElement.UnloadedEvent;
-​
+
             uc.RaiseEvent(unloaded);
-​
+
             // We had both a loaded/hit test visible change/unloaded happen.
             new[] { true, false }.AssertAreEqual(activated);
         }
-​
+
         [Fact]
         public void IsHitTestVisibleDeactivatesFrameworkElement()
         {
             var uc = new WpfTestUserControl();
             var activation = new ActivationForViewFetcher();
-​
+
             var obs = activation.GetActivationForView(uc);
             obs.ToObservableChangeSet(scheduler: ImmediateScheduler.Instance).Bind(out var activated).Subscribe();
-​
+
             var loaded = new RoutedEventArgs();
             loaded.RoutedEvent = FrameworkElement.LoadedEvent;
-​
+
             uc.RaiseEvent(loaded);
-​
+
             new[] { true }.AssertAreEqual(activated);
-​
+
             uc.IsHitTestVisible = false;
-​
+
             new[] { true, false }.AssertAreEqual(activated);
         }
-​
+
         [Fact]
         public void FrameworkElementIsActivatedAndDeactivatedWithHitTest()
         {
             var uc = new WpfTestUserControl();
             var activation = new ActivationForViewFetcher();
-​
+
             var obs = activation.GetActivationForView(uc);
             obs.ToObservableChangeSet(scheduler: ImmediateScheduler.Instance).Bind(out var activated).Subscribe();
-​
+
             var loaded = new RoutedEventArgs();
             loaded.RoutedEvent = FrameworkElement.LoadedEvent;
-​
+
             uc.RaiseEvent(loaded);
-​
+
             new[] { true }.AssertAreEqual(activated);
-​
+
             // this should deactivate it
             uc.IsHitTestVisible = false;
-​
+
             new[] { true, false }.AssertAreEqual(activated);
-​
+
             // this should activate it
             uc.IsHitTestVisible = true;
-​
+
             new[] { true, false, true }.AssertAreEqual(activated);
-​
+
             var unloaded = new RoutedEventArgs();
             unloaded.RoutedEvent = FrameworkElement.UnloadedEvent;
-​
+
             uc.RaiseEvent(unloaded);
-​
+
             new[] { true, false, true, false }.AssertAreEqual(activated);
         }
     }

--- a/src/ReactiveUI.Wpf/ActivationForViewFetcher.cs
+++ b/src/ReactiveUI.Wpf/ActivationForViewFetcher.cs
@@ -55,9 +55,32 @@ namespace ReactiveUI
                 x => fe.Unloaded += x,
                 x => fe.Unloaded -= x);
 
+            var windowActivation = GetActivationForWindow(view);
+
             return viewLoaded
                 .Merge(viewUnloaded)
                 .Merge(hitTestVisible)
+                .Merge(windowActivation)
+                .DistinctUntilChanged();
+        }
+
+        private static IObservable<bool> GetActivationForWindow(IActivatableView view)
+        {
+            if (view is not Window window)
+            {
+                return Observable<bool>.Empty;
+            }
+
+            var viewClosed = Observable.FromEvent<EventHandler, bool>(
+                eventHandler =>
+                {
+                    void Handler(object? sender, EventArgs e) => eventHandler(false);
+                    return Handler;
+                },
+                x => window.Closed += x,
+                x => window.Closed -= x);
+
+            return viewClosed
                 .DistinctUntilChanged();
         }
     }

--- a/src/ReactiveUI.Wpf/ActivationForViewFetcher.cs
+++ b/src/ReactiveUI.Wpf/ActivationForViewFetcher.cs
@@ -84,8 +84,7 @@ namespace ReactiveUI
                 x => window.Closed += x,
                 x => window.Closed -= x);
 
-            return viewClosed
-                .DistinctUntilChanged();
+            return viewClosed;
         }
 
         private static IObservable<bool> GetActivationForDispatcher(DispatcherObject dispatcherObject)
@@ -99,8 +98,7 @@ namespace ReactiveUI
                 x => dispatcherObject.Dispatcher.ShutdownStarted += x,
                 x => dispatcherObject.Dispatcher.ShutdownStarted -= x);
 
-            return dispatcherShutdownStarted
-                .DistinctUntilChanged();
+            return dispatcherShutdownStarted;
         }
     }
 }

--- a/src/ReactiveUI/RegistrationNamespace.cs
+++ b/src/ReactiveUI/RegistrationNamespace.cs
@@ -12,7 +12,7 @@ namespace ReactiveUI
     {
         /// <summary>No platform to register.</summary>
         None = 0,
-        
+
         /// <summary>
         /// Xamarin Forms.
         /// </summary>


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bug fix.

**What is the current behavior?**

When a WPF application is shutdown, the `Unloaded` event is not fired and, as a result, the `View` is not deactivated by `ReactiveUI`; as explained in the issue https://github.com/reactiveui/ReactiveUI/issues/2490.

**What is the new behavior?**

The `ActivationForViewFetcher` will observe the `Closing` event (if the `View` is a `Window`) to determine if the `View` should be deactivated.

**What might this PR break?**

Nothing.

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)