### PR TITLE
fix: Removed net6.0-windows10.0.17763.0 target from Uno.WinUI project.

### DIFF
--- a/src/ReactiveUI.Uno.WinUI/ReactiveUI.Uno.WinUI.csproj
+++ b/src/ReactiveUI.Uno.WinUI/ReactiveUI.Uno.WinUI.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
-    <TargetFrameworks>netstandard20;MonoAndroid11.0;Xamarin.iOS10;Xamarin.Mac20;net6.0-android;net6.0-ios;net6.0-macos;net6.0-windows10.0.17763.0</TargetFrameworks>
+    <TargetFrameworks>netstandard20;MonoAndroid11.0;Xamarin.iOS10;Xamarin.Mac20;net6.0-android;net6.0-ios;net6.0-macos</TargetFrameworks>
     <PackageId>ReactiveUI.Uno.WinUI</PackageId>
     <PackageDescription>Contains the ReactiveUI platform specific extensions for Uno WinUI</PackageDescription>
     <DefineConstants>$(DefineConstants);HAS_UNO;HAS_WINUI</DefineConstants>


### PR DESCRIPTION
net6.0 is prioritized over .Net Standard, because of this, .Net Standard Uno projects do not work

<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here. -->



**What is the new behavior?**
<!-- If this is a feature change -->



**What might this PR break?**



**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

