### PR TITLE
fix: Incorrect version of JavaInterop included

### DIFF
--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -33,12 +33,20 @@
 
   <!-- MonoAndroid doesn't seem to want to allow debugging for maintainers -->
   <PropertyGroup Condition=" $(TargetFramework.StartsWith('MonoAndroid')) ">
-    <DebugType>Full</DebugType>
+    <DebugType>portable</DebugType>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
+  
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('MonoAndroid')) ">
+    <!-- Hack to get around invalid version of Java.Interop -->
+    <Reference Include="Java.Interop">
+       <!-- Path to a VS 2019 Java.Interop.dll -->
+       <HintPath>C:\Program Files\Microsoft Visual Studio\2022\Preview\Common7\IDE\ReferenceAssemblies\Microsoft\Framework\MonoAndroid\v1.0\Java.Interop.dll</HintPath>
+    </Reference> 
+  </ItemGroup>
   
   <ItemGroup Condition="$(IsTestProject)">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

bug fix

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

Fixes https://github.com/reactiveui/ReactiveUI/issues/2994

Using full PDB 
**What is the new behavior?**
<!-- If this is a feature change -->

Temporarily include Java.Interop direct from the folder for MonoAndroid10

Now also use portable format which is the preferred format now.
