### PR TITLE
Optimize null filtering

### DIFF
--- a/src/ReactiveUI.Blazor/ReactiveComponentBase.cs
+++ b/src/ReactiveUI.Blazor/ReactiveComponentBase.cs
@@ -88,7 +88,7 @@ public class ReactiveComponentBase<T> : ComponentBase, IViewFor<T>, INotifyPrope
             // The following subscriptions are here because if they are done in OnInitialized, they conflict with certain JavaScript frameworks.
             var viewModelChanged =
                 this.WhenAnyValue(x => x.ViewModel)
-                    .Where(x => x is not null)
+                    .WhereNotNull()
                     .Publish()
                     .RefCount(2);
 
@@ -97,7 +97,6 @@ public class ReactiveComponentBase<T> : ComponentBase, IViewFor<T>, INotifyPrope
                 .DisposeWith(_compositeDisposable);
 
             viewModelChanged
-                .WhereNotNull()
                 .Select(x =>
                             Observable
                                 .FromEvent<PropertyChangedEventHandler?, Unit>(

--- a/src/ReactiveUI.Blazor/ReactiveInjectableComponentBase.cs
+++ b/src/ReactiveUI.Blazor/ReactiveInjectableComponentBase.cs
@@ -88,7 +88,7 @@ public class ReactiveInjectableComponentBase<T> : ComponentBase, IViewFor<T>, IN
             // The following subscriptions are here because if they are done in OnInitialized, they conflict with certain JavaScript frameworks.
             var viewModelChanged =
                 this.WhenAnyValue(x => x.ViewModel)
-                    .Where(x => x is not null)
+                    .WhereNotNull()
                     .Publish()
                     .RefCount(2);
 
@@ -97,7 +97,6 @@ public class ReactiveInjectableComponentBase<T> : ComponentBase, IViewFor<T>, IN
                 .DisposeWith(_compositeDisposable);
 
             viewModelChanged
-                .WhereNotNull()
                 .Select(x =>
                             Observable
                                 .FromEvent<PropertyChangedEventHandler, Unit>(


### PR DESCRIPTION
Null was filtered twice.


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Optimization.

**What is the current behavior?**
<!-- You can also link to an open issue here. -->
The `viewModelChanged` checked the null twice.

**What is the new behavior?**
<!-- If this is a feature change -->
Filters only once.

**Other information**:

The new version of #3319. That cannot be updated because its branch was deleted.