### PR TITLE
fix Transitioning Content Control DPI issue

### DIFF
--- a/src/ReactiveUI.Tests/Platforms/wpf/Mocks/TransitionMock/FirstView.xaml
+++ b/src/ReactiveUI.Tests/Platforms/wpf/Mocks/TransitionMock/FirstView.xaml
@@ -1,0 +1,12 @@
+﻿<UserControl
+    x:Class="ReactiveUI.Tests.Wpf.FirstView"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="clr-namespace:ReactiveUI.Tests.Wpf"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    Width="450"
+    Height="450"
+    mc:Ignorable="d">
+    <Grid Background="#FFF80606" />
+</UserControl>

--- a/src/ReactiveUI.Tests/Platforms/wpf/Mocks/TransitionMock/FirstView.xaml.cs
+++ b/src/ReactiveUI.Tests/Platforms/wpf/Mocks/TransitionMock/FirstView.xaml.cs
@@ -3,20 +3,18 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Windows;
 using System.Windows.Controls;
 
 namespace ReactiveUI.Tests.Wpf
 {
-    public class WpfTestWindow : Window, IActivatableView
+    /// <summary>
+    /// Interaction logic for FirstView.xaml.
+    /// </summary>
+    public partial class FirstView : UserControl
     {
-        public WpfTestWindow()
+        public FirstView()
         {
-            RootGrid = new Grid();
-
-            AddChild(RootGrid);
+            InitializeComponent();
         }
-
-        public Grid RootGrid { get; }
     }
 }

--- a/src/ReactiveUI.Tests/Platforms/wpf/Mocks/TransitionMock/SecondView.xaml
+++ b/src/ReactiveUI.Tests/Platforms/wpf/Mocks/TransitionMock/SecondView.xaml
@@ -1,0 +1,12 @@
+﻿<UserControl
+    x:Class="ReactiveUI.Tests.Wpf.SecondView"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="clr-namespace:ReactiveUI.Tests.Wpf"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    Width="0.5"
+    Height="0.5"
+    mc:Ignorable="d">
+    <Grid Background="#FFF7E40D" />
+</UserControl>

--- a/src/ReactiveUI.Tests/Platforms/wpf/Mocks/TransitionMock/SecondView.xaml.cs
+++ b/src/ReactiveUI.Tests/Platforms/wpf/Mocks/TransitionMock/SecondView.xaml.cs
@@ -3,20 +3,18 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Windows;
 using System.Windows.Controls;
 
 namespace ReactiveUI.Tests.Wpf
 {
-    public class WpfTestWindow : Window, IActivatableView
+    /// <summary>
+    /// Interaction logic for SecondView.xaml.
+    /// </summary>
+    public partial class SecondView : UserControl
     {
-        public WpfTestWindow()
+        public SecondView()
         {
-            RootGrid = new Grid();
-
-            AddChild(RootGrid);
+            InitializeComponent();
         }
-
-        public Grid RootGrid { get; }
     }
 }

--- a/src/ReactiveUI.Tests/Platforms/wpf/Mocks/TransitionMock/TCMockWindow.xaml
+++ b/src/ReactiveUI.Tests/Platforms/wpf/Mocks/TransitionMock/TCMockWindow.xaml
@@ -1,0 +1,20 @@
+﻿<rxui:ReactiveWindow
+    x:Class="ReactiveUI.Tests.Wpf.TCMockWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="clr-namespace:ReactiveUI.Tests.Wpf"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:rxui="http://reactiveui.net"
+    Title="DPITest"
+    Width="600"
+    Height="600"
+    x:TypeArguments="local:TCMockWindowViewModel"
+    mc:Ignorable="d">
+    <Grid>
+        <rxui:TransitioningContentControl
+            x:Name="TransitioningContent"
+            Width="500"
+            Height="500" />
+    </Grid>
+</rxui:ReactiveWindow>

--- a/src/ReactiveUI.Tests/Platforms/wpf/Mocks/TransitionMock/TCMockWindow.xaml.cs
+++ b/src/ReactiveUI.Tests/Platforms/wpf/Mocks/TransitionMock/TCMockWindow.xaml.cs
@@ -3,20 +3,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Windows;
-using System.Windows.Controls;
-
 namespace ReactiveUI.Tests.Wpf
 {
-    public class WpfTestWindow : Window, IActivatableView
+    /// <summary>
+    /// Interaction logic for MainWindow.xaml.
+    /// </summary>
+    public partial class TCMockWindow
     {
-        public WpfTestWindow()
+        public TCMockWindow()
         {
-            RootGrid = new Grid();
-
-            AddChild(RootGrid);
+            InitializeComponent();
         }
-
-        public Grid RootGrid { get; }
     }
 }

--- a/src/ReactiveUI.Tests/Platforms/wpf/Mocks/TransitionMock/TCMockWindowViewModel.cs
+++ b/src/ReactiveUI.Tests/Platforms/wpf/Mocks/TransitionMock/TCMockWindowViewModel.cs
@@ -3,20 +3,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Windows;
-using System.Windows.Controls;
-
 namespace ReactiveUI.Tests.Wpf
 {
-    public class WpfTestWindow : Window, IActivatableView
+    public class TCMockWindowViewModel : ReactiveObject
     {
-        public WpfTestWindow()
-        {
-            RootGrid = new Grid();
-
-            AddChild(RootGrid);
-        }
-
-        public Grid RootGrid { get; }
     }
 }

--- a/src/ReactiveUI.Tests/Platforms/wpf/WpfActivationForViewFetcherTest.cs
+++ b/src/ReactiveUI.Tests/Platforms/wpf/WpfActivationForViewFetcherTest.cs
@@ -5,6 +5,8 @@
 
 using System;
 using System.Reactive.Concurrency;
+using System.Threading;
+using System.Threading.Tasks;
 using System.Windows;
 
 using DynamicData;
@@ -177,6 +179,60 @@ namespace ReactiveUI.Tests.Wpf
             uc.RaiseEvent(unloaded);
 
             new[] { true, false, true, false }.AssertAreEqual(activated);
+        }
+
+        [StaFact]
+        public void TransitioninContentControlDpiTest()
+        {
+            var uiThread = new Thread(() =>
+            {
+                var window = new TCMockWindow();
+                var app = new Application();
+
+                window.WhenActivated(async d =>
+                {
+                    TransitioningContentControl.OverrideDpi = true;
+                    window.TransitioningContent.Height = 500;
+                    window.TransitioningContent.Width = 500;
+                    window.TransitioningContent.Content = new FirstView();
+                    await Task.Delay(5000).ConfigureAwait(true);
+                    window.TransitioningContent.Content = new SecondView();
+                    await Task.Delay(5000).ConfigureAwait(true);
+                    window.TransitioningContent.Height = 300;
+                    window.TransitioningContent.Width = 300;
+                    window.TransitioningContent.Content = new FirstView();
+                    await Task.Delay(5000).ConfigureAwait(true);
+                    window.TransitioningContent.Content = new SecondView();
+                    window.TransitioningContent.Height = 0.25;
+                    window.TransitioningContent.Width = 0.25;
+                    window.TransitioningContent.Content = new FirstView();
+                    await Task.Delay(5000).ConfigureAwait(true);
+                    window.TransitioningContent.Content = new SecondView();
+                    window.TransitioningContent.Height = 500;
+                    window.TransitioningContent.Width = 500;
+                    window.TransitioningContent.Content = new FirstView();
+                    await Task.Delay(5000).ConfigureAwait(true);
+                    window.TransitioningContent.Content = new SecondView();
+                    await Task.Delay(5000).ConfigureAwait(true);
+                    window.TransitioningContent.Height = 300;
+                    window.TransitioningContent.Width = 300;
+                    window.TransitioningContent.Content = new FirstView();
+                    await Task.Delay(5000).ConfigureAwait(true);
+                    window.TransitioningContent.Content = new SecondView();
+                    window.TransitioningContent.Height = 0.25;
+                    window.TransitioningContent.Width = 0.25;
+                    window.TransitioningContent.Content = new FirstView();
+                    await Task.Delay(5000).ConfigureAwait(true);
+                    window.TransitioningContent.Content = new SecondView();
+                    window.Dispatcher.InvokeShutdown();
+                    app.Shutdown();
+                });
+                app.Run(window);
+            });
+            uiThread.SetApartmentState(ApartmentState.STA);
+            uiThread.Start();
+            Thread.Sleep(100);
+            uiThread.Join();
         }
     }
 }

--- a/src/ReactiveUI.Tests/ReactiveUI.Tests.csproj
+++ b/src/ReactiveUI.Tests/ReactiveUI.Tests.csproj
@@ -26,6 +26,10 @@
 
   <ItemGroup>
     <None Remove="Platforms\Winforms\Mocks\TestFormNotCanActivate.cs" />
+    <None Remove="Platforms\wpf\Mocks\TransitionMock\FirstView.xaml.cs" />
+    <None Remove="Platforms\wpf\Mocks\TransitionMock\MainWindow.xaml.cs" />
+    <None Remove="Platforms\wpf\Mocks\TransitionMock\SecondView.xaml.cs" />
+    <None Remove="Platforms\wpf\Mocks\TransitionMock\TCMockWindowViewModel.cs" />
   </ItemGroup>
 
   <Choose>
@@ -103,5 +107,17 @@
       <AutoGen>True</AutoGen>
       <DependentUpon>TestFormNotCanActivate.resx</DependentUpon>
     </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Page Update="Platforms\wpf\Mocks\TransitionMock\FirstView.xaml">
+      <XamlRuntime>$(DefaultXamlRuntime)</XamlRuntime>
+    </Page>
+    <Page Update="Platforms\wpf\Mocks\TransitionMock\TCMockWindow.xaml">
+      <XamlRuntime>$(DefaultXamlRuntime)</XamlRuntime>
+    </Page>
+    <Page Update="Platforms\wpf\Mocks\TransitionMock\SecondView.xaml">
+      <XamlRuntime>$(DefaultXamlRuntime)</XamlRuntime>
+    </Page>
   </ItemGroup>
 </Project>

--- a/src/ReactiveUI.Wpf/Themes/Generic.xaml
+++ b/src/ReactiveUI.Wpf/Themes/Generic.xaml
@@ -1,486 +1,22 @@
 <ResourceDictionary
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" 
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" 
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:Controls="clr-namespace:ReactiveUI">
 
-    <!-- Default style for a TransitioningContentControl. -->
+    <!--  Default style for a TransitioningContentControl.  -->
     <Style TargetType="Controls:TransitioningContentControl">
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="Controls:TransitioningContentControl">
-                    <Grid 
+                    <Grid
                         x:Name="PART_Container"
-                        VerticalAlignment="{TemplateBinding VerticalAlignment}"
-                        HorizontalAlignment="{TemplateBinding HorizontalAlignment}">
-                        <VisualStateManager.VisualStateGroups>
-                            <VisualStateGroup x:Name="PresentationStates">
-
-                                <VisualState x:Name="Normal">
-                                    <Storyboard>
-                                        <ObjectAnimationUsingKeyFrames 
-                                            BeginTime="00:00:00" 
-                                            Storyboard.TargetName="PART_PreviousImageSite" 
-                                            Storyboard.TargetProperty="(UIElement.Visibility)">
-                                            <DiscreteObjectKeyFrame KeyTime="00:00:00">
-                                                <DiscreteObjectKeyFrame.Value>
-                                                    <Visibility>Collapsed</Visibility>
-                                                </DiscreteObjectKeyFrame.Value>
-                                            </DiscreteObjectKeyFrame>
-                                        </ObjectAnimationUsingKeyFrames>
-                                    </Storyboard>
-                                </VisualState>
-
-                                <VisualState x:Name="Transition_Fade">
-                                    <Storyboard>
-                                        <DoubleAnimation 
-                                            BeginTime="00:00:00" Duration="00:00:00.3"
-                                            Storyboard.TargetName="PART_PreviousImageSite"
-                                            Storyboard.TargetProperty="(UIElement.Opacity)"
-                                            From="1" To="0"/>
-
-                                        <DoubleAnimation 
-                                            BeginTime="00:00:00" Duration="00:00:00.3"
-                                            Storyboard.TargetName="PART_CurrentContentPresentationSite"
-                                            Storyboard.TargetProperty="(UIElement.Opacity)"
-                                            From="0" To="1"/>
-                                    </Storyboard>
-                                </VisualState>
-
-                                <VisualState x:Name="Transition_SlideLeft">
-                                    <Storyboard>
-                                        <DoubleAnimation 
-                                            BeginTime="00:00:00" Duration="00:00:00.3"
-                                            Storyboard.TargetName="PART_CurrentContentPresentationSite" 
-                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[1].(TranslateTransform.X)"
-                                            From="-30" To="0"/>
-                                    </Storyboard>
-                                </VisualState>
-
-                                <VisualState x:Name="Transition_SlideRight">
-                                    <Storyboard>
-                                        <DoubleAnimation 
-                                            BeginTime="00:00:00" Duration="00:00:00.3"
-                                            Storyboard.TargetName="PART_CurrentContentPresentationSite" 
-                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[1].(TranslateTransform.X)"
-                                            From="-30" To="0"/>
-                                    </Storyboard>
-                                </VisualState>
-
-                                <VisualState x:Name="Transition_SlideDown">
-                                    <Storyboard>
-                                        <DoubleAnimation 
-                                            BeginTime="00:00:00" Duration="00:00:00.3"
-                                            Storyboard.TargetName="PART_CurrentContentPresentationSite" 
-                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[1].(TranslateTransform.Y)"
-                                            From="-30" To="0"/>
-                                    </Storyboard>
-                                </VisualState>
-
-                                <VisualState x:Name="Transition_SlideUp">
-                                    <Storyboard>
-                                        <DoubleAnimation 
-                                            BeginTime="00:00:00" Duration="00:00:00.3"
-                                            Storyboard.TargetName="PART_CurrentContentPresentationSite" 
-                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[1].(TranslateTransform.Y)"
-                                            From="-30" To="0"/>
-                                    </Storyboard>
-                                </VisualState>
-
-                                <VisualState x:Name="Transition_MoveLeft">
-                                    <Storyboard>
-                                        <DoubleAnimation 
-                                            BeginTime="00:00:00" Duration="00:00:00.3"
-                                            Storyboard.TargetName="PART_CurrentContentPresentationSite" 
-                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[1].(TranslateTransform.X)"
-                                            From="-30" To="0"/>
-
-                                        <DoubleAnimation 
-                                            BeginTime="00:00:00" Duration="00:00:00.3"
-                                            Storyboard.TargetName="PART_PreviousImageSite" 
-                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[1].(TranslateTransform.X)"
-                                            From="0" To="30"/>
-                                    </Storyboard>
-                                </VisualState>
-
-                                <VisualState x:Name="Transition_MoveRight">
-                                    <Storyboard>
-                                        <DoubleAnimation 
-                                            BeginTime="00:00:00" Duration="00:00:00.3"
-                                            Storyboard.TargetName="PART_CurrentContentPresentationSite" 
-                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[1].(TranslateTransform.X)"
-                                            From="-30" To="0"/>
-
-                                        <DoubleAnimation 
-                                            BeginTime="00:00:00" Duration="00:00:00.3"
-                                            Storyboard.TargetName="PART_PreviousImageSite" 
-                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[1].(TranslateTransform.X)"
-                                            From="0" To="30"/>
-                                    </Storyboard>
-                                </VisualState>
-
-                                <VisualState x:Name="Transition_MoveDown">
-                                    <Storyboard>
-                                        <DoubleAnimation 
-                                            BeginTime="00:00:00" Duration="00:00:00.3"
-                                            Storyboard.TargetName="PART_CurrentContentPresentationSite" 
-                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[1].(TranslateTransform.Y)"
-                                            From="-30" To="0"/>
-
-                                        <DoubleAnimation 
-                                            BeginTime="00:00:00" Duration="00:00:00.3"
-                                            Storyboard.TargetName="PART_PreviousImageSite" 
-                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[1].(TranslateTransform.Y)"
-                                            From="0" To="30"/>
-                                    </Storyboard>
-                                </VisualState>
-
-                                <VisualState x:Name="Transition_MoveUp">
-                                    <Storyboard>
-                                        <DoubleAnimation 
-                                            BeginTime="00:00:00" Duration="00:00:00.3"
-                                            Storyboard.TargetName="PART_CurrentContentPresentationSite" 
-                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[1].(TranslateTransform.Y)"
-                                            From="-30" To="0"/>
-
-                                        <DoubleAnimation 
-                                            BeginTime="00:00:00" Duration="00:00:00.3"
-                                            Storyboard.TargetName="PART_PreviousImageSite" 
-                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[1].(TranslateTransform.Y)"
-                                            From="0" To="30"/>
-                                    </Storyboard>
-                                </VisualState>
-
-                                <VisualState x:Name="Transition_DropDown">
-                                    <Storyboard>
-                                        <DoubleAnimation 
-                                            BeginTime="00:00:00" Duration="00:00:00.3"
-                                            Storyboard.TargetName="PART_CurrentContentPresentationSite" 
-                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[1].(TranslateTransform.Y)"
-                                            From="-30" To="0"/>
-
-                                        <DoubleAnimation 
-                                            BeginTime="00:00:00" Duration="00:00:00.3"
-                                            Storyboard.TargetName="PART_PreviousImageSite" 
-                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[1].(TranslateTransform.Y)"
-                                            From="0" To="30"/>
-
-                                        <DoubleAnimation 
-                                            BeginTime="00:00:00" Duration="00:00:00.3"
-                                            Storyboard.TargetName="PART_CurrentContentPresentationSite"
-                                            Storyboard.TargetProperty="(UIElement.Opacity)"
-                                            From="0" To="1"/>
-
-                                        <DoubleAnimation 
-                                            BeginTime="00:00:00" Duration="00:00:00.3"
-                                            Storyboard.TargetName="PART_PreviousImageSite"
-                                            Storyboard.TargetProperty="(UIElement.Opacity)"
-                                            From="1" To="0"/>
-                                    </Storyboard>
-                                </VisualState>
-
-                                <VisualState x:Name="Transition_DropUp">
-                                    <Storyboard>
-                                        <DoubleAnimation 
-                                            BeginTime="00:00:00" Duration="00:00:00.3"
-                                            Storyboard.TargetName="PART_CurrentContentPresentationSite" 
-                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[1].(TranslateTransform.Y)"
-                                            From="0" To="30"/>
- 
-                                        <DoubleAnimation 
-                                            BeginTime="00:00:00" Duration="00:00:00.3"
-                                            Storyboard.TargetName="PART_PreviousImageSite" 
-                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[1].(TranslateTransform.Y)"
-                                            From="-30" To="0"/>
-
-                                        <DoubleAnimation 
-                                            BeginTime="00:00:00" Duration="00:00:00.3"
-                                            Storyboard.TargetName="PART_CurrentContentPresentationSite"
-                                            Storyboard.TargetProperty="(UIElement.Opacity)"
-                                            From="0" To="1"/>
-
-                                        <DoubleAnimation 
-                                            BeginTime="00:00:00" Duration="00:00:00.3"
-                                            Storyboard.TargetName="PART_PreviousImageSite"
-                                            Storyboard.TargetProperty="(UIElement.Opacity)"
-                                            From="1" To="0"/>
-                                    </Storyboard>
-                                </VisualState>
-
-                                <VisualState x:Name="Transition_DropRight">
-                                    <Storyboard>
-                                        <DoubleAnimation 
-                                            BeginTime="00:00:00" Duration="00:00:00.3"
-                                            Storyboard.TargetName="PART_CurrentContentPresentationSite" 
-                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[1].(TranslateTransform.X)"
-                                            From="-30" To="0"/>
-
-                                        <DoubleAnimation 
-                                            BeginTime="00:00:00" Duration="00:00:00.3"
-                                            Storyboard.TargetName="PART_PreviousImageSite" 
-                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[1].(TranslateTransform.X)"
-                                            From="0" To="30"/>
-
-                                        <DoubleAnimation 
-                                            BeginTime="00:00:00" Duration="00:00:00.3"
-                                            Storyboard.TargetName="PART_CurrentContentPresentationSite"
-                                            Storyboard.TargetProperty="(UIElement.Opacity)"
-                                            From="0" To="1"/>
-
-                                        <DoubleAnimation 
-                                            BeginTime="00:00:00" Duration="00:00:00.3"
-                                            Storyboard.TargetName="PART_PreviousImageSite"
-                                            Storyboard.TargetProperty="(UIElement.Opacity)"
-                                            From="1" To="0"/>
-                                    </Storyboard>
-                                </VisualState>
-
-                                <VisualState x:Name="Transition_DropLeft">
-                                    <Storyboard>
-                                        <DoubleAnimation 
-                                            BeginTime="00:00:00" Duration="00:00:00.3"
-                                            Storyboard.TargetName="PART_CurrentContentPresentationSite" 
-                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[1].(TranslateTransform.X)"
-                                            From="-30" To="0"/>
-
-                                        <DoubleAnimation 
-                                            BeginTime="00:00:00" Duration="00:00:00.3"
-                                            Storyboard.TargetName="PART_PreviousImageSite" 
-                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[1].(TranslateTransform.X)"
-                                            From="0" To="30"/>
-
-                                        <DoubleAnimation 
-                                            BeginTime="00:00:00" Duration="00:00:00.3"
-                                            Storyboard.TargetName="PART_CurrentContentPresentationSite"
-                                            Storyboard.TargetProperty="(UIElement.Opacity)"
-                                            From="0" To="1"/>
-
-                                        <DoubleAnimation 
-                                            BeginTime="00:00:00" Duration="00:00:00.3"
-                                            Storyboard.TargetName="PART_PreviousImageSite"
-                                            Storyboard.TargetProperty="(UIElement.Opacity)"
-                                            From="1" To="0"/>
-                                    </Storyboard>
-                                </VisualState>
-
-                                <VisualState x:Name="Transition_BounceLeftIn">
-                                    <Storyboard>
-                                        <DoubleAnimationUsingKeyFrames 
-                                            Storyboard.TargetName="PART_CurrentContentPresentationSite"
-                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[1].(TranslateTransform.X)">
-                                            <EasingDoubleKeyFrame KeyTime="00:00:00" Value="-90"/>
-                                            <EasingDoubleKeyFrame KeyTime="00:00:00.4" Value="-90"/>
-                                            <EasingDoubleKeyFrame KeyTime="00:00:00.7" Value="0">
-                                                <EasingDoubleKeyFrame.EasingFunction>
-                                                    <CircleEase EasingMode="EaseOut"/>
-                                                </EasingDoubleKeyFrame.EasingFunction>
-                                            </EasingDoubleKeyFrame>
-                                        </DoubleAnimationUsingKeyFrames>
-
-                                        <DoubleAnimationUsingKeyFrames 
-                                            Storyboard.TargetName="PART_CurrentContentPresentationSite" 
-                                            Storyboard.TargetProperty="(UIElement.Opacity)">
-                                            <DiscreteDoubleKeyFrame KeyTime="00:00:00" Value="0"/>
-                                            <DiscreteDoubleKeyFrame KeyTime="00:00:00.4" Value="1"/>
-                                        </DoubleAnimationUsingKeyFrames>
-
-                                        <ObjectAnimationUsingKeyFrames 
-                                            Storyboard.TargetName="PART_PreviousImageSite" 
-                                            Storyboard.TargetProperty="(UIElement.Visibility)">
-                                            <DiscreteObjectKeyFrame KeyTime="00:00:00">
-                                                <DiscreteObjectKeyFrame.Value>
-                                                    <Visibility>Collapsed</Visibility>
-                                                </DiscreteObjectKeyFrame.Value>
-                                            </DiscreteObjectKeyFrame>
-                                        </ObjectAnimationUsingKeyFrames>
-                                    </Storyboard>
-                                </VisualState>
-
-                                <VisualState x:Name="Transition_BounceLeftOut">
-                                    <Storyboard>
-                                        <DoubleAnimation 
-                                            BeginTime="00:00:00" Duration="00:00:00.2"
-                                            Storyboard.TargetName="PART_PreviousImageSite" 
-                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[1].(TranslateTransform.X)"
-                                            From="0" To="-90"/>
-
-                                        <ObjectAnimationUsingKeyFrames 
-                                            Storyboard.TargetName="PART_CurrentContentPresentationSite" 
-                                            Storyboard.TargetProperty="(UIElement.Visibility)">
-                                            <DiscreteObjectKeyFrame KeyTime="00:00:00">
-                                                <DiscreteObjectKeyFrame.Value>
-                                                    <Visibility>Collapsed</Visibility>
-                                                </DiscreteObjectKeyFrame.Value>
-                                            </DiscreteObjectKeyFrame>
-                                        </ObjectAnimationUsingKeyFrames>
-                                    </Storyboard>
-                                </VisualState>
-                                
-                                <VisualState x:Name="Transition_BounceRightIn">
-                                    <Storyboard>
-                                        <DoubleAnimationUsingKeyFrames 
-                                            Storyboard.TargetName="PART_CurrentContentPresentationSite"
-                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[1].(TranslateTransform.X)">
-                                            <EasingDoubleKeyFrame KeyTime="00:00:00" Value="-90"/>
-                                            <EasingDoubleKeyFrame KeyTime="00:00:00.4" Value="-90"/>
-                                            <EasingDoubleKeyFrame KeyTime="00:00:00.7" Value="0">
-                                                <EasingDoubleKeyFrame.EasingFunction>
-                                                    <CircleEase EasingMode="EaseOut"/>
-                                                </EasingDoubleKeyFrame.EasingFunction>
-                                            </EasingDoubleKeyFrame>
-                                        </DoubleAnimationUsingKeyFrames>
-
-                                        <DoubleAnimationUsingKeyFrames 
-                                            Storyboard.TargetName="PART_CurrentContentPresentationSite" 
-                                            Storyboard.TargetProperty="(UIElement.Opacity)">
-                                            <DiscreteDoubleKeyFrame KeyTime="00:00:00" Value="0"/>
-                                            <DiscreteDoubleKeyFrame KeyTime="00:00:00.4" Value="1"/>
-                                        </DoubleAnimationUsingKeyFrames>
-
-                                        <ObjectAnimationUsingKeyFrames 
-                                            Storyboard.TargetName="PART_PreviousImageSite" 
-                                            Storyboard.TargetProperty="(UIElement.Visibility)">
-                                            <DiscreteObjectKeyFrame KeyTime="00:00:00">
-                                                <DiscreteObjectKeyFrame.Value>
-                                                    <Visibility>Collapsed</Visibility>
-                                                </DiscreteObjectKeyFrame.Value>
-                                            </DiscreteObjectKeyFrame>
-                                        </ObjectAnimationUsingKeyFrames>
-                                    </Storyboard>
-                                </VisualState>
-
-                                <VisualState x:Name="Transition_BounceRightOut">
-                                    <Storyboard>
-                                        <DoubleAnimation 
-                                            BeginTime="00:00:00" Duration="00:00:00.2"
-                                            Storyboard.TargetName="PART_PreviousImageSite" 
-                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[1].(TranslateTransform.X)"
-                                            From="0" To="-90"/>
-
-                                        <ObjectAnimationUsingKeyFrames 
-                                            Storyboard.TargetName="PART_CurrentContentPresentationSite" 
-                                            Storyboard.TargetProperty="(UIElement.Visibility)">
-                                            <DiscreteObjectKeyFrame KeyTime="00:00:00">
-                                                <DiscreteObjectKeyFrame.Value>
-                                                    <Visibility>Collapsed</Visibility>
-                                                </DiscreteObjectKeyFrame.Value>
-                                            </DiscreteObjectKeyFrame>
-                                        </ObjectAnimationUsingKeyFrames>
-                                    </Storyboard>
-                                </VisualState>
-                                
-                                <VisualState x:Name="Transition_BounceUpIn">
-                                    <Storyboard>
-                                        <DoubleAnimationUsingKeyFrames 
-                                            Storyboard.TargetName="PART_CurrentContentPresentationSite"
-                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[1].(TranslateTransform.Y)">
-                                            <EasingDoubleKeyFrame KeyTime="00:00:00" Value="-90"/>
-                                            <EasingDoubleKeyFrame KeyTime="00:00:00.4" Value="-90"/>
-                                            <EasingDoubleKeyFrame KeyTime="00:00:00.7" Value="0">
-                                                <EasingDoubleKeyFrame.EasingFunction>
-                                                    <CircleEase EasingMode="EaseOut"/>
-                                                </EasingDoubleKeyFrame.EasingFunction>
-                                            </EasingDoubleKeyFrame>
-                                        </DoubleAnimationUsingKeyFrames>
-
-                                        <DoubleAnimationUsingKeyFrames 
-                                            Storyboard.TargetName="PART_CurrentContentPresentationSite" 
-                                            Storyboard.TargetProperty="(UIElement.Opacity)">
-                                            <DiscreteDoubleKeyFrame KeyTime="00:00:00" Value="0"/>
-                                            <DiscreteDoubleKeyFrame KeyTime="00:00:00.4" Value="1"/>
-                                        </DoubleAnimationUsingKeyFrames>
-
-                                        <ObjectAnimationUsingKeyFrames 
-                                            Storyboard.TargetName="PART_PreviousImageSite" 
-                                            Storyboard.TargetProperty="(UIElement.Visibility)">
-                                            <DiscreteObjectKeyFrame KeyTime="00:00:00">
-                                                <DiscreteObjectKeyFrame.Value>
-                                                    <Visibility>Collapsed</Visibility>
-                                                </DiscreteObjectKeyFrame.Value>
-                                            </DiscreteObjectKeyFrame>
-                                        </ObjectAnimationUsingKeyFrames>
-                                    </Storyboard>
-                                </VisualState>
-
-                                <VisualState x:Name="Transition_BounceUpOut">
-                                    <Storyboard>
-                                        <DoubleAnimation 
-                                            BeginTime="00:00:00" Duration="00:00:00.2"
-                                            Storyboard.TargetName="PART_PreviousImageSite" 
-                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[1].(TranslateTransform.Y)"
-                                            From="0" To="-90"/>
-
-                                        <ObjectAnimationUsingKeyFrames 
-                                            Storyboard.TargetName="PART_CurrentContentPresentationSite" 
-                                            Storyboard.TargetProperty="(UIElement.Visibility)">
-                                            <DiscreteObjectKeyFrame KeyTime="00:00:00">
-                                                <DiscreteObjectKeyFrame.Value>
-                                                    <Visibility>Collapsed</Visibility>
-                                                </DiscreteObjectKeyFrame.Value>
-                                            </DiscreteObjectKeyFrame>
-                                        </ObjectAnimationUsingKeyFrames>
-                                    </Storyboard>
-                                </VisualState>
-                                
-                                <VisualState x:Name="Transition_BounceDownIn">
-                                    <Storyboard>
-                                        <DoubleAnimationUsingKeyFrames 
-                                            Storyboard.TargetName="PART_CurrentContentPresentationSite"
-                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[1].(TranslateTransform.Y)">
-                                            <EasingDoubleKeyFrame KeyTime="00:00:00" Value="-90"/>
-                                            <EasingDoubleKeyFrame KeyTime="00:00:00.4" Value="-90"/>
-                                            <EasingDoubleKeyFrame KeyTime="00:00:00.7" Value="0">
-                                                <EasingDoubleKeyFrame.EasingFunction>
-                                                    <CircleEase EasingMode="EaseOut"/>
-                                                </EasingDoubleKeyFrame.EasingFunction>
-                                            </EasingDoubleKeyFrame>
-                                        </DoubleAnimationUsingKeyFrames>
-
-                                        <DoubleAnimationUsingKeyFrames 
-                                            Storyboard.TargetName="PART_CurrentContentPresentationSite" 
-                                            Storyboard.TargetProperty="(UIElement.Opacity)">
-                                            <DiscreteDoubleKeyFrame KeyTime="00:00:00" Value="0"/>
-                                            <DiscreteDoubleKeyFrame KeyTime="00:00:00.4" Value="1"/>
-                                        </DoubleAnimationUsingKeyFrames>
-
-                                        <ObjectAnimationUsingKeyFrames 
-                                            Storyboard.TargetName="PART_PreviousImageSite" 
-                                            Storyboard.TargetProperty="(UIElement.Visibility)">
-                                            <DiscreteObjectKeyFrame KeyTime="00:00:00">
-                                                <DiscreteObjectKeyFrame.Value>
-                                                    <Visibility>Collapsed</Visibility>
-                                                </DiscreteObjectKeyFrame.Value>
-                                            </DiscreteObjectKeyFrame>
-                                        </ObjectAnimationUsingKeyFrames>
-                                    </Storyboard>
-                                </VisualState>
-
-                                <VisualState x:Name="Transition_BounceDownOut">
-                                    <Storyboard>
-                                        <DoubleAnimation 
-                                            BeginTime="00:00:00" Duration="00:00:00.2"
-                                            Storyboard.TargetName="PART_PreviousImageSite" 
-                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[1].(TranslateTransform.Y)"
-                                            From="0" To="-90"/>
-
-                                        <ObjectAnimationUsingKeyFrames 
-                                            Storyboard.TargetName="PART_CurrentContentPresentationSite" 
-                                            Storyboard.TargetProperty="(UIElement.Visibility)">
-                                            <DiscreteObjectKeyFrame KeyTime="00:00:00">
-                                                <DiscreteObjectKeyFrame.Value>
-                                                    <Visibility>Collapsed</Visibility>
-                                                </DiscreteObjectKeyFrame.Value>
-                                            </DiscreteObjectKeyFrame>
-                                        </ObjectAnimationUsingKeyFrames>
-                                    </Storyboard>
-                                </VisualState>
-                            </VisualStateGroup>
-                        </VisualStateManager.VisualStateGroups>
-
-                        <Image 
+                        HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
+                        VerticalAlignment="{TemplateBinding VerticalAlignment}">
+                        <Image
                             x:Name="PART_PreviousImageSite"
-                            Source="{x:Null}"
                             HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
+                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                            Source="{x:Null}">
                             <Image.RenderTransform>
                                 <TransformGroup>
                                     <TransformGroup.Children>
@@ -493,10 +29,10 @@
 
                         <ContentPresenter
                             x:Name="PART_CurrentContentPresentationSite"
-                            Content="{x:Null}"
-                            ContentTemplate="{TemplateBinding ContentTemplate}"
                             HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
+                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                            Content="{x:Null}"
+                            ContentTemplate="{TemplateBinding ContentTemplate}">
                             <ContentPresenter.RenderTransform>
                                 <TransformGroup>
                                     <TransformGroup.Children>
@@ -506,6 +42,505 @@
                                 </TransformGroup>
                             </ContentPresenter.RenderTransform>
                         </ContentPresenter>
+                        <VisualStateManager.VisualStateGroups>
+                            <VisualStateGroup x:Name="PresentationStates">
+
+                                <VisualState x:Name="Normal">
+                                    <Storyboard>
+                                        <ObjectAnimationUsingKeyFrames
+                                            BeginTime="00:00:00"
+                                            Storyboard.TargetName="PART_PreviousImageSite"
+                                            Storyboard.TargetProperty="(UIElement.Visibility)">
+                                            <DiscreteObjectKeyFrame KeyTime="00:00:00">
+                                                <DiscreteObjectKeyFrame.Value>
+                                                    <Visibility>Collapsed</Visibility>
+                                                </DiscreteObjectKeyFrame.Value>
+                                            </DiscreteObjectKeyFrame>
+                                        </ObjectAnimationUsingKeyFrames>
+                                    </Storyboard>
+                                </VisualState>
+
+                                <VisualState x:Name="Transition_Fade">
+                                    <Storyboard>
+                                        <DoubleAnimation
+                                            BeginTime="00:00:00"
+                                            Storyboard.TargetName="PART_PreviousImageSite"
+                                            Storyboard.TargetProperty="(UIElement.Opacity)"
+                                            From="1"
+                                            To="0"
+                                            Duration="00:00:00.3" />
+
+                                        <DoubleAnimation
+                                            BeginTime="00:00:00"
+                                            Storyboard.TargetName="PART_CurrentContentPresentationSite"
+                                            Storyboard.TargetProperty="(UIElement.Opacity)"
+                                            From="0"
+                                            To="1"
+                                            Duration="00:00:00.3" />
+                                    </Storyboard>
+                                </VisualState>
+
+                                <VisualState x:Name="Transition_SlideLeft">
+                                    <Storyboard>
+                                        <DoubleAnimation
+                                            BeginTime="00:00:00"
+                                            Storyboard.TargetName="PART_CurrentContentPresentationSite"
+                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[1].(TranslateTransform.X)"
+                                            From="-30"
+                                            To="0"
+                                            Duration="00:00:00.3" />
+                                    </Storyboard>
+                                </VisualState>
+
+                                <VisualState x:Name="Transition_SlideRight">
+                                    <Storyboard>
+                                        <DoubleAnimation
+                                            BeginTime="00:00:00"
+                                            Storyboard.TargetName="PART_CurrentContentPresentationSite"
+                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[1].(TranslateTransform.X)"
+                                            From="-30"
+                                            To="0"
+                                            Duration="00:00:00.3" />
+                                    </Storyboard>
+                                </VisualState>
+
+                                <VisualState x:Name="Transition_SlideDown">
+                                    <Storyboard>
+                                        <DoubleAnimation
+                                            BeginTime="00:00:00"
+                                            Storyboard.TargetName="PART_CurrentContentPresentationSite"
+                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[1].(TranslateTransform.Y)"
+                                            From="-30"
+                                            To="0"
+                                            Duration="00:00:00.3" />
+                                    </Storyboard>
+                                </VisualState>
+
+                                <VisualState x:Name="Transition_SlideUp">
+                                    <Storyboard>
+                                        <DoubleAnimation
+                                            BeginTime="00:00:00"
+                                            Storyboard.TargetName="PART_CurrentContentPresentationSite"
+                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[1].(TranslateTransform.Y)"
+                                            From="-30"
+                                            To="0"
+                                            Duration="00:00:00.3" />
+                                    </Storyboard>
+                                </VisualState>
+
+                                <VisualState x:Name="Transition_MoveLeft">
+                                    <Storyboard>
+                                        <DoubleAnimation
+                                            BeginTime="00:00:00"
+                                            Storyboard.TargetName="PART_CurrentContentPresentationSite"
+                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[1].(TranslateTransform.X)"
+                                            From="-30"
+                                            To="0"
+                                            Duration="00:00:00.3" />
+
+                                        <DoubleAnimation
+                                            BeginTime="00:00:00"
+                                            Storyboard.TargetName="PART_PreviousImageSite"
+                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[1].(TranslateTransform.X)"
+                                            From="0"
+                                            To="30"
+                                            Duration="00:00:00.3" />
+                                    </Storyboard>
+                                </VisualState>
+
+                                <VisualState x:Name="Transition_MoveRight">
+                                    <Storyboard>
+                                        <DoubleAnimation
+                                            BeginTime="00:00:00"
+                                            Storyboard.TargetName="PART_CurrentContentPresentationSite"
+                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[1].(TranslateTransform.X)"
+                                            From="-30"
+                                            To="0"
+                                            Duration="00:00:00.3" />
+
+                                        <DoubleAnimation
+                                            BeginTime="00:00:00"
+                                            Storyboard.TargetName="PART_PreviousImageSite"
+                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[1].(TranslateTransform.X)"
+                                            From="0"
+                                            To="30"
+                                            Duration="00:00:00.3" />
+                                    </Storyboard>
+                                </VisualState>
+
+                                <VisualState x:Name="Transition_MoveDown">
+                                    <Storyboard>
+                                        <DoubleAnimation
+                                            BeginTime="00:00:00"
+                                            Storyboard.TargetName="PART_CurrentContentPresentationSite"
+                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[1].(TranslateTransform.Y)"
+                                            From="-30"
+                                            To="0"
+                                            Duration="00:00:00.3" />
+
+                                        <DoubleAnimation
+                                            BeginTime="00:00:00"
+                                            Storyboard.TargetName="PART_PreviousImageSite"
+                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[1].(TranslateTransform.Y)"
+                                            From="0"
+                                            To="30"
+                                            Duration="00:00:00.3" />
+                                    </Storyboard>
+                                </VisualState>
+
+                                <VisualState x:Name="Transition_MoveUp">
+                                    <Storyboard>
+                                        <DoubleAnimation
+                                            BeginTime="00:00:00"
+                                            Storyboard.TargetName="PART_CurrentContentPresentationSite"
+                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[1].(TranslateTransform.Y)"
+                                            From="-30"
+                                            To="0"
+                                            Duration="00:00:00.3" />
+
+                                        <DoubleAnimation
+                                            BeginTime="00:00:00"
+                                            Storyboard.TargetName="PART_PreviousImageSite"
+                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[1].(TranslateTransform.Y)"
+                                            From="0"
+                                            To="30"
+                                            Duration="00:00:00.3" />
+                                    </Storyboard>
+                                </VisualState>
+
+                                <VisualState x:Name="Transition_DropDown">
+                                    <Storyboard>
+                                        <DoubleAnimation
+                                            BeginTime="00:00:00"
+                                            Storyboard.TargetName="PART_CurrentContentPresentationSite"
+                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[1].(TranslateTransform.Y)"
+                                            From="-30"
+                                            To="0"
+                                            Duration="00:00:00.3" />
+
+                                        <DoubleAnimation
+                                            BeginTime="00:00:00"
+                                            Storyboard.TargetName="PART_PreviousImageSite"
+                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[1].(TranslateTransform.Y)"
+                                            From="0"
+                                            To="30"
+                                            Duration="00:00:00.3" />
+
+                                        <DoubleAnimation
+                                            BeginTime="00:00:00"
+                                            Storyboard.TargetName="PART_CurrentContentPresentationSite"
+                                            Storyboard.TargetProperty="(UIElement.Opacity)"
+                                            From="0"
+                                            To="1"
+                                            Duration="00:00:00.3" />
+
+                                        <DoubleAnimation
+                                            BeginTime="00:00:00"
+                                            Storyboard.TargetName="PART_PreviousImageSite"
+                                            Storyboard.TargetProperty="(UIElement.Opacity)"
+                                            From="1"
+                                            To="0"
+                                            Duration="00:00:00.3" />
+                                    </Storyboard>
+                                </VisualState>
+
+                                <VisualState x:Name="Transition_DropUp">
+                                    <Storyboard>
+                                        <DoubleAnimation
+                                            BeginTime="00:00:00"
+                                            Storyboard.TargetName="PART_CurrentContentPresentationSite"
+                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[1].(TranslateTransform.Y)"
+                                            From="0"
+                                            To="30"
+                                            Duration="00:00:00.3" />
+
+                                        <DoubleAnimation
+                                            BeginTime="00:00:00"
+                                            Storyboard.TargetName="PART_PreviousImageSite"
+                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[1].(TranslateTransform.Y)"
+                                            From="-30"
+                                            To="0"
+                                            Duration="00:00:00.3" />
+
+                                        <DoubleAnimation
+                                            BeginTime="00:00:00"
+                                            Storyboard.TargetName="PART_CurrentContentPresentationSite"
+                                            Storyboard.TargetProperty="(UIElement.Opacity)"
+                                            From="0"
+                                            To="1"
+                                            Duration="00:00:00.3" />
+
+                                        <DoubleAnimation
+                                            BeginTime="00:00:00"
+                                            Storyboard.TargetName="PART_PreviousImageSite"
+                                            Storyboard.TargetProperty="(UIElement.Opacity)"
+                                            From="1"
+                                            To="0"
+                                            Duration="00:00:00.3" />
+                                    </Storyboard>
+                                </VisualState>
+
+                                <VisualState x:Name="Transition_DropRight">
+                                    <Storyboard>
+                                        <DoubleAnimation
+                                            BeginTime="00:00:00"
+                                            Storyboard.TargetName="PART_CurrentContentPresentationSite"
+                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[1].(TranslateTransform.X)"
+                                            From="-30"
+                                            To="0"
+                                            Duration="00:00:00.3" />
+
+                                        <DoubleAnimation
+                                            BeginTime="00:00:00"
+                                            Storyboard.TargetName="PART_PreviousImageSite"
+                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[1].(TranslateTransform.X)"
+                                            From="0"
+                                            To="30"
+                                            Duration="00:00:00.3" />
+
+                                        <DoubleAnimation
+                                            BeginTime="00:00:00"
+                                            Storyboard.TargetName="PART_CurrentContentPresentationSite"
+                                            Storyboard.TargetProperty="(UIElement.Opacity)"
+                                            From="0"
+                                            To="1"
+                                            Duration="00:00:00.3" />
+
+                                        <DoubleAnimation
+                                            BeginTime="00:00:00"
+                                            Storyboard.TargetName="PART_PreviousImageSite"
+                                            Storyboard.TargetProperty="(UIElement.Opacity)"
+                                            From="1"
+                                            To="0"
+                                            Duration="00:00:00.3" />
+                                    </Storyboard>
+                                </VisualState>
+
+                                <VisualState x:Name="Transition_DropLeft">
+                                    <Storyboard>
+                                        <DoubleAnimation
+                                            BeginTime="00:00:00"
+                                            Storyboard.TargetName="PART_CurrentContentPresentationSite"
+                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[1].(TranslateTransform.X)"
+                                            From="-30"
+                                            To="0"
+                                            Duration="00:00:00.3" />
+
+                                        <DoubleAnimation
+                                            BeginTime="00:00:00"
+                                            Storyboard.TargetName="PART_PreviousImageSite"
+                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[1].(TranslateTransform.X)"
+                                            From="0"
+                                            To="30"
+                                            Duration="00:00:00.3" />
+
+                                        <DoubleAnimation
+                                            BeginTime="00:00:00"
+                                            Storyboard.TargetName="PART_CurrentContentPresentationSite"
+                                            Storyboard.TargetProperty="(UIElement.Opacity)"
+                                            From="0"
+                                            To="1"
+                                            Duration="00:00:00.3" />
+
+                                        <DoubleAnimation
+                                            BeginTime="00:00:00"
+                                            Storyboard.TargetName="PART_PreviousImageSite"
+                                            Storyboard.TargetProperty="(UIElement.Opacity)"
+                                            From="1"
+                                            To="0"
+                                            Duration="00:00:00.3" />
+                                    </Storyboard>
+                                </VisualState>
+
+                                <VisualState x:Name="Transition_BounceLeftIn">
+                                    <Storyboard>
+                                        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_CurrentContentPresentationSite" Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[1].(TranslateTransform.X)">
+                                            <EasingDoubleKeyFrame KeyTime="00:00:00" Value="-90" />
+                                            <EasingDoubleKeyFrame KeyTime="00:00:00.4" Value="-90" />
+                                            <EasingDoubleKeyFrame KeyTime="00:00:00.7" Value="0">
+                                                <EasingDoubleKeyFrame.EasingFunction>
+                                                    <CircleEase EasingMode="EaseOut" />
+                                                </EasingDoubleKeyFrame.EasingFunction>
+                                            </EasingDoubleKeyFrame>
+                                        </DoubleAnimationUsingKeyFrames>
+
+                                        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_CurrentContentPresentationSite" Storyboard.TargetProperty="(UIElement.Opacity)">
+                                            <DiscreteDoubleKeyFrame KeyTime="00:00:00" Value="0" />
+                                            <DiscreteDoubleKeyFrame KeyTime="00:00:00.4" Value="1" />
+                                        </DoubleAnimationUsingKeyFrames>
+
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PART_PreviousImageSite" Storyboard.TargetProperty="(UIElement.Visibility)">
+                                            <DiscreteObjectKeyFrame KeyTime="00:00:00">
+                                                <DiscreteObjectKeyFrame.Value>
+                                                    <Visibility>Collapsed</Visibility>
+                                                </DiscreteObjectKeyFrame.Value>
+                                            </DiscreteObjectKeyFrame>
+                                        </ObjectAnimationUsingKeyFrames>
+                                    </Storyboard>
+                                </VisualState>
+
+                                <VisualState x:Name="Transition_BounceLeftOut">
+                                    <Storyboard>
+                                        <DoubleAnimation
+                                            BeginTime="00:00:00"
+                                            Storyboard.TargetName="PART_PreviousImageSite"
+                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[1].(TranslateTransform.X)"
+                                            From="0"
+                                            To="-90"
+                                            Duration="00:00:00.2" />
+
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PART_CurrentContentPresentationSite" Storyboard.TargetProperty="(UIElement.Visibility)">
+                                            <DiscreteObjectKeyFrame KeyTime="00:00:00">
+                                                <DiscreteObjectKeyFrame.Value>
+                                                    <Visibility>Collapsed</Visibility>
+                                                </DiscreteObjectKeyFrame.Value>
+                                            </DiscreteObjectKeyFrame>
+                                        </ObjectAnimationUsingKeyFrames>
+                                    </Storyboard>
+                                </VisualState>
+
+                                <VisualState x:Name="Transition_BounceRightIn">
+                                    <Storyboard>
+                                        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_CurrentContentPresentationSite" Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[1].(TranslateTransform.X)">
+                                            <EasingDoubleKeyFrame KeyTime="00:00:00" Value="-90" />
+                                            <EasingDoubleKeyFrame KeyTime="00:00:00.4" Value="-90" />
+                                            <EasingDoubleKeyFrame KeyTime="00:00:00.7" Value="0">
+                                                <EasingDoubleKeyFrame.EasingFunction>
+                                                    <CircleEase EasingMode="EaseOut" />
+                                                </EasingDoubleKeyFrame.EasingFunction>
+                                            </EasingDoubleKeyFrame>
+                                        </DoubleAnimationUsingKeyFrames>
+
+                                        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_CurrentContentPresentationSite" Storyboard.TargetProperty="(UIElement.Opacity)">
+                                            <DiscreteDoubleKeyFrame KeyTime="00:00:00" Value="0" />
+                                            <DiscreteDoubleKeyFrame KeyTime="00:00:00.4" Value="1" />
+                                        </DoubleAnimationUsingKeyFrames>
+
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PART_PreviousImageSite" Storyboard.TargetProperty="(UIElement.Visibility)">
+                                            <DiscreteObjectKeyFrame KeyTime="00:00:00">
+                                                <DiscreteObjectKeyFrame.Value>
+                                                    <Visibility>Collapsed</Visibility>
+                                                </DiscreteObjectKeyFrame.Value>
+                                            </DiscreteObjectKeyFrame>
+                                        </ObjectAnimationUsingKeyFrames>
+                                    </Storyboard>
+                                </VisualState>
+
+                                <VisualState x:Name="Transition_BounceRightOut">
+                                    <Storyboard>
+                                        <DoubleAnimation
+                                            BeginTime="00:00:00"
+                                            Storyboard.TargetName="PART_PreviousImageSite"
+                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[1].(TranslateTransform.X)"
+                                            From="0"
+                                            To="-90"
+                                            Duration="00:00:00.2" />
+
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PART_CurrentContentPresentationSite" Storyboard.TargetProperty="(UIElement.Visibility)">
+                                            <DiscreteObjectKeyFrame KeyTime="00:00:00">
+                                                <DiscreteObjectKeyFrame.Value>
+                                                    <Visibility>Collapsed</Visibility>
+                                                </DiscreteObjectKeyFrame.Value>
+                                            </DiscreteObjectKeyFrame>
+                                        </ObjectAnimationUsingKeyFrames>
+                                    </Storyboard>
+                                </VisualState>
+
+                                <VisualState x:Name="Transition_BounceUpIn">
+                                    <Storyboard>
+                                        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_CurrentContentPresentationSite" Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[1].(TranslateTransform.Y)">
+                                            <EasingDoubleKeyFrame KeyTime="00:00:00" Value="-90" />
+                                            <EasingDoubleKeyFrame KeyTime="00:00:00.4" Value="-90" />
+                                            <EasingDoubleKeyFrame KeyTime="00:00:00.7" Value="0">
+                                                <EasingDoubleKeyFrame.EasingFunction>
+                                                    <CircleEase EasingMode="EaseOut" />
+                                                </EasingDoubleKeyFrame.EasingFunction>
+                                            </EasingDoubleKeyFrame>
+                                        </DoubleAnimationUsingKeyFrames>
+
+                                        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_CurrentContentPresentationSite" Storyboard.TargetProperty="(UIElement.Opacity)">
+                                            <DiscreteDoubleKeyFrame KeyTime="00:00:00" Value="0" />
+                                            <DiscreteDoubleKeyFrame KeyTime="00:00:00.4" Value="1" />
+                                        </DoubleAnimationUsingKeyFrames>
+
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PART_PreviousImageSite" Storyboard.TargetProperty="(UIElement.Visibility)">
+                                            <DiscreteObjectKeyFrame KeyTime="00:00:00">
+                                                <DiscreteObjectKeyFrame.Value>
+                                                    <Visibility>Collapsed</Visibility>
+                                                </DiscreteObjectKeyFrame.Value>
+                                            </DiscreteObjectKeyFrame>
+                                        </ObjectAnimationUsingKeyFrames>
+                                    </Storyboard>
+                                </VisualState>
+
+                                <VisualState x:Name="Transition_BounceUpOut">
+                                    <Storyboard>
+                                        <DoubleAnimation
+                                            BeginTime="00:00:00"
+                                            Storyboard.TargetName="PART_PreviousImageSite"
+                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[1].(TranslateTransform.Y)"
+                                            From="0"
+                                            To="-90"
+                                            Duration="00:00:00.2" />
+
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PART_CurrentContentPresentationSite" Storyboard.TargetProperty="(UIElement.Visibility)">
+                                            <DiscreteObjectKeyFrame KeyTime="00:00:00">
+                                                <DiscreteObjectKeyFrame.Value>
+                                                    <Visibility>Collapsed</Visibility>
+                                                </DiscreteObjectKeyFrame.Value>
+                                            </DiscreteObjectKeyFrame>
+                                        </ObjectAnimationUsingKeyFrames>
+                                    </Storyboard>
+                                </VisualState>
+
+                                <VisualState x:Name="Transition_BounceDownIn">
+                                    <Storyboard>
+                                        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_CurrentContentPresentationSite" Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[1].(TranslateTransform.Y)">
+                                            <EasingDoubleKeyFrame KeyTime="00:00:00" Value="-90" />
+                                            <EasingDoubleKeyFrame KeyTime="00:00:00.4" Value="-90" />
+                                            <EasingDoubleKeyFrame KeyTime="00:00:00.7" Value="0">
+                                                <EasingDoubleKeyFrame.EasingFunction>
+                                                    <CircleEase EasingMode="EaseOut" />
+                                                </EasingDoubleKeyFrame.EasingFunction>
+                                            </EasingDoubleKeyFrame>
+                                        </DoubleAnimationUsingKeyFrames>
+
+                                        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_CurrentContentPresentationSite" Storyboard.TargetProperty="(UIElement.Opacity)">
+                                            <DiscreteDoubleKeyFrame KeyTime="00:00:00" Value="0" />
+                                            <DiscreteDoubleKeyFrame KeyTime="00:00:00.4" Value="1" />
+                                        </DoubleAnimationUsingKeyFrames>
+
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PART_PreviousImageSite" Storyboard.TargetProperty="(UIElement.Visibility)">
+                                            <DiscreteObjectKeyFrame KeyTime="00:00:00">
+                                                <DiscreteObjectKeyFrame.Value>
+                                                    <Visibility>Collapsed</Visibility>
+                                                </DiscreteObjectKeyFrame.Value>
+                                            </DiscreteObjectKeyFrame>
+                                        </ObjectAnimationUsingKeyFrames>
+                                    </Storyboard>
+                                </VisualState>
+
+                                <VisualState x:Name="Transition_BounceDownOut">
+                                    <Storyboard>
+                                        <DoubleAnimation
+                                            BeginTime="00:00:00"
+                                            Storyboard.TargetName="PART_PreviousImageSite"
+                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[1].(TranslateTransform.Y)"
+                                            From="0"
+                                            To="-90"
+                                            Duration="00:00:00.2" />
+
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PART_CurrentContentPresentationSite" Storyboard.TargetProperty="(UIElement.Visibility)">
+                                            <DiscreteObjectKeyFrame KeyTime="00:00:00">
+                                                <DiscreteObjectKeyFrame.Value>
+                                                    <Visibility>Collapsed</Visibility>
+                                                </DiscreteObjectKeyFrame.Value>
+                                            </DiscreteObjectKeyFrame>
+                                        </ObjectAnimationUsingKeyFrames>
+                                    </Storyboard>
+                                </VisualState>
+                            </VisualStateGroup>
+                        </VisualStateManager.VisualStateGroups>
                     </Grid>
                 </ControlTemplate>
             </Setter.Value>

--- a/src/ReactiveUI.Wpf/TransitioningContentControl.cs
+++ b/src/ReactiveUI.Wpf/TransitioningContentControl.cs
@@ -6,11 +6,14 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Imaging;
+
+[assembly: InternalsVisibleTo("ReactiveUI.Tests")]
 
 // This control is gratefully borrowed from http://blog.landdolphin.net/?p=17
 // Thanks guys!
@@ -51,6 +54,10 @@ namespace ReactiveUI
             typeof(TimeSpan),
             typeof(TransitioningContentControl),
             new PropertyMetadata(TimeSpan.FromSeconds(0.3)));
+
+#pragma warning disable SA1401 // Fields should be private
+        internal static bool OverrideDpi = false;
+#pragma warning restore SA1401 // Fields should be private
 
         private const string PresentationGroup = "PresentationStates";
         private const string NormalState = "Normal";
@@ -232,9 +239,16 @@ namespace ReactiveUI
             var dpiScale = VisualTreeHelper.GetDpi(uiElement);
 #endif
 
+            if (OverrideDpi)
+            {
+                dpiScale = new DpiScale(1.25, 1.25);
+            }
+
+            var pixelWidth = Math.Max(1.0, uiElement.RenderSize.Width * dpiScale.DpiScaleX);
+            var pixelHeight = Math.Max(1.0, uiElement.RenderSize.Height * dpiScale.DpiScaleY);
             var renderTargetBitmap = new RenderTargetBitmap(
-                                                            Convert.ToInt32(uiElement.RenderSize.Width * dpiScale.DpiScaleX),
-                                                            Convert.ToInt32(uiElement.RenderSize.Height * dpiScale.DpiScaleY),
+                                                            Convert.ToInt32(pixelWidth),
+                                                            Convert.ToInt32(pixelHeight),
                                                             dpiScale.PixelsPerInchX,
                                                             dpiScale.PixelsPerInchY,
                                                             PixelFormats.Pbgra32);
@@ -416,21 +430,25 @@ namespace ReactiveUI
                                 completingDoubleAnimation.From = -ActualHeight;
 
                                 break;
+
                             case TransitionDirection.Up:
                                 startingDoubleAnimation.To = -ActualHeight;
                                 completingDoubleAnimation.From = ActualHeight;
 
                                 break;
+
                             case TransitionDirection.Right:
                                 startingDoubleAnimation.To = ActualWidth;
                                 completingDoubleAnimation.From = -ActualWidth;
 
                                 break;
+
                             case TransitionDirection.Left:
                                 startingDoubleAnimation.To = -ActualWidth;
                                 completingDoubleAnimation.From = ActualWidth;
 
                                 break;
+
                             default: throw new ArgumentOutOfRangeException(nameof(TransitionDirection));
                         }
 


### PR DESCRIPTION
RenderTargetBitmap take an int therefore the minimum input value must be 1.

<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

fix #2801 

**What is the current behaviour?**
<!-- You can also link to an open issue here. -->

Transitioning Content Control has a DPI issue with a calculation returning less than 1;

**What is the new behaviour?**
<!-- If this is a feature change -->

Transitioning Content Control handles DPI issue with a calculation returning less than 1 but being resolved to 1;

**What might this PR break?**

none as is only used for animation.

**Please check if the PR fulfils these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

