### PR TITLE
[FIX] nullable conversions

### DIFF
--- a/src/ReactiveUI/Bindings/Converter/NullableByteToStringTypeConverter.cs
+++ b/src/ReactiveUI/Bindings/Converter/NullableByteToStringTypeConverter.cs
@@ -46,6 +46,12 @@ public class NullableByteToStringTypeConverter : IBindingTypeConverter
 
         if (from is string fromString)
         {
+            if (string.IsNullOrEmpty(fromString))
+            {
+                result = null!;
+                return true;
+            }
+
             var success = byte.TryParse(fromString, out var outByte);
             if (success)
             {

--- a/src/ReactiveUI/Bindings/Converter/NullableByteToStringTypeConverter.cs
+++ b/src/ReactiveUI/Bindings/Converter/NullableByteToStringTypeConverter.cs
@@ -44,6 +44,12 @@ public class NullableByteToStringTypeConverter : IBindingTypeConverter
             return true;
         }
 
+        if (from is null)
+        {
+            result = null!;
+            return true;
+        }
+
         if (from is string fromString)
         {
             if (string.IsNullOrEmpty(fromString))

--- a/src/ReactiveUI/Bindings/Converter/NullableDecimalToStringTypeConverter.cs
+++ b/src/ReactiveUI/Bindings/Converter/NullableDecimalToStringTypeConverter.cs
@@ -44,6 +44,12 @@ public class NullableDecimalToStringTypeConverter : IBindingTypeConverter
             return true;
         }
 
+        if (from is null)
+        {
+            result = null!;
+            return true;
+        }
+
         if (from is string fromString)
         {
             if (string.IsNullOrEmpty(fromString))

--- a/src/ReactiveUI/Bindings/Converter/NullableDecimalToStringTypeConverter.cs
+++ b/src/ReactiveUI/Bindings/Converter/NullableDecimalToStringTypeConverter.cs
@@ -46,6 +46,12 @@ public class NullableDecimalToStringTypeConverter : IBindingTypeConverter
 
         if (from is string fromString)
         {
+            if (string.IsNullOrEmpty(fromString))
+            {
+                result = null!;
+                return true;
+            }
+
             var success = decimal.TryParse(fromString, out var outDecimal);
             if (success)
             {

--- a/src/ReactiveUI/Bindings/Converter/NullableDoubleToStringTypeConverter.cs
+++ b/src/ReactiveUI/Bindings/Converter/NullableDoubleToStringTypeConverter.cs
@@ -46,6 +46,12 @@ public class NullableDoubleToStringTypeConverter : IBindingTypeConverter
 
         if (from is string fromString)
         {
+            if (string.IsNullOrEmpty(fromString))
+            {
+                result = null!;
+                return true;
+            }
+
             var success = double.TryParse(fromString, out var outDouble);
             if (success)
             {

--- a/src/ReactiveUI/Bindings/Converter/NullableDoubleToStringTypeConverter.cs
+++ b/src/ReactiveUI/Bindings/Converter/NullableDoubleToStringTypeConverter.cs
@@ -44,6 +44,12 @@ public class NullableDoubleToStringTypeConverter : IBindingTypeConverter
             return true;
         }
 
+        if (from is null)
+        {
+            result = null!;
+            return true;
+        }
+
         if (from is string fromString)
         {
             if (string.IsNullOrEmpty(fromString))

--- a/src/ReactiveUI/Bindings/Converter/NullableIntegerToStringTypeConverter.cs
+++ b/src/ReactiveUI/Bindings/Converter/NullableIntegerToStringTypeConverter.cs
@@ -46,6 +46,12 @@ public class NullableIntegerToStringTypeConverter : IBindingTypeConverter
 
         if (from is string fromString)
         {
+            if (string.IsNullOrEmpty(fromString))
+            {
+                result = null!;
+                return true;
+            }
+
             var success = int.TryParse(fromString, out var outInt);
             if (success)
             {

--- a/src/ReactiveUI/Bindings/Converter/NullableIntegerToStringTypeConverter.cs
+++ b/src/ReactiveUI/Bindings/Converter/NullableIntegerToStringTypeConverter.cs
@@ -44,6 +44,12 @@ public class NullableIntegerToStringTypeConverter : IBindingTypeConverter
             return true;
         }
 
+        if (from is null)
+        {
+            result = null!;
+            return true;
+        }
+
         if (from is string fromString)
         {
             if (string.IsNullOrEmpty(fromString))

--- a/src/ReactiveUI/Bindings/Converter/NullableLongToStringTypeConverter.cs
+++ b/src/ReactiveUI/Bindings/Converter/NullableLongToStringTypeConverter.cs
@@ -46,6 +46,13 @@ public class NullableLongToStringTypeConverter : IBindingTypeConverter
 
         if (from is string fromString)
         {
+
+            if (string.IsNullOrEmpty(fromString))
+            {
+                result = null!;
+                return true;
+            }
+
             var success = long.TryParse(fromString, out var outLong);
             if (success)
             {

--- a/src/ReactiveUI/Bindings/Converter/NullableLongToStringTypeConverter.cs
+++ b/src/ReactiveUI/Bindings/Converter/NullableLongToStringTypeConverter.cs
@@ -44,9 +44,14 @@ public class NullableLongToStringTypeConverter : IBindingTypeConverter
             return true;
         }
 
+        if (from is null)
+        {
+            result = null!;
+            return true;
+        }
+
         if (from is string fromString)
         {
-
             if (string.IsNullOrEmpty(fromString))
             {
                 result = null!;

--- a/src/ReactiveUI/Bindings/Converter/NullableShortToStringTypeConverter.cs
+++ b/src/ReactiveUI/Bindings/Converter/NullableShortToStringTypeConverter.cs
@@ -44,7 +44,7 @@ public class NullableShortToStringTypeConverter : IBindingTypeConverter
             return true;
         }
 
-        if(from is null)
+        if (from is null)
         {
             result = null!;
             return true;

--- a/src/ReactiveUI/Bindings/Converter/NullableShortToStringTypeConverter.cs
+++ b/src/ReactiveUI/Bindings/Converter/NullableShortToStringTypeConverter.cs
@@ -44,9 +44,14 @@ public class NullableShortToStringTypeConverter : IBindingTypeConverter
             return true;
         }
 
+        if(from is null)
+        {
+            result = null!;
+            return true;
+        }
+
         if (from is string fromString)
         {
-
             if (string.IsNullOrEmpty(fromString))
             {
                 result = null!;

--- a/src/ReactiveUI/Bindings/Converter/NullableShortToStringTypeConverter.cs
+++ b/src/ReactiveUI/Bindings/Converter/NullableShortToStringTypeConverter.cs
@@ -46,6 +46,13 @@ public class NullableShortToStringTypeConverter : IBindingTypeConverter
 
         if (from is string fromString)
         {
+
+            if (string.IsNullOrEmpty(fromString))
+            {
+                result = null!;
+                return true;
+            }
+
             var success = short.TryParse(fromString, out var outShort);
             if (success)
             {

--- a/src/ReactiveUI/Bindings/Converter/NullableSingleToStringTypeConverter.cs
+++ b/src/ReactiveUI/Bindings/Converter/NullableSingleToStringTypeConverter.cs
@@ -44,9 +44,14 @@ public class NullableSingleToStringTypeConverter : IBindingTypeConverter
             return true;
         }
 
+        if (from is null)
+        {
+            result = null!;
+            return true;
+        }
+
         if (from is string fromString)
         {
-
             if (string.IsNullOrEmpty(fromString))
             {
                 result = null!;

--- a/src/ReactiveUI/Bindings/Converter/NullableSingleToStringTypeConverter.cs
+++ b/src/ReactiveUI/Bindings/Converter/NullableSingleToStringTypeConverter.cs
@@ -46,6 +46,13 @@ public class NullableSingleToStringTypeConverter : IBindingTypeConverter
 
         if (from is string fromString)
         {
+
+            if (string.IsNullOrEmpty(fromString))
+            {
+                result = null!;
+                return true;
+            }
+
             var success = float.TryParse(fromString, out var outSingle);
             if (success)
             {


### PR DESCRIPTION
Current implementation doesnt respect the possibility to assign null on null/empty string.

This potentially Fixes #3166.

But this might be breaking change, so I am not sure if it is good idea.

I have personally already stumbled on this issue few times and caused me headache, but never got into checking what is the issue.

Because when I declare number as nullable, then I expect it to be null, when I delete the text from TextBox. The way it is now is counter intuitive.

The fix makes sense to me, but could break lot of apps relying in that """feature""".