### PR TITLE
Update to AndriodX 1.7.0.1

### DIFF
--- a/src/ReactiveUI.AndroidX/ReactiveUI.AndroidX.csproj
+++ b/src/ReactiveUI.AndroidX/ReactiveUI.AndroidX.csproj
@@ -17,10 +17,11 @@
 
   <ItemGroup>
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
-    <PackageReference Include="Xamarin.AndroidX.Preference" Version="1.1.1.11" />
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.3.1.1" />
+    <PackageReference Include="Xamarin.AndroidX.Preference" Version="1.1.1.12" />
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.4.0.1" />
     <PackageReference Include="Xamarin.AndroidX.Legacy.Support.Core.UI" Version="1.0.0.12" />
-    <PackageReference Include="Xamarin.Google.Android.Material" Version="1.4.0.4" />
+    <PackageReference Include="Xamarin.Google.Android.Material" Version="1.4.0.5" />
+    <PackageReference Include="Xamarin.AndroidX.Core" Version="1.7.0.1" />
     <Reference Include="System.Runtime.Serialization" />
   </ItemGroup>
 

--- a/src/ReactiveUI.XamForms/ReactiveUI.XamForms.csproj
+++ b/src/ReactiveUI.XamForms/ReactiveUI.XamForms.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="5.0.*" />
+    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2244" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->



**What is the current behaviour?**
<!-- You can also link to an open issue here. -->

Existing code using  ReactiveUI V17.0.13 to V17.1.4 will not compile without adding extra packages

**What is the new behaviour?**
<!-- If this is a feature change -->

Xamarin.Forms has been updated to use 1.7.0.1 of AndroidX.Core
Removed * from Xamarin.Forms version due to breaking change by Xamarin without following SemVer 2

**What might this PR break?**

None expected

**Please check if the PR fulfils these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

