### PR TITLE
Fix: Add Java.Interop to all MonoAndroid projects

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -40,6 +40,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        lfs: true
 
     - name: Install .NET Core
       uses: actions/setup-dotnet@v1.8.2

--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -39,15 +39,7 @@
   <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
-  
-  <ItemGroup Condition=" $(TargetFramework.StartsWith('MonoAndroid')) ">
-    <!-- Hack to get around invalid version of Java.Interop -->
-    <Reference Include="Java.Interop">
-       <!-- Path to a VS 2019 Java.Interop.dll -->
-       <HintPath>C:\Program Files\Microsoft Visual Studio\2022\Preview\Common7\IDE\ReferenceAssemblies\Microsoft\Framework\MonoAndroid\v1.0\Java.Interop.dll</HintPath>
-    </Reference> 
-  </ItemGroup>
-  
+
   <ItemGroup Condition="$(IsTestProject)">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/src/Java.Interop.dll
+++ b/src/Java.Interop.dll
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bf36e42a425d140c6217c512bfe15862ed062a1715d74562475c2547bc5376e1
+size 208760

--- a/src/ReactiveUI.AndroidSupport/ReactiveUI.AndroidSupport.csproj
+++ b/src/ReactiveUI.AndroidSupport/ReactiveUI.AndroidSupport.csproj
@@ -13,7 +13,7 @@
     <!-- Hack to get around invalid version of Java.Interop -->
     <Reference Include="Java.Interop">
        <!-- Path to a VS 2019 Java.Interop.dll -->
-       <HintPath>C:\Program Files\Microsoft Visual Studio\2022\Preview\Common7\IDE\ReferenceAssemblies\Microsoft\Framework\MonoAndroid\v1.0\Java.Interop.dll</HintPath>
+       <HintPath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\ReferenceAssemblies\Microsoft\Framework\MonoAndroid\v1.0\Java.Interop.dll</HintPath>
     </Reference> 
   </ItemGroup>
 

--- a/src/ReactiveUI.AndroidSupport/ReactiveUI.AndroidSupport.csproj
+++ b/src/ReactiveUI.AndroidSupport/ReactiveUI.AndroidSupport.csproj
@@ -13,7 +13,7 @@
     <!-- Hack to get around invalid version of Java.Interop -->
     <Reference Include="Java.Interop">
        <!-- Path to a VS 2019 Java.Interop.dll -->
-       <HintPath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\ReferenceAssemblies\Microsoft\Framework\MonoAndroid\v1.0\Java.Interop.dll</HintPath>
+       <HintPath>..\Java.Interop.dll</HintPath>
     </Reference> 
   </ItemGroup>
 

--- a/src/ReactiveUI.AndroidSupport/ReactiveUI.AndroidSupport.csproj
+++ b/src/ReactiveUI.AndroidSupport/ReactiveUI.AndroidSupport.csproj
@@ -9,6 +9,14 @@
     <PackageTags>mvvm;reactiveui;rx;reactive extensions;observable;LINQ;events;frp;xamarin;android;forms;monodroid;monotouch;xamarin.android;net;</PackageTags>
   </PropertyGroup>
 
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('MonoAndroid')) ">
+    <!-- Hack to get around invalid version of Java.Interop -->
+    <Reference Include="Java.Interop">
+       <!-- Path to a VS 2019 Java.Interop.dll -->
+       <HintPath>C:\Program Files\Microsoft Visual Studio\2022\Preview\Common7\IDE\ReferenceAssemblies\Microsoft\Framework\MonoAndroid\v1.0\Java.Interop.dll</HintPath>
+    </Reference> 
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Xamarin.Android.Support.Animated.Vector.Drawable" Version="28.*" />
     <PackageReference Include="Xamarin.Android.Support.v4" Version="28.*" />

--- a/src/ReactiveUI.AndroidX/ReactiveUI.AndroidX.csproj
+++ b/src/ReactiveUI.AndroidX/ReactiveUI.AndroidX.csproj
@@ -13,7 +13,7 @@
     <!-- Hack to get around invalid version of Java.Interop -->
     <Reference Include="Java.Interop">
        <!-- Path to a VS 2019 Java.Interop.dll -->
-       <HintPath>C:\Program Files\Microsoft Visual Studio\2022\Preview\Common7\IDE\ReferenceAssemblies\Microsoft\Framework\MonoAndroid\v1.0\Java.Interop.dll</HintPath>
+       <HintPath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\ReferenceAssemblies\Microsoft\Framework\MonoAndroid\v1.0\Java.Interop.dll</HintPath>
     </Reference> 
   </ItemGroup>
 

--- a/src/ReactiveUI.AndroidX/ReactiveUI.AndroidX.csproj
+++ b/src/ReactiveUI.AndroidX/ReactiveUI.AndroidX.csproj
@@ -13,7 +13,7 @@
     <!-- Hack to get around invalid version of Java.Interop -->
     <Reference Include="Java.Interop">
        <!-- Path to a VS 2019 Java.Interop.dll -->
-       <HintPath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\ReferenceAssemblies\Microsoft\Framework\MonoAndroid\v1.0\Java.Interop.dll</HintPath>
+       <HintPath>..\Java.Interop.dll</HintPath>
     </Reference> 
   </ItemGroup>
 

--- a/src/ReactiveUI.AndroidX/ReactiveUI.AndroidX.csproj
+++ b/src/ReactiveUI.AndroidX/ReactiveUI.AndroidX.csproj
@@ -9,6 +9,14 @@
     <PackageTags>mvvm;reactiveui;rx;reactive extensions;observable;LINQ;events;frp;xamarin;android;forms;monodroid;monotouch;xamarin.android;net;</PackageTags>
   </PropertyGroup>
 
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('MonoAndroid')) ">
+    <!-- Hack to get around invalid version of Java.Interop -->
+    <Reference Include="Java.Interop">
+       <!-- Path to a VS 2019 Java.Interop.dll -->
+       <HintPath>C:\Program Files\Microsoft Visual Studio\2022\Preview\Common7\IDE\ReferenceAssemblies\Microsoft\Framework\MonoAndroid\v1.0\Java.Interop.dll</HintPath>
+    </Reference> 
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
     <PackageReference Include="Xamarin.AndroidX.AppCompat" Version="1.3.1.3" />

--- a/src/ReactiveUI.Drawing/ReactiveUI.Drawing.csproj
+++ b/src/ReactiveUI.Drawing/ReactiveUI.Drawing.csproj
@@ -14,7 +14,7 @@
     <!-- Hack to get around invalid version of Java.Interop -->
     <Reference Include="Java.Interop">
        <!-- Path to a VS 2019 Java.Interop.dll -->
-       <HintPath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\ReferenceAssemblies\Microsoft\Framework\MonoAndroid\v1.0\Java.Interop.dll</HintPath>
+       <HintPath>..\Java.Interop.dll</HintPath>
     </Reference> 
   </ItemGroup>
 

--- a/src/ReactiveUI.Drawing/ReactiveUI.Drawing.csproj
+++ b/src/ReactiveUI.Drawing/ReactiveUI.Drawing.csproj
@@ -14,7 +14,7 @@
     <!-- Hack to get around invalid version of Java.Interop -->
     <Reference Include="Java.Interop">
        <!-- Path to a VS 2019 Java.Interop.dll -->
-       <HintPath>C:\Program Files\Microsoft Visual Studio\2022\Preview\Common7\IDE\ReferenceAssemblies\Microsoft\Framework\MonoAndroid\v1.0\Java.Interop.dll</HintPath>
+       <HintPath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\ReferenceAssemblies\Microsoft\Framework\MonoAndroid\v1.0\Java.Interop.dll</HintPath>
     </Reference> 
   </ItemGroup>
 

--- a/src/ReactiveUI.Drawing/ReactiveUI.Drawing.csproj
+++ b/src/ReactiveUI.Drawing/ReactiveUI.Drawing.csproj
@@ -9,6 +9,15 @@
     <Nullable>enable</Nullable>
     <LangVersion>preview</LangVersion>
   </PropertyGroup>
+
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('MonoAndroid')) ">
+    <!-- Hack to get around invalid version of Java.Interop -->
+    <Reference Include="Java.Interop">
+       <!-- Path to a VS 2019 Java.Interop.dll -->
+       <HintPath>C:\Program Files\Microsoft Visual Studio\2022\Preview\Common7\IDE\ReferenceAssemblies\Microsoft\Framework\MonoAndroid\v1.0\Java.Interop.dll</HintPath>
+    </Reference> 
+  </ItemGroup>
+
   <ItemGroup>
     <Compile Remove="Resources\**" />
     <EmbeddedResource Remove="Resources\**" />

--- a/src/ReactiveUI.Fody.Helpers/ReactiveUI.Fody.Helpers.csproj
+++ b/src/ReactiveUI.Fody.Helpers/ReactiveUI.Fody.Helpers.csproj
@@ -20,7 +20,7 @@
     <!-- Hack to get around invalid version of Java.Interop -->
     <Reference Include="Java.Interop">
        <!-- Path to a VS 2019 Java.Interop.dll -->
-       <HintPath>C:\Program Files\Microsoft Visual Studio\2022\Preview\Common7\IDE\ReferenceAssemblies\Microsoft\Framework\MonoAndroid\v1.0\Java.Interop.dll</HintPath>
+       <HintPath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\ReferenceAssemblies\Microsoft\Framework\MonoAndroid\v1.0\Java.Interop.dll</HintPath>
     </Reference> 
   </ItemGroup>
 

--- a/src/ReactiveUI.Fody.Helpers/ReactiveUI.Fody.Helpers.csproj
+++ b/src/ReactiveUI.Fody.Helpers/ReactiveUI.Fody.Helpers.csproj
@@ -20,7 +20,7 @@
     <!-- Hack to get around invalid version of Java.Interop -->
     <Reference Include="Java.Interop">
        <!-- Path to a VS 2019 Java.Interop.dll -->
-       <HintPath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\ReferenceAssemblies\Microsoft\Framework\MonoAndroid\v1.0\Java.Interop.dll</HintPath>
+       <HintPath>..\Java.Interop.dll</HintPath>
     </Reference> 
   </ItemGroup>
 

--- a/src/ReactiveUI.Fody.Helpers/ReactiveUI.Fody.Helpers.csproj
+++ b/src/ReactiveUI.Fody.Helpers/ReactiveUI.Fody.Helpers.csproj
@@ -16,6 +16,14 @@
     <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('MonoAndroid')) ">
+    <!-- Hack to get around invalid version of Java.Interop -->
+    <Reference Include="Java.Interop">
+       <!-- Path to a VS 2019 Java.Interop.dll -->
+       <HintPath>C:\Program Files\Microsoft Visual Studio\2022\Preview\Common7\IDE\ReferenceAssemblies\Microsoft\Framework\MonoAndroid\v1.0\Java.Interop.dll</HintPath>
+    </Reference> 
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Fody" Version="6.6.0" PrivateAssets="None" />
     <PackageReference Include="FodyPackaging" Version="6.6.0" PrivateAssets="All" />

--- a/src/ReactiveUI.Testing/ReactiveUI.Testing.csproj
+++ b/src/ReactiveUI.Testing/ReactiveUI.Testing.csproj
@@ -15,7 +15,7 @@
     <!-- Hack to get around invalid version of Java.Interop -->
     <Reference Include="Java.Interop">
        <!-- Path to a VS 2019 Java.Interop.dll -->
-       <HintPath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\ReferenceAssemblies\Microsoft\Framework\MonoAndroid\v1.0\Java.Interop.dll</HintPath>
+       <HintPath>..\Java.Interop.dll</HintPath>
     </Reference> 
   </ItemGroup>
 

--- a/src/ReactiveUI.Testing/ReactiveUI.Testing.csproj
+++ b/src/ReactiveUI.Testing/ReactiveUI.Testing.csproj
@@ -15,7 +15,7 @@
     <!-- Hack to get around invalid version of Java.Interop -->
     <Reference Include="Java.Interop">
        <!-- Path to a VS 2019 Java.Interop.dll -->
-       <HintPath>C:\Program Files\Microsoft Visual Studio\2022\Preview\Common7\IDE\ReferenceAssemblies\Microsoft\Framework\MonoAndroid\v1.0\Java.Interop.dll</HintPath>
+       <HintPath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\ReferenceAssemblies\Microsoft\Framework\MonoAndroid\v1.0\Java.Interop.dll</HintPath>
     </Reference> 
   </ItemGroup>
 

--- a/src/ReactiveUI.Testing/ReactiveUI.Testing.csproj
+++ b/src/ReactiveUI.Testing/ReactiveUI.Testing.csproj
@@ -11,6 +11,14 @@
     <PackageTags>mvvm;reactiveui;rx;reactive extensions;observable;LINQ;events;frp;test;</PackageTags>
   </PropertyGroup>
 
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('MonoAndroid')) ">
+    <!-- Hack to get around invalid version of Java.Interop -->
+    <Reference Include="Java.Interop">
+       <!-- Path to a VS 2019 Java.Interop.dll -->
+       <HintPath>C:\Program Files\Microsoft Visual Studio\2022\Preview\Common7\IDE\ReferenceAssemblies\Microsoft\Framework\MonoAndroid\v1.0\Java.Interop.dll</HintPath>
+    </Reference> 
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Reactive.Testing" Version="5.0.0" />
     <ProjectReference Include="..\ReactiveUI\ReactiveUI.csproj" />

--- a/src/ReactiveUI.Uno.WinUI/ReactiveUI.Uno.WinUI.csproj
+++ b/src/ReactiveUI.Uno.WinUI/ReactiveUI.Uno.WinUI.csproj
@@ -14,6 +14,14 @@
     <DefineConstants>$(DefineConstants);WASM</DefineConstants>
   </PropertyGroup>
 
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('MonoAndroid')) ">
+    <!-- Hack to get around invalid version of Java.Interop -->
+    <Reference Include="Java.Interop">
+       <!-- Path to a VS 2019 Java.Interop.dll -->
+       <HintPath>C:\Program Files\Microsoft Visual Studio\2022\Preview\Common7\IDE\ReferenceAssemblies\Microsoft\Framework\MonoAndroid\v1.0\Java.Interop.dll</HintPath>
+    </Reference> 
+  </ItemGroup>
+
   <ItemGroup>
     <EmbeddedResource Remove="Resources\**" />
     <None Remove="Resources\**" />

--- a/src/ReactiveUI.Uno.WinUI/ReactiveUI.Uno.WinUI.csproj
+++ b/src/ReactiveUI.Uno.WinUI/ReactiveUI.Uno.WinUI.csproj
@@ -18,7 +18,7 @@
     <!-- Hack to get around invalid version of Java.Interop -->
     <Reference Include="Java.Interop">
        <!-- Path to a VS 2019 Java.Interop.dll -->
-       <HintPath>C:\Program Files\Microsoft Visual Studio\2022\Preview\Common7\IDE\ReferenceAssemblies\Microsoft\Framework\MonoAndroid\v1.0\Java.Interop.dll</HintPath>
+       <HintPath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\ReferenceAssemblies\Microsoft\Framework\MonoAndroid\v1.0\Java.Interop.dll</HintPath>
     </Reference> 
   </ItemGroup>
 

--- a/src/ReactiveUI.Uno.WinUI/ReactiveUI.Uno.WinUI.csproj
+++ b/src/ReactiveUI.Uno.WinUI/ReactiveUI.Uno.WinUI.csproj
@@ -18,7 +18,7 @@
     <!-- Hack to get around invalid version of Java.Interop -->
     <Reference Include="Java.Interop">
        <!-- Path to a VS 2019 Java.Interop.dll -->
-       <HintPath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\ReferenceAssemblies\Microsoft\Framework\MonoAndroid\v1.0\Java.Interop.dll</HintPath>
+       <HintPath>..\Java.Interop.dll</HintPath>
     </Reference> 
   </ItemGroup>
 

--- a/src/ReactiveUI.Uno/ReactiveUI.Uno.csproj
+++ b/src/ReactiveUI.Uno/ReactiveUI.Uno.csproj
@@ -15,6 +15,14 @@
     <DefineConstants>$(DefineConstants);WASM</DefineConstants>
   </PropertyGroup>
 
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('MonoAndroid')) ">
+    <!-- Hack to get around invalid version of Java.Interop -->
+    <Reference Include="Java.Interop">
+       <!-- Path to a VS 2019 Java.Interop.dll -->
+       <HintPath>C:\Program Files\Microsoft Visual Studio\2022\Preview\Common7\IDE\ReferenceAssemblies\Microsoft\Framework\MonoAndroid\v1.0\Java.Interop.dll</HintPath>
+    </Reference> 
+  </ItemGroup>
+
   <ItemGroup>
     <EmbeddedResource Remove="Resources\**" />
     <None Remove="Resources\**" />

--- a/src/ReactiveUI.Uno/ReactiveUI.Uno.csproj
+++ b/src/ReactiveUI.Uno/ReactiveUI.Uno.csproj
@@ -19,7 +19,7 @@
     <!-- Hack to get around invalid version of Java.Interop -->
     <Reference Include="Java.Interop">
        <!-- Path to a VS 2019 Java.Interop.dll -->
-       <HintPath>C:\Program Files\Microsoft Visual Studio\2022\Preview\Common7\IDE\ReferenceAssemblies\Microsoft\Framework\MonoAndroid\v1.0\Java.Interop.dll</HintPath>
+       <HintPath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\ReferenceAssemblies\Microsoft\Framework\MonoAndroid\v1.0\Java.Interop.dll</HintPath>
     </Reference> 
   </ItemGroup>
 

--- a/src/ReactiveUI.Uno/ReactiveUI.Uno.csproj
+++ b/src/ReactiveUI.Uno/ReactiveUI.Uno.csproj
@@ -19,7 +19,7 @@
     <!-- Hack to get around invalid version of Java.Interop -->
     <Reference Include="Java.Interop">
        <!-- Path to a VS 2019 Java.Interop.dll -->
-       <HintPath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\ReferenceAssemblies\Microsoft\Framework\MonoAndroid\v1.0\Java.Interop.dll</HintPath>
+       <HintPath>..\Java.Interop.dll</HintPath>
     </Reference> 
   </ItemGroup>
 

--- a/src/ReactiveUI/ReactiveUI.csproj
+++ b/src/ReactiveUI/ReactiveUI.csproj
@@ -22,7 +22,7 @@
     <!-- Hack to get around invalid version of Java.Interop -->
     <Reference Include="Java.Interop">
        <!-- Path to a VS 2019 Java.Interop.dll -->
-       <HintPath>C:\Program Files\Microsoft Visual Studio\2022\Preview\Common7\IDE\ReferenceAssemblies\Microsoft\Framework\MonoAndroid\v1.0\Java.Interop.dll</HintPath>
+       <HintPath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\ReferenceAssemblies\Microsoft\Framework\MonoAndroid\v1.0\Java.Interop.dll</HintPath>
     </Reference> 
   </ItemGroup>
 

--- a/src/ReactiveUI/ReactiveUI.csproj
+++ b/src/ReactiveUI/ReactiveUI.csproj
@@ -22,7 +22,7 @@
     <!-- Hack to get around invalid version of Java.Interop -->
     <Reference Include="Java.Interop">
        <!-- Path to a VS 2019 Java.Interop.dll -->
-       <HintPath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\ReferenceAssemblies\Microsoft\Framework\MonoAndroid\v1.0\Java.Interop.dll</HintPath>
+       <HintPath>..\Java.Interop.dll</HintPath>
     </Reference> 
   </ItemGroup>
 

--- a/src/ReactiveUI/ReactiveUI.csproj
+++ b/src/ReactiveUI/ReactiveUI.csproj
@@ -18,6 +18,14 @@
     <None Remove="Resources\**" />
   </ItemGroup>
 
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('MonoAndroid')) ">
+    <!-- Hack to get around invalid version of Java.Interop -->
+    <Reference Include="Java.Interop">
+       <!-- Path to a VS 2019 Java.Interop.dll -->
+       <HintPath>C:\Program Files\Microsoft Visual Studio\2022\Preview\Common7\IDE\ReferenceAssemblies\Microsoft\Framework\MonoAndroid\v1.0\Java.Interop.dll</HintPath>
+    </Reference> 
+  </ItemGroup>
+
   <ItemGroup Condition=" $(TargetFramework.StartsWith('netstandard')) ">
     <Compile Include="Platforms\netstandard2.0\**\*.cs" />
     <Compile Include="Platforms\shared\**\*.cs" />


### PR DESCRIPTION
Adds the Java.Interop temporary fix to any project containing the MonoAndroid target framework.

This gets around a bug until the next Visual Studio release where it includes too recent of version of Java.Interop for Xamarin.

Attempted to previously fix with Directory.Build.Props but needs to be included in every file.