### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/build-samples.yml
+++ b/.github/workflows/build-samples.yml
@@ -9,8 +9,13 @@ on:
 env:
   productNamespacePrefix: "ReactiveUI"
 
+permissions:
+  contents: read
+
 jobs:
   build:
+    permissions:
+      contents: none
     uses: reactiveui/actions-common/.github/workflows/workflow-common-setup-and-build.yml@main
     with:
       configuration: Release

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -9,8 +9,13 @@ on:
 env:
   productNamespacePrefix: "ReactiveUI"
 
+permissions:
+  contents: read
+
 jobs:
   build:
+    permissions:
+      contents: none
     uses: reactiveui/actions-common/.github/workflows/workflow-common-setup-and-build.yml@main
     with:
       configuration: Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,13 @@ on:
 env:
   productNamespacePrefix: "Splat"
 
+permissions:
+  contents: read
+
 jobs:
   release:
+    permissions:
+      contents: none
     uses: reactiveui/actions-common/.github/workflows/workflow-common-release.yml@main
     with:
       configuration: Release


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
