### PR TITLE
housekeeping: Release 16.4.x

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "16.3",
+  "version": "16.4",
   "publicReleaseRefSpec": [
     "^refs/heads/master$", // we release out of master
     "^refs/heads/main$",


### PR DESCRIPTION
Release 16.4.x

Has a breaking change, changing ReactiveCommand not to have a can execute scheduler. You can specify a scheduler if you need it by using `ObserveOn` on your IObservable you pass in for the `CanExecute`

Additionally, there are some additional default converters that handle nullable types.