### PR TITLE
fix: memory leak on WPF

### DIFF
--- a/src/ReactiveUI.Tests/Platforms/wpf/WpfActivationForViewFetcherTest.cs
+++ b/src/ReactiveUI.Tests/Platforms/wpf/WpfActivationForViewFetcherTest.cs
@@ -3,10 +3,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
 using System;
 using System.Reactive.Concurrency;
-using System.Threading;
-using System.Threading.Tasks;
 using System.Windows;
 
 using DynamicData;

--- a/src/ReactiveUI.Tests/Platforms/wpf/WpfActivationForViewFetcherTest.cs
+++ b/src/ReactiveUI.Tests/Platforms/wpf/WpfActivationForViewFetcherTest.cs
@@ -3,11 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for full license information.
-
 using System;
 using System.Reactive.Concurrency;
 using System.Windows;

--- a/src/ReactiveUI.Tests/Platforms/wpf/WpfActivationForViewFetcherTest.cs
+++ b/src/ReactiveUI.Tests/Platforms/wpf/WpfActivationForViewFetcherTest.cs
@@ -41,58 +41,6 @@ namespace ReactiveUI.Tests.Wpf
         }
 
         [Fact]
-        public void WindowIsActivatedAndDeactivated()
-        {
-            var window = new WpfTestWindow();
-            var activation = new ActivationForViewFetcher();
-
-            var obs = activation.GetActivationForView(window);
-            obs.ToObservableChangeSet(scheduler: ImmediateScheduler.Instance).Bind(out var activated).Subscribe();
-
-            var loaded = new RoutedEventArgs();
-            loaded.RoutedEvent = FrameworkElement.LoadedEvent;
-
-            window.RaiseEvent(loaded);
-
-            new[] { true }.AssertAreEqual(activated);
-
-            window.Close();
-
-            new[] { true, false }.AssertAreEqual(activated);
-        }
-
-        [StaFact]
-        public void WindowAndFrameworkElementAreActivatedAndDeactivated()
-        {
-            var window = new WpfTestWindow();
-            var uc = new WpfTestUserControl();
-
-            window.RootGrid.Children.Add(uc);
-
-            var activation = new ActivationForViewFetcher();
-
-            var windowObs = activation.GetActivationForView(window);
-            windowObs.ToObservableChangeSet(scheduler: ImmediateScheduler.Instance).Bind(out var windowActivated).Subscribe();
-
-            var ucObs = activation.GetActivationForView(uc);
-            ucObs.ToObservableChangeSet(scheduler: ImmediateScheduler.Instance).Bind(out var controlActivated).Subscribe();
-
-            var loaded = new RoutedEventArgs();
-            loaded.RoutedEvent = FrameworkElement.LoadedEvent;
-
-            window.RaiseEvent(loaded);
-            uc.RaiseEvent(loaded);
-
-            new[] { true }.AssertAreEqual(windowActivated);
-            new[] { true }.AssertAreEqual(controlActivated);
-
-            window.Dispatcher.InvokeShutdown();
-
-            new[] { true, false }.AssertAreEqual(windowActivated);
-            new[] { true, false }.AssertAreEqual(controlActivated);
-        }
-
-        [Fact]
         public void IsHitTestVisibleActivatesFrameworkElement()
         {
             var uc = new WpfTestUserControl();

--- a/src/ReactiveUI.Wpf/ActivationForViewFetcher.cs
+++ b/src/ReactiveUI.Wpf/ActivationForViewFetcher.cs
@@ -58,8 +58,6 @@ namespace ReactiveUI
 
             var windowActivation = GetActivationForWindow(view);
 
-            var dispatcherActivation = GetActivationForDispatcher(fe);
-
             return viewLoaded
                 .Merge(viewUnloaded)
                 .Merge(hitTestVisible)

--- a/src/ReactiveUI.Wpf/ActivationForViewFetcher.cs
+++ b/src/ReactiveUI.Wpf/ActivationForViewFetcher.cs
@@ -64,7 +64,6 @@ namespace ReactiveUI
                 .Merge(viewUnloaded)
                 .Merge(hitTestVisible)
                 .Merge(windowActivation)
-                .Merge(dispatcherActivation)
                 .DistinctUntilChanged();
         }
 
@@ -85,20 +84,6 @@ namespace ReactiveUI
                 x => window.Closed -= x);
 
             return viewClosed;
-        }
-
-        private static IObservable<bool> GetActivationForDispatcher(DispatcherObject dispatcherObject)
-        {
-            var dispatcherShutdownStarted = Observable.FromEvent<EventHandler, bool>(
-                eventHandler =>
-                {
-                    void Handler(object? sender, EventArgs e) => eventHandler(false);
-                    return Handler;
-                },
-                x => dispatcherObject.Dispatcher.ShutdownStarted += x,
-                x => dispatcherObject.Dispatcher.ShutdownStarted -= x);
-
-            return dispatcherShutdownStarted;
         }
     }
 }


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
fixes https://github.com/reactiveui/ReactiveUI/issues/2935


**What is the current behavior?**
<!-- You can also link to an open issue here. -->
There is a memory leak introduced in #2793


**What is the new behavior?**
<!-- If this is a feature change -->
Remove the dispatcher object hook to prevent the memory leak.


**What might this PR break?**

Users relying on the dispatcher closing, but this will cause a memory leak which is the greater evil.

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

