### PR TITLE
fixes #2811 Updated nullable values for OAPH

### DIFF
--- a/src/ReactiveUI.Fody.Helpers/ObservableAsPropertyExtensions.cs
+++ b/src/ReactiveUI.Fody.Helpers/ObservableAsPropertyExtensions.cs
@@ -31,7 +31,12 @@ namespace ReactiveUI.Fody.Helpers
         /// or
         /// Backing field not found for " + propertyInfo.
         /// </exception>
-        public static ObservableAsPropertyHelper<TRet> ToPropertyEx<TObj, TRet>(this IObservable<TRet> item, TObj source, Expression<Func<TObj, TRet>> property, bool deferSubscription = false, IScheduler? scheduler = null)
+        public static ObservableAsPropertyHelper<TRet> ToPropertyEx<TObj, TRet>(
+            this IObservable<TRet> item,
+            TObj? source,
+            Expression<Func<TObj, TRet?>> property,
+            bool deferSubscription = false,
+            IScheduler? scheduler = null)
             where TObj : ReactiveObject
         {
             if (item is null)
@@ -81,7 +86,13 @@ namespace ReactiveUI.Fody.Helpers
         /// or
         /// Backing field not found for " + propertyInfo.
         /// </exception>
-        public static ObservableAsPropertyHelper<TRet> ToPropertyEx<TObj, TRet>(this IObservable<TRet> item, TObj source, Expression<Func<TObj, TRet>> property, TRet initialValue, bool deferSubscription = false, IScheduler? scheduler = null)
+        public static ObservableAsPropertyHelper<TRet> ToPropertyEx<TObj, TRet>(
+            this IObservable<TRet> item,
+            TObj? source,
+            Expression<Func<TObj, TRet?>> property,
+            TRet initialValue,
+            bool deferSubscription = false,
+            IScheduler? scheduler = null)
             where TObj : ReactiveObject
         {
             if (item is null)

--- a/src/ReactiveUI.Fody.Tests/API/ApiApprovalTests.ReactiveUIFody.net5.0.approved.txt
+++ b/src/ReactiveUI.Fody.Tests/API/ApiApprovalTests.ReactiveUIFody.net5.0.approved.txt
@@ -14,9 +14,9 @@ namespace ReactiveUI.Fody.Helpers
     }
     public static class ObservableAsPropertyExtensions
     {
-        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToPropertyEx<TObj, TRet>(this System.IObservable<TRet> item, TObj source, System.Linq.Expressions.Expression<System.Func<TObj, TRet>> property, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
+        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToPropertyEx<TObj, TRet>(this System.IObservable<TRet> item, TObj? source, System.Linq.Expressions.Expression<System.Func<TObj, TRet?>> property, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
             where TObj : ReactiveUI.ReactiveObject { }
-        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToPropertyEx<TObj, TRet>(this System.IObservable<TRet> item, TObj source, System.Linq.Expressions.Expression<System.Func<TObj, TRet>> property, TRet initialValue, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
+        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToPropertyEx<TObj, TRet>(this System.IObservable<TRet> item, TObj? source, System.Linq.Expressions.Expression<System.Func<TObj, TRet?>> property, TRet initialValue, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
             where TObj : ReactiveUI.ReactiveObject { }
     }
     [System.AttributeUsage(System.AttributeTargets.Property | System.AttributeTargets.All)]

--- a/src/ReactiveUI.Fody.Tests/API/ApiApprovalTests.ReactiveUIFody.netcoreapp3.1.approved.txt
+++ b/src/ReactiveUI.Fody.Tests/API/ApiApprovalTests.ReactiveUIFody.netcoreapp3.1.approved.txt
@@ -14,9 +14,9 @@ namespace ReactiveUI.Fody.Helpers
     }
     public static class ObservableAsPropertyExtensions
     {
-        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToPropertyEx<TObj, TRet>(this System.IObservable<TRet> item, TObj source, System.Linq.Expressions.Expression<System.Func<TObj, TRet>> property, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
+        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToPropertyEx<TObj, TRet>(this System.IObservable<TRet> item, TObj? source, System.Linq.Expressions.Expression<System.Func<TObj, TRet?>> property, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
             where TObj : ReactiveUI.ReactiveObject { }
-        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToPropertyEx<TObj, TRet>(this System.IObservable<TRet> item, TObj source, System.Linq.Expressions.Expression<System.Func<TObj, TRet>> property, TRet initialValue, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
+        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToPropertyEx<TObj, TRet>(this System.IObservable<TRet> item, TObj? source, System.Linq.Expressions.Expression<System.Func<TObj, TRet?>> property, TRet initialValue, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
             where TObj : ReactiveUI.ReactiveObject { }
     }
     [System.AttributeUsage(System.AttributeTargets.Property | System.AttributeTargets.All)]

--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.net472.approved.txt
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.net472.approved.txt
@@ -187,7 +187,7 @@ namespace ReactiveUI
     public interface ICreatesObservableForProperty : Splat.IEnableLogger
     {
         int GetAffinityForObject(System.Type type, string propertyName, bool beforeChanged = false);
-        System.IObservable<ReactiveUI.IObservedChange<object, object?>> GetNotificationForProperty(object sender, System.Linq.Expressions.Expression expression, string propertyName, bool beforeChanged = false, bool suppressWarnings = false);
+        System.IObservable<ReactiveUI.IObservedChange<object?, object?>> GetNotificationForProperty(object sender, System.Linq.Expressions.Expression expression, string propertyName, bool beforeChanged = false, bool suppressWarnings = false);
     }
     public interface IHandleObservableErrors
     {
@@ -217,7 +217,7 @@ namespace ReactiveUI
     {
         public INPCObservableForProperty() { }
         public int GetAffinityForObject(System.Type type, string propertyName, bool beforeChanged) { }
-        public System.IObservable<ReactiveUI.IObservedChange<object, object?>> GetNotificationForProperty(object sender, System.Linq.Expressions.Expression expression, string propertyName, bool beforeChanged = false, bool suppressWarnings = false) { }
+        public System.IObservable<ReactiveUI.IObservedChange<object?, object?>> GetNotificationForProperty(object sender, System.Linq.Expressions.Expression expression, string propertyName, bool beforeChanged = false, bool suppressWarnings = false) { }
     }
     public interface IObservedChange<out TSender, out TValue>
     {
@@ -401,27 +401,27 @@ namespace ReactiveUI
     }
     public static class OAPHCreationHelperMixin
     {
-        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj source, System.Linq.Expressions.Expression<System.Func<TObj, TRet>> property, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
+        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj? source, System.Linq.Expressions.Expression<System.Func<TObj, TRet?>> property, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
             where TObj :  class, ReactiveUI.IReactiveObject { }
-        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj source, string property, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
+        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj? source, string property, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
             where TObj :  class, ReactiveUI.IReactiveObject { }
-        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj source, System.Linq.Expressions.Expression<System.Func<TObj, TRet>> property, out ReactiveUI.ObservableAsPropertyHelper<TRet> result, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
+        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj? source, System.Linq.Expressions.Expression<System.Func<TObj, TRet?>> property, out ReactiveUI.ObservableAsPropertyHelper<TRet> result, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
             where TObj :  class, ReactiveUI.IReactiveObject { }
-        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj source, System.Linq.Expressions.Expression<System.Func<TObj, TRet>> property, System.Func<TRet> getInitialValue, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
+        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj? source, System.Linq.Expressions.Expression<System.Func<TObj, TRet?>> property, System.Func<TRet> getInitialValue, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
             where TObj :  class, ReactiveUI.IReactiveObject { }
-        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj source, System.Linq.Expressions.Expression<System.Func<TObj, TRet>> property, TRet initialValue, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
+        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj? source, System.Linq.Expressions.Expression<System.Func<TObj, TRet?>> property, TRet initialValue, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
             where TObj :  class, ReactiveUI.IReactiveObject { }
-        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj source, string property, out ReactiveUI.ObservableAsPropertyHelper<TRet> result, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
+        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj? source, string property, out ReactiveUI.ObservableAsPropertyHelper<TRet> result, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
             where TObj :  class, ReactiveUI.IReactiveObject { }
-        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj source, string property, System.Func<TRet> getInitialValue, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
+        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj? source, string property, System.Func<TRet> getInitialValue, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
             where TObj :  class, ReactiveUI.IReactiveObject { }
-        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj source, string property, TRet initialValue, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
+        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj? source, string property, TRet initialValue, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
             where TObj :  class, ReactiveUI.IReactiveObject { }
-        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj source, System.Linq.Expressions.Expression<System.Func<TObj, TRet>> property, out ReactiveUI.ObservableAsPropertyHelper<TRet> result, System.Func<TRet> getInitialValue, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
+        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj? source, System.Linq.Expressions.Expression<System.Func<TObj, TRet?>> property, out ReactiveUI.ObservableAsPropertyHelper<TRet> result, System.Func<TRet> getInitialValue, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
             where TObj :  class, ReactiveUI.IReactiveObject { }
-        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj source, System.Linq.Expressions.Expression<System.Func<TObj, TRet>> property, out ReactiveUI.ObservableAsPropertyHelper<TRet> result, TRet initialValue, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
+        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj? source, System.Linq.Expressions.Expression<System.Func<TObj, TRet?>> property, out ReactiveUI.ObservableAsPropertyHelper<TRet> result, TRet initialValue, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
             where TObj :  class, ReactiveUI.IReactiveObject { }
-        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj source, string property, out ReactiveUI.ObservableAsPropertyHelper<TRet> result, System.Func<TRet> getInitialValue, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
+        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj? source, string property, out ReactiveUI.ObservableAsPropertyHelper<TRet> result, System.Func<TRet> getInitialValue, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
             where TObj :  class, ReactiveUI.IReactiveObject { }
     }
     public sealed class ObservableAsPropertyHelper<T> : ReactiveUI.IHandleObservableErrors, Splat.IEnableLogger, System.IDisposable

--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.net5.0.approved.txt
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.net5.0.approved.txt
@@ -189,7 +189,7 @@ namespace ReactiveUI
     public interface ICreatesObservableForProperty : Splat.IEnableLogger
     {
         int GetAffinityForObject(System.Type type, string propertyName, bool beforeChanged = false);
-        System.IObservable<ReactiveUI.IObservedChange<object, object?>> GetNotificationForProperty(object sender, System.Linq.Expressions.Expression expression, string propertyName, bool beforeChanged = false, bool suppressWarnings = false);
+        System.IObservable<ReactiveUI.IObservedChange<object?, object?>> GetNotificationForProperty(object sender, System.Linq.Expressions.Expression expression, string propertyName, bool beforeChanged = false, bool suppressWarnings = false);
     }
     public interface IHandleObservableErrors
     {
@@ -217,7 +217,7 @@ namespace ReactiveUI
     {
         public INPCObservableForProperty() { }
         public int GetAffinityForObject(System.Type type, string propertyName, bool beforeChanged) { }
-        public System.IObservable<ReactiveUI.IObservedChange<object, object?>> GetNotificationForProperty(object sender, System.Linq.Expressions.Expression expression, string propertyName, bool beforeChanged = false, bool suppressWarnings = false) { }
+        public System.IObservable<ReactiveUI.IObservedChange<object?, object?>> GetNotificationForProperty(object sender, System.Linq.Expressions.Expression expression, string propertyName, bool beforeChanged = false, bool suppressWarnings = false) { }
     }
     public interface IObservedChange<out TSender, out TValue>
     {
@@ -396,27 +396,27 @@ namespace ReactiveUI
     }
     public static class OAPHCreationHelperMixin
     {
-        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj source, System.Linq.Expressions.Expression<System.Func<TObj, TRet>> property, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
+        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj? source, System.Linq.Expressions.Expression<System.Func<TObj, TRet?>> property, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
             where TObj :  class, ReactiveUI.IReactiveObject { }
-        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj source, string property, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
+        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj? source, string property, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
             where TObj :  class, ReactiveUI.IReactiveObject { }
-        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj source, System.Linq.Expressions.Expression<System.Func<TObj, TRet>> property, out ReactiveUI.ObservableAsPropertyHelper<TRet> result, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
+        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj? source, System.Linq.Expressions.Expression<System.Func<TObj, TRet?>> property, out ReactiveUI.ObservableAsPropertyHelper<TRet> result, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
             where TObj :  class, ReactiveUI.IReactiveObject { }
-        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj source, System.Linq.Expressions.Expression<System.Func<TObj, TRet>> property, System.Func<TRet> getInitialValue, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
+        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj? source, System.Linq.Expressions.Expression<System.Func<TObj, TRet?>> property, System.Func<TRet> getInitialValue, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
             where TObj :  class, ReactiveUI.IReactiveObject { }
-        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj source, System.Linq.Expressions.Expression<System.Func<TObj, TRet>> property, TRet initialValue, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
+        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj? source, System.Linq.Expressions.Expression<System.Func<TObj, TRet?>> property, TRet initialValue, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
             where TObj :  class, ReactiveUI.IReactiveObject { }
-        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj source, string property, out ReactiveUI.ObservableAsPropertyHelper<TRet> result, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
+        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj? source, string property, out ReactiveUI.ObservableAsPropertyHelper<TRet> result, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
             where TObj :  class, ReactiveUI.IReactiveObject { }
-        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj source, string property, System.Func<TRet> getInitialValue, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
+        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj? source, string property, System.Func<TRet> getInitialValue, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
             where TObj :  class, ReactiveUI.IReactiveObject { }
-        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj source, string property, TRet initialValue, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
+        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj? source, string property, TRet initialValue, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
             where TObj :  class, ReactiveUI.IReactiveObject { }
-        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj source, System.Linq.Expressions.Expression<System.Func<TObj, TRet>> property, out ReactiveUI.ObservableAsPropertyHelper<TRet> result, System.Func<TRet> getInitialValue, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
+        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj? source, System.Linq.Expressions.Expression<System.Func<TObj, TRet?>> property, out ReactiveUI.ObservableAsPropertyHelper<TRet> result, System.Func<TRet> getInitialValue, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
             where TObj :  class, ReactiveUI.IReactiveObject { }
-        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj source, System.Linq.Expressions.Expression<System.Func<TObj, TRet>> property, out ReactiveUI.ObservableAsPropertyHelper<TRet> result, TRet initialValue, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
+        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj? source, System.Linq.Expressions.Expression<System.Func<TObj, TRet?>> property, out ReactiveUI.ObservableAsPropertyHelper<TRet> result, TRet initialValue, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
             where TObj :  class, ReactiveUI.IReactiveObject { }
-        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj source, string property, out ReactiveUI.ObservableAsPropertyHelper<TRet> result, System.Func<TRet> getInitialValue, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
+        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj? source, string property, out ReactiveUI.ObservableAsPropertyHelper<TRet> result, System.Func<TRet> getInitialValue, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
             where TObj :  class, ReactiveUI.IReactiveObject { }
     }
     public sealed class ObservableAsPropertyHelper<T> : ReactiveUI.IHandleObservableErrors, Splat.IEnableLogger, System.IDisposable

--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.netcoreapp3.1.approved.txt
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.netcoreapp3.1.approved.txt
@@ -187,7 +187,7 @@ namespace ReactiveUI
     public interface ICreatesObservableForProperty : Splat.IEnableLogger
     {
         int GetAffinityForObject(System.Type type, string propertyName, bool beforeChanged = false);
-        System.IObservable<ReactiveUI.IObservedChange<object, object?>> GetNotificationForProperty(object sender, System.Linq.Expressions.Expression expression, string propertyName, bool beforeChanged = false, bool suppressWarnings = false);
+        System.IObservable<ReactiveUI.IObservedChange<object?, object?>> GetNotificationForProperty(object sender, System.Linq.Expressions.Expression expression, string propertyName, bool beforeChanged = false, bool suppressWarnings = false);
     }
     public interface IHandleObservableErrors
     {
@@ -215,7 +215,7 @@ namespace ReactiveUI
     {
         public INPCObservableForProperty() { }
         public int GetAffinityForObject(System.Type type, string propertyName, bool beforeChanged) { }
-        public System.IObservable<ReactiveUI.IObservedChange<object, object?>> GetNotificationForProperty(object sender, System.Linq.Expressions.Expression expression, string propertyName, bool beforeChanged = false, bool suppressWarnings = false) { }
+        public System.IObservable<ReactiveUI.IObservedChange<object?, object?>> GetNotificationForProperty(object sender, System.Linq.Expressions.Expression expression, string propertyName, bool beforeChanged = false, bool suppressWarnings = false) { }
     }
     public interface IObservedChange<out TSender, out TValue>
     {
@@ -394,27 +394,27 @@ namespace ReactiveUI
     }
     public static class OAPHCreationHelperMixin
     {
-        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj source, System.Linq.Expressions.Expression<System.Func<TObj, TRet>> property, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
+        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj? source, System.Linq.Expressions.Expression<System.Func<TObj, TRet?>> property, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
             where TObj :  class, ReactiveUI.IReactiveObject { }
-        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj source, string property, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
+        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj? source, string property, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
             where TObj :  class, ReactiveUI.IReactiveObject { }
-        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj source, System.Linq.Expressions.Expression<System.Func<TObj, TRet>> property, out ReactiveUI.ObservableAsPropertyHelper<TRet> result, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
+        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj? source, System.Linq.Expressions.Expression<System.Func<TObj, TRet?>> property, out ReactiveUI.ObservableAsPropertyHelper<TRet> result, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
             where TObj :  class, ReactiveUI.IReactiveObject { }
-        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj source, System.Linq.Expressions.Expression<System.Func<TObj, TRet>> property, System.Func<TRet> getInitialValue, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
+        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj? source, System.Linq.Expressions.Expression<System.Func<TObj, TRet?>> property, System.Func<TRet> getInitialValue, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
             where TObj :  class, ReactiveUI.IReactiveObject { }
-        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj source, System.Linq.Expressions.Expression<System.Func<TObj, TRet>> property, TRet initialValue, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
+        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj? source, System.Linq.Expressions.Expression<System.Func<TObj, TRet?>> property, TRet initialValue, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
             where TObj :  class, ReactiveUI.IReactiveObject { }
-        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj source, string property, out ReactiveUI.ObservableAsPropertyHelper<TRet> result, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
+        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj? source, string property, out ReactiveUI.ObservableAsPropertyHelper<TRet> result, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
             where TObj :  class, ReactiveUI.IReactiveObject { }
-        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj source, string property, System.Func<TRet> getInitialValue, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
+        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj? source, string property, System.Func<TRet> getInitialValue, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
             where TObj :  class, ReactiveUI.IReactiveObject { }
-        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj source, string property, TRet initialValue, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
+        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj? source, string property, TRet initialValue, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
             where TObj :  class, ReactiveUI.IReactiveObject { }
-        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj source, System.Linq.Expressions.Expression<System.Func<TObj, TRet>> property, out ReactiveUI.ObservableAsPropertyHelper<TRet> result, System.Func<TRet> getInitialValue, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
+        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj? source, System.Linq.Expressions.Expression<System.Func<TObj, TRet?>> property, out ReactiveUI.ObservableAsPropertyHelper<TRet> result, System.Func<TRet> getInitialValue, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
             where TObj :  class, ReactiveUI.IReactiveObject { }
-        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj source, System.Linq.Expressions.Expression<System.Func<TObj, TRet>> property, out ReactiveUI.ObservableAsPropertyHelper<TRet> result, TRet initialValue, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
+        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj? source, System.Linq.Expressions.Expression<System.Func<TObj, TRet?>> property, out ReactiveUI.ObservableAsPropertyHelper<TRet> result, TRet initialValue, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
             where TObj :  class, ReactiveUI.IReactiveObject { }
-        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj source, string property, out ReactiveUI.ObservableAsPropertyHelper<TRet> result, System.Func<TRet> getInitialValue, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
+        public static ReactiveUI.ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(this System.IObservable<TRet> target, TObj? source, string property, out ReactiveUI.ObservableAsPropertyHelper<TRet> result, System.Func<TRet> getInitialValue, bool deferSubscription = false, System.Reactive.Concurrency.IScheduler? scheduler = null)
             where TObj :  class, ReactiveUI.IReactiveObject { }
     }
     public sealed class ObservableAsPropertyHelper<T> : ReactiveUI.IHandleObservableErrors, Splat.IEnableLogger, System.IDisposable

--- a/src/ReactiveUI.Tests/Platforms/windows-xaml/RxAppDependencyObjectTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/windows-xaml/RxAppDependencyObjectTests.cs
@@ -3,11 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Splat;
 using Xunit;
 

--- a/src/ReactiveUI.Tests/ReactiveObject/Mocks/OaphNameOfTestFixture.cs
+++ b/src/ReactiveUI.Tests/ReactiveObject/Mocks/OaphNameOfTestFixture.cs
@@ -17,7 +17,7 @@ namespace ReactiveUI.Tests
         private readonly ObservableAsPropertyHelper<string?> _firstThreeLettersOfOneWord;
 
         [IgnoreDataMember]
-        private readonly ObservableAsPropertyHelper<string?> _lastThreeLettersOfOneWord;
+        private readonly ObservableAsPropertyHelper<string> _lastThreeLettersOfOneWord;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="OaphNameOfTestFixture"/> class.
@@ -25,7 +25,7 @@ namespace ReactiveUI.Tests
         public OaphNameOfTestFixture()
         {
             this.WhenAnyValue(x => x.IsOnlyOneWord).Select(x => x ?? string.Empty).Select(x => x.Length >= 3 ? x.Substring(0, 3) : x).ToProperty(this, nameof(FirstThreeLettersOfOneWord), out _firstThreeLettersOfOneWord);
-            _lastThreeLettersOfOneWord = this.WhenAnyValue(x => x.IsOnlyOneWord).Select(x => x ?? string.Empty).Select(x => x.Length >= 3 ? x.Substring(x.Length - 3, 3) : (string?)x).ToProperty(this, nameof(LastThreeLettersOfOneWord));
+            _lastThreeLettersOfOneWord = this.WhenAnyValue(x => x.IsOnlyOneWord).Select(x => x ?? string.Empty).Select(x => x.Length >= 3 ? x.Substring(x.Length - 3, 3) : x).ToProperty(this, nameof(LastThreeLettersOfOneWord));
         }
 
         /// <summary>
@@ -38,6 +38,6 @@ namespace ReactiveUI.Tests
         /// Gets the last three letters of one word.
         /// </summary>
         [IgnoreDataMember]
-        public string? LastThreeLettersOfOneWord => _lastThreeLettersOfOneWord.Value;
+        public string LastThreeLettersOfOneWord => _lastThreeLettersOfOneWord.Value;
     }
 }

--- a/src/ReactiveUI.Tests/ReactiveObject/Mocks/WhenAnyTestFixture.cs
+++ b/src/ReactiveUI.Tests/ReactiveObject/Mocks/WhenAnyTestFixture.cs
@@ -32,6 +32,8 @@ namespace ReactiveUI.Tests
         private string? _value8;
         private string _value9 = "9";
         private string? _value10;
+        private string _value11 = "11";
+        private string? _value12;
 
         /// <summary>
         /// Gets or sets the account service.
@@ -193,6 +195,32 @@ namespace ReactiveUI.Tests
         {
             get => _value10;
             set => this.RaiseAndSetIfChanged(ref _value10, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the value11.
+        /// </summary>
+        /// <value>
+        /// The value11.
+        /// </value>
+        [DataMember]
+        public string Value11
+        {
+            get => _value11;
+            set => this.RaiseAndSetIfChanged(ref _value11, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the value12.
+        /// </summary>
+        /// <value>
+        /// The value12.
+        /// </value>
+        [DataMember]
+        public string? Value12
+        {
+            get => _value12;
+            set => this.RaiseAndSetIfChanged(ref _value12, value);
         }
     }
 }

--- a/src/ReactiveUI.Tests/Resolvers/INPCObservableForPropertyTests.cs
+++ b/src/ReactiveUI.Tests/Resolvers/INPCObservableForPropertyTests.cs
@@ -40,7 +40,7 @@ namespace ReactiveUI.Tests
             Expression<Func<TestClassChanged, string?>> expr = x => x!.Property1;
             var exp = Reflection.Rewrite(expr.Body);
 
-            var changes = new List<IObservedChange<object, object?>>();
+            var changes = new List<IObservedChange<object?, object?>>();
 
             var propertyName = exp.GetMemberInfo()?.Name;
 
@@ -70,7 +70,7 @@ namespace ReactiveUI.Tests
             Expression<Func<TestClassChanged, string?>> expr = x => x.Property1;
             var exp = Reflection.Rewrite(expr.Body);
 
-            var changes = new List<IObservedChange<object, object?>>();
+            var changes = new List<IObservedChange<object?, object?>>();
 
             var propertyName = exp.GetMemberInfo()?.Name;
 
@@ -100,7 +100,7 @@ namespace ReactiveUI.Tests
             Expression<Func<TestClassChanged, string?>> expr = x => x.Property1;
             var exp = Reflection.Rewrite(expr.Body);
 
-            var changes = new List<IObservedChange<object, object?>>();
+            var changes = new List<IObservedChange<object?, object?>>();
 
             var propertyName = exp.GetMemberInfo()?.Name;
 
@@ -130,7 +130,7 @@ namespace ReactiveUI.Tests
             Expression<Func<TestClassChanged, string?>> expr = x => x.Property1;
             var exp = Reflection.Rewrite(expr.Body);
 
-            var changes = new List<IObservedChange<object, object?>>();
+            var changes = new List<IObservedChange<object?, object?>>();
 
             var propertyName = exp.GetMemberInfo()?.Name;
 

--- a/src/ReactiveUI.Tests/WhenAny/ReactiveNotifyPropertyChangedMixinTest.cs
+++ b/src/ReactiveUI.Tests/WhenAny/ReactiveNotifyPropertyChangedMixinTest.cs
@@ -1167,5 +1167,127 @@ namespace ReactiveUI.Tests
 
             Assert.Equal(result, "1357");
         }
+
+        /// <summary>
+        /// Whens any value with8 paramerters returns values.
+        /// </summary>
+        [Fact]
+        public void WhenAnyValueWith9ParamertersReturnsValues()
+        {
+            WhenAnyTestFixture fixture = new();
+            string? result = null;
+            fixture.WhenAnyValue(
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7,
+                x => x.Value8,
+                x => x.Value9,
+                (v1, v2, v3, v4, v5, v6, v7, v8, v9) => (v1, v2, v3, v4, v5, v6, v7, v8, v9))
+                   .Select(tuple =>
+                   {
+                       var (value1, value2, value3, value4, value5, value6, value7, value8, value9) = tuple;
+                       return value1 + value2 + value3 + value4 + value5 + value6 + value7 + value8 + value9;
+                   })
+                   .Subscribe(value => result = value);
+
+            Assert.Equal(result, "13579");
+        }
+
+        /// <summary>
+        /// Whens any value with8 paramerters returns values.
+        /// </summary>
+        [Fact]
+        public void WhenAnyValueWith10ParamertersReturnsValues()
+        {
+            WhenAnyTestFixture fixture = new();
+            string? result = null;
+            fixture.WhenAnyValue(
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7,
+                x => x.Value8,
+                x => x.Value9,
+                x => x.Value10,
+                (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10) => (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10))
+                   .Select(tuple =>
+                   {
+                       var (value1, value2, value3, value4, value5, value6, value7, value8, value9, value10) = tuple;
+                       return value1 + value2 + value3 + value4 + value5 + value6 + value7 + value8 + value9 + value10;
+                   })
+                   .Subscribe(value => result = value);
+
+            Assert.Equal(result, "13579");
+        }
+
+        /// <summary>
+        /// Whens any value with8 paramerters returns values.
+        /// </summary>
+        [Fact]
+        public void WhenAnyValueWith11ParamertersReturnsValues()
+        {
+            WhenAnyTestFixture fixture = new();
+            string? result = null;
+            fixture.WhenAnyValue(
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7,
+                x => x.Value8,
+                x => x.Value9,
+                x => x.Value10,
+                x => x.Value11,
+                (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11) => (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11))
+                   .Select(tuple =>
+                   {
+                       var (value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11) = tuple;
+                       return value1 + value2 + value3 + value4 + value5 + value6 + value7 + value8 + value9 + value10 + value11;
+                   })
+                   .Subscribe(value => result = value);
+
+            Assert.Equal(result, "1357911");
+        }
+
+        /// <summary>
+        /// Whens any value with8 paramerters returns values.
+        /// </summary>
+        [Fact]
+        public void WhenAnyValueWith12ParamertersReturnsValues()
+        {
+            WhenAnyTestFixture fixture = new();
+            string? result = null;
+            fixture.WhenAnyValue(
+                x => x.Value1,
+                x => x.Value2,
+                x => x.Value3,
+                x => x.Value4,
+                x => x.Value5,
+                x => x.Value6,
+                x => x.Value7,
+                x => x.Value8,
+                x => x.Value9,
+                x => x.Value10,
+                x => x.Value11,
+                x => x.Value12,
+                (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12) => (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12))
+                   .Select(tuple =>
+                   {
+                       var (value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12) = tuple;
+                       return value1 + value2 + value3 + value4 + value5 + value6 + value7 + value8 + value9 + value10 + value11 + value12;
+                   })
+                   .Subscribe(value => result = value);
+
+            Assert.Equal(result, "1357911");
+        }
     }
 }

--- a/src/ReactiveUI/Interfaces/ICreatesObservableForProperty.cs
+++ b/src/ReactiveUI/Interfaces/ICreatesObservableForProperty.cs
@@ -48,6 +48,6 @@ namespace ReactiveUI
         /// <returns>An IObservable which is signaled whenever the specified
         /// property on the object changes. If this cannot be done for a
         /// specified value of beforeChanged, return Observable.Never.</returns>
-        IObservable<IObservedChange<object, object?>> GetNotificationForProperty(object sender, Expression expression, string propertyName, bool beforeChanged = false, bool suppressWarnings = false);
+        IObservable<IObservedChange<object?, object?>> GetNotificationForProperty(object sender, Expression expression, string propertyName, bool beforeChanged = false, bool suppressWarnings = false);
     }
 }

--- a/src/ReactiveUI/Mixins/ReactiveNotifyPropertyChangedMixin.cs
+++ b/src/ReactiveUI/Mixins/ReactiveNotifyPropertyChangedMixin.cs
@@ -174,10 +174,10 @@ namespace ReactiveUI
             return r.DistinctUntilChanged(x => x.Value);
         }
 
-        private static IObservable<IObservedChange<object, object?>> NestedObservedChanges(Expression expression, IObservedChange<object?, object?> sourceChange, bool beforeChange, bool suppressWarnings)
+        private static IObservable<IObservedChange<object?, object?>> NestedObservedChanges(Expression expression, IObservedChange<object?, object?> sourceChange, bool beforeChange, bool suppressWarnings)
         {
             // Make sure a change at a root node propagates events down
-            var kicker = new ObservedChange<object, object?>(sourceChange.Value!, expression, default);
+            var kicker = new ObservedChange<object?, object?>(sourceChange.Value!, expression, default);
 
             // Handle null values in the chain
             if (sourceChange.Value is null)
@@ -188,10 +188,10 @@ namespace ReactiveUI
             // Handle non null values in the chain
             return NotifyForProperty(sourceChange.Value, expression, beforeChange, suppressWarnings)
                 .StartWith(kicker)
-                .Select(x => new ObservedChange<object, object?>(x.Sender, x.Expression, x.GetValueOrDefault()));
+                .Select(x => new ObservedChange<object?, object?>(x.Sender, x.Expression, x.GetValueOrDefault()));
         }
 
-        private static IObservable<IObservedChange<object, object?>> NotifyForProperty(object sender, Expression expression, bool beforeChange, bool suppressWarnings)
+        private static IObservable<IObservedChange<object?, object?>> NotifyForProperty(object sender, Expression expression, bool beforeChange, bool suppressWarnings)
         {
             if (expression is null)
             {

--- a/src/ReactiveUI/ObservableForProperty/INPCObservableForProperty.cs
+++ b/src/ReactiveUI/ObservableForProperty/INPCObservableForProperty.cs
@@ -25,7 +25,7 @@ namespace ReactiveUI
         }
 
         /// <inheritdoc/>
-        public IObservable<IObservedChange<object, object?>> GetNotificationForProperty(object sender, Expression expression, string propertyName, bool beforeChanged = false, bool suppressWarnings = false)
+        public IObservable<IObservedChange<object?, object?>> GetNotificationForProperty(object sender, Expression expression, string propertyName, bool beforeChanged = false, bool suppressWarnings = false)
         {
             if (expression == null)
             {
@@ -47,12 +47,12 @@ namespace ReactiveUI
                 {
                     return obs.Where(x => string.IsNullOrEmpty(x)
                         || x?.Equals(propertyName + "[]", StringComparison.InvariantCulture) == true)
-                        .Select(_ => new ObservedChange<object, object>(sender, expression, default!));
+                        .Select(_ => new ObservedChange<object?, object?>(sender, expression, default!));
                 }
 
                 return obs.Where(x => string.IsNullOrEmpty(x)
                     || x?.Equals(propertyName, StringComparison.InvariantCulture) == true)
-                .Select(_ => new ObservedChange<object, object>(sender, expression, default!));
+                .Select(_ => new ObservedChange<object?, object?>(sender, expression, default!));
             }
             else if (sender is INotifyPropertyChanged after)
             {
@@ -69,16 +69,16 @@ namespace ReactiveUI
                 {
                     return obs.Where(x => string.IsNullOrEmpty(x)
                         || x?.Equals(propertyName + "[]", StringComparison.InvariantCulture) == true)
-                    .Select(_ => new ObservedChange<object, object>(sender, expression, default!));
+                    .Select(_ => new ObservedChange<object?, object?>(sender, expression, default!));
                 }
 
                 return obs.Where(x => string.IsNullOrEmpty(x)
                     || x?.Equals(propertyName, StringComparison.InvariantCulture) == true)
-                .Select(_ => new ObservedChange<object, object>(sender, expression, default!));
+                .Select(_ => new ObservedChange<object?, object?>(sender, expression, default!));
             }
             else
             {
-                return Observable<IObservedChange<object, object?>>.Never;
+                return Observable<IObservedChange<object?, object?>>.Never;
             }
         }
     }

--- a/src/ReactiveUI/ObservableForProperty/OAPHCreationHelperMixin.cs
+++ b/src/ReactiveUI/ObservableForProperty/OAPHCreationHelperMixin.cs
@@ -46,8 +46,8 @@ namespace ReactiveUI
         /// </returns>
         public static ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(
             this IObservable<TRet> target,
-            TObj source,
-            Expression<Func<TObj, TRet>> property,
+            TObj? source,
+            Expression<Func<TObj, TRet?>> property,
             bool deferSubscription = false,
             IScheduler? scheduler = null) // TODO: Create Test
             where TObj : class, IReactiveObject
@@ -105,8 +105,8 @@ namespace ReactiveUI
         /// </returns>
         public static ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(
             this IObservable<TRet> target,
-            TObj source,
-            Expression<Func<TObj, TRet>> property,
+            TObj? source,
+            Expression<Func<TObj, TRet?>> property,
             TRet initialValue,
             bool deferSubscription = false,
             IScheduler? scheduler = null) // TODO: Create Test
@@ -148,8 +148,8 @@ namespace ReactiveUI
         /// </returns>
         public static ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(
             this IObservable<TRet> target,
-            TObj source,
-            Expression<Func<TObj, TRet>> property,
+            TObj? source,
+            Expression<Func<TObj, TRet?>> property,
             Func<TRet> getInitialValue,
             bool deferSubscription = false,
             IScheduler? scheduler = null) // TODO: Create Test
@@ -190,8 +190,8 @@ namespace ReactiveUI
         /// </returns>
         public static ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(
             this IObservable<TRet> target,
-            TObj source,
-            Expression<Func<TObj, TRet>> property,
+            TObj? source,
+            Expression<Func<TObj, TRet?>> property,
             out ObservableAsPropertyHelper<TRet> result,
             bool deferSubscription = false,
             IScheduler? scheduler = null) // TODO: Create Test
@@ -257,8 +257,8 @@ namespace ReactiveUI
         /// </returns>
         public static ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(
             this IObservable<TRet> target,
-            TObj source,
-            Expression<Func<TObj, TRet>> property,
+            TObj? source,
+            Expression<Func<TObj, TRet?>> property,
             out ObservableAsPropertyHelper<TRet> result,
             TRet initialValue,
             bool deferSubscription = false,
@@ -304,8 +304,8 @@ namespace ReactiveUI
         /// </returns>
         public static ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(
             this IObservable<TRet> target,
-            TObj source,
-            Expression<Func<TObj, TRet>> property,
+            TObj? source,
+            Expression<Func<TObj, TRet?>> property,
             out ObservableAsPropertyHelper<TRet> result,
             Func<TRet> getInitialValue,
             bool deferSubscription = false,
@@ -354,7 +354,7 @@ namespace ReactiveUI
         /// </returns>
         public static ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(
             this IObservable<TRet> target,
-            TObj source,
+            TObj? source,
             string property,
             TRet initialValue,
             bool deferSubscription = false,
@@ -395,7 +395,7 @@ namespace ReactiveUI
         /// </returns>
         public static ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(
             this IObservable<TRet> target,
-            TObj source,
+            TObj? source,
             string property,
             bool deferSubscription = false,
             IScheduler? scheduler = null) // TODO: Create Test
@@ -455,7 +455,7 @@ namespace ReactiveUI
         /// </returns>
         public static ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(
             this IObservable<TRet> target,
-            TObj source,
+            TObj? source,
             string property,
             Func<TRet> getInitialValue,
             bool deferSubscription = false,
@@ -515,7 +515,7 @@ namespace ReactiveUI
         /// </returns>
         public static ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(
             this IObservable<TRet> target,
-            TObj source,
+            TObj? source,
             string property,
             out ObservableAsPropertyHelper<TRet> result,
             bool deferSubscription = false,
@@ -584,7 +584,7 @@ namespace ReactiveUI
         /// </returns>
         public static ObservableAsPropertyHelper<TRet> ToProperty<TObj, TRet>(
             this IObservable<TRet> target,
-            TObj source,
+            TObj? source,
             string property,
             out ObservableAsPropertyHelper<TRet> result,
             Func<TRet> getInitialValue,
@@ -618,9 +618,9 @@ namespace ReactiveUI
         }
 
         private static ObservableAsPropertyHelper<TRet> ObservableToProperty<TObj, TRet>(
-            this TObj target,
-            IObservable<TRet> observable,
-            Expression<Func<TObj, TRet>> property,
+            this TObj? target,
+            IObservable<TRet?> observable,
+            Expression<Func<TObj, TRet?>> property,
             Func<TRet> getInitialValue,
             bool deferSubscription = false,
             IScheduler? scheduler = null)
@@ -678,9 +678,9 @@ namespace ReactiveUI
         }
 
         private static ObservableAsPropertyHelper<TRet> ObservableToProperty<TObj, TRet>(
-            this TObj target,
-            IObservable<TRet> observable,
-            Expression<Func<TObj, TRet>> property,
+            this TObj? target,
+            IObservable<TRet?> observable,
+            Expression<Func<TObj, TRet?>> property,
             bool deferSubscription = false,
             IScheduler? scheduler = null)
                 where TObj : class, IReactiveObject
@@ -731,14 +731,14 @@ namespace ReactiveUI
                 observable,
                 _ => target.RaisingPropertyChanged(name),
                 _ => target.RaisingPropertyChanging(name),
-                () => default!,
+                () => default,
                 deferSubscription,
                 scheduler);
         }
 
         private static ObservableAsPropertyHelper<TRet> ObservableToProperty<TObj, TRet>(
-            this TObj target,
-            IObservable<TRet> observable,
+            this TObj? target,
+            IObservable<TRet?> observable,
             string property,
             Func<TRet> getInitialValue,
             bool deferSubscription = false,
@@ -770,8 +770,8 @@ namespace ReactiveUI
         }
 
         private static ObservableAsPropertyHelper<TRet> ObservableToProperty<TObj, TRet>(
-            this TObj target,
-            IObservable<TRet> observable,
+            this TObj? target,
+            IObservable<TRet?> observable,
             string property,
             bool deferSubscription = false,
             IScheduler? scheduler = null)
@@ -796,7 +796,7 @@ namespace ReactiveUI
                 observable,
                 _ => target.RaisingPropertyChanged(property),
                 _ => target.RaisingPropertyChanging(property),
-                () => default!,
+                () => default,
                 deferSubscription,
                 scheduler);
         }

--- a/src/ReactiveUI/ObservableForProperty/ObservableAsPropertyHelper.cs
+++ b/src/ReactiveUI/ObservableForProperty/ObservableAsPropertyHelper.cs
@@ -167,13 +167,13 @@ namespace ReactiveUI
 
             if (deferSubscription)
             {
-                _lastValue = default!;
+                _lastValue = default;
                 Source = observable.DistinctUntilChanged();
             }
             else
             {
                 _lastValue = _getInitialValue();
-                Source = observable.StartWith(_lastValue!).DistinctUntilChanged();
+                Source = observable.StartWith(_lastValue).DistinctUntilChanged();
                 Source.Subscribe(_subject).DisposeWith(_disposable);
                 _activated = 1;
             }
@@ -182,7 +182,7 @@ namespace ReactiveUI
         /// <summary>
         /// Gets the last provided value from the Observable.
         /// </summary>
-        public T? Value
+        public T Value
         {
             get
             {
@@ -197,7 +197,7 @@ namespace ReactiveUI
                     }
                 }
 
-                return _lastValue;
+                return _lastValue!;
             }
         }
 


### PR DESCRIPTION
fixes #2811 can pass nullable in but return type is not forced to nullable

<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

fix

**What is the current behaviour?**
<!-- You can also link to an open issue here. -->

OAPH returns a nullable type regardless of the OAPH it is attached to

**What is the new behaviour?**
<!-- If this is a feature change -->

OAPH returns a matching type of the OAPH it is attached to

**What might this PR break?**

none

**Please check if the PR fulfils these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

