### PR TITLE
fix: add windows net6 to uno winui

### DIFF
--- a/src/Directory.build.targets
+++ b/src/Directory.build.targets
@@ -32,9 +32,6 @@
   <PropertyGroup Condition="$(TargetFramework.StartsWith('net6.0-ios'))">
     <DefineConstants>$(DefineConstants);MONO;UIKIT;COCOA;IOS</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition="$(TargetFramework.StartsWith('net6.0-windows10'))">
-    <DefineConstants>$(DefineConstants);HAS_UNO_WINUI</DefineConstants>
-  </PropertyGroup>
   <PropertyGroup Condition="$(TargetFramework.StartsWith('Xamarin.Mac'))">
     <DefineConstants>$(DefineConstants);MONO;COCOA;MAC</DefineConstants>
   </PropertyGroup>

--- a/src/Directory.build.targets
+++ b/src/Directory.build.targets
@@ -32,6 +32,9 @@
   <PropertyGroup Condition="$(TargetFramework.StartsWith('net6.0-ios'))">
     <DefineConstants>$(DefineConstants);MONO;UIKIT;COCOA;IOS</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup Condition="$(TargetFramework.StartsWith('net6.0-windows10'))">
+    <DefineConstants>$(DefineConstants);HAS_UNO_WINUI</DefineConstants>
+  </PropertyGroup>
   <PropertyGroup Condition="$(TargetFramework.StartsWith('Xamarin.Mac'))">
     <DefineConstants>$(DefineConstants);MONO;COCOA;MAC</DefineConstants>
   </PropertyGroup>

--- a/src/ReactiveUI.Uno.WinUI/ReactiveUI.Uno.WinUI.csproj
+++ b/src/ReactiveUI.Uno.WinUI/ReactiveUI.Uno.WinUI.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
-    <TargetFrameworks>netstandard20;MonoAndroid11.0;Xamarin.iOS10;Xamarin.Mac20;net6.0-android;net6.0-ios;net6.0-macos</TargetFrameworks>
+    <TargetFrameworks>netstandard20;MonoAndroid11.0;Xamarin.iOS10;Xamarin.Mac20;net6.0-android;net6.0-ios;net6.0-macos;net6.0-windows10.0.17763.0</TargetFrameworks>
     <PackageId>ReactiveUI.Uno.WinUI</PackageId>
     <PackageDescription>Contains the ReactiveUI platform specific extensions for Uno WinUI</PackageDescription>
     <DefineConstants>$(DefineConstants);HAS_UNO;HAS_WINUI</DefineConstants>

--- a/src/ReactiveUI.Uno.WinUI/ReactiveUI.Uno.WinUI.csproj
+++ b/src/ReactiveUI.Uno.WinUI/ReactiveUI.Uno.WinUI.csproj
@@ -26,11 +26,11 @@
     <Compile Remove="Resources\**" />
   </ItemGroup>
 
-  <ItemGroup Condition=" !$(TargetFramework.StartsWith('net6.0-windows')) ">
+  <ItemGroup Condition=" !$(TargetFramework.StartsWith('net6.0-windows10')) ">
     <PackageReference Include="Uno.WinUI" Version="4.0.9" />
   </ItemGroup>
    
-  <ItemGroup Condition=" $(TargetFramework.StartsWith('net6.0-windows')) ">
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('net6.0-windows10')) ">
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.0.0" />
   </ItemGroup>
 

--- a/src/ReactiveUI.Uno.WinUI/ReactiveUI.Uno.WinUI.csproj
+++ b/src/ReactiveUI.Uno.WinUI/ReactiveUI.Uno.WinUI.csproj
@@ -29,6 +29,10 @@
   <ItemGroup Condition=" !$(TargetFramework.StartsWith('net6.0-windows')) ">
     <PackageReference Include="Uno.WinUI" Version="4.0.9" />
   </ItemGroup>
+   
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('net6.0-windows')) ">
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.0.0" />
+  </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('netstandard')) ">
     <PackageReference Include="Reactive.Wasm" Version="1.*" />

--- a/src/ReactiveUI.Uno.WinUI/ReactiveUI.Uno.WinUI.csproj
+++ b/src/ReactiveUI.Uno.WinUI/ReactiveUI.Uno.WinUI.csproj
@@ -26,7 +26,7 @@
     <Compile Remove="Resources\**" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition=" !$(TargetFramework.StartsWith('net6.0-windows')) ">
     <PackageReference Include="Uno.WinUI" Version="4.0.9" />
   </ItemGroup>
 

--- a/src/ReactiveUI.Uno.WinUI/ReactiveUI.Uno.WinUI.csproj
+++ b/src/ReactiveUI.Uno.WinUI/ReactiveUI.Uno.WinUI.csproj
@@ -11,6 +11,9 @@
   <PropertyGroup Condition=" $(TargetFramework.StartsWith('netstandard')) ">
     <DefineConstants>$(DefineConstants);WASM</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup Condition="$(TargetFramework.StartsWith('net6.0-windows10'))">
+    <DefineConstants>$(DefineConstants);HAS_UNO_WINUI</DefineConstants>
+  </PropertyGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('MonoAndroid')) ">
     <!-- Hack to get around invalid version of Java.Interop -->
@@ -29,11 +32,12 @@
   <ItemGroup Condition=" !$(TargetFramework.StartsWith('net6.0-windows10')) ">
     <PackageReference Include="Uno.WinUI" Version="4.0.9" />
   </ItemGroup>
-   
+   <PropertyGroup Condition="$(TargetFramework.StartsWith('net6.0-windows10'))">
+    <DefineConstants>$(DefineConstants);HAS_UNO_WINUI</DefineConstants>
+  </PropertyGroup>
   <ItemGroup Condition=" $(TargetFramework.StartsWith('net6.0-windows10')) ">
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.0.0" />
   </ItemGroup>
-
   <ItemGroup Condition=" $(TargetFramework.StartsWith('netstandard')) ">
     <PackageReference Include="Reactive.Wasm" Version="1.*" />
   </ItemGroup>

--- a/src/ReactiveUI.Uno/ActivationForViewFetcher.cs
+++ b/src/ReactiveUI.Uno/ActivationForViewFetcher.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.Linq;
-using System.Reactive;
 using System.Reactive.Linq;
 using System.Reflection;
 

--- a/src/ReactiveUI.Wpf/ReactiveUI.Wpf.csproj
+++ b/src/ReactiveUI.Wpf/ReactiveUI.Wpf.csproj
@@ -16,7 +16,7 @@
     <None Include="..\ReactiveUI.Uwp\Rx\**\*.cs" LinkBase="Rx" />
   </ItemGroup>
 
-  <ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) or $(TargetFramework) == 'net5.0-windows' or $(TargetFramework) == 'net6.0-windows' ">
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) or $(TargetFramework) == 'net6.0-windows' ">
     <Compile Include="..\ReactiveUI.Uwp\Rx\Concurrency\DispatcherScheduler.cs" LinkBase="Rx" />
     <Compile Include="..\ReactiveUI.Uwp\Rx\Internal\Constants.cs" LinkBase="Rx" />
     <Compile Include="..\ReactiveUI.Uwp\Rx\Linq\**\*.cs" LinkBase="Rx" Exclude="..\ReactiveUI.Uwp\Rx\Linq\ControlObservable.cs" />


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
fix


**What is the current behavior?**
<!-- You can also link to an open issue here. -->

There is no windows target framework

**What is the new behavior?**
<!-- If this is a feature change -->

There's a windows target framework.
