### PR TITLE
Fix for MAUI RoutedViewHost

### DIFF
--- a/src/ReactiveUI.Maui/RoutedViewHost.cs
+++ b/src/ReactiveUI.Maui/RoutedViewHost.cs
@@ -161,7 +161,7 @@ public class RoutedViewHost : NavigationPage, IActivatableView, IEnableLogger
     /// <param name="vm">The vm.</param>
     /// <returns>An observable of the page associated to a <see cref="IRoutableViewModel"/>.</returns>
     [SuppressMessage("Design", "CA1822: Can be made static", Justification = "Might be used by implementors.")]
-    protected IObservable<Page> PagesForViewModel(IRoutableViewModel? vm)
+    protected virtual IObservable<Page> PagesForViewModel(IRoutableViewModel? vm)
     {
         if (vm is null)
         {
@@ -190,7 +190,7 @@ public class RoutedViewHost : NavigationPage, IActivatableView, IEnableLogger
     /// <param name="vm">The vm.</param>
     /// <returns>An observable of the page associated to a <see cref="IRoutableViewModel"/>.</returns>
     [SuppressMessage("Design", "CA1822: Can be made static", Justification = "Might be used by implementors.")]
-    protected Page PageForViewModel(IRoutableViewModel vm)
+    protected virtual Page PageForViewModel(IRoutableViewModel vm)
     {
         if (vm is null)
         {
@@ -232,7 +232,6 @@ public class RoutedViewHost : NavigationPage, IActivatableView, IEnableLogger
     /// </summary>
     protected void SyncNavigationStacks()
     {
-
         if (Navigation.NavigationStack.Count != Router.NavigationStack.Count
             || StacksAreDifferent())
         {

--- a/src/ReactiveUI.Maui/RoutedViewHost.cs
+++ b/src/ReactiveUI.Maui/RoutedViewHost.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Reactive;
+using System.Reactive.Concurrency;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reflection;

--- a/src/ReactiveUI.Maui/RoutedViewHost.cs
+++ b/src/ReactiveUI.Maui/RoutedViewHost.cs
@@ -178,6 +178,10 @@ public class RoutedViewHost : NavigationPage, IActivatableView, IEnableLogger
         ret.ViewModel = vm;
 
         var pg = (Page)ret;
+        MainThread.BeginInvokeOnMainThread(() =>
+        {
+            pg.Title = vm.UrlPathSegment;
+        });
 
         return Observable.Return(pg);
     }
@@ -205,7 +209,13 @@ public class RoutedViewHost : NavigationPage, IActivatableView, IEnableLogger
 
         ret.ViewModel = vm;
 
-        return (Page)ret;
+        var pg = (Page)ret;
+        MainThread.BeginInvokeOnMainThread(() =>
+        {
+            pg.Title = vm.UrlPathSegment;
+        });
+
+        return pg;
     }
 
     /// <summary>

--- a/src/ReactiveUI.Maui/RoutedViewHost.cs
+++ b/src/ReactiveUI.Maui/RoutedViewHost.cs
@@ -3,12 +3,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Reactive;
-using System.Reactive.Concurrency;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reflection;
+using Microsoft.Maui.Controls;
 using Splat;
 
 namespace ReactiveUI.Maui;
@@ -182,7 +183,7 @@ public class RoutedViewHost : NavigationPage, IActivatableView, IEnableLogger
     {
         if (vm is null)
         {
-            return Observable.Empty<Page>();
+            return Observable<Page>.Empty;
         }
 
         var ret = ViewLocator.Current.ResolveView(vm);

--- a/src/ReactiveUI.Maui/RoutedViewHost.cs
+++ b/src/ReactiveUI.Maui/RoutedViewHost.cs
@@ -8,7 +8,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Reactive;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
-using System.Reactive.Threading.Tasks;
 using System.Reflection;
 using Microsoft.Maui.Controls;
 using Splat;
@@ -179,7 +178,6 @@ public class RoutedViewHost : NavigationPage, IActivatableView, IEnableLogger
         ret.ViewModel = vm;
 
         var pg = (Page)ret;
-        // pg.Title = vm.UrlPathSegment;
 
         return Observable.Return(pg);
     }
@@ -207,10 +205,7 @@ public class RoutedViewHost : NavigationPage, IActivatableView, IEnableLogger
 
         ret.ViewModel = vm;
 
-        var pg = (Page)ret;
-        // pg.Title = vm.UrlPathSegment;
-
-        return pg;
+        return (Page)ret;
     }
 
     /// <summary>

--- a/src/ReactiveUI.Maui/RoutedViewHost.cs
+++ b/src/ReactiveUI.Maui/RoutedViewHost.cs
@@ -9,6 +9,7 @@ using System.Reactive;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reflection;
+using Microsoft.Maui.ApplicationModel;
 using Microsoft.Maui.Controls;
 using Splat;
 

--- a/src/ReactiveUI.Maui/RoutedViewHost.cs
+++ b/src/ReactiveUI.Maui/RoutedViewHost.cs
@@ -179,7 +179,7 @@ public class RoutedViewHost : NavigationPage, IActivatableView, IEnableLogger
         ret.ViewModel = vm;
 
         var pg = (Page)ret;
-        pg.Title = vm.UrlPathSegment;
+        // pg.Title = vm.UrlPathSegment;
 
         return Observable.Return(pg);
     }
@@ -208,7 +208,7 @@ public class RoutedViewHost : NavigationPage, IActivatableView, IEnableLogger
         ret.ViewModel = vm;
 
         var pg = (Page)ret;
-        pg.Title = vm.UrlPathSegment;
+        // pg.Title = vm.UrlPathSegment;
 
         return pg;
     }


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

Fix for #3035


**What is the current behavior?**

1. Direct `Router.NavigationStack` manipulations are not affected on MAUI's `NavigationPage.Navigation.NavigationStack`
2. MAUI's `NavigationPage.PoppedToRoot` event is not supported
3. Double navigation to the same `VM` occures on application start


**What is the new behavior?**

Bugs are fixed
Sample app: https://github.com/ili/ReactiveUI-Navigation-Issue/tree/fix-maui-navigation

**Other information**:

Direct `NavigationPage.Navigation` manipulations are used to avoid page activations.