### PR TITLE
fix: Uno UI registrations are not initialized

### DIFF
--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.DotNet6_0.verified.txt
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.DotNet6_0.verified.txt
@@ -756,12 +756,13 @@ namespace ReactiveUI
         Winforms = 2,
         Wpf = 3,
         Uno = 4,
-        Blazor = 5,
-        Drawing = 6,
-        Avalonia = 7,
-        Maui = 8,
-        Uwp = 9,
-        WinUI = 10,
+        UnoWinUI = 5,
+        Blazor = 6,
+        Drawing = 7,
+        Avalonia = 8,
+        Maui = 9,
+        Uwp = 10,
+        WinUI = 11,
     }
     public class Registrations
     {

--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.Net4_8.verified.txt
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.Net4_8.verified.txt
@@ -763,12 +763,13 @@ namespace ReactiveUI
         Winforms = 2,
         Wpf = 3,
         Uno = 4,
-        Blazor = 5,
-        Drawing = 6,
-        Avalonia = 7,
-        Maui = 8,
-        Uwp = 9,
-        WinUI = 10,
+        UnoWinUI = 5,
+        Blazor = 6,
+        Drawing = 7,
+        Avalonia = 8,
+        Maui = 9,
+        Uwp = 10,
+        WinUI = 11,
     }
     public class Registrations
     {

--- a/src/ReactiveUI/Mixins/DependencyResolverMixins.cs
+++ b/src/ReactiveUI/Mixins/DependencyResolverMixins.cs
@@ -44,6 +44,7 @@ public static class DependencyResolverMixins
             { RegistrationNamespace.Winforms, "ReactiveUI.Winforms" },
             { RegistrationNamespace.Wpf, "ReactiveUI.Wpf" },
             { RegistrationNamespace.Uno, "ReactiveUI.Uno" },
+            { RegistrationNamespace.UnoWinUI, "ReactiveUI.Uno.WinUI" },
             { RegistrationNamespace.Blazor, "ReactiveUI.Blazor" },
             { RegistrationNamespace.Drawing, "ReactiveUI.Drawing" },
             { RegistrationNamespace.Maui, "ReactiveUI.Maui" },

--- a/src/ReactiveUI/RegistrationNamespace.cs
+++ b/src/ReactiveUI/RegistrationNamespace.cs
@@ -34,6 +34,11 @@ public enum RegistrationNamespace
     Uno,
 
     /// <summary>
+    /// Uno Win UI.
+    /// </summary>
+    UnoWinUI,
+    
+    /// <summary>
     /// Blazor.
     /// </summary>
     Blazor,

--- a/src/ReactiveUI/RegistrationNamespace.cs
+++ b/src/ReactiveUI/RegistrationNamespace.cs
@@ -37,7 +37,7 @@ public enum RegistrationNamespace
     /// Uno Win UI.
     /// </summary>
     UnoWinUI,
-    
+
     /// <summary>
     /// Blazor.
     /// </summary>


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
fixes #3081 


**What is the current behavior?**
<!-- You can also link to an open issue here. -->

Uno WinUI package is not part of the Dependency Resolver

**What is the new behavior?**
<!-- If this is a feature change -->

Add Uno WinUI to the list.

