### PR TITLE
fix: Remove permissions on release since we need ability to release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,15 +7,10 @@ on:
       - patches/*
     
 env:
-  productNamespacePrefix: "Splat"
-
-permissions:
-  contents: read
+  productNamespacePrefix: "ReactiveUI"
 
 jobs:
   release:
-    permissions:
-      contents: none
     uses: reactiveui/actions-common/.github/workflows/workflow-common-release.yml@main
     with:
       configuration: Release


### PR DESCRIPTION
Fixes the release by removing the permissions tab. Will work out what permissions we need in the future.

This action is behind a approval system anyway so less critical then the main build task.