### PR TITLE
fix #2866 CanExecute Scheduler

### DIFF
--- a/src/ReactiveUI/ReactiveCommand/ReactiveCommand.cs
+++ b/src/ReactiveUI/ReactiveCommand/ReactiveCommand.cs
@@ -766,13 +766,14 @@ namespace ReactiveUI
                 .CombineLatest(_isExecuting, (canEx, isEx) => canEx && !isEx)
                 .DistinctUntilChanged()
                 .Replay(1)
-                .RefCount()
-                .ObserveOn(_canExecuteScheduler);
+                .RefCount();
 
             _results = _synchronizedExecutionInfo.Where(x => x.Demarcation == ExecutionDemarcation.Result)
                 .Select(x => x.Result);
 
-            _canExecuteSubscription = _canExecute.Subscribe(OnCanExecuteChanged);
+            _canExecuteSubscription = _canExecute
+                .ObserveOn(_canExecuteScheduler)
+                .Subscribe(OnCanExecuteChanged);
         }
 
         private enum ExecutionDemarcation


### PR DESCRIPTION
Changed ObserveOn to only affect the internal subscription

<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

fix #2866

**What is the current behaviour?**
<!-- You can also link to an open issue here. -->

CanExecute stops Execute functioning when ObserveOn is assigned to global function

**What is the new behaviour?**
<!-- If this is a feature change -->

CanExecute only has ObserveOn assigned to internal subscription

**What might this PR break?**

none expected all existing tests are passing

**Please check if the PR fulfils these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

