### PR TITLE
fix Bind with Trigger reinstated ViewToViewModel added option

### DIFF
--- a/integrationtests/IntegrationTests.Android/MainActivity.cs
+++ b/integrationtests/IntegrationTests.Android/MainActivity.cs
@@ -4,6 +4,7 @@
 // See the LICENSE file in the project root for full license information.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Reactive;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
@@ -20,6 +21,7 @@ namespace IntegrationTests.Android
     /// The main activity for the application.
     /// </summary>
     [Activity(Label = "@string/app_name", Theme = "@style/AppTheme.NoActionBar", MainLauncher = true)]
+    [ExcludeFromCodeCoverage]
     public class MainActivity : ReactiveActivity<LoginViewModel>
     {
         /// <summary>

--- a/integrationtests/IntegrationTests.Mac/AppDelegate.cs
+++ b/integrationtests/IntegrationTests.Mac/AppDelegate.cs
@@ -12,6 +12,7 @@ namespace IntegrationTests.Mac
     /// The main application delegate.
     /// </summary>
     [Register("AppDelegate")]
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public class AppDelegate : NSApplicationDelegate
     {
         /// <inheritdoc />

--- a/integrationtests/IntegrationTests.Mac/LoginViewController.cs
+++ b/integrationtests/IntegrationTests.Mac/LoginViewController.cs
@@ -17,6 +17,7 @@ namespace IntegrationTests.Mac
     /// <summary>
     /// A controller responsible for logging in the user.
     /// </summary>
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public partial class LoginViewController : ReactiveViewController<LoginViewModel>
     {
         /// <summary>

--- a/integrationtests/IntegrationTests.Mac/MainClass.cs
+++ b/integrationtests/IntegrationTests.Mac/MainClass.cs
@@ -10,6 +10,7 @@ namespace IntegrationTests.Mac
     /// <summary>
     /// The class which hosts the main entry point for the application.
     /// </summary>
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public static class MainClass
     {
         /// <summary>

--- a/integrationtests/IntegrationTests.Shared/LoginViewModel.cs
+++ b/integrationtests/IntegrationTests.Shared/LoginViewModel.cs
@@ -16,6 +16,7 @@ namespace IntegrationTests.Shared
     /// View model for login functionality.
     /// </summary>
     /// <seealso cref="ReactiveUI.ReactiveObject" />
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public class LoginViewModel : ReactiveObject
     {
         private string _userName;

--- a/integrationtests/IntegrationTests.UWP/App.xaml.cs
+++ b/integrationtests/IntegrationTests.UWP/App.xaml.cs
@@ -15,6 +15,7 @@ namespace IntegrationTests.UWP
     /// <summary>
     /// Provides application-specific behavior to supplement the default Application class.
     /// </summary>
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public sealed partial class App : Application
     {
         /// <summary>

--- a/integrationtests/IntegrationTests.UWP/LoginControlBase.cs
+++ b/integrationtests/IntegrationTests.UWP/LoginControlBase.cs
@@ -11,6 +11,7 @@ namespace IntegrationTests.UWP
     /// <summary>
     /// A base level control for logging the user in.
     /// </summary>
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public class LoginControlBase : ReactiveUserControl<LoginViewModel>
     {
     }

--- a/integrationtests/IntegrationTests.UWP/MainPage.xaml.cs
+++ b/integrationtests/IntegrationTests.UWP/MainPage.xaml.cs
@@ -10,6 +10,7 @@ namespace IntegrationTests.UWP
     /// <summary>
     /// An empty page that can be used on its own or navigated to within a Frame.
     /// </summary>
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public sealed partial class MainPage : Page
     {
         /// <summary>

--- a/integrationtests/IntegrationTests.WPF/App.xaml.cs
+++ b/integrationtests/IntegrationTests.WPF/App.xaml.cs
@@ -10,6 +10,7 @@ namespace IntegrationTests.WPF
     /// <summary>
     /// Interaction logic for App.xaml.
     /// </summary>
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public partial class App : Application
     {
     }

--- a/integrationtests/IntegrationTests.WPF/LoginControl.xaml.cs
+++ b/integrationtests/IntegrationTests.WPF/LoginControl.xaml.cs
@@ -15,6 +15,7 @@ namespace IntegrationTests.WPF
     /// <summary>
     /// Interaction logic for LoginControl.xaml.
     /// </summary>
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public partial class LoginControl : ReactiveUserControl<LoginViewModel>
     {
         /// <summary>

--- a/integrationtests/IntegrationTests.WPF/UserControlExtensions.cs
+++ b/integrationtests/IntegrationTests.WPF/UserControlExtensions.cs
@@ -15,6 +15,7 @@ namespace IntegrationTests.WPF
     /// <summary>
     /// Extension methods associated with the UserControl class.
     /// </summary>
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public static class UserControlExtensions
     {
         /// <summary>

--- a/integrationtests/IntegrationTests.WinForms/LoginControl.cs
+++ b/integrationtests/IntegrationTests.WinForms/LoginControl.cs
@@ -17,6 +17,7 @@ namespace IntegrationTests.WinForms
     /// <summary>
     /// A control for logging in a user.
     /// </summary>
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public partial class LoginControl : UserControl, IViewFor<LoginViewModel>
     {
         /// <summary>

--- a/integrationtests/IntegrationTests.WinForms/MainForm.cs
+++ b/integrationtests/IntegrationTests.WinForms/MainForm.cs
@@ -10,6 +10,7 @@ namespace IntegrationTests.WinForms
     /// <summary>
     /// The main form of the application.
     /// </summary>
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public partial class MainForm : Form
     {
         /// <summary>

--- a/integrationtests/IntegrationTests.WinForms/Program.cs
+++ b/integrationtests/IntegrationTests.WinForms/Program.cs
@@ -11,6 +11,7 @@ namespace IntegrationTests.WinForms
     /// <summary>
     /// The class which hosts the main entry point to the application.
     /// </summary>
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public static class Program
     {
         /// <summary>

--- a/integrationtests/IntegrationTests.XamarinForms.Android/MainActivity.cs
+++ b/integrationtests/IntegrationTests.XamarinForms.Android/MainActivity.cs
@@ -14,6 +14,7 @@ namespace IntegrationTests.XamarinForms.Droid
     /// The main activity for the application.
     /// </summary>
     [Activity(Label = "IntegrationTests.XamarinForms", Icon = "@mipmap/icon", Theme = "@style/MainTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation)]
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public class MainActivity : global::Xamarin.Forms.Platform.Android.FormsAppCompatActivity
     {
         /// <inheritdoc />

--- a/integrationtests/IntegrationTests.XamarinForms.UWP/App.xaml.cs
+++ b/integrationtests/IntegrationTests.XamarinForms.UWP/App.xaml.cs
@@ -15,6 +15,7 @@ namespace IntegrationTests.XamarinForms.UWP
     /// <summary>
     /// Provides application-specific behavior to supplement the default Application class.
     /// </summary>
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public sealed partial class App : Application
     {
         /// <summary>

--- a/integrationtests/IntegrationTests.XamarinForms.UWP/MainPage.xaml.cs
+++ b/integrationtests/IntegrationTests.XamarinForms.UWP/MainPage.xaml.cs
@@ -8,6 +8,7 @@ namespace IntegrationTests.XamarinForms.UWP
     /// <summary>
     /// The main page for the application.
     /// </summary>
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public sealed partial class MainPage
     {
         /// <summary>

--- a/integrationtests/IntegrationTests.XamarinForms.iOS/AppDelegate.cs
+++ b/integrationtests/IntegrationTests.XamarinForms.iOS/AppDelegate.cs
@@ -14,6 +14,7 @@ namespace IntegrationTests.XamarinForms.iOS
     /// application events from iOS.
     /// </summary>
     [Register("AppDelegate")]
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public partial class AppDelegate : global::Xamarin.Forms.Platform.iOS.FormsApplicationDelegate
     {
         /// <summary>

--- a/integrationtests/IntegrationTests.XamarinForms.iOS/AppLaunch.cs
+++ b/integrationtests/IntegrationTests.XamarinForms.iOS/AppLaunch.cs
@@ -10,6 +10,7 @@ namespace IntegrationTests.XamarinForms.iOS
     /// <summary>
     /// The class which hosts the main entry point to the application.
     /// </summary>
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public static class AppLaunch
     {
         /// <summary>

--- a/integrationtests/IntegrationTests.XamarinForms/App.xaml.cs
+++ b/integrationtests/IntegrationTests.XamarinForms/App.xaml.cs
@@ -11,6 +11,7 @@ namespace IntegrationTests.XamarinForms
     /// <summary>
     /// The class which represents the main application.
     /// </summary>
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public partial class App : Application
     {
         /// <summary>

--- a/integrationtests/IntegrationTests.XamarinForms/MainPage.xaml.cs
+++ b/integrationtests/IntegrationTests.XamarinForms/MainPage.xaml.cs
@@ -17,6 +17,7 @@ namespace IntegrationTests.XamarinForms
     /// <summary>
     /// The main page for the application.
     /// </summary>
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public partial class MainPage : ReactiveContentPage<LoginViewModel>
     {
         /// <summary>

--- a/integrationtests/IntegrationTests.iOS/AppDelegate.cs
+++ b/integrationtests/IntegrationTests.iOS/AppDelegate.cs
@@ -7,6 +7,7 @@ using Foundation;
 using UIKit;
 
 #pragma warning disable SA1300 // Element should begin with upper-case letter
+
 namespace IntegrationTests.iOS
 {
     /// <summary>
@@ -14,6 +15,7 @@ namespace IntegrationTests.iOS
     /// User Interface of the application, as well as listening (and optionally responding) to application events from iOS.
     /// </summary>
     [Register("AppDelegate")]
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public class AppDelegate : UIApplicationDelegate
     {
         /// <summary>

--- a/integrationtests/IntegrationTests.iOS/Application.cs
+++ b/integrationtests/IntegrationTests.iOS/Application.cs
@@ -6,11 +6,13 @@
 using UIKit;
 
 #pragma warning disable SA1300 // Element should begin with upper-case letter
+
 namespace IntegrationTests.iOS
 {
     /// <summary>
     /// The main application which contains the entry point to the application.
     /// </summary>
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public static class Application
     {
         /// <summary>

--- a/integrationtests/IntegrationTests.iOS/LoginViewController.cs
+++ b/integrationtests/IntegrationTests.iOS/LoginViewController.cs
@@ -20,6 +20,7 @@ namespace IntegrationTests.iOS
     /// <summary>
     /// The main login view controller for the application.
     /// </summary>
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public partial class LoginViewController : ReactiveViewController<LoginViewModel>
     {
         /// <summary>

--- a/integrationtests/IntegrationTests.iOS/LoginViewController.designer.cs
+++ b/integrationtests/IntegrationTests.iOS/LoginViewController.designer.cs
@@ -10,7 +10,8 @@ using System.CodeDom.Compiler;
 namespace IntegrationTests.iOS
 {
 	[Register ("LoginViewController")]
-	partial class LoginViewController
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    partial class LoginViewController
 	{
 		[Outlet]
 		UIKit.UIButton CancelButton { get; set; }

--- a/integrationtests/IntegrationTests.iOS/LoginViewController.designer.cs
+++ b/integrationtests/IntegrationTests.iOS/LoginViewController.designer.cs
@@ -10,7 +10,6 @@ using System.CodeDom.Compiler;
 namespace IntegrationTests.iOS
 {
 	[Register ("LoginViewController")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     partial class LoginViewController
 	{
 		[Outlet]

--- a/src/Benchmarks/AutoPersistBenchmark.cs
+++ b/src/Benchmarks/AutoPersistBenchmark.cs
@@ -20,6 +20,7 @@ namespace ReactiveUI.Benchmarks
     [CoreJob]
     [MemoryDiagnoser]
     [MarkdownExporterAttribute.GitHub]
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public class AutoPersistBenchmark
     {
         private ObservableCollection<MockViewModel>? _collection;

--- a/src/Benchmarks/INPCObservableForPropertyBenchmarks.cs
+++ b/src/Benchmarks/INPCObservableForPropertyBenchmarks.cs
@@ -19,6 +19,7 @@ namespace ReactiveUI.Benchmarks
     [CoreJob]
     [MemoryDiagnoser]
     [MarkdownExporterAttribute.GitHub]
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public class INPCObservableForPropertyBenchmarks
     {
         private readonly Expression<Func<TestClassChanged, string?>> _expr = x => x.Property1;

--- a/src/Benchmarks/Mocks/MockHostScreen.cs
+++ b/src/Benchmarks/Mocks/MockHostScreen.cs
@@ -8,6 +8,7 @@ namespace ReactiveUI.Benchmarks
     /// <summary>
     /// A mock for the screen in ReactiveUI. This will only contain the routing state.
     /// </summary>
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public class MockHostScreen : IScreen
     {
         /// <summary>

--- a/src/Benchmarks/Mocks/MockViewModel.cs
+++ b/src/Benchmarks/Mocks/MockViewModel.cs
@@ -11,6 +11,7 @@ namespace ReactiveUI.Benchmarks
     /// A mock for a ReactiveObject which is routable.
     /// </summary>
     [DataContract]
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public class MockViewModel : ReactiveObject, IRoutableViewModel
     {
         /// <summary>

--- a/src/Benchmarks/NavigationStackBenchmark.cs
+++ b/src/Benchmarks/NavigationStackBenchmark.cs
@@ -19,6 +19,7 @@ namespace ReactiveUI.Benchmarks
     [CoreJob]
     [MemoryDiagnoser]
     [MarkdownExporterAttribute.GitHub]
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public class NavigationStackBenchmark
     {
         private static readonly Func<MockViewModel> _mockViewModel;

--- a/src/Benchmarks/Program.cs
+++ b/src/Benchmarks/Program.cs
@@ -15,6 +15,7 @@ namespace ReactiveUI.Benchmarks
     /// <summary>
     /// Class which hosts the main entry point into the application.
     /// </summary>
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public static class Program
     {
         /// <summary>

--- a/src/Benchmarks/ReactiveCommandCreateBenchmark.cs
+++ b/src/Benchmarks/ReactiveCommandCreateBenchmark.cs
@@ -18,6 +18,7 @@ namespace ReactiveUI.Benchmarks
     [CoreJob]
     [MemoryDiagnoser]
     [MarkdownExporterAttribute.GitHub]
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public class ReactiveCommandCreateBenchmark
     {
         private readonly IObservable<bool> _canExecute = new Subject<bool>().AsObservable();

--- a/src/Benchmarks/RoutableViewModelMixinsBenchmarks.cs
+++ b/src/Benchmarks/RoutableViewModelMixinsBenchmarks.cs
@@ -19,6 +19,7 @@ namespace ReactiveUI.Benchmarks
     [CoreJob]
     [MemoryDiagnoser]
     [MarkdownExporterAttribute.GitHub]
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public class RoutableViewModelMixinsBenchmarks
     {
         private Func<MockViewModel>? _mockViewModel;

--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -42,7 +42,7 @@
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.Reactive.Testing" Version="5.0.0" />
     <PackageReference Include="PublicApiGenerator" Version="10.2.0" />
-    <PackageReference Include="DiffEngine" Version="6.10.1" />
+    <PackageReference Include="DiffEngine" Version="7.1.0" />
     <PackageReference Include="coverlet.msbuild" Version="3.1.0" PrivateAssets="All" />
   </ItemGroup>
   

--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -42,7 +42,7 @@
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.Reactive.Testing" Version="5.0.0" />
     <PackageReference Include="PublicApiGenerator" Version="10.2.0" />
-    <PackageReference Include="DiffEngine" Version="7.1.0" />
+    <PackageReference Include="DiffEngine" Version="6.10.1" />
     <PackageReference Include="coverlet.msbuild" Version="3.1.0" PrivateAssets="All" />
   </ItemGroup>
   

--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.net472.approved.txt
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.net472.approved.txt
@@ -120,6 +120,12 @@ namespace ReactiveUI
         public System.IDisposable? BindCommandToObject<TEventArgs>(System.Windows.Input.ICommand? command, object? target, System.IObservable<object?> commandParameter, string eventName) { }
         public int GetAffinityForObject(System.Type type, bool hasEventTarget) { }
     }
+    public class DecimalToStringTypeConverter : ReactiveUI.IBindingTypeConverter, Splat.IEnableLogger
+    {
+        public DecimalToStringTypeConverter() { }
+        public int GetAffinityForObjects(System.Type fromType, System.Type toType) { }
+        public bool TryConvert(object? from, System.Type toType, object? conversionHint, out object result) { }
+    }
     public sealed class DefaultViewLocator : ReactiveUI.IViewLocator, Splat.IEnableLogger
     {
         public System.Func<string, string> ViewModelToViewFunc { get; set; }
@@ -129,6 +135,12 @@ namespace ReactiveUI
     {
         public static void InitializeReactiveUI(this Splat.IMutableDependencyResolver resolver, params ReactiveUI.RegistrationNamespace[] registrationNamespaces) { }
         public static void RegisterViewsForViewModels(this Splat.IMutableDependencyResolver resolver, System.Reflection.Assembly assembly) { }
+    }
+    public class DoubleToStringTypeConverter : ReactiveUI.IBindingTypeConverter, Splat.IEnableLogger
+    {
+        public DoubleToStringTypeConverter() { }
+        public int GetAffinityForObjects(System.Type fromType, System.Type toType) { }
+        public bool TryConvert(object? from, System.Type toType, object? conversionHint, out object result) { }
     }
     public class DummySuspensionDriver : ReactiveUI.ISuspensionDriver
     {

--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.net472.approved.txt
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.net472.approved.txt
@@ -234,14 +234,14 @@ namespace ReactiveUI
         [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {
                 "view",
                 "isViewModel"})]
-        ReactiveUI.IReactiveBinding<TView, System.ValueTuple<object?, bool>> Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp?>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, System.IObservable<TDontCare>? signalViewUpdate, System.Func<TVMProp?, TVProp> vmToViewConverter, System.Func<TVProp, TVMProp?> viewToVmConverter)
+        ReactiveUI.IReactiveBinding<TView, System.ValueTuple<object?, bool>> Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp?>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, System.IObservable<TDontCare>? signalViewUpdate, System.Func<TVMProp?, TVProp> vmToViewConverter, System.Func<TVProp, TVMProp?> viewToVmConverter, ReactiveUI.TriggerUpdate triggerUpdate = 0)
             where TViewModel :  class
             where TView :  class, ReactiveUI.IViewFor
         ;
         [return: System.Runtime.CompilerServices.TupleElementNames(new string?[]?[] {
                 "view",
                 "isViewModel"})]
-        ReactiveUI.IReactiveBinding<TView, System.ValueTuple<object?, bool>> Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp?>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, System.IObservable<TDontCare>? signalViewUpdate, object? conversionHint, ReactiveUI.IBindingTypeConverter? vmToViewConverterOverride = null, ReactiveUI.IBindingTypeConverter? viewToVMConverterOverride = null)
+        ReactiveUI.IReactiveBinding<TView, System.ValueTuple<object?, bool>> Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp?>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, System.IObservable<TDontCare>? signalViewUpdate, object? conversionHint, ReactiveUI.IBindingTypeConverter? vmToViewConverterOverride = null, ReactiveUI.IBindingTypeConverter? viewToVMConverterOverride = null, ReactiveUI.TriggerUpdate triggerUpdate = 0)
             where TViewModel :  class
             where TView :  class, ReactiveUI.IViewFor
         ;
@@ -500,13 +500,13 @@ namespace ReactiveUI
         [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {
                 "view",
                 "isViewModel"})]
-        public ReactiveUI.IReactiveBinding<TView, System.ValueTuple<object?, bool>> Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp?>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, System.IObservable<TDontCare>? signalViewUpdate, System.Func<TVMProp?, TVProp> vmToViewConverter, System.Func<TVProp, TVMProp?> viewToVmConverter)
+        public ReactiveUI.IReactiveBinding<TView, System.ValueTuple<object?, bool>> Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp?>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, System.IObservable<TDontCare>? signalViewUpdate, System.Func<TVMProp?, TVProp> vmToViewConverter, System.Func<TVProp, TVMProp?> viewToVmConverter, ReactiveUI.TriggerUpdate triggerUpdate = 0)
             where TViewModel :  class
             where TView :  class, ReactiveUI.IViewFor { }
         [return: System.Runtime.CompilerServices.TupleElementNames(new string?[]?[] {
                 "view",
                 "isViewModel"})]
-        public ReactiveUI.IReactiveBinding<TView, System.ValueTuple<object?, bool>> Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp?>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, System.IObservable<TDontCare>? signalViewUpdate, object? conversionHint, ReactiveUI.IBindingTypeConverter? vmToViewConverterOverride = null, ReactiveUI.IBindingTypeConverter? viewToVMConverterOverride = null)
+        public ReactiveUI.IReactiveBinding<TView, System.ValueTuple<object?, bool>> Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp?>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, System.IObservable<TDontCare>? signalViewUpdate, object? conversionHint, ReactiveUI.IBindingTypeConverter? vmToViewConverterOverride = null, ReactiveUI.IBindingTypeConverter? viewToVMConverterOverride = null, ReactiveUI.TriggerUpdate triggerUpdate = 0)
             where TViewModel :  class
             where TView :  class, ReactiveUI.IViewFor { }
         public System.IDisposable BindTo<TValue, TTarget, TTValue>(System.IObservable<TValue> observedChange, TTarget? target, System.Linq.Expressions.Expression<System.Func<TTarget, TTValue?>> propertyExpression, object? conversionHint = null, ReactiveUI.IBindingTypeConverter? vmToViewConverterOverride = null)
@@ -535,13 +535,13 @@ namespace ReactiveUI
         [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {
                 "view",
                 "isViewModel"})]
-        public static ReactiveUI.IReactiveBinding<TView, System.ValueTuple<object?, bool>> Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(this TView view, TViewModel? viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp?>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, System.IObservable<TDontCare>? signalViewUpdate, System.Func<TVMProp?, TVProp> vmToViewConverter, System.Func<TVProp, TVMProp?> viewToVmConverter)
+        public static ReactiveUI.IReactiveBinding<TView, System.ValueTuple<object?, bool>> Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(this TView view, TViewModel? viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp?>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, System.IObservable<TDontCare>? signalViewUpdate, System.Func<TVMProp?, TVProp> vmToViewConverter, System.Func<TVProp, TVMProp?> viewToVmConverter, ReactiveUI.TriggerUpdate triggerUpdate = 0)
             where TViewModel :  class
             where TView :  class, ReactiveUI.IViewFor { }
         [return: System.Runtime.CompilerServices.TupleElementNames(new string?[]?[] {
                 "view",
                 "isViewModel"})]
-        public static ReactiveUI.IReactiveBinding<TView, System.ValueTuple<object?, bool>> Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(this TView view, TViewModel? viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp?>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, System.IObservable<TDontCare>? signalViewUpdate, object? conversionHint = null, ReactiveUI.IBindingTypeConverter? vmToViewConverterOverride = null, ReactiveUI.IBindingTypeConverter? viewToVMConverterOverride = null)
+        public static ReactiveUI.IReactiveBinding<TView, System.ValueTuple<object?, bool>> Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(this TView view, TViewModel? viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp?>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, System.IObservable<TDontCare>? signalViewUpdate, object? conversionHint = null, ReactiveUI.IBindingTypeConverter? vmToViewConverterOverride = null, ReactiveUI.IBindingTypeConverter? viewToVMConverterOverride = null, ReactiveUI.TriggerUpdate triggerUpdate = 0)
             where TViewModel :  class
             where TView :  class, ReactiveUI.IViewFor { }
         public static System.IDisposable BindTo<TValue, TTarget, TTValue>(this System.IObservable<TValue> @this, TTarget? target, System.Linq.Expressions.Expression<System.Func<TTarget, TTValue?>> property, object? conversionHint = null, ReactiveUI.IBindingTypeConverter? vmToViewConverterOverride = null)
@@ -766,6 +766,11 @@ namespace ReactiveUI
         public static System.IObservable<T> ObserveAppState<T>(this ReactiveUI.ISuspensionHost item)
             where T :  class { }
         public static System.IDisposable SetupDefaultSuspendResume(this ReactiveUI.ISuspensionHost item, ReactiveUI.ISuspensionDriver? driver = null) { }
+    }
+    public enum TriggerUpdate
+    {
+        ViewToViewModel = 0,
+        ViewModelToView = 1,
     }
     [System.Serializable]
     public class UnhandledErrorException : System.Exception

--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.net5.0.approved.txt
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.net5.0.approved.txt
@@ -122,6 +122,12 @@ namespace ReactiveUI
         public System.IDisposable? BindCommandToObject<TEventArgs>(System.Windows.Input.ICommand? command, object? target, System.IObservable<object?> commandParameter, string eventName) { }
         public int GetAffinityForObject(System.Type type, bool hasEventTarget) { }
     }
+    public class DecimalToStringTypeConverter : ReactiveUI.IBindingTypeConverter, Splat.IEnableLogger
+    {
+        public DecimalToStringTypeConverter() { }
+        public int GetAffinityForObjects(System.Type fromType, System.Type toType) { }
+        public bool TryConvert(object? from, System.Type toType, object? conversionHint, out object result) { }
+    }
     public sealed class DefaultViewLocator : ReactiveUI.IViewLocator, Splat.IEnableLogger
     {
         public System.Func<string, string> ViewModelToViewFunc { get; set; }
@@ -131,6 +137,12 @@ namespace ReactiveUI
     {
         public static void InitializeReactiveUI(this Splat.IMutableDependencyResolver resolver, params ReactiveUI.RegistrationNamespace[] registrationNamespaces) { }
         public static void RegisterViewsForViewModels(this Splat.IMutableDependencyResolver resolver, System.Reflection.Assembly assembly) { }
+    }
+    public class DoubleToStringTypeConverter : ReactiveUI.IBindingTypeConverter, Splat.IEnableLogger
+    {
+        public DoubleToStringTypeConverter() { }
+        public int GetAffinityForObjects(System.Type fromType, System.Type toType) { }
+        public bool TryConvert(object? from, System.Type toType, object? conversionHint, out object result) { }
     }
     public class DummySuspensionDriver : ReactiveUI.ISuspensionDriver
     {

--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.net5.0.approved.txt
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.net5.0.approved.txt
@@ -234,13 +234,13 @@ namespace ReactiveUI
         [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {
                 "view",
                 "isViewModel"})]
-        ReactiveUI.IReactiveBinding<TView, System.ValueTuple<object?, bool>> Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp?>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, System.IObservable<TDontCare>? signalViewUpdate, System.Func<TVMProp?, TVProp> vmToViewConverter, System.Func<TVProp, TVMProp?> viewToVmConverter)
+        ReactiveUI.IReactiveBinding<TView, System.ValueTuple<object?, bool>> Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp?>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, System.IObservable<TDontCare>? signalViewUpdate, System.Func<TVMProp?, TVProp> vmToViewConverter, System.Func<TVProp, TVMProp?> viewToVmConverter, ReactiveUI.TriggerUpdate triggerUpdate = 0)
             where TViewModel :  class
             where TView :  class, ReactiveUI.IViewFor;
         [return: System.Runtime.CompilerServices.TupleElementNames(new string?[]?[] {
                 "view",
                 "isViewModel"})]
-        ReactiveUI.IReactiveBinding<TView, System.ValueTuple<object?, bool>> Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp?>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, System.IObservable<TDontCare>? signalViewUpdate, object? conversionHint, ReactiveUI.IBindingTypeConverter? vmToViewConverterOverride = null, ReactiveUI.IBindingTypeConverter? viewToVMConverterOverride = null)
+        ReactiveUI.IReactiveBinding<TView, System.ValueTuple<object?, bool>> Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp?>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, System.IObservable<TDontCare>? signalViewUpdate, object? conversionHint, ReactiveUI.IBindingTypeConverter? vmToViewConverterOverride = null, ReactiveUI.IBindingTypeConverter? viewToVMConverterOverride = null, ReactiveUI.TriggerUpdate triggerUpdate = 0)
             where TViewModel :  class
             where TView :  class, ReactiveUI.IViewFor;
         System.IDisposable BindTo<TValue, TTarget, TTValue>(System.IObservable<TValue> observedChange, TTarget? target, System.Linq.Expressions.Expression<System.Func<TTarget, TTValue?>> propertyExpression, object? conversionHint, ReactiveUI.IBindingTypeConverter? vmToViewConverterOverride = null)
@@ -495,13 +495,13 @@ namespace ReactiveUI
         [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {
                 "view",
                 "isViewModel"})]
-        public ReactiveUI.IReactiveBinding<TView, System.ValueTuple<object?, bool>> Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp?>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, System.IObservable<TDontCare>? signalViewUpdate, System.Func<TVMProp?, TVProp> vmToViewConverter, System.Func<TVProp, TVMProp?> viewToVmConverter)
+        public ReactiveUI.IReactiveBinding<TView, System.ValueTuple<object?, bool>> Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp?>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, System.IObservable<TDontCare>? signalViewUpdate, System.Func<TVMProp?, TVProp> vmToViewConverter, System.Func<TVProp, TVMProp?> viewToVmConverter, ReactiveUI.TriggerUpdate triggerUpdate = 0)
             where TViewModel :  class
             where TView :  class, ReactiveUI.IViewFor { }
         [return: System.Runtime.CompilerServices.TupleElementNames(new string?[]?[] {
                 "view",
                 "isViewModel"})]
-        public ReactiveUI.IReactiveBinding<TView, System.ValueTuple<object?, bool>> Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp?>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, System.IObservable<TDontCare>? signalViewUpdate, object? conversionHint, ReactiveUI.IBindingTypeConverter? vmToViewConverterOverride = null, ReactiveUI.IBindingTypeConverter? viewToVMConverterOverride = null)
+        public ReactiveUI.IReactiveBinding<TView, System.ValueTuple<object?, bool>> Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp?>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, System.IObservable<TDontCare>? signalViewUpdate, object? conversionHint, ReactiveUI.IBindingTypeConverter? vmToViewConverterOverride = null, ReactiveUI.IBindingTypeConverter? viewToVMConverterOverride = null, ReactiveUI.TriggerUpdate triggerUpdate = 0)
             where TViewModel :  class
             where TView :  class, ReactiveUI.IViewFor { }
         public System.IDisposable BindTo<TValue, TTarget, TTValue>(System.IObservable<TValue> observedChange, TTarget? target, System.Linq.Expressions.Expression<System.Func<TTarget, TTValue?>> propertyExpression, object? conversionHint = null, ReactiveUI.IBindingTypeConverter? vmToViewConverterOverride = null)
@@ -530,13 +530,13 @@ namespace ReactiveUI
         [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {
                 "view",
                 "isViewModel"})]
-        public static ReactiveUI.IReactiveBinding<TView, System.ValueTuple<object?, bool>> Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(this TView view, TViewModel? viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp?>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, System.IObservable<TDontCare>? signalViewUpdate, System.Func<TVMProp?, TVProp> vmToViewConverter, System.Func<TVProp, TVMProp?> viewToVmConverter)
+        public static ReactiveUI.IReactiveBinding<TView, System.ValueTuple<object?, bool>> Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(this TView view, TViewModel? viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp?>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, System.IObservable<TDontCare>? signalViewUpdate, System.Func<TVMProp?, TVProp> vmToViewConverter, System.Func<TVProp, TVMProp?> viewToVmConverter, ReactiveUI.TriggerUpdate triggerUpdate = 0)
             where TViewModel :  class
             where TView :  class, ReactiveUI.IViewFor { }
         [return: System.Runtime.CompilerServices.TupleElementNames(new string?[]?[] {
                 "view",
                 "isViewModel"})]
-        public static ReactiveUI.IReactiveBinding<TView, System.ValueTuple<object?, bool>> Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(this TView view, TViewModel? viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp?>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, System.IObservable<TDontCare>? signalViewUpdate, object? conversionHint = null, ReactiveUI.IBindingTypeConverter? vmToViewConverterOverride = null, ReactiveUI.IBindingTypeConverter? viewToVMConverterOverride = null)
+        public static ReactiveUI.IReactiveBinding<TView, System.ValueTuple<object?, bool>> Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(this TView view, TViewModel? viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp?>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, System.IObservable<TDontCare>? signalViewUpdate, object? conversionHint = null, ReactiveUI.IBindingTypeConverter? vmToViewConverterOverride = null, ReactiveUI.IBindingTypeConverter? viewToVMConverterOverride = null, ReactiveUI.TriggerUpdate triggerUpdate = 0)
             where TViewModel :  class
             where TView :  class, ReactiveUI.IViewFor { }
         public static System.IDisposable BindTo<TValue, TTarget, TTValue>(this System.IObservable<TValue> @this, TTarget? target, System.Linq.Expressions.Expression<System.Func<TTarget, TTValue?>> property, object? conversionHint = null, ReactiveUI.IBindingTypeConverter? vmToViewConverterOverride = null)
@@ -761,6 +761,11 @@ namespace ReactiveUI
         public static System.IObservable<T> ObserveAppState<T>(this ReactiveUI.ISuspensionHost item)
             where T :  class { }
         public static System.IDisposable SetupDefaultSuspendResume(this ReactiveUI.ISuspensionHost item, ReactiveUI.ISuspensionDriver? driver = null) { }
+    }
+    public enum TriggerUpdate
+    {
+        ViewToViewModel = 0,
+        ViewModelToView = 1,
     }
     [System.Serializable]
     public class UnhandledErrorException : System.Exception

--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.netcoreapp3.1.approved.txt
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.netcoreapp3.1.approved.txt
@@ -232,13 +232,13 @@ namespace ReactiveUI
         [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {
                 "view",
                 "isViewModel"})]
-        ReactiveUI.IReactiveBinding<TView, System.ValueTuple<object?, bool>> Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp?>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, System.IObservable<TDontCare>? signalViewUpdate, System.Func<TVMProp?, TVProp> vmToViewConverter, System.Func<TVProp, TVMProp?> viewToVmConverter)
+        ReactiveUI.IReactiveBinding<TView, System.ValueTuple<object?, bool>> Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp?>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, System.IObservable<TDontCare>? signalViewUpdate, System.Func<TVMProp?, TVProp> vmToViewConverter, System.Func<TVProp, TVMProp?> viewToVmConverter, ReactiveUI.TriggerUpdate triggerUpdate = 0)
             where TViewModel :  class
             where TView :  class, ReactiveUI.IViewFor;
         [return: System.Runtime.CompilerServices.TupleElementNames(new string?[]?[] {
                 "view",
                 "isViewModel"})]
-        ReactiveUI.IReactiveBinding<TView, System.ValueTuple<object?, bool>> Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp?>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, System.IObservable<TDontCare>? signalViewUpdate, object? conversionHint, ReactiveUI.IBindingTypeConverter? vmToViewConverterOverride = null, ReactiveUI.IBindingTypeConverter? viewToVMConverterOverride = null)
+        ReactiveUI.IReactiveBinding<TView, System.ValueTuple<object?, bool>> Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp?>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, System.IObservable<TDontCare>? signalViewUpdate, object? conversionHint, ReactiveUI.IBindingTypeConverter? vmToViewConverterOverride = null, ReactiveUI.IBindingTypeConverter? viewToVMConverterOverride = null, ReactiveUI.TriggerUpdate triggerUpdate = 0)
             where TViewModel :  class
             where TView :  class, ReactiveUI.IViewFor;
         System.IDisposable BindTo<TValue, TTarget, TTValue>(System.IObservable<TValue> observedChange, TTarget? target, System.Linq.Expressions.Expression<System.Func<TTarget, TTValue?>> propertyExpression, object? conversionHint, ReactiveUI.IBindingTypeConverter? vmToViewConverterOverride = null)
@@ -493,13 +493,13 @@ namespace ReactiveUI
         [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {
                 "view",
                 "isViewModel"})]
-        public ReactiveUI.IReactiveBinding<TView, System.ValueTuple<object?, bool>> Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp?>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, System.IObservable<TDontCare>? signalViewUpdate, System.Func<TVMProp?, TVProp> vmToViewConverter, System.Func<TVProp, TVMProp?> viewToVmConverter)
+        public ReactiveUI.IReactiveBinding<TView, System.ValueTuple<object?, bool>> Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp?>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, System.IObservable<TDontCare>? signalViewUpdate, System.Func<TVMProp?, TVProp> vmToViewConverter, System.Func<TVProp, TVMProp?> viewToVmConverter, ReactiveUI.TriggerUpdate triggerUpdate = 0)
             where TViewModel :  class
             where TView :  class, ReactiveUI.IViewFor { }
         [return: System.Runtime.CompilerServices.TupleElementNames(new string?[]?[] {
                 "view",
                 "isViewModel"})]
-        public ReactiveUI.IReactiveBinding<TView, System.ValueTuple<object?, bool>> Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp?>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, System.IObservable<TDontCare>? signalViewUpdate, object? conversionHint, ReactiveUI.IBindingTypeConverter? vmToViewConverterOverride = null, ReactiveUI.IBindingTypeConverter? viewToVMConverterOverride = null)
+        public ReactiveUI.IReactiveBinding<TView, System.ValueTuple<object?, bool>> Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp?>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, System.IObservable<TDontCare>? signalViewUpdate, object? conversionHint, ReactiveUI.IBindingTypeConverter? vmToViewConverterOverride = null, ReactiveUI.IBindingTypeConverter? viewToVMConverterOverride = null, ReactiveUI.TriggerUpdate triggerUpdate = 0)
             where TViewModel :  class
             where TView :  class, ReactiveUI.IViewFor { }
         public System.IDisposable BindTo<TValue, TTarget, TTValue>(System.IObservable<TValue> observedChange, TTarget? target, System.Linq.Expressions.Expression<System.Func<TTarget, TTValue?>> propertyExpression, object? conversionHint = null, ReactiveUI.IBindingTypeConverter? vmToViewConverterOverride = null)
@@ -528,13 +528,13 @@ namespace ReactiveUI
         [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {
                 "view",
                 "isViewModel"})]
-        public static ReactiveUI.IReactiveBinding<TView, System.ValueTuple<object?, bool>> Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(this TView view, TViewModel? viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp?>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, System.IObservable<TDontCare>? signalViewUpdate, System.Func<TVMProp?, TVProp> vmToViewConverter, System.Func<TVProp, TVMProp?> viewToVmConverter)
+        public static ReactiveUI.IReactiveBinding<TView, System.ValueTuple<object?, bool>> Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(this TView view, TViewModel? viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp?>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, System.IObservable<TDontCare>? signalViewUpdate, System.Func<TVMProp?, TVProp> vmToViewConverter, System.Func<TVProp, TVMProp?> viewToVmConverter, ReactiveUI.TriggerUpdate triggerUpdate = 0)
             where TViewModel :  class
             where TView :  class, ReactiveUI.IViewFor { }
         [return: System.Runtime.CompilerServices.TupleElementNames(new string?[]?[] {
                 "view",
                 "isViewModel"})]
-        public static ReactiveUI.IReactiveBinding<TView, System.ValueTuple<object?, bool>> Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(this TView view, TViewModel? viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp?>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, System.IObservable<TDontCare>? signalViewUpdate, object? conversionHint = null, ReactiveUI.IBindingTypeConverter? vmToViewConverterOverride = null, ReactiveUI.IBindingTypeConverter? viewToVMConverterOverride = null)
+        public static ReactiveUI.IReactiveBinding<TView, System.ValueTuple<object?, bool>> Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(this TView view, TViewModel? viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TVMProp?>> vmProperty, System.Linq.Expressions.Expression<System.Func<TView, TVProp>> viewProperty, System.IObservable<TDontCare>? signalViewUpdate, object? conversionHint = null, ReactiveUI.IBindingTypeConverter? vmToViewConverterOverride = null, ReactiveUI.IBindingTypeConverter? viewToVMConverterOverride = null, ReactiveUI.TriggerUpdate triggerUpdate = 0)
             where TViewModel :  class
             where TView :  class, ReactiveUI.IViewFor { }
         public static System.IDisposable BindTo<TValue, TTarget, TTValue>(this System.IObservable<TValue> @this, TTarget? target, System.Linq.Expressions.Expression<System.Func<TTarget, TTValue?>> property, object? conversionHint = null, ReactiveUI.IBindingTypeConverter? vmToViewConverterOverride = null)
@@ -759,6 +759,11 @@ namespace ReactiveUI
         public static System.IObservable<T> ObserveAppState<T>(this ReactiveUI.ISuspensionHost item)
             where T :  class { }
         public static System.IDisposable SetupDefaultSuspendResume(this ReactiveUI.ISuspensionHost item, ReactiveUI.ISuspensionDriver? driver = null) { }
+    }
+    public enum TriggerUpdate
+    {
+        ViewToViewModel = 0,
+        ViewModelToView = 1,
     }
     [System.Serializable]
     public class UnhandledErrorException : System.Exception

--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.netcoreapp3.1.approved.txt
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.netcoreapp3.1.approved.txt
@@ -120,6 +120,12 @@ namespace ReactiveUI
         public System.IDisposable? BindCommandToObject<TEventArgs>(System.Windows.Input.ICommand? command, object? target, System.IObservable<object?> commandParameter, string eventName) { }
         public int GetAffinityForObject(System.Type type, bool hasEventTarget) { }
     }
+    public class DecimalToStringTypeConverter : ReactiveUI.IBindingTypeConverter, Splat.IEnableLogger
+    {
+        public DecimalToStringTypeConverter() { }
+        public int GetAffinityForObjects(System.Type fromType, System.Type toType) { }
+        public bool TryConvert(object? from, System.Type toType, object? conversionHint, out object result) { }
+    }
     public sealed class DefaultViewLocator : ReactiveUI.IViewLocator, Splat.IEnableLogger
     {
         public System.Func<string, string> ViewModelToViewFunc { get; set; }
@@ -129,6 +135,12 @@ namespace ReactiveUI
     {
         public static void InitializeReactiveUI(this Splat.IMutableDependencyResolver resolver, params ReactiveUI.RegistrationNamespace[] registrationNamespaces) { }
         public static void RegisterViewsForViewModels(this Splat.IMutableDependencyResolver resolver, System.Reflection.Assembly assembly) { }
+    }
+    public class DoubleToStringTypeConverter : ReactiveUI.IBindingTypeConverter, Splat.IEnableLogger
+    {
+        public DoubleToStringTypeConverter() { }
+        public int GetAffinityForObjects(System.Type fromType, System.Type toType) { }
+        public bool TryConvert(object? from, System.Type toType, object? conversionHint, out object result) { }
     }
     public class DummySuspensionDriver : ReactiveUI.ISuspensionDriver
     {

--- a/src/ReactiveUI/Bindings/Converter/DecimalToStringTypeConverter.cs
+++ b/src/ReactiveUI/Bindings/Converter/DecimalToStringTypeConverter.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+
+namespace ReactiveUI
+{
+    /// <summary>
+    /// Decimal To String Type Converter.
+    /// </summary>
+    /// <seealso cref="ReactiveUI.IBindingTypeConverter" />
+    public class DecimalToStringTypeConverter : IBindingTypeConverter
+    {
+        /// <inheritdoc/>
+        public int GetAffinityForObjects(Type fromType, Type toType)
+        {
+            if (fromType == typeof(decimal) && toType == typeof(string))
+            {
+                return 10;
+            }
+
+            if (fromType == typeof(string) && toType == typeof(decimal))
+            {
+                return 10;
+            }
+
+            return 0;
+        }
+
+        /// <inheritdoc/>
+        public bool TryConvert(object? from, Type toType, object? conversionHint, out object result)
+        {
+            if (toType == typeof(string) && from is decimal fromDecimal)
+            {
+                if (conversionHint is int decimalHint)
+                {
+                    result = fromDecimal.ToString($"F{decimalHint}");
+                    return true;
+                }
+
+                result = fromDecimal.ToString();
+                return true;
+            }
+
+            if (from is string fromString)
+            {
+                var outDecimal = decimal.Zero;
+                decimal.TryParse(fromString, out outDecimal);
+
+                if (conversionHint is int decimalHint)
+                {
+                    result = Math.Round(outDecimal, decimalHint);
+                    return true;
+                }
+
+                result = outDecimal;
+
+                return true;
+            }
+
+            result = null!;
+            return false;
+        }
+    }
+}

--- a/src/ReactiveUI/Bindings/Converter/DoubleToStringTypeConverter.cs
+++ b/src/ReactiveUI/Bindings/Converter/DoubleToStringTypeConverter.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+
+namespace ReactiveUI
+{
+    /// <summary>
+    /// Double To String Type Converter.
+    /// </summary>
+    /// <seealso cref="ReactiveUI.IBindingTypeConverter" />
+    public class DoubleToStringTypeConverter : IBindingTypeConverter
+    {
+        /// <inheritdoc/>
+        public int GetAffinityForObjects(Type fromType, Type toType)
+        {
+            if (fromType == typeof(double) && toType == typeof(string))
+            {
+                return 10;
+            }
+
+            if (fromType == typeof(string) && toType == typeof(double))
+            {
+                return 10;
+            }
+
+            return 0;
+        }
+
+        /// <inheritdoc/>
+        public bool TryConvert(object? from, Type toType, object? conversionHint, out object result)
+        {
+            if (toType == typeof(string) && from is double fromDouble)
+            {
+                if (conversionHint is int doubleHint)
+                {
+                    result = fromDouble.ToString($"F{doubleHint}");
+                    return true;
+                }
+
+                result = fromDouble.ToString();
+                return true;
+            }
+
+            if (from is string fromString)
+            {
+                var outDouble = double.NaN;
+                double.TryParse(fromString, out outDouble);
+
+                if (conversionHint is int doubleHint)
+                {
+                    result = Math.Round(outDouble, doubleHint);
+                    return true;
+                }
+
+                result = outDouble;
+
+                return true;
+            }
+
+            result = null!;
+            return false;
+        }
+    }
+}

--- a/src/ReactiveUI/Bindings/Property/IPropertyBinderImplementation.cs
+++ b/src/ReactiveUI/Bindings/Property/IPropertyBinderImplementation.cs
@@ -19,50 +19,37 @@ namespace ReactiveUI
         /// <summary>
         /// Creates a two-way binding between a view model and a view.
         /// This binding will attempt to convert the values of the
-        /// view and view model properties using a <see cref="IBindingTypeConverter"/>
+        /// view and view model properties using a <see cref="IBindingTypeConverter" />
         /// if they are not of the same type.
         /// </summary>
         /// <typeparam name="TViewModel">The type of the view model that is bound.</typeparam>
         /// <typeparam name="TView">The type of the view being bound.</typeparam>
         /// <typeparam name="TVMProp">The type of the property bound on the view model.</typeparam>
         /// <typeparam name="TVProp">The type of the property bound on the view.</typeparam>
-        /// <typeparam name="TDontCare">
-        /// A dummy type, only the fact that <paramref name="signalViewUpdate"/>
-        /// emits values is considered, not the actual values emitted.
-        /// </typeparam>
+        /// <typeparam name="TDontCare">A dummy type, only the fact that <paramref name="signalViewUpdate" />
+        /// emits values is considered, not the actual values emitted.</typeparam>
         /// <param name="viewModel">The instance of the view model object to be bound.</param>
         /// <param name="view">The instance of the view object to be bound.</param>
-        /// <param name="vmProperty">
-        /// An expression representing the property to be bound to on the view model.
+        /// <param name="vmProperty">An expression representing the property to be bound to on the view model.
         /// This can be a child property, for example <c>x =&gt; x.Foo.Bar.Baz</c> in which case
         /// the binding will attempt to subscribe recursively to updates in order to
-        /// always get and set the correct property.
-        /// </param>
-        /// <param name="viewProperty">
-        /// An expression representing the property to be bound to on the view.
+        /// always get and set the correct property.</param>
+        /// <param name="viewProperty">An expression representing the property to be bound to on the view.
         /// This can be a child property, for example <c>x =&gt; x.Foo.Bar.Baz</c> in which case
         /// the binding will attempt to subscribe recursively to updates in order to
-        /// always get and set the correct property.
-        /// </param>
-        /// <param name="signalViewUpdate">
-        /// An observable, that when signaled, indicates that the view property
+        /// always get and set the correct property.</param>
+        /// <param name="signalViewUpdate">An observable, that when signaled, indicates that the view property
         /// has been changed, and that the binding should update the view model
-        /// property accordingly.
-        /// </param>
-        /// <param name="conversionHint">
-        /// An object that can provide a hint for the converter.
-        /// The semantics of this object is defined by the converter used.
-        /// </param>
-        /// <param name="vmToViewConverterOverride">
-        /// An optional <see cref="IBindingTypeConverter"/> to use when converting from the
-        /// viewModel to view property.
-        /// </param>
-        /// <param name="viewToVMConverterOverride">
-        /// An optional <see cref="IBindingTypeConverter"/> to use when converting from the
-        /// view to viewModel property.
-        /// </param>
+        /// property accordingly.</param>
+        /// <param name="conversionHint">An object that can provide a hint for the converter.
+        /// The semantics of this object is defined by the converter used.</param>
+        /// <param name="vmToViewConverterOverride">An optional <see cref="IBindingTypeConverter" /> to use when converting from the
+        /// viewModel to view property.</param>
+        /// <param name="viewToVMConverterOverride">An optional <see cref="IBindingTypeConverter" /> to use when converting from the
+        /// view to viewModel property.</param>
+        /// <param name="triggerUpdate">The trigger update direction.</param>
         /// <returns>
-        /// An instance of <see cref="IDisposable"/> that, when disposed,
+        /// An instance of <see cref="IDisposable" /> that, when disposed,
         /// disconnects the binding.
         /// </returns>
         IReactiveBinding<TView, (object? view, bool isViewModel)> Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(
@@ -73,53 +60,43 @@ namespace ReactiveUI
                 IObservable<TDontCare>? signalViewUpdate,
                 object? conversionHint,
                 IBindingTypeConverter? vmToViewConverterOverride = null,
-                IBindingTypeConverter? viewToVMConverterOverride = null)
+                IBindingTypeConverter? viewToVMConverterOverride = null,
+                TriggerUpdate triggerUpdate = TriggerUpdate.ViewToViewModel)
             where TViewModel : class
             where TView : class, IViewFor;
 
         /// <summary>
         /// Creates a two-way binding between a view model and a view.
         /// This binding will attempt to convert the values of the
-        /// view and view model properties using a <see cref="IBindingTypeConverter"/>
+        /// view and view model properties using a <see cref="IBindingTypeConverter" />
         /// if they are not of the same type.
         /// </summary>
         /// <typeparam name="TViewModel">The type of the view model that is bound.</typeparam>
         /// <typeparam name="TView">The type of the view being bound.</typeparam>
         /// <typeparam name="TVMProp">The type of the property bound on the view model.</typeparam>
         /// <typeparam name="TVProp">The type of the property bound on the view.</typeparam>
-        /// <typeparam name="TDontCare">
-        /// A dummy type, only the fact that <paramref name="signalViewUpdate"/>
-        /// emits values is considered, not the actual values emitted.
-        /// </typeparam>
+        /// <typeparam name="TDontCare">A dummy type, only the fact that <paramref name="signalViewUpdate" />
+        /// emits values is considered, not the actual values emitted.</typeparam>
         /// <param name="viewModel">The instance of the view model object to be bound.</param>
         /// <param name="view">The instance of the view object to be bound.</param>
-        /// <param name="vmProperty">
-        /// An expression representing the property to be bound to on the view model.
+        /// <param name="vmProperty">An expression representing the property to be bound to on the view model.
         /// This can be a child property, for example <c>x =&gt; x.Foo.Bar.Baz</c> in which case
         /// the binding will attempt to subscribe recursively to updates in order to
-        /// always get and set the correct property.
-        /// </param>
-        /// <param name="viewProperty">
-        /// An expression representing the property to be bound to on the view.
+        /// always get and set the correct property.</param>
+        /// <param name="viewProperty">An expression representing the property to be bound to on the view.
         /// This can be a child property, for example <c>x =&gt; x.Foo.Bar.Baz</c> in which case
         /// the binding will attempt to subscribe recursively to updates in order to
-        /// always get and set the correct property.
-        /// </param>
-        /// <param name="signalViewUpdate">
-        /// An observable, that when signaled, indicates that the view property
+        /// always get and set the correct property.</param>
+        /// <param name="signalViewUpdate">An observable, that when signaled, indicates that the view property
         /// has been changed, and that the binding should update the view model
-        /// property accordingly.
-        /// </param>
-        /// <param name="vmToViewConverter">
-        /// Delegate to convert the value of the view model's property's type to a value of the
-        /// view's property's type.
-        /// </param>
-        /// <param name="viewToVmConverter">
-        /// Delegate to convert the value of the view's property's type to a value of the
-        /// view model's property's type.
-        /// </param>
+        /// property accordingly.</param>
+        /// <param name="vmToViewConverter">Delegate to convert the value of the view model's property's type to a value of the
+        /// view's property's type.</param>
+        /// <param name="viewToVmConverter">Delegate to convert the value of the view's property's type to a value of the
+        /// view model's property's type.</param>
+        /// <param name="triggerUpdate">The trigger update direction.</param>
         /// <returns>
-        /// An instance of <see cref="IDisposable"/> that, when disposed,
+        /// An instance of <see cref="IDisposable" /> that, when disposed,
         /// disconnects the binding.
         /// </returns>
         IReactiveBinding<TView, (object? view, bool isViewModel)> Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(
@@ -129,7 +106,8 @@ namespace ReactiveUI
                 Expression<Func<TView, TVProp>> viewProperty,
                 IObservable<TDontCare>? signalViewUpdate,
                 Func<TVMProp?, TVProp> vmToViewConverter,
-                Func<TVProp, TVMProp?> viewToVmConverter)
+                Func<TVProp, TVMProp?> viewToVmConverter,
+                TriggerUpdate triggerUpdate = TriggerUpdate.ViewToViewModel)
             where TViewModel : class
             where TView : class, IViewFor;
 

--- a/src/ReactiveUI/Bindings/Property/PropertyBindingMixins.cs
+++ b/src/ReactiveUI/Bindings/Property/PropertyBindingMixins.cs
@@ -85,41 +85,28 @@ namespace ReactiveUI
         /// <typeparam name="TView">The type of the view being bound.</typeparam>
         /// <typeparam name="TVMProp">The type of the property bound on the view model.</typeparam>
         /// <typeparam name="TVProp">The type of the property bound on the view.</typeparam>
+        /// <typeparam name="TDontCare">A dummy type, only the fact that <paramref name="signalViewUpdate" />
+        /// emits values is considered, not the actual values emitted.</typeparam>
         /// <param name="view">The instance of the view to bind.</param>
-        /// <typeparam name="TDontCare">
-        /// A dummy type, only the fact that <paramref name="signalViewUpdate"/>
-        /// emits values is considered, not the actual values emitted.
-        /// </typeparam>
         /// <param name="viewModel">The instance of the view model to bind.</param>
-        /// <param name="vmProperty">
-        /// An expression indicating the property that is bound on the view model.
+        /// <param name="vmProperty">An expression indicating the property that is bound on the view model.
         /// This can be a chain of properties of the form. <c>vm =&gt; vm.Foo.Bar.Baz</c>
-        /// and the binder will attempt to subscribe to changes on each recursively.
-        /// </param>
-        /// <param name="viewProperty">
-        /// The property on the view that is to be bound.
-        /// This can be a chain of properties of the form. <c>view => view.Foo.Bar.Baz</c>
-        /// and the binder will attempt to set the last one each time the view model property is updated.
-        /// </param>
-        /// <param name="signalViewUpdate">
-        /// An observable, that when signaled, indicates that the view property
+        /// and the binder will attempt to subscribe to changes on each recursively.</param>
+        /// <param name="viewProperty">The property on the view that is to be bound.
+        /// This can be a chain of properties of the form. <c>view =&gt; view.Foo.Bar.Baz</c>
+        /// and the binder will attempt to set the last one each time the view model property is updated.</param>
+        /// <param name="signalViewUpdate">An observable, that when signaled, indicates that the view property
         /// has been changed, and that the binding should update the view model
-        /// property accordingly.
-        /// </param>
-        /// <param name="conversionHint">
-        /// An object that can provide a hint for the converter.
-        /// The semantics of this object is defined by the converter used.
-        /// </param>
-        /// <param name="vmToViewConverterOverride">
-        /// An optional <see cref="IBindingTypeConverter"/> to use when converting from the
-        /// viewModel to view property.
-        /// </param>
-        /// <param name="viewToVMConverterOverride">
-        /// An optional <see cref="IBindingTypeConverter"/> to use when converting from the
-        /// view to viewModel property.
-        /// </param>
+        /// property accordingly.</param>
+        /// <param name="conversionHint">An object that can provide a hint for the converter.
+        /// The semantics of this object is defined by the converter used.</param>
+        /// <param name="vmToViewConverterOverride">An optional <see cref="IBindingTypeConverter" /> to use when converting from the
+        /// viewModel to view property.</param>
+        /// <param name="viewToVMConverterOverride">An optional <see cref="IBindingTypeConverter" /> to use when converting from the
+        /// view to viewModel property.</param>
+        /// <param name="triggerUpdate">The trigger update direction.</param>
         /// <returns>
-        /// An instance of <see cref="IDisposable"/> that, when disposed,
+        /// An instance of <see cref="IDisposable" /> that, when disposed,
         /// disconnects the binding.
         /// </returns>
         public static IReactiveBinding<TView, (object? view, bool isViewModel)> Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(
@@ -130,10 +117,11 @@ namespace ReactiveUI
                 IObservable<TDontCare>? signalViewUpdate,
                 object? conversionHint = null,
                 IBindingTypeConverter? vmToViewConverterOverride = null,
-                IBindingTypeConverter? viewToVMConverterOverride = null) // TODO: Create Test
+                IBindingTypeConverter? viewToVMConverterOverride = null,
+                TriggerUpdate triggerUpdate = TriggerUpdate.ViewToViewModel) // TODO: Create Test
             where TViewModel : class
             where TView : class, IViewFor =>
-            _binderImplementation.Bind(viewModel, view, vmProperty, viewProperty, signalViewUpdate, conversionHint, vmToViewConverterOverride, viewToVMConverterOverride);
+            _binderImplementation.Bind(viewModel, view, vmProperty, viewProperty, signalViewUpdate, conversionHint, vmToViewConverterOverride, viewToVMConverterOverride, triggerUpdate);
 
         /// <summary>
         /// Binds the specified view model property to the given view property.
@@ -183,37 +171,26 @@ namespace ReactiveUI
         /// <typeparam name="TView">The type of the view being bound.</typeparam>
         /// <typeparam name="TVMProp">The type of the property bound on the view model.</typeparam>
         /// <typeparam name="TVProp">The type of the property bound on the view.</typeparam>
-        /// /// <typeparam name="TDontCare">
-        /// A dummy type, only the fact that <paramref name="signalViewUpdate"/>
-        /// emits values is considered, not the actual values emitted.
-        /// </typeparam>
+        /// <typeparam name="TDontCare">A dummy type, only the fact that <paramref name="signalViewUpdate" />
+        /// emits values is considered, not the actual values emitted.</typeparam>
         /// <param name="view">The instance of the view to bind.</param>
         /// <param name="viewModel">The instance of the view model to bind.</param>
-        /// <param name="vmProperty">
-        /// An expression indicating the property that is bound on the view model.
+        /// <param name="vmProperty">An expression indicating the property that is bound on the view model.
         /// This can be a chain of properties of the form. <c>vm =&gt; vm.Foo.Bar.Baz</c>
-        /// and the binder will attempt to subscribe to changes on each recursively.
-        /// </param>
-        /// <param name="viewProperty">
-        /// The property on the view that is to be bound.
-        /// This can be a chain of properties of the form. <c>view => view.Foo.Bar.Baz</c>
-        /// and the binder will attempt to set the last one each time the view model property is updated.
-        /// </param>
-        /// <param name="signalViewUpdate">
-        /// An observable, that when signaled, indicates that the view property
+        /// and the binder will attempt to subscribe to changes on each recursively.</param>
+        /// <param name="viewProperty">The property on the view that is to be bound.
+        /// This can be a chain of properties of the form. <c>view =&gt; view.Foo.Bar.Baz</c>
+        /// and the binder will attempt to set the last one each time the view model property is updated.</param>
+        /// <param name="signalViewUpdate">An observable, that when signaled, indicates that the view property
         /// has been changed, and that the binding should update the view model
-        /// property accordingly.
-        /// </param>
-        /// <param name="vmToViewConverter">
-        /// Delegate to convert the value of the view model's property's type to a value of the
-        /// view's property's type.
-        /// </param>
-        /// <param name="viewToVmConverter">
-        /// Delegate to convert the value of the view's property's type to a value of the
-        /// view model's property's type.
-        /// </param>
+        /// property accordingly.</param>
+        /// <param name="vmToViewConverter">Delegate to convert the value of the view model's property's type to a value of the
+        /// view's property's type.</param>
+        /// <param name="viewToVmConverter">Delegate to convert the value of the view's property's type to a value of the
+        /// view model's property's type.</param>
+        /// <param name="triggerUpdate">The trigger update direction.</param>
         /// <returns>
-        /// An instance of <see cref="IDisposable"/> that, when disposed,
+        /// An instance of <see cref="IDisposable" /> that, when disposed,
         /// disconnects the binding.
         /// </returns>
         public static IReactiveBinding<TView, (object? view, bool isViewModel)> Bind<TViewModel, TView, TVMProp, TVProp, TDontCare>(
@@ -223,10 +200,11 @@ namespace ReactiveUI
             Expression<Func<TView, TVProp>> viewProperty,
             IObservable<TDontCare>? signalViewUpdate,
             Func<TVMProp?, TVProp> vmToViewConverter,
-            Func<TVProp, TVMProp?> viewToVmConverter)
+            Func<TVProp, TVMProp?> viewToVmConverter,
+            TriggerUpdate triggerUpdate = TriggerUpdate.ViewToViewModel)
             where TViewModel : class
             where TView : class, IViewFor =>
-            _binderImplementation.Bind(viewModel, view, vmProperty, viewProperty, signalViewUpdate, vmToViewConverter, viewToVmConverter);
+            _binderImplementation.Bind(viewModel, view, vmProperty, viewProperty, signalViewUpdate, vmToViewConverter, viewToVmConverter, triggerUpdate);
 
         /// <summary>
         /// Binds the given property on the view model to a given property on the view in a one-way (view model to view) fashion.

--- a/src/ReactiveUI/Bindings/Property/PropertyBindingMixins.cs
+++ b/src/ReactiveUI/Bindings/Property/PropertyBindingMixins.cs
@@ -118,7 +118,7 @@ namespace ReactiveUI
                 object? conversionHint = null,
                 IBindingTypeConverter? vmToViewConverterOverride = null,
                 IBindingTypeConverter? viewToVMConverterOverride = null,
-                TriggerUpdate triggerUpdate = TriggerUpdate.ViewToViewModel) // TODO: Create Test
+                TriggerUpdate triggerUpdate = TriggerUpdate.ViewToViewModel)
             where TViewModel : class
             where TView : class, IViewFor =>
             _binderImplementation.Bind(viewModel, view, vmProperty, viewProperty, signalViewUpdate, conversionHint, vmToViewConverterOverride, viewToVMConverterOverride, triggerUpdate);

--- a/src/ReactiveUI/Bindings/Property/TriggerUpdate.cs
+++ b/src/ReactiveUI/Bindings/Property/TriggerUpdate.cs
@@ -3,20 +3,21 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-namespace IntegrationTests.WPF
+namespace ReactiveUI
 {
     /// <summary>
-    /// Interaction logic for MainWindow.xaml.
+    /// Trigger Update.
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-    public partial class MainWindow
+    public enum TriggerUpdate
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="MainWindow"/> class.
+        /// The view to view model.
         /// </summary>
-        public MainWindow()
-        {
-            InitializeComponent();
-        }
+        ViewToViewModel,
+
+        /// <summary>
+        /// The view model to view.
+        /// </summary>
+        ViewModelToView
     }
 }

--- a/src/ReactiveUI/Platforms/uap/PlatformRegistrations.cs
+++ b/src/ReactiveUI/Platforms/uap/PlatformRegistrations.cs
@@ -27,6 +27,8 @@ namespace ReactiveUI
             registerFunction(() => new ActivationForViewFetcher(), typeof(IActivationForViewFetcher));
             registerFunction(() => new DependencyObjectObservableForProperty(), typeof(ICreatesObservableForProperty));
             registerFunction(() => new BooleanToVisibilityTypeConverter(), typeof(IBindingTypeConverter));
+            registerFunction(() => new DoubleToStringTypeConverter(), typeof(IBindingTypeConverter));
+            registerFunction(() => new DecimalToStringTypeConverter(), typeof(IBindingTypeConverter));
             registerFunction(() => new AutoDataTemplateBindingHook(), typeof(IPropertyBindingHook));
 
             if (!ModeDetector.InUnitTestRunner())


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

fix #2861 reinstate ViewToViewModel trigger
feature can now choose the direction the trigger will affect

**What is the current behaviour?**
<!-- You can also link to an open issue here. -->

after #2772 the trigger was fixed to match a test incorrectly, v14.1 and v14.2 have the ViewModelToView implementation which is the reverse of the correct functionality according to the documentation.

**What is the new behaviour?**
<!-- If this is a feature change -->

Added the ability to choose the direction with the default being ViewToViewModel as per the documentation

**What might this PR break?**

those who have used the ViewModelToView implementation in V14.1 and V14.2 will need to specify the direction in the binding as TriggerUpdate.ViewModelToView.

**Please check if the PR fulfils these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

