### PR TITLE
Add Integer to string BindingTypeConverters

### DIFF
--- a/src/ReactiveUI.Blazor/Registrations.cs
+++ b/src/ReactiveUI.Blazor/Registrations.cs
@@ -24,6 +24,10 @@ namespace ReactiveUI.Blazor
             }
 
             registerFunction(() => new StringConverter(), typeof(IBindingTypeConverter));
+            registerFunction(() => new ByteToStringTypeConverter(), typeof(IBindingTypeConverter));
+            registerFunction(() => new ShortToStringTypeConverter(), typeof(IBindingTypeConverter));
+            registerFunction(() => new IntegerToStringTypeConverter(), typeof(IBindingTypeConverter));
+            registerFunction(() => new LongToStringTypeConverter(), typeof(IBindingTypeConverter));
             registerFunction(() => new SingleToStringTypeConverter(), typeof(IBindingTypeConverter));
             registerFunction(() => new DoubleToStringTypeConverter(), typeof(IBindingTypeConverter));
             registerFunction(() => new DecimalToStringTypeConverter(), typeof(IBindingTypeConverter));

--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.net472.approved.txt
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.net472.approved.txt
@@ -43,6 +43,12 @@ namespace ReactiveUI
         TwoWay = 1,
         AsyncOneWay = 2,
     }
+    public class ByteToStringTypeConverter : ReactiveUI.IBindingTypeConverter, Splat.IEnableLogger
+    {
+        public ByteToStringTypeConverter() { }
+        public int GetAffinityForObjects(System.Type fromType, System.Type toType) { }
+        public bool TryConvert(object? from, System.Type toType, object? conversionHint, out object result) { }
+    }
     public class CanActivateViewFetcher : ReactiveUI.IActivationForViewFetcher
     {
         public CanActivateViewFetcher() { }
@@ -365,6 +371,12 @@ namespace ReactiveUI
     {
         ReactiveUI.IViewFor? ResolveView<T>(T? viewModel, string? contract = null);
     }
+    public class IntegerToStringTypeConverter : ReactiveUI.IBindingTypeConverter, Splat.IEnableLogger
+    {
+        public IntegerToStringTypeConverter() { }
+        public int GetAffinityForObjects(System.Type fromType, System.Type toType) { }
+        public bool TryConvert(object? from, System.Type toType, object? conversionHint, out object result) { }
+    }
     public class InteractionBinderImplementation : ReactiveUI.IInteractionBinderImplementation, Splat.IEnableLogger
     {
         public InteractionBinderImplementation() { }
@@ -399,6 +411,12 @@ namespace ReactiveUI
         public System.IDisposable RegisterHandler(System.Action<ReactiveUI.InteractionContext<TInput, TOutput>> handler) { }
         public System.IDisposable RegisterHandler(System.Func<ReactiveUI.InteractionContext<TInput, TOutput>, System.Threading.Tasks.Task> handler) { }
         public System.IDisposable RegisterHandler<TDontCare>(System.Func<ReactiveUI.InteractionContext<TInput, TOutput>, System.IObservable<TDontCare>> handler) { }
+    }
+    public class LongToStringTypeConverter : ReactiveUI.IBindingTypeConverter, Splat.IEnableLogger
+    {
+        public LongToStringTypeConverter() { }
+        public int GetAffinityForObjects(System.Type fromType, System.Type toType) { }
+        public bool TryConvert(object? from, System.Type toType, object? conversionHint, out object result) { }
     }
     public class MessageBus : ReactiveUI.IMessageBus, Splat.IEnableLogger
     {
@@ -760,6 +778,12 @@ namespace ReactiveUI
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    public class ShortToStringTypeConverter : ReactiveUI.IBindingTypeConverter, Splat.IEnableLogger
+    {
+        public ShortToStringTypeConverter() { }
+        public int GetAffinityForObjects(System.Type fromType, System.Type toType) { }
+        public bool TryConvert(object? from, System.Type toType, object? conversionHint, out object result) { }
     }
     [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.All)]
     public class SingleInstanceViewAttribute : System.Attribute

--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.net5.0.approved.txt
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.net5.0.approved.txt
@@ -45,6 +45,12 @@ namespace ReactiveUI
         TwoWay = 1,
         AsyncOneWay = 2,
     }
+    public class ByteToStringTypeConverter : ReactiveUI.IBindingTypeConverter, Splat.IEnableLogger
+    {
+        public ByteToStringTypeConverter() { }
+        public int GetAffinityForObjects(System.Type fromType, System.Type toType) { }
+        public bool TryConvert(object? from, System.Type toType, object? conversionHint, out object result) { }
+    }
     public class CanActivateViewFetcher : ReactiveUI.IActivationForViewFetcher
     {
         public CanActivateViewFetcher() { }
@@ -360,6 +366,12 @@ namespace ReactiveUI
     {
         ReactiveUI.IViewFor? ResolveView<T>(T? viewModel, string? contract = null);
     }
+    public class IntegerToStringTypeConverter : ReactiveUI.IBindingTypeConverter, Splat.IEnableLogger
+    {
+        public IntegerToStringTypeConverter() { }
+        public int GetAffinityForObjects(System.Type fromType, System.Type toType) { }
+        public bool TryConvert(object? from, System.Type toType, object? conversionHint, out object result) { }
+    }
     public class InteractionBinderImplementation : ReactiveUI.IInteractionBinderImplementation, Splat.IEnableLogger
     {
         public InteractionBinderImplementation() { }
@@ -394,6 +406,12 @@ namespace ReactiveUI
         public System.IDisposable RegisterHandler(System.Action<ReactiveUI.InteractionContext<TInput, TOutput>> handler) { }
         public System.IDisposable RegisterHandler(System.Func<ReactiveUI.InteractionContext<TInput, TOutput>, System.Threading.Tasks.Task> handler) { }
         public System.IDisposable RegisterHandler<TDontCare>(System.Func<ReactiveUI.InteractionContext<TInput, TOutput>, System.IObservable<TDontCare>> handler) { }
+    }
+    public class LongToStringTypeConverter : ReactiveUI.IBindingTypeConverter, Splat.IEnableLogger
+    {
+        public LongToStringTypeConverter() { }
+        public int GetAffinityForObjects(System.Type fromType, System.Type toType) { }
+        public bool TryConvert(object? from, System.Type toType, object? conversionHint, out object result) { }
     }
     public class MessageBus : ReactiveUI.IMessageBus, Splat.IEnableLogger
     {
@@ -755,6 +773,12 @@ namespace ReactiveUI
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    public class ShortToStringTypeConverter : ReactiveUI.IBindingTypeConverter, Splat.IEnableLogger
+    {
+        public ShortToStringTypeConverter() { }
+        public int GetAffinityForObjects(System.Type fromType, System.Type toType) { }
+        public bool TryConvert(object? from, System.Type toType, object? conversionHint, out object result) { }
     }
     [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.All)]
     public class SingleInstanceViewAttribute : System.Attribute

--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.netcoreapp3.1.approved.txt
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.netcoreapp3.1.approved.txt
@@ -43,6 +43,12 @@ namespace ReactiveUI
         TwoWay = 1,
         AsyncOneWay = 2,
     }
+    public class ByteToStringTypeConverter : ReactiveUI.IBindingTypeConverter, Splat.IEnableLogger
+    {
+        public ByteToStringTypeConverter() { }
+        public int GetAffinityForObjects(System.Type fromType, System.Type toType) { }
+        public bool TryConvert(object? from, System.Type toType, object? conversionHint, out object result) { }
+    }
     public class CanActivateViewFetcher : ReactiveUI.IActivationForViewFetcher
     {
         public CanActivateViewFetcher() { }
@@ -358,6 +364,12 @@ namespace ReactiveUI
     {
         ReactiveUI.IViewFor? ResolveView<T>(T? viewModel, string? contract = null);
     }
+    public class IntegerToStringTypeConverter : ReactiveUI.IBindingTypeConverter, Splat.IEnableLogger
+    {
+        public IntegerToStringTypeConverter() { }
+        public int GetAffinityForObjects(System.Type fromType, System.Type toType) { }
+        public bool TryConvert(object? from, System.Type toType, object? conversionHint, out object result) { }
+    }
     public class InteractionBinderImplementation : ReactiveUI.IInteractionBinderImplementation, Splat.IEnableLogger
     {
         public InteractionBinderImplementation() { }
@@ -392,6 +404,12 @@ namespace ReactiveUI
         public System.IDisposable RegisterHandler(System.Action<ReactiveUI.InteractionContext<TInput, TOutput>> handler) { }
         public System.IDisposable RegisterHandler(System.Func<ReactiveUI.InteractionContext<TInput, TOutput>, System.Threading.Tasks.Task> handler) { }
         public System.IDisposable RegisterHandler<TDontCare>(System.Func<ReactiveUI.InteractionContext<TInput, TOutput>, System.IObservable<TDontCare>> handler) { }
+    }
+    public class LongToStringTypeConverter : ReactiveUI.IBindingTypeConverter, Splat.IEnableLogger
+    {
+        public LongToStringTypeConverter() { }
+        public int GetAffinityForObjects(System.Type fromType, System.Type toType) { }
+        public bool TryConvert(object? from, System.Type toType, object? conversionHint, out object result) { }
     }
     public class MessageBus : ReactiveUI.IMessageBus, Splat.IEnableLogger
     {
@@ -753,6 +771,12 @@ namespace ReactiveUI
         public void OnError(System.Exception error) { }
         public void OnNext(T value) { }
         public System.IDisposable Subscribe(System.IObserver<T> observer) { }
+    }
+    public class ShortToStringTypeConverter : ReactiveUI.IBindingTypeConverter, Splat.IEnableLogger
+    {
+        public ShortToStringTypeConverter() { }
+        public int GetAffinityForObjects(System.Type fromType, System.Type toType) { }
+        public bool TryConvert(object? from, System.Type toType, object? conversionHint, out object result) { }
     }
     [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.All)]
     public class SingleInstanceViewAttribute : System.Attribute

--- a/src/ReactiveUI.Tests/Mocks/PropertyBindViewModel.cs
+++ b/src/ReactiveUI.Tests/Mocks/PropertyBindViewModel.cs
@@ -21,7 +21,10 @@ namespace ReactiveUI.Tests
         private double _justADouble;
         private decimal _justADecimal;
         private double? _nullableDouble;
+        private byte _justAByte;
+        private short _justAInt16;
         private int _justAInt32;
+        private long _justAInt64;
         private bool _justABoolean;
         private Visibility _justAVisibility;
 
@@ -86,10 +89,37 @@ namespace ReactiveUI.Tests
         /// <summary>
         /// Gets or sets the just a int32.
         /// </summary>
+        public byte JustAByte
+        {
+            get => _justAByte;
+            set => this.RaiseAndSetIfChanged(ref _justAByte, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the just a int32.
+        /// </summary>
+        public short JustAInt16
+        {
+            get => _justAInt16;
+            set => this.RaiseAndSetIfChanged(ref _justAInt16, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the just a int32.
+        /// </summary>
         public int JustAInt32
         {
             get => _justAInt32;
             set => this.RaiseAndSetIfChanged(ref _justAInt32, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the just a int32.
+        /// </summary>
+        public long JustAInt64
+        {
+            get => _justAInt64;
+            set => this.RaiseAndSetIfChanged(ref _justAInt64, value);
         }
 
         /// <summary>

--- a/src/ReactiveUI.Tests/Platforms/windows-xaml/PropertyBindingTest.cs
+++ b/src/ReactiveUI.Tests/Platforms/windows-xaml/PropertyBindingTest.cs
@@ -837,6 +837,54 @@ namespace ReactiveUI.Tests.Xaml
         }
 
         [Fact]
+        public void BindWithFuncToTriggerUpdateTestViewModelToViewWithDoubleConverterNoRound()
+        {
+            CompositeDisposable dis = new();
+            PropertyBindViewModel? vm = new();
+            var view = new PropertyBindView { ViewModel = vm };
+            var update = new Subject<bool>();
+
+            vm.JustADouble = 123.45;
+            Assert.NotEqual(vm.JustADouble.ToString(CultureInfo.InvariantCulture), view.SomeTextBox.Text);
+
+            var doubleToStringTypeConverter = new DoubleToStringTypeConverter();
+
+            view.Bind(vm, x => x.JustADouble, x => x.SomeTextBox.Text, update.AsObservable(), null, doubleToStringTypeConverter, doubleToStringTypeConverter, TriggerUpdate.ViewModelToView).DisposeWith(dis);
+
+            vm.JustADouble = 1.0;
+
+            // value should have pre bind value
+            Assert.Equal(view.SomeTextBox.Text, "123.45");
+
+            // trigger UI update
+            update.OnNext(true);
+            Assert.Equal(view.SomeTextBox.Text, "1");
+
+            vm.JustADouble = 2.0;
+            Assert.Equal(view.SomeTextBox.Text, "1");
+
+            update.OnNext(true);
+            Assert.Equal(view.SomeTextBox.Text, "2");
+
+            // test reverse bind no trigger required
+            view.SomeTextBox.Text = "3";
+            Assert.Equal(vm.JustADouble, 3.0);
+
+            view.SomeTextBox.Text = "4";
+            Assert.Equal(vm.JustADouble, 4.0);
+
+            // test forward bind to ensure trigger is still honoured.
+            vm.JustADouble = 2.0;
+            Assert.Equal(view.SomeTextBox.Text, "4");
+
+            update.OnNext(true);
+            Assert.Equal(view.SomeTextBox.Text, "2");
+
+            dis.Dispose();
+            Assert.True(dis.IsDisposed);
+        }
+
+        [Fact]
         public void BindWithFuncToTriggerUpdateTestViewModelToViewWithSingleConverter()
         {
             CompositeDisposable dis = new();
@@ -879,6 +927,54 @@ namespace ReactiveUI.Tests.Xaml
 
             update.OnNext(true);
             Assert.Equal(view.SomeTextBox.Text, "2.00");
+
+            dis.Dispose();
+            Assert.True(dis.IsDisposed);
+        }
+
+        [Fact]
+        public void BindWithFuncToTriggerUpdateTestViewModelToViewWithSingleConverterNoRound()
+        {
+            CompositeDisposable dis = new();
+            PropertyBindViewModel? vm = new();
+            var view = new PropertyBindView { ViewModel = vm };
+            var update = new Subject<bool>();
+
+            vm.JustASingle = 123.45f;
+            Assert.NotEqual(vm.JustASingle.ToString(CultureInfo.InvariantCulture), view.SomeTextBox.Text);
+
+            var singleToStringTypeConverter = new SingleToStringTypeConverter();
+
+            view.Bind(vm, x => x.JustASingle, x => x.SomeTextBox.Text, update.AsObservable(), null, singleToStringTypeConverter, singleToStringTypeConverter, TriggerUpdate.ViewModelToView).DisposeWith(dis);
+
+            vm.JustASingle = 1.0f;
+
+            // value should have pre bind value
+            Assert.Equal(view.SomeTextBox.Text, "123.45");
+
+            // trigger UI update
+            update.OnNext(true);
+            Assert.Equal(view.SomeTextBox.Text, "1");
+
+            vm.JustASingle = 2.0f;
+            Assert.Equal(view.SomeTextBox.Text, "1");
+
+            update.OnNext(true);
+            Assert.Equal(view.SomeTextBox.Text, "2");
+
+            // test reverse bind no trigger required
+            view.SomeTextBox.Text = "3";
+            Assert.Equal(vm.JustASingle, 3.0f);
+
+            view.SomeTextBox.Text = "4";
+            Assert.Equal(vm.JustASingle, 4.0f);
+
+            // test forward bind to ensure trigger is still honoured.
+            vm.JustASingle = 2.0f;
+            Assert.Equal(view.SomeTextBox.Text, "4");
+
+            update.OnNext(true);
+            Assert.Equal(view.SomeTextBox.Text, "2");
 
             dis.Dispose();
             Assert.True(dis.IsDisposed);
@@ -933,6 +1029,54 @@ namespace ReactiveUI.Tests.Xaml
         }
 
         [Fact]
+        public void BindWithFuncToTriggerUpdateTestViewModelToViewWithByteConverterNoHint()
+        {
+            CompositeDisposable dis = new();
+            PropertyBindViewModel? vm = new();
+            var view = new PropertyBindView { ViewModel = vm };
+            var update = new Subject<bool>();
+
+            vm.JustAByte = 123;
+            Assert.NotEqual(vm.JustAByte.ToString(CultureInfo.InvariantCulture), view.SomeTextBox.Text);
+
+            var singleToStringTypeConverter = new ByteToStringTypeConverter();
+
+            view.Bind(vm, x => x.JustAByte, x => x.SomeTextBox.Text, update.AsObservable(), null, singleToStringTypeConverter, singleToStringTypeConverter, TriggerUpdate.ViewModelToView).DisposeWith(dis);
+
+            vm.JustAByte = 1;
+
+            // value should have pre bind value
+            Assert.Equal(view.SomeTextBox.Text, "123");
+
+            // trigger UI update
+            update.OnNext(true);
+            Assert.Equal(view.SomeTextBox.Text, "1");
+
+            vm.JustAByte = 2;
+            Assert.Equal(view.SomeTextBox.Text, "1");
+
+            update.OnNext(true);
+            Assert.Equal(view.SomeTextBox.Text, "2");
+
+            // test reverse bind no trigger required
+            view.SomeTextBox.Text = "3";
+            Assert.Equal(vm.JustAByte, 3);
+
+            view.SomeTextBox.Text = "4";
+            Assert.Equal(vm.JustAByte, 4);
+
+            // test forward bind to ensure trigger is still honoured.
+            vm.JustAByte = 2;
+            Assert.Equal(view.SomeTextBox.Text, "4");
+
+            update.OnNext(true);
+            Assert.Equal(view.SomeTextBox.Text, "2");
+
+            dis.Dispose();
+            Assert.True(dis.IsDisposed);
+        }
+
+        [Fact]
         public void BindWithFuncToTriggerUpdateTestViewModelToViewWithShortConverter()
         {
             CompositeDisposable dis = new();
@@ -975,6 +1119,54 @@ namespace ReactiveUI.Tests.Xaml
 
             update.OnNext(true);
             Assert.Equal(view.SomeTextBox.Text, "002");
+
+            dis.Dispose();
+            Assert.True(dis.IsDisposed);
+        }
+
+        [Fact]
+        public void BindWithFuncToTriggerUpdateTestViewModelToViewWithShortConverterNoHint()
+        {
+            CompositeDisposable dis = new();
+            PropertyBindViewModel? vm = new();
+            var view = new PropertyBindView { ViewModel = vm };
+            var update = new Subject<bool>();
+
+            vm.JustAInt16 = 123;
+            Assert.NotEqual(vm.JustAInt16.ToString(CultureInfo.InvariantCulture), view.SomeTextBox.Text);
+
+            var singleToStringTypeConverter = new ShortToStringTypeConverter();
+
+            view.Bind(vm, x => x.JustAInt16, x => x.SomeTextBox.Text, update.AsObservable(), null, singleToStringTypeConverter, singleToStringTypeConverter, TriggerUpdate.ViewModelToView).DisposeWith(dis);
+
+            vm.JustAInt16 = 1;
+
+            // value should have pre bind value
+            Assert.Equal(view.SomeTextBox.Text, "123");
+
+            // trigger UI update
+            update.OnNext(true);
+            Assert.Equal(view.SomeTextBox.Text, "1");
+
+            vm.JustAInt16 = 2;
+            Assert.Equal(view.SomeTextBox.Text, "1");
+
+            update.OnNext(true);
+            Assert.Equal(view.SomeTextBox.Text, "2");
+
+            // test reverse bind no trigger required
+            view.SomeTextBox.Text = "3";
+            Assert.Equal(vm.JustAInt16, 3);
+
+            view.SomeTextBox.Text = "4";
+            Assert.Equal(vm.JustAInt16, 4);
+
+            // test forward bind to ensure trigger is still honoured.
+            vm.JustAInt16 = 2;
+            Assert.Equal(view.SomeTextBox.Text, "4");
+
+            update.OnNext(true);
+            Assert.Equal(view.SomeTextBox.Text, "2");
 
             dis.Dispose();
             Assert.True(dis.IsDisposed);
@@ -1029,6 +1221,54 @@ namespace ReactiveUI.Tests.Xaml
         }
 
         [Fact]
+        public void BindWithFuncToTriggerUpdateTestViewModelToViewWithIntegerConverterNoHint()
+        {
+            CompositeDisposable dis = new();
+            PropertyBindViewModel? vm = new();
+            var view = new PropertyBindView { ViewModel = vm };
+            var update = new Subject<bool>();
+
+            vm.JustAInt32 = 123;
+            Assert.NotEqual(vm.JustAInt32.ToString(CultureInfo.InvariantCulture), view.SomeTextBox.Text);
+
+            var singleToStringTypeConverter = new IntegerToStringTypeConverter();
+
+            view.Bind(vm, x => x.JustAInt32, x => x.SomeTextBox.Text, update.AsObservable(), null, singleToStringTypeConverter, singleToStringTypeConverter, TriggerUpdate.ViewModelToView).DisposeWith(dis);
+
+            vm.JustAInt32 = 1;
+
+            // value should have pre bind value
+            Assert.Equal(view.SomeTextBox.Text, "123");
+
+            // trigger UI update
+            update.OnNext(true);
+            Assert.Equal(view.SomeTextBox.Text, "1");
+
+            vm.JustAInt32 = 2;
+            Assert.Equal(view.SomeTextBox.Text, "1");
+
+            update.OnNext(true);
+            Assert.Equal(view.SomeTextBox.Text, "2");
+
+            // test reverse bind no trigger required
+            view.SomeTextBox.Text = "3";
+            Assert.Equal(vm.JustAInt32, 3);
+
+            view.SomeTextBox.Text = "4";
+            Assert.Equal(vm.JustAInt32, 4);
+
+            // test forward bind to ensure trigger is still honoured.
+            vm.JustAInt32 = 2;
+            Assert.Equal(view.SomeTextBox.Text, "4");
+
+            update.OnNext(true);
+            Assert.Equal(view.SomeTextBox.Text, "2");
+
+            dis.Dispose();
+            Assert.True(dis.IsDisposed);
+        }
+
+        [Fact]
         public void BindWithFuncToTriggerUpdateTestViewModelToViewWithLongConverter()
         {
             CompositeDisposable dis = new();
@@ -1071,6 +1311,54 @@ namespace ReactiveUI.Tests.Xaml
 
             update.OnNext(true);
             Assert.Equal(view.SomeTextBox.Text, "002");
+
+            dis.Dispose();
+            Assert.True(dis.IsDisposed);
+        }
+
+        [Fact]
+        public void BindWithFuncToTriggerUpdateTestViewModelToViewWithLongConverterNoHint()
+        {
+            CompositeDisposable dis = new();
+            PropertyBindViewModel? vm = new();
+            var view = new PropertyBindView { ViewModel = vm };
+            var update = new Subject<bool>();
+
+            vm.JustAInt64 = 123;
+            Assert.NotEqual(vm.JustAInt64.ToString(CultureInfo.InvariantCulture), view.SomeTextBox.Text);
+
+            var singleToStringTypeConverter = new LongToStringTypeConverter();
+
+            view.Bind(vm, x => x.JustAInt64, x => x.SomeTextBox.Text, update.AsObservable(), null, singleToStringTypeConverter, singleToStringTypeConverter, TriggerUpdate.ViewModelToView).DisposeWith(dis);
+
+            vm.JustAInt64 = 1;
+
+            // value should have pre bind value
+            Assert.Equal(view.SomeTextBox.Text, "123");
+
+            // trigger UI update
+            update.OnNext(true);
+            Assert.Equal(view.SomeTextBox.Text, "1");
+
+            vm.JustAInt64 = 2;
+            Assert.Equal(view.SomeTextBox.Text, "1");
+
+            update.OnNext(true);
+            Assert.Equal(view.SomeTextBox.Text, "2");
+
+            // test reverse bind no trigger required
+            view.SomeTextBox.Text = "3";
+            Assert.Equal(vm.JustAInt64, 3);
+
+            view.SomeTextBox.Text = "4";
+            Assert.Equal(vm.JustAInt64, 4);
+
+            // test forward bind to ensure trigger is still honoured.
+            vm.JustAInt64 = 2;
+            Assert.Equal(view.SomeTextBox.Text, "4");
+
+            update.OnNext(true);
+            Assert.Equal(view.SomeTextBox.Text, "2");
 
             dis.Dispose();
             Assert.True(dis.IsDisposed);

--- a/src/ReactiveUI.Tests/Platforms/windows-xaml/PropertyBindingTest.cs
+++ b/src/ReactiveUI.Tests/Platforms/windows-xaml/PropertyBindingTest.cs
@@ -799,9 +799,9 @@ namespace ReactiveUI.Tests.Xaml
             vm.JustADouble = 123.45;
             Assert.NotEqual(vm.JustADouble.ToString(CultureInfo.InvariantCulture), view.SomeTextBox.Text);
 
-            var doubleToStringTypeConverter = new DoubleToStringTypeConverter();
+            var xToStringTypeConverter = new DoubleToStringTypeConverter();
 
-            view.Bind(vm, x => x.JustADouble, x => x.SomeTextBox.Text, update.AsObservable(), 2, doubleToStringTypeConverter, doubleToStringTypeConverter, TriggerUpdate.ViewModelToView).DisposeWith(dis);
+            view.Bind(vm, x => x.JustADouble, x => x.SomeTextBox.Text, update.AsObservable(), 2, xToStringTypeConverter, xToStringTypeConverter, TriggerUpdate.ViewModelToView).DisposeWith(dis);
 
             vm.JustADouble = 1.0;
 
@@ -847,9 +847,7 @@ namespace ReactiveUI.Tests.Xaml
             vm.JustADouble = 123.45;
             Assert.NotEqual(vm.JustADouble.ToString(CultureInfo.InvariantCulture), view.SomeTextBox.Text);
 
-            var doubleToStringTypeConverter = new DoubleToStringTypeConverter();
-
-            view.Bind(vm, x => x.JustADouble, x => x.SomeTextBox.Text, update.AsObservable(), null, doubleToStringTypeConverter, doubleToStringTypeConverter, TriggerUpdate.ViewModelToView).DisposeWith(dis);
+            view.Bind(vm, x => x.JustADouble, x => x.SomeTextBox.Text, update.AsObservable(), null, triggerUpdate: TriggerUpdate.ViewModelToView).DisposeWith(dis);
 
             vm.JustADouble = 1.0;
 
@@ -895,9 +893,9 @@ namespace ReactiveUI.Tests.Xaml
             vm.JustASingle = 123.45f;
             Assert.NotEqual(vm.JustASingle.ToString(CultureInfo.InvariantCulture), view.SomeTextBox.Text);
 
-            var singleToStringTypeConverter = new SingleToStringTypeConverter();
+            var xToStringTypeConverter = new SingleToStringTypeConverter();
 
-            view.Bind(vm, x => x.JustASingle, x => x.SomeTextBox.Text, update.AsObservable(), 2, singleToStringTypeConverter, singleToStringTypeConverter, TriggerUpdate.ViewModelToView).DisposeWith(dis);
+            view.Bind(vm, x => x.JustASingle, x => x.SomeTextBox.Text, update.AsObservable(), 2, xToStringTypeConverter, xToStringTypeConverter, TriggerUpdate.ViewModelToView).DisposeWith(dis);
 
             vm.JustASingle = 1.0f;
 
@@ -943,9 +941,7 @@ namespace ReactiveUI.Tests.Xaml
             vm.JustASingle = 123.45f;
             Assert.NotEqual(vm.JustASingle.ToString(CultureInfo.InvariantCulture), view.SomeTextBox.Text);
 
-            var singleToStringTypeConverter = new SingleToStringTypeConverter();
-
-            view.Bind(vm, x => x.JustASingle, x => x.SomeTextBox.Text, update.AsObservable(), null, singleToStringTypeConverter, singleToStringTypeConverter, TriggerUpdate.ViewModelToView).DisposeWith(dis);
+            view.Bind(vm, x => x.JustASingle, x => x.SomeTextBox.Text, update.AsObservable(), null, triggerUpdate: TriggerUpdate.ViewModelToView).DisposeWith(dis);
 
             vm.JustASingle = 1.0f;
 
@@ -991,9 +987,9 @@ namespace ReactiveUI.Tests.Xaml
             vm.JustAByte = 123;
             Assert.NotEqual(vm.JustAByte.ToString(CultureInfo.InvariantCulture), view.SomeTextBox.Text);
 
-            var singleToStringTypeConverter = new ByteToStringTypeConverter();
+            var xToStringTypeConverter = new ByteToStringTypeConverter();
 
-            view.Bind(vm, x => x.JustAByte, x => x.SomeTextBox.Text, update.AsObservable(), 3, singleToStringTypeConverter, singleToStringTypeConverter, TriggerUpdate.ViewModelToView).DisposeWith(dis);
+            view.Bind(vm, x => x.JustAByte, x => x.SomeTextBox.Text, update.AsObservable(), 3, xToStringTypeConverter, xToStringTypeConverter, TriggerUpdate.ViewModelToView).DisposeWith(dis);
 
             vm.JustAByte = 1;
 
@@ -1039,9 +1035,7 @@ namespace ReactiveUI.Tests.Xaml
             vm.JustAByte = 123;
             Assert.NotEqual(vm.JustAByte.ToString(CultureInfo.InvariantCulture), view.SomeTextBox.Text);
 
-            var singleToStringTypeConverter = new ByteToStringTypeConverter();
-
-            view.Bind(vm, x => x.JustAByte, x => x.SomeTextBox.Text, update.AsObservable(), null, singleToStringTypeConverter, singleToStringTypeConverter, TriggerUpdate.ViewModelToView).DisposeWith(dis);
+            view.Bind(vm, x => x.JustAByte, x => x.SomeTextBox.Text, update.AsObservable(), null, triggerUpdate: TriggerUpdate.ViewModelToView).DisposeWith(dis);
 
             vm.JustAByte = 1;
 
@@ -1087,9 +1081,9 @@ namespace ReactiveUI.Tests.Xaml
             vm.JustAInt16 = 123;
             Assert.NotEqual(vm.JustAInt16.ToString(CultureInfo.InvariantCulture), view.SomeTextBox.Text);
 
-            var singleToStringTypeConverter = new ShortToStringTypeConverter();
+            var xToStringTypeConverter = new ShortToStringTypeConverter();
 
-            view.Bind(vm, x => x.JustAInt16, x => x.SomeTextBox.Text, update.AsObservable(), 3, singleToStringTypeConverter, singleToStringTypeConverter, TriggerUpdate.ViewModelToView).DisposeWith(dis);
+            view.Bind(vm, x => x.JustAInt16, x => x.SomeTextBox.Text, update.AsObservable(), 3, xToStringTypeConverter, xToStringTypeConverter, TriggerUpdate.ViewModelToView).DisposeWith(dis);
 
             vm.JustAInt16 = 1;
 
@@ -1135,9 +1129,7 @@ namespace ReactiveUI.Tests.Xaml
             vm.JustAInt16 = 123;
             Assert.NotEqual(vm.JustAInt16.ToString(CultureInfo.InvariantCulture), view.SomeTextBox.Text);
 
-            var singleToStringTypeConverter = new ShortToStringTypeConverter();
-
-            view.Bind(vm, x => x.JustAInt16, x => x.SomeTextBox.Text, update.AsObservable(), null, singleToStringTypeConverter, singleToStringTypeConverter, TriggerUpdate.ViewModelToView).DisposeWith(dis);
+            view.Bind(vm, x => x.JustAInt16, x => x.SomeTextBox.Text, update.AsObservable(), null, triggerUpdate: TriggerUpdate.ViewModelToView).DisposeWith(dis);
 
             vm.JustAInt16 = 1;
 
@@ -1183,9 +1175,9 @@ namespace ReactiveUI.Tests.Xaml
             vm.JustAInt32 = 123;
             Assert.NotEqual(vm.JustAInt32.ToString(CultureInfo.InvariantCulture), view.SomeTextBox.Text);
 
-            var singleToStringTypeConverter = new IntegerToStringTypeConverter();
+            var xToStringTypeConverter = new IntegerToStringTypeConverter();
 
-            view.Bind(vm, x => x.JustAInt32, x => x.SomeTextBox.Text, update.AsObservable(), 3, singleToStringTypeConverter, singleToStringTypeConverter, TriggerUpdate.ViewModelToView).DisposeWith(dis);
+            view.Bind(vm, x => x.JustAInt32, x => x.SomeTextBox.Text, update.AsObservable(), 3, xToStringTypeConverter, xToStringTypeConverter, TriggerUpdate.ViewModelToView).DisposeWith(dis);
 
             vm.JustAInt32 = 1;
 
@@ -1231,9 +1223,7 @@ namespace ReactiveUI.Tests.Xaml
             vm.JustAInt32 = 123;
             Assert.NotEqual(vm.JustAInt32.ToString(CultureInfo.InvariantCulture), view.SomeTextBox.Text);
 
-            var singleToStringTypeConverter = new IntegerToStringTypeConverter();
-
-            view.Bind(vm, x => x.JustAInt32, x => x.SomeTextBox.Text, update.AsObservable(), null, singleToStringTypeConverter, singleToStringTypeConverter, TriggerUpdate.ViewModelToView).DisposeWith(dis);
+            view.Bind(vm, x => x.JustAInt32, x => x.SomeTextBox.Text, update.AsObservable(), null, triggerUpdate: TriggerUpdate.ViewModelToView).DisposeWith(dis);
 
             vm.JustAInt32 = 1;
 
@@ -1279,9 +1269,9 @@ namespace ReactiveUI.Tests.Xaml
             vm.JustAInt64 = 123;
             Assert.NotEqual(vm.JustAInt64.ToString(CultureInfo.InvariantCulture), view.SomeTextBox.Text);
 
-            var singleToStringTypeConverter = new LongToStringTypeConverter();
+            var xToStringTypeConverter = new LongToStringTypeConverter();
 
-            view.Bind(vm, x => x.JustAInt64, x => x.SomeTextBox.Text, update.AsObservable(), 3, singleToStringTypeConverter, singleToStringTypeConverter, TriggerUpdate.ViewModelToView).DisposeWith(dis);
+            view.Bind(vm, x => x.JustAInt64, x => x.SomeTextBox.Text, update.AsObservable(), 3, xToStringTypeConverter, xToStringTypeConverter, TriggerUpdate.ViewModelToView).DisposeWith(dis);
 
             vm.JustAInt64 = 1;
 
@@ -1327,9 +1317,7 @@ namespace ReactiveUI.Tests.Xaml
             vm.JustAInt64 = 123;
             Assert.NotEqual(vm.JustAInt64.ToString(CultureInfo.InvariantCulture), view.SomeTextBox.Text);
 
-            var singleToStringTypeConverter = new LongToStringTypeConverter();
-
-            view.Bind(vm, x => x.JustAInt64, x => x.SomeTextBox.Text, update.AsObservable(), null, singleToStringTypeConverter, singleToStringTypeConverter, TriggerUpdate.ViewModelToView).DisposeWith(dis);
+            view.Bind(vm, x => x.JustAInt64, x => x.SomeTextBox.Text, update.AsObservable(), null, triggerUpdate: TriggerUpdate.ViewModelToView).DisposeWith(dis);
 
             vm.JustAInt64 = 1;
 

--- a/src/ReactiveUI.Tests/Platforms/windows-xaml/PropertyBindingTest.cs
+++ b/src/ReactiveUI.Tests/Platforms/windows-xaml/PropertyBindingTest.cs
@@ -883,5 +883,197 @@ namespace ReactiveUI.Tests.Xaml
             dis.Dispose();
             Assert.True(dis.IsDisposed);
         }
+
+        [Fact]
+        public void BindWithFuncToTriggerUpdateTestViewModelToViewWithByteConverter()
+        {
+            CompositeDisposable dis = new();
+            PropertyBindViewModel? vm = new();
+            var view = new PropertyBindView { ViewModel = vm };
+            var update = new Subject<bool>();
+
+            vm.JustAByte = 123;
+            Assert.NotEqual(vm.JustAByte.ToString(CultureInfo.InvariantCulture), view.SomeTextBox.Text);
+
+            var singleToStringTypeConverter = new ByteToStringTypeConverter();
+
+            view.Bind(vm, x => x.JustAByte, x => x.SomeTextBox.Text, update.AsObservable(), 3, singleToStringTypeConverter, singleToStringTypeConverter, TriggerUpdate.ViewModelToView).DisposeWith(dis);
+
+            vm.JustAByte = 1;
+
+            // value should have pre bind value
+            Assert.Equal(view.SomeTextBox.Text, "123");
+
+            // trigger UI update
+            update.OnNext(true);
+            Assert.Equal(view.SomeTextBox.Text, "001");
+
+            vm.JustAByte = 2;
+            Assert.Equal(view.SomeTextBox.Text, "001");
+
+            update.OnNext(true);
+            Assert.Equal(view.SomeTextBox.Text, "002");
+
+            // test reverse bind no trigger required
+            view.SomeTextBox.Text = "003";
+            Assert.Equal(vm.JustAByte, 3);
+
+            view.SomeTextBox.Text = "004";
+            Assert.Equal(vm.JustAByte, 4);
+
+            // test forward bind to ensure trigger is still honoured.
+            vm.JustAByte = 2;
+            Assert.Equal(view.SomeTextBox.Text, "004");
+
+            update.OnNext(true);
+            Assert.Equal(view.SomeTextBox.Text, "002");
+
+            dis.Dispose();
+            Assert.True(dis.IsDisposed);
+        }
+
+        [Fact]
+        public void BindWithFuncToTriggerUpdateTestViewModelToViewWithShortConverter()
+        {
+            CompositeDisposable dis = new();
+            PropertyBindViewModel? vm = new();
+            var view = new PropertyBindView { ViewModel = vm };
+            var update = new Subject<bool>();
+
+            vm.JustAInt16 = 123;
+            Assert.NotEqual(vm.JustAInt16.ToString(CultureInfo.InvariantCulture), view.SomeTextBox.Text);
+
+            var singleToStringTypeConverter = new ShortToStringTypeConverter();
+
+            view.Bind(vm, x => x.JustAInt16, x => x.SomeTextBox.Text, update.AsObservable(), 3, singleToStringTypeConverter, singleToStringTypeConverter, TriggerUpdate.ViewModelToView).DisposeWith(dis);
+
+            vm.JustAInt16 = 1;
+
+            // value should have pre bind value
+            Assert.Equal(view.SomeTextBox.Text, "123");
+
+            // trigger UI update
+            update.OnNext(true);
+            Assert.Equal(view.SomeTextBox.Text, "001");
+
+            vm.JustAInt16 = 2;
+            Assert.Equal(view.SomeTextBox.Text, "001");
+
+            update.OnNext(true);
+            Assert.Equal(view.SomeTextBox.Text, "002");
+
+            // test reverse bind no trigger required
+            view.SomeTextBox.Text = "003";
+            Assert.Equal(vm.JustAInt16, 3);
+
+            view.SomeTextBox.Text = "004";
+            Assert.Equal(vm.JustAInt16, 4);
+
+            // test forward bind to ensure trigger is still honoured.
+            vm.JustAInt16 = 2;
+            Assert.Equal(view.SomeTextBox.Text, "004");
+
+            update.OnNext(true);
+            Assert.Equal(view.SomeTextBox.Text, "002");
+
+            dis.Dispose();
+            Assert.True(dis.IsDisposed);
+        }
+
+        [Fact]
+        public void BindWithFuncToTriggerUpdateTestViewModelToViewWithIntegerConverter()
+        {
+            CompositeDisposable dis = new();
+            PropertyBindViewModel? vm = new();
+            var view = new PropertyBindView { ViewModel = vm };
+            var update = new Subject<bool>();
+
+            vm.JustAInt32 = 123;
+            Assert.NotEqual(vm.JustAInt32.ToString(CultureInfo.InvariantCulture), view.SomeTextBox.Text);
+
+            var singleToStringTypeConverter = new IntegerToStringTypeConverter();
+
+            view.Bind(vm, x => x.JustAInt32, x => x.SomeTextBox.Text, update.AsObservable(), 3, singleToStringTypeConverter, singleToStringTypeConverter, TriggerUpdate.ViewModelToView).DisposeWith(dis);
+
+            vm.JustAInt32 = 1;
+
+            // value should have pre bind value
+            Assert.Equal(view.SomeTextBox.Text, "123");
+
+            // trigger UI update
+            update.OnNext(true);
+            Assert.Equal(view.SomeTextBox.Text, "001");
+
+            vm.JustAInt32 = 2;
+            Assert.Equal(view.SomeTextBox.Text, "001");
+
+            update.OnNext(true);
+            Assert.Equal(view.SomeTextBox.Text, "002");
+
+            // test reverse bind no trigger required
+            view.SomeTextBox.Text = "003";
+            Assert.Equal(vm.JustAInt32, 3);
+
+            view.SomeTextBox.Text = "004";
+            Assert.Equal(vm.JustAInt32, 4);
+
+            // test forward bind to ensure trigger is still honoured.
+            vm.JustAInt32 = 2;
+            Assert.Equal(view.SomeTextBox.Text, "004");
+
+            update.OnNext(true);
+            Assert.Equal(view.SomeTextBox.Text, "002");
+
+            dis.Dispose();
+            Assert.True(dis.IsDisposed);
+        }
+
+        [Fact]
+        public void BindWithFuncToTriggerUpdateTestViewModelToViewWithLongConverter()
+        {
+            CompositeDisposable dis = new();
+            PropertyBindViewModel? vm = new();
+            var view = new PropertyBindView { ViewModel = vm };
+            var update = new Subject<bool>();
+
+            vm.JustAInt64 = 123;
+            Assert.NotEqual(vm.JustAInt64.ToString(CultureInfo.InvariantCulture), view.SomeTextBox.Text);
+
+            var singleToStringTypeConverter = new LongToStringTypeConverter();
+
+            view.Bind(vm, x => x.JustAInt64, x => x.SomeTextBox.Text, update.AsObservable(), 3, singleToStringTypeConverter, singleToStringTypeConverter, TriggerUpdate.ViewModelToView).DisposeWith(dis);
+
+            vm.JustAInt64 = 1;
+
+            // value should have pre bind value
+            Assert.Equal(view.SomeTextBox.Text, "123");
+
+            // trigger UI update
+            update.OnNext(true);
+            Assert.Equal(view.SomeTextBox.Text, "001");
+
+            vm.JustAInt64 = 2;
+            Assert.Equal(view.SomeTextBox.Text, "001");
+
+            update.OnNext(true);
+            Assert.Equal(view.SomeTextBox.Text, "002");
+
+            // test reverse bind no trigger required
+            view.SomeTextBox.Text = "003";
+            Assert.Equal(vm.JustAInt64, 3);
+
+            view.SomeTextBox.Text = "004";
+            Assert.Equal(vm.JustAInt64, 4);
+
+            // test forward bind to ensure trigger is still honoured.
+            vm.JustAInt64 = 2;
+            Assert.Equal(view.SomeTextBox.Text, "004");
+
+            update.OnNext(true);
+            Assert.Equal(view.SomeTextBox.Text, "002");
+
+            dis.Dispose();
+            Assert.True(dis.IsDisposed);
+        }
     }
 }

--- a/src/ReactiveUI.Uno/Registrations.cs
+++ b/src/ReactiveUI.Uno/Registrations.cs
@@ -27,6 +27,10 @@ namespace ReactiveUI.Uno
             registerFunction(() => new ActivationForViewFetcher(), typeof(IActivationForViewFetcher));
             registerFunction(() => new DependencyObjectObservableForProperty(), typeof(ICreatesObservableForProperty));
             registerFunction(() => new StringConverter(), typeof(IBindingTypeConverter));
+            registerFunction(() => new ByteToStringTypeConverter(), typeof(IBindingTypeConverter));
+            registerFunction(() => new ShortToStringTypeConverter(), typeof(IBindingTypeConverter));
+            registerFunction(() => new IntegerToStringTypeConverter(), typeof(IBindingTypeConverter));
+            registerFunction(() => new LongToStringTypeConverter(), typeof(IBindingTypeConverter));
             registerFunction(() => new SingleToStringTypeConverter(), typeof(IBindingTypeConverter));
             registerFunction(() => new DoubleToStringTypeConverter(), typeof(IBindingTypeConverter));
             registerFunction(() => new DecimalToStringTypeConverter(), typeof(IBindingTypeConverter));

--- a/src/ReactiveUI.XamForms/Registrations.cs
+++ b/src/ReactiveUI.XamForms/Registrations.cs
@@ -27,6 +27,10 @@ namespace ReactiveUI.XamForms
             }
 
             registerFunction(() => new StringConverter(), typeof(IBindingTypeConverter));
+            registerFunction(() => new ByteToStringTypeConverter(), typeof(IBindingTypeConverter));
+            registerFunction(() => new ShortToStringTypeConverter(), typeof(IBindingTypeConverter));
+            registerFunction(() => new IntegerToStringTypeConverter(), typeof(IBindingTypeConverter));
+            registerFunction(() => new LongToStringTypeConverter(), typeof(IBindingTypeConverter));
             registerFunction(() => new SingleToStringTypeConverter(), typeof(IBindingTypeConverter));
             registerFunction(() => new DoubleToStringTypeConverter(), typeof(IBindingTypeConverter));
             registerFunction(() => new DecimalToStringTypeConverter(), typeof(IBindingTypeConverter));

--- a/src/ReactiveUI/Bindings/Converter/ByteToStringTypeConverter.cs
+++ b/src/ReactiveUI/Bindings/Converter/ByteToStringTypeConverter.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+
+namespace ReactiveUI
+{
+    /// <summary>
+    /// Short To String Type Converter.
+    /// </summary>
+    /// <seealso cref="ReactiveUI.IBindingTypeConverter" />
+    public class ByteToStringTypeConverter : IBindingTypeConverter
+    {
+        /// <inheritdoc/>
+        public int GetAffinityForObjects(Type fromType, Type toType)
+        {
+            if (fromType == typeof(byte) && toType == typeof(string))
+            {
+                return 10;
+            }
+
+            if (fromType == typeof(string) && toType == typeof(byte))
+            {
+                return 10;
+            }
+
+            return 0;
+        }
+
+        /// <inheritdoc/>
+        public bool TryConvert(object? from, Type toType, object? conversionHint, out object result)
+        {
+            if (toType == typeof(string) && from is byte fromByte)
+            {
+                if (conversionHint is int byteHint)
+                {
+                    result = fromByte.ToString($"D{byteHint}");
+                    return true;
+                }
+
+                result = fromByte.ToString();
+                return true;
+            }
+
+            if (from is string fromString)
+            {
+                var success = byte.TryParse(fromString, out var outByte);
+                if (success)
+                {
+                    result = outByte;
+
+                    return true;
+                }
+            }
+
+            result = null!;
+            return false;
+        }
+    }
+}

--- a/src/ReactiveUI/Bindings/Converter/IntegerToStringTypeConverter.cs
+++ b/src/ReactiveUI/Bindings/Converter/IntegerToStringTypeConverter.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+
+namespace ReactiveUI
+{
+    /// <summary>
+    /// Integer To String Type Converter.
+    /// </summary>
+    /// <seealso cref="ReactiveUI.IBindingTypeConverter" />
+    public class IntegerToStringTypeConverter : IBindingTypeConverter
+    {
+        /// <inheritdoc/>
+        public int GetAffinityForObjects(Type fromType, Type toType)
+        {
+            if (fromType == typeof(int) && toType == typeof(string))
+            {
+                return 10;
+            }
+
+            if (fromType == typeof(string) && toType == typeof(int))
+            {
+                return 10;
+            }
+
+            return 0;
+        }
+
+        /// <inheritdoc/>
+        public bool TryConvert(object? from, Type toType, object? conversionHint, out object result)
+        {
+            if (toType == typeof(string) && from is int fromInt)
+            {
+                if (conversionHint is int intHint)
+                {
+                    result = fromInt.ToString($"D{intHint}");
+                    return true;
+                }
+
+                result = fromInt.ToString();
+                return true;
+            }
+
+            if (from is string fromString)
+            {
+                var success = int.TryParse(fromString, out var outInt);
+                if (success)
+                {
+                    result = outInt;
+
+                    return true;
+                }
+            }
+
+            result = null!;
+            return false;
+        }
+    }
+}

--- a/src/ReactiveUI/Bindings/Converter/LongToStringTypeConverter.cs
+++ b/src/ReactiveUI/Bindings/Converter/LongToStringTypeConverter.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+
+namespace ReactiveUI
+{
+    /// <summary>
+    /// Integer To String Type Converter.
+    /// </summary>
+    /// <seealso cref="ReactiveUI.IBindingTypeConverter" />
+    public class LongToStringTypeConverter : IBindingTypeConverter
+    {
+        /// <inheritdoc/>
+        public int GetAffinityForObjects(Type fromType, Type toType)
+        {
+            if (fromType == typeof(long) && toType == typeof(string))
+            {
+                return 10;
+            }
+
+            if (fromType == typeof(string) && toType == typeof(long))
+            {
+                return 10;
+            }
+
+            return 0;
+        }
+
+        /// <inheritdoc/>
+        public bool TryConvert(object? from, Type toType, object? conversionHint, out object result)
+        {
+            if (toType == typeof(string) && from is long fromLong)
+            {
+                if (conversionHint is int longHint)
+                {
+                    result = fromLong.ToString($"D{longHint}");
+                    return true;
+                }
+
+                result = fromLong.ToString();
+                return true;
+            }
+
+            if (from is string fromString)
+            {
+                var success = long.TryParse(fromString, out var outLong);
+                if (success)
+                {
+                    result = outLong;
+
+                    return true;
+                }
+            }
+
+            result = null!;
+            return false;
+        }
+    }
+}

--- a/src/ReactiveUI/Bindings/Converter/ShortToStringTypeConverter.cs
+++ b/src/ReactiveUI/Bindings/Converter/ShortToStringTypeConverter.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+
+namespace ReactiveUI
+{
+    /// <summary>
+    /// Short To String Type Converter.
+    /// </summary>
+    /// <seealso cref="ReactiveUI.IBindingTypeConverter" />
+    public class ShortToStringTypeConverter : IBindingTypeConverter
+    {
+        /// <inheritdoc/>
+        public int GetAffinityForObjects(Type fromType, Type toType)
+        {
+            if (fromType == typeof(short) && toType == typeof(string))
+            {
+                return 10;
+            }
+
+            if (fromType == typeof(string) && toType == typeof(short))
+            {
+                return 10;
+            }
+
+            return 0;
+        }
+
+        /// <inheritdoc/>
+        public bool TryConvert(object? from, Type toType, object? conversionHint, out object result)
+        {
+            if (toType == typeof(string) && from is short fromShort)
+            {
+                if (conversionHint is int shortHint)
+                {
+                    result = fromShort.ToString($"D{shortHint}");
+                    return true;
+                }
+
+                result = fromShort.ToString();
+                return true;
+            }
+
+            if (from is string fromString)
+            {
+                var success = short.TryParse(fromString, out var outShort);
+                if (success)
+                {
+                    result = outShort;
+
+                    return true;
+                }
+            }
+
+            result = null!;
+            return false;
+        }
+    }
+}

--- a/src/ReactiveUI/Platforms/apple-common/ReactiveControl.cs
+++ b/src/ReactiveUI/Platforms/apple-common/ReactiveControl.cs
@@ -90,10 +90,17 @@ namespace ReactiveUI
         /// <inheritdoc/>
         public IObservable<Exception> ThrownExceptions => this.GetThrownExceptionsObservable();
 
+#if MAC
+        /// <summary>
+        /// Gets a observable when the control is activated.
+        /// </summary>
+        public new IObservable<Unit> Activated => _activated.AsObservable();
+#else
         /// <summary>
         /// Gets a observable when the control is activated.
         /// </summary>
         public IObservable<Unit> Activated => _activated.AsObservable();
+#endif
 
         /// <summary>
         /// Gets a observable that occurs when the control is deactivated.

--- a/src/ReactiveUI/Platforms/apple-common/ReactiveImageView.cs
+++ b/src/ReactiveUI/Platforms/apple-common/ReactiveImageView.cs
@@ -107,8 +107,13 @@ namespace ReactiveUI
         /// <inheritdoc/>
         public IObservable<Exception> ThrownExceptions => this.GetThrownExceptionsObservable();
 
+#if UIKIT
+        /// <inheritdoc/>
+        public IObservable<Unit> Activated => _activated.AsObservable();
+#else
         /// <inheritdoc/>
         public new IObservable<Unit> Activated => _activated.AsObservable();
+#endif
 
         /// <inheritdoc/>
         public IObservable<Unit> Deactivated => _deactivated.AsObservable();

--- a/src/ReactiveUI/Registration/Registrations.cs
+++ b/src/ReactiveUI/Registration/Registrations.cs
@@ -30,6 +30,10 @@ namespace ReactiveUI
             registerFunction(() => new POCOObservableForProperty(), typeof(ICreatesObservableForProperty));
             registerFunction(() => new EqualityTypeConverter(), typeof(IBindingTypeConverter));
             registerFunction(() => new StringConverter(), typeof(IBindingTypeConverter));
+            registerFunction(() => new ByteToStringTypeConverter(), typeof(IBindingTypeConverter));
+            registerFunction(() => new ShortToStringTypeConverter(), typeof(IBindingTypeConverter));
+            registerFunction(() => new IntegerToStringTypeConverter(), typeof(IBindingTypeConverter));
+            registerFunction(() => new LongToStringTypeConverter(), typeof(IBindingTypeConverter));
             registerFunction(() => new SingleToStringTypeConverter(), typeof(IBindingTypeConverter));
             registerFunction(() => new DoubleToStringTypeConverter(), typeof(IBindingTypeConverter));
             registerFunction(() => new DecimalToStringTypeConverter(), typeof(IBindingTypeConverter));


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

feature

**What is the current behaviour?**
<!-- You can also link to an open issue here. -->

few default converters exist

**What is the new behaviour?**
<!-- If this is a feature change -->

Add Byte, Short, Integer and Long to String BindingTypeConverters

**What might this PR break?**

users should set any custom BindingTypeConverters to an affinity > 10

**Please check if the PR fulfils these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

