### PR TITLE
fix: uno winui csproj incorrectly configured

### DIFF
--- a/src/ReactiveUI.Uno.WinUI/ReactiveUI.Uno.WinUI.csproj
+++ b/src/ReactiveUI.Uno.WinUI/ReactiveUI.Uno.WinUI.csproj
@@ -1,5 +1,4 @@
-﻿<Project>
-  
+﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
     <TargetFrameworks>netstandard20;MonoAndroid11.0;Xamarin.iOS10;Xamarin.Mac20;net6.0-android;net6.0-ios;net6.0-macos</TargetFrameworks>
     <PackageId>ReactiveUI.Uno.WinUI</PackageId>
@@ -33,9 +32,9 @@
     <Compile Include="..\ReactiveUI.Uwp\TransitioningContentControl.Empty.cs" LinkBase="ReactiveUI.Uwp" />
     <Compile Include="..\ReactiveUI.Uwp\DependencyObjectObservableForProperty.cs" LinkBase="ReactiveUI.Uwp" />
     <Compile Include="..\ReactiveUI.Uwp\common\**\*.cs" LinkBase="common" />
-    <Compile Include="..\ReactiveUI.Uno\*.cs" LinkBase="common" />
+    <Compile Include="..\ReactiveUI.Uno\*.cs" LinkBase="ReactiveUI.Uno" />
 
-  	<None Include="..\ReactiveUI.Uwp\ReactiveUI.rd.xml" PackagePath="lib\uap\ReactiveUI\Properties\ReactiveUI.rd.xml" Pack="true" />
+    <None Include="..\ReactiveUI.Uwp\ReactiveUI.rd.xml" PackagePath="lib\uap\ReactiveUI\Properties\ReactiveUI.rd.xml" Pack="true" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ReactiveUI.Uno.WinUI/ReactiveUI.Uno.WinUI.csproj
+++ b/src/ReactiveUI.Uno.WinUI/ReactiveUI.Uno.WinUI.csproj
@@ -8,7 +8,7 @@
     <NoWarn>$(NoWarn);SA1648;CA1816;CA1001;CS0108;CS0114;CS3021;CS1574;CA1303</NoWarn>
     <Nullable>enable</Nullable>
     <LangVersion>preview</LangVersion>
-    <PackageTags>mvvm;reactiveui;rx;reactive extensions;observable;LINQ;events;frp;net;unoplatform</PackageTags>
+    <PackageTags>mvvm;reactiveui;rx;reactive extensions;observable;LINQ;events;frp;net;unoplatform;winui</PackageTags>
   </PropertyGroup>
 
   <PropertyGroup Condition=" $(TargetFramework.StartsWith('netstandard')) ">

--- a/src/ReactiveUI.Uno.WinUI/ReactiveUI.Uno.WinUI.csproj
+++ b/src/ReactiveUI.Uno.WinUI/ReactiveUI.Uno.WinUI.csproj
@@ -38,7 +38,7 @@
     <Compile Include="..\ReactiveUI.Uwp\TransitioningContentControl.Empty.cs" LinkBase="ReactiveUI.Uwp" />
     <Compile Include="..\ReactiveUI.Uwp\DependencyObjectObservableForProperty.cs" LinkBase="ReactiveUI.Uwp" />
     <Compile Include="..\ReactiveUI.Uwp\common\**\*.cs" LinkBase="common" />
-    <Compile Include="..\ReactiveUI.Uno\**\*.cs" LinkBase="common" />
+    <Compile Include="..\ReactiveUI.Uno\*.cs" LinkBase="common" />
 
   	<None Include="..\ReactiveUI.Uwp\ReactiveUI.rd.xml" PackagePath="lib\uap\ReactiveUI\Properties\ReactiveUI.rd.xml" Pack="true" />
   </ItemGroup>

--- a/src/ReactiveUI.Uno.WinUI/ReactiveUI.Uno.WinUI.csproj
+++ b/src/ReactiveUI.Uno.WinUI/ReactiveUI.Uno.WinUI.csproj
@@ -1,19 +1,50 @@
 ﻿<Project>
   
-  <PropertyGroup>
-    <DefineConstants>$(DefineConstants);HAS_WINUI</DefineConstants>
-  </PropertyGroup>
-
-  <Import Project="..\ReactiveUI.Uno\ReactiveUI.Uno.csproj" />
-
-  <PropertyGroup>
-     <!-- Remove uap target --> 
+     <PropertyGroup>
     <TargetFrameworks>netstandard20;MonoAndroid11.0;Xamarin.iOS10;Xamarin.Mac20;net6.0-android;net6.0-ios;net6.0-macos</TargetFrameworks>
+    <PackageId>ReactiveUI.Uno.WinUI</PackageId>
+    <PackageDescription>Contains the ReactiveUI platform specific extensions for Uno WinUI</PackageDescription>
+    <DefineConstants>$(DefineConstants);HAS_UNO;HAS_WINUI</DefineConstants>
+    <NoWarn>$(NoWarn);SA1648;CA1816;CA1001;CS0108;CS0114;CS3021;CS1574;CA1303</NoWarn>
+    <Nullable>enable</Nullable>
+    <LangVersion>preview</LangVersion>
+    <PackageTags>mvvm;reactiveui;rx;reactive extensions;observable;LINQ;events;frp;net;unoplatform</PackageTags>
   </PropertyGroup>
-  
+
+  <PropertyGroup Condition=" $(TargetFramework.StartsWith('netstandard')) ">
+    <DefineConstants>$(DefineConstants);WASM</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup>
-    <PackageReference Remove="Uno.UI" />
+    <EmbeddedResource Remove="Resources\**" />
+    <None Remove="Resources\**" />
+    <Compile Remove="Resources\**" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Uno.WinUI" Version="3.9.7" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('netstandard')) ">
+    <PackageReference Include="Reactive.Wasm" Version="1.*" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('uap')) ">
+    <!-- UAP is just here for convenience with namespaces, don't need to duplicate up the scheduler/registrations -->
+    <Compile Remove=".\**\*.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\ReactiveUI.Uwp\TransitioningContentControl.Empty.cs" LinkBase="ReactiveUI.Uwp" />
+    <Compile Include="..\ReactiveUI.Uwp\DependencyObjectObservableForProperty.cs" LinkBase="ReactiveUI.Uwp" />
+    <Compile Include="..\ReactiveUI.Uwp\common\**\*.cs" LinkBase="common" />
+    <Compile Include="..\ReactiveUI.Uno\**\*.cs" LinkBase="common" />
+
+  	<None Include="..\ReactiveUI.Uwp\ReactiveUI.rd.xml" PackagePath="lib\uap\ReactiveUI\Properties\ReactiveUI.rd.xml" Pack="true" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ReactiveUI\ReactiveUI.csproj" />
   </ItemGroup>
   
 </Project>

--- a/src/ReactiveUI.Uno.WinUI/ReactiveUI.Uno.WinUI.csproj
+++ b/src/ReactiveUI.Uno.WinUI/ReactiveUI.Uno.WinUI.csproj
@@ -1,6 +1,6 @@
 ﻿<Project>
   
-     <PropertyGroup>
+  <PropertyGroup>
     <TargetFrameworks>netstandard20;MonoAndroid11.0;Xamarin.iOS10;Xamarin.Mac20;net6.0-android;net6.0-ios;net6.0-macos</TargetFrameworks>
     <PackageId>ReactiveUI.Uno.WinUI</PackageId>
     <PackageDescription>Contains the ReactiveUI platform specific extensions for Uno WinUI</PackageDescription>
@@ -27,11 +27,6 @@
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('netstandard')) ">
     <PackageReference Include="Reactive.Wasm" Version="1.*" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" $(TargetFramework.StartsWith('uap')) ">
-    <!-- UAP is just here for convenience with namespaces, don't need to duplicate up the scheduler/registrations -->
-    <Compile Remove=".\**\*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ReactiveUI.Uno.WinUI/ReactiveUI.Uno.WinUI.csproj
+++ b/src/ReactiveUI.Uno.WinUI/ReactiveUI.Uno.WinUI.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Uno.WinUI" Version="3.9.7" />
+    <PackageReference Include="Uno.WinUI" Version="3.10.11" />
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('netstandard')) ">
@@ -40,5 +40,5 @@
   <ItemGroup>
     <ProjectReference Include="..\ReactiveUI\ReactiveUI.csproj" />
   </ItemGroup>
-  
+
 </Project>

--- a/src/ReactiveUI.Uno/ActivationForViewFetcher.cs
+++ b/src/ReactiveUI.Uno/ActivationForViewFetcher.cs
@@ -9,8 +9,13 @@ using System.Reactive;
 using System.Reactive.Linq;
 using System.Reflection;
 
+#if HAS_UNO_WINUI
+using Microsoft.UI.Xaml;
+using Windows.Foundation;
+#else
 using Windows.Foundation;
 using Windows.UI.Xaml;
+#endif
 
 namespace ReactiveUI.Uno
 {

--- a/src/ReactiveUI.Uno/CoreDispatcherScheduler.cs
+++ b/src/ReactiveUI.Uno/CoreDispatcherScheduler.cs
@@ -9,8 +9,13 @@ using System.Reactive.Disposables;
 using System.Runtime.ExceptionServices;
 using System.Threading;
 
+#if HAS_UNO_WINUI
+using Microsoft.UI.Xaml;
+using Windows.UI.Core;
+#else
 using Windows.UI.Core;
 using Windows.UI.Xaml;
+#endif
 
 namespace System.Reactive.Concurrency
 {

--- a/src/ReactiveUI.Uno/ReactiveUI.Uno.csproj
+++ b/src/ReactiveUI.Uno/ReactiveUI.Uno.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" !$(TargetFramework.StartsWith('uap')) ">
-    <PackageReference Include="Uno.UI" Version="3.9.7" />
+    <PackageReference Include="Uno.UI" Version="3.10.11" />
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('netstandard')) ">


### PR DESCRIPTION
Fix the WinUI package for Uno not to have imported package. This causes problems with duplicate package names.