### PR TITLE
fix: resolve ci failure by adding maui-check to install openjdk

### DIFF
--- a/.github/workflows/build-samples.yml
+++ b/.github/workflows/build-samples.yml
@@ -60,6 +60,8 @@ jobs:
         dotnet workload install tvos
         dotnet workload install macos
         dotnet workload install maui
+        dotnet tool install -g Redth.Net.Maui.Check
+        maui-check --non-interactive --fix
         
     - name: Add MSBuild to PATH
       uses: glennawatson/setup-msbuild@v1.0.3

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -67,6 +67,8 @@ jobs:
         dotnet workload install macos
         dotnet workload install maui
         dotnet workload restore "src/ReactiveUI/ReactiveUI.csproj"
+        dotnet tool install -g Redth.Net.Maui.Check
+        maui-check --non-interactive --fix
 
     - name: Add MSBuild to PATH
       uses: glennawatson/setup-msbuild@v1.0.3


### PR DESCRIPTION
**What kind of change does this PR introduce?**
build fix


**What is the current behavior?**
openjdk 11 missing so net6 failing


**What is the new behavior?**
adds maui check which installs openjdk 11


**What might this PR break?**
n/a


**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

