### PR TITLE
fix RoutedViewHost and ViewModelViewHost to allow DefaultContent

### DIFF
--- a/src/ReactiveUI.Tests/Routing/Mocks/TestView.cs
+++ b/src/ReactiveUI.Tests/Routing/Mocks/TestView.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Splat;
+
+namespace ReactiveUI.Tests
+{
+    public class TestView : ReactiveUserControl<TestViewModel>, IScreen
+    {
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+
+        public TestView()
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+        {
+        }
+
+        public TestView(IScreen? screen = null)
+        {
+            Router = screen?.Router ?? Locator.Current.GetService<RoutingState>()!;
+        }
+
+        public RoutingState Router { get; }
+    }
+}

--- a/src/ReactiveUI.Tests/Routing/RoutedViewHostTests.cs
+++ b/src/ReactiveUI.Tests/Routing/RoutedViewHostTests.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Reactive.Concurrency;
+using System.Windows;
+using DynamicData;
+using ReactiveUI.Tests.Wpf;
+using Xunit;
+
+namespace ReactiveUI.Tests
+{
+    public class RoutedViewHostTests
+    {
+        [StaFact]
+        public void RoutedViewHostDefaultContentNotNull()
+        {
+            var uc = new RoutedViewHost
+            {
+                DefaultContent = new System.Windows.Controls.Label()
+            };
+            var window = new WpfTestWindow();
+            window.RootGrid.Children.Add(uc);
+
+            var activation = new ActivationForViewFetcher();
+
+            activation.GetActivationForView(window).ToObservableChangeSet(scheduler: ImmediateScheduler.Instance).Bind(out var windowActivated).Subscribe();
+
+            activation.GetActivationForView(uc).ToObservableChangeSet(scheduler: ImmediateScheduler.Instance).Bind(out var controlActivated).Subscribe();
+
+            var loaded = new RoutedEventArgs
+            {
+                RoutedEvent = FrameworkElement.LoadedEvent
+            };
+
+            window.RaiseEvent(loaded);
+            uc.RaiseEvent(loaded);
+
+            new[] { true }.AssertAreEqual(windowActivated);
+            new[] { true }.AssertAreEqual(controlActivated);
+
+            Assert.NotNull(uc.Content);
+
+            window.Dispatcher.InvokeShutdown();
+        }
+    }
+}

--- a/src/ReactiveUI.Tests/Routing/RoutedViewHostTests.cs
+++ b/src/ReactiveUI.Tests/Routing/RoutedViewHostTests.cs
@@ -8,6 +8,7 @@ using System.Reactive.Concurrency;
 using System.Windows;
 using DynamicData;
 using ReactiveUI.Tests.Wpf;
+using Splat;
 using Xunit;
 
 namespace ReactiveUI.Tests
@@ -42,6 +43,90 @@ namespace ReactiveUI.Tests
             new[] { true }.AssertAreEqual(controlActivated);
 
             Assert.NotNull(uc.Content);
+
+            window.Dispatcher.InvokeShutdown();
+        }
+
+        [StaFact]
+        public void RoutedViewHostDefaultContentNotNullWithViewModelAndActivated()
+        {
+            Locator.CurrentMutable.Register<RoutingState>(() => new(ImmediateScheduler.Instance));
+            Locator.CurrentMutable.Register<TestViewModel>(() => new());
+            Locator.CurrentMutable.Register<IViewFor<TestViewModel>>(() => new TestView());
+
+            var uc = new RoutedViewHost
+            {
+                DefaultContent = new System.Windows.Controls.Label(),
+                Router = Locator.Current.GetService<RoutingState>()!
+            };
+            var window = new WpfTestWindow();
+            window.RootGrid.Children.Add(uc);
+
+            var activation = new ActivationForViewFetcher();
+
+            activation.GetActivationForView(window).ToObservableChangeSet(scheduler: ImmediateScheduler.Instance).Bind(out var windowActivated).Subscribe();
+
+            activation.GetActivationForView(uc).ToObservableChangeSet(scheduler: ImmediateScheduler.Instance).Bind(out var controlActivated).Subscribe();
+
+            var loaded = new RoutedEventArgs
+            {
+                RoutedEvent = FrameworkElement.LoadedEvent
+            };
+
+            window.RaiseEvent(loaded);
+            uc.RaiseEvent(loaded);
+
+            new[] { true }.AssertAreEqual(windowActivated);
+            new[] { true }.AssertAreEqual(controlActivated);
+
+            // Default Content
+            Assert.IsType<System.Windows.Controls.Label>(uc.Content);
+
+            // Test Navigation after activated
+            uc.Router.Navigate.Execute(Locator.Current.GetService<TestViewModel>()!);
+            Assert.IsType<TestView>(uc.Content);
+
+            window.Dispatcher.InvokeShutdown();
+        }
+
+        [StaFact]
+        public void RoutedViewHostDefaultContentNotNullWithViewModelAndNotActivated()
+        {
+            Locator.CurrentMutable.Register<RoutingState>(() => new(ImmediateScheduler.Instance));
+            Locator.CurrentMutable.Register<TestViewModel>(() => new());
+            Locator.CurrentMutable.Register<IViewFor<TestViewModel>>(() => new TestView());
+
+            var uc = new RoutedViewHost
+            {
+                DefaultContent = new System.Windows.Controls.Label(),
+                Router = Locator.Current.GetService<RoutingState>()!
+            };
+            var window = new WpfTestWindow();
+            window.RootGrid.Children.Add(uc);
+
+            var activation = new ActivationForViewFetcher();
+
+            activation.GetActivationForView(window).ToObservableChangeSet(scheduler: ImmediateScheduler.Instance).Bind(out var windowActivated).Subscribe();
+
+            activation.GetActivationForView(uc).ToObservableChangeSet(scheduler: ImmediateScheduler.Instance).Bind(out var controlActivated).Subscribe();
+
+            var loaded = new RoutedEventArgs
+            {
+                RoutedEvent = FrameworkElement.LoadedEvent
+            };
+
+            // Test navigation before Activation.
+            uc.Router.Navigate.Execute(Locator.Current.GetService<TestViewModel>()!);
+
+            // Activate
+            window.RaiseEvent(loaded);
+            uc.RaiseEvent(loaded);
+
+            new[] { true }.AssertAreEqual(windowActivated);
+            new[] { true }.AssertAreEqual(controlActivated);
+
+            // Test Navigation before activated
+            Assert.IsType<TestView>(uc.Content);
 
             window.Dispatcher.InvokeShutdown();
         }

--- a/src/ReactiveUI.Tests/Routing/ViewModelViewHostTests.cs
+++ b/src/ReactiveUI.Tests/Routing/ViewModelViewHostTests.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Reactive.Concurrency;
+using System.Windows;
+using DynamicData;
+using ReactiveUI.Tests.Wpf;
+using Xunit;
+
+namespace ReactiveUI.Tests
+{
+    public class ViewModelViewHostTests
+    {
+        [StaFact]
+        public void ViewModelViewHostDefaultContentNotNull()
+        {
+            var uc = new ViewModelViewHost
+            {
+                DefaultContent = new System.Windows.Controls.Label()
+            };
+            var window = new WpfTestWindow();
+            window.RootGrid.Children.Add(uc);
+
+            var activation = new ActivationForViewFetcher();
+
+            activation.GetActivationForView(window)
+                 .ToObservableChangeSet(scheduler: ImmediateScheduler.Instance)
+                 .Bind(out var windowActivated)
+                 .Subscribe();
+
+            activation.GetActivationForView(uc)
+                .ToObservableChangeSet(scheduler: ImmediateScheduler.Instance)
+                .Bind(out var controlActivated)
+                .Subscribe();
+
+            var loaded = new RoutedEventArgs
+            {
+                RoutedEvent = FrameworkElement.LoadedEvent
+            };
+
+            window.RaiseEvent(loaded);
+            uc.RaiseEvent(loaded);
+
+            new[] { true }.AssertAreEqual(windowActivated);
+            new[] { true }.AssertAreEqual(controlActivated);
+
+            Assert.NotNull(uc.Content);
+
+            window.Dispatcher.InvokeShutdown();
+        }
+    }
+}

--- a/src/ReactiveUI/Platforms/windows-common/RoutedViewHost.cs
+++ b/src/ReactiveUI/Platforms/windows-common/RoutedViewHost.cs
@@ -95,15 +95,13 @@ namespace ReactiveUI
                     },
                     x => SizeChanged += x,
                     x => SizeChanged -= x)
-                .DistinctUntilChanged()
-                .StartWith(platformGetter())
-                .Select(x => x);
+               .StartWith(platformGetter())
+               .DistinctUntilChanged();
 
             IRoutableViewModel? currentViewModel = null;
-            var vmAndContract = this.WhenAnyObservable(x => x.Router.CurrentViewModel).Do(x => currentViewModel = x).CombineLatest(
-                this.WhenAnyObservable(x => x.ViewContractObservable),
-                (viewModel, contract) => (viewModel, contract))
-                .StartWith((currentViewModel, ViewContract));
+            var vmAndContract = this.WhenAnyObservable(x => x.Router.CurrentViewModel).Do(x => currentViewModel = x).StartWith(currentViewModel).CombineLatest(
+                this.WhenAnyObservable(x => x.ViewContractObservable).Do(x => _viewContract = x).StartWith(ViewContract),
+                (viewModel, contract) => (viewModel, contract));
 
             this.WhenActivated(d =>
             {

--- a/src/ReactiveUI/Platforms/windows-common/ViewModelViewHost.cs
+++ b/src/ReactiveUI/Platforms/windows-common/ViewModelViewHost.cs
@@ -8,13 +8,14 @@ using System.Diagnostics.CodeAnalysis;
 using System.Reactive;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
-using System.Reactive.Subjects;
 using System.Windows;
 using Splat;
 
 #if NETFX_CORE || HAS_UNO
+
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+
 #else
 
 using System.Windows.Controls;
@@ -22,6 +23,7 @@ using System.Windows.Controls;
 #endif
 
 #if HAS_UNO
+
 namespace ReactiveUI.Uno
 #else
 
@@ -33,13 +35,11 @@ namespace ReactiveUI
     /// the ViewModel property and display it. This control is very useful
     /// inside a DataTemplate to display the View associated with a ViewModel.
     /// </summary>
-    [SuppressMessage("Design", "CA1010:Collections should implement generic interface", Justification = "Deliberate usage")]
-    [SuppressMessage("Design", "CA1063: Remove IDisposable from the list of interfaces implemented", Justification = "Deliberate usage")]
     public
 #if HAS_UNO
         partial
 #endif
-        class ViewModelViewHost : TransitioningContentControl, IViewFor, IEnableLogger, IDisposable
+        class ViewModelViewHost : TransitioningContentControl, IViewFor, IEnableLogger
     {
         /// <summary>
         /// The default content dependency property.
@@ -51,18 +51,15 @@ namespace ReactiveUI
         /// The view model dependency property.
         /// </summary>
         public static readonly DependencyProperty ViewModelProperty =
-            DependencyProperty.Register(nameof(ViewModel), typeof(object), typeof(ViewModelViewHost), new PropertyMetadata(null, ViewModelChanged));
+            DependencyProperty.Register(nameof(ViewModel), typeof(object), typeof(ViewModelViewHost), new PropertyMetadata(null));
 
         /// <summary>
         /// The view contract observable dependency property.
         /// </summary>
         public static readonly DependencyProperty ViewContractObservableProperty =
-            DependencyProperty.Register(nameof(ViewContractObservable), typeof(IObservable<string>), typeof(ViewModelViewHost), new PropertyMetadata(Observable<string>.Default, ViewContractChanged));
+            DependencyProperty.Register(nameof(ViewContractObservable), typeof(IObservable<string>), typeof(ViewModelViewHost), new PropertyMetadata(Observable<string>.Default));
 
-        private readonly Subject<Unit> _updateViewModel = new();
-        private readonly Subject<Unit> _updateViewContract = new();
         private string? _viewContract;
-        private bool _isDisposed;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ViewModelViewHost"/> class.
@@ -72,14 +69,6 @@ namespace ReactiveUI
 #if NETFX_CORE
             DefaultStyleKey = typeof(ViewModelViewHost);
 #endif
-
-            ////if (ModeDetector.InUnitTestRunner())
-            ////{
-            ////    ViewContractObservable = Observable<string>.Never;
-
-            ////    // NB: InUnitTestRunner also returns true in Design Mode
-            ////    return;
-            ////}
 
             var platform = Locator.Current.GetService<IPlatformOperations>();
             Func<string?> platformGetter = () => default;
@@ -96,8 +85,8 @@ namespace ReactiveUI
             }
 
             ViewContractObservable = ModeDetector.InUnitTestRunner()
-                ? Observable<string>.Never
-                : Observable.FromEvent<SizeChangedEventHandler, string>(
+                ? Observable<string?>.Never
+                : Observable.FromEvent<SizeChangedEventHandler, string?>(
                   eventHandler =>
                   {
                       void Handler(object? sender, SizeChangedEventArgs e) => eventHandler(platformGetter()!);
@@ -108,14 +97,15 @@ namespace ReactiveUI
                   .StartWith(platformGetter())
                   .DistinctUntilChanged();
 
-            var contractChanged = _updateViewContract.Select(_ => ViewContractObservable).Switch();
-            var viewModelChanged = _updateViewModel.Select(_ => ViewModel);
-
-            var vmAndContract = contractChanged.CombineLatest(viewModelChanged, (contract, vm) => (ViewModel: vm, Contract: contract)).StartWith((default, null));
+            var contractChanged = this.WhenAnyObservable(x => x.ViewContractObservable).Do(x => _viewContract = x).StartWith(ViewContract);
+            var viewModelChanged = this.WhenAnyValue(x => x.ViewModel).StartWith(ViewModel);
 
             contractChanged
                 .ObserveOn(RxApp.MainThreadScheduler)
                 .Subscribe(x => _viewContract = x ?? string.Empty);
+
+            var vmAndContract = contractChanged
+                .CombineLatest(viewModelChanged, (contract, vm) => (ViewModel: vm, Contract: contract));
 
             this.WhenActivated(d => d(vmAndContract.DistinctUntilChanged().Subscribe(x => ResolveViewForViewModel(x.ViewModel, x.Contract))));
         }
@@ -160,43 +150,6 @@ namespace ReactiveUI
         /// Gets or sets the view locator.
         /// </summary>
         public IViewLocator? ViewLocator { get; set; }
-
-        /// <inheritdoc/>
-        public void Dispose()
-        {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        /// <summary>
-        /// Disposes of resources inside the class.
-        /// </summary>
-        /// <param name="isDisposing">If we are disposing managed resources.</param>
-        protected virtual void Dispose(bool isDisposing)
-        {
-            if (_isDisposed)
-            {
-                return;
-            }
-
-            if (isDisposing)
-            {
-                _updateViewModel.Dispose();
-                _updateViewContract.Dispose();
-            }
-
-            _isDisposed = true;
-        }
-
-        private static void ViewModelChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
-        {
-            ((ViewModelViewHost)dependencyObject)._updateViewModel.OnNext(Unit.Default);
-        }
-
-        private static void ViewContractChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
-        {
-            ((ViewModelViewHost)dependencyObject)._updateViewContract.OnNext(Unit.Default);
-        }
 
         private void ResolveViewForViewModel(object? viewModel, string? contract)
         {


### PR DESCRIPTION
Refactored RoutedViewHost and ViewModelViewHost to allow DefaultContent to be shown

fixes #2815

<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

fix 

**What is the current behaviour?**
<!-- You can also link to an open issue here. -->

DefaultContent is not displayed for RoutedViewHost and ViewModelViewHost when loaded with null ViewModel

**What is the new behaviour?**
<!-- If this is a feature change -->

DefaultContent is displayed for RoutedViewHost and ViewModelViewHost when loaded with null ViewModel

**What might this PR break?**

Content will have a value when previously may not have depending upon the version of ReactiveUI i.e. >9.8.9

**Please check if the PR fulfils these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

