### PR TITLE
refactor: Clean up code duplication in ReactiveComponentBase classes

### DIFF
--- a/src/ReactiveUI.Blazor/ReactiveInjectableComponentBase.cs
+++ b/src/ReactiveUI.Blazor/ReactiveInjectableComponentBase.cs
@@ -3,140 +3,24 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Diagnostics.CodeAnalysis;
-using System.Reactive;
-using System.Reactive.Disposables;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
-using System.Runtime.CompilerServices;
 using Microsoft.AspNetCore.Components;
 
 namespace ReactiveUI.Blazor;
 
 /// <summary>
-/// A base component for handling property changes and updating the blazer view appropriately.
+/// Same as ReactiveComponentBase, except that ViewModel will be injected (automatically set) via
+/// DI.
 /// </summary>
 /// <typeparam name="T">The type of view model. Must support INotifyPropertyChanged.</typeparam>
-public class ReactiveInjectableComponentBase<T> : ComponentBase, IViewFor<T>, INotifyPropertyChanged, ICanActivate, IDisposable
+public abstract class ReactiveInjectableComponentBase<T> : ReactiveComponentBase<T>
     where T : class, INotifyPropertyChanged
 {
-    private readonly Subject<Unit> _initSubject = new();
-    [SuppressMessage("Design", "CA2213: Dispose object", Justification = "Used for deactivation.")]
-    private readonly Subject<Unit> _deactivateSubject = new();
-    private readonly CompositeDisposable _compositeDisposable = new();
-
-    private T? _viewModel;
-
-    private bool _disposedValue; // To detect redundant calls
-
-    /// <inheritdoc />
-    public event PropertyChangedEventHandler? PropertyChanged;
-
     /// <inheritdoc />
     [Inject]
-    public T? ViewModel
+    public override T? ViewModel
     {
-        get => _viewModel;
-        set
-        {
-            if (EqualityComparer<T?>.Default.Equals(_viewModel, value))
-            {
-                return;
-            }
-
-            _viewModel = value;
-            OnPropertyChanged();
-        }
-    }
-
-    /// <inheritdoc />
-    object? IViewFor.ViewModel
-    {
-        get => ViewModel;
-        set => ViewModel = (T?)value;
-    }
-
-    /// <inheritdoc />
-    public IObservable<Unit> Activated => _initSubject.AsObservable();
-
-    /// <inheritdoc />
-    public IObservable<Unit> Deactivated => _deactivateSubject.AsObservable();
-
-    /// <inheritdoc />
-    public void Dispose()
-    {
-        // Do not change this code. Put cleanup code in Dispose(bool disposing) below.
-        Dispose(true);
-        GC.SuppressFinalize(this);
-    }
-
-    /// <inheritdoc />
-    protected override void OnInitialized()
-    {
-        _initSubject.OnNext(Unit.Default);
-        base.OnInitialized();
-    }
-
-    /// <inheritdoc/>
-    protected override void OnAfterRender(bool firstRender)
-    {
-        if (firstRender)
-        {
-            // The following subscriptions are here because if they are done in OnInitialized, they conflict with certain JavaScript frameworks.
-            var viewModelChanged =
-                this.WhenAnyValue(x => x.ViewModel)
-                    .WhereNotNull()
-                    .Publish()
-                    .RefCount(2);
-
-            viewModelChanged
-                .Subscribe(_ => InvokeAsync(StateHasChanged))
-                .DisposeWith(_compositeDisposable);
-
-            viewModelChanged
-                .Select(x =>
-                            Observable
-                                .FromEvent<PropertyChangedEventHandler, Unit>(
-                                                                              eventHandler =>
-                                                                              {
-                                                                                  void Handler(object? sender, PropertyChangedEventArgs e) => eventHandler(Unit.Default);
-                                                                                  return Handler;
-                                                                              },
-                                                                              eh => x.PropertyChanged += eh,
-                                                                              eh => x.PropertyChanged -= eh))
-                .Switch()
-                .Subscribe(_ => InvokeAsync(StateHasChanged))
-                .DisposeWith(_compositeDisposable);
-        }
-
-        base.OnAfterRender(firstRender);
-    }
-
-    /// <summary>
-    /// Invokes the property changed event.
-    /// </summary>
-    /// <param name="propertyName">The name of the property.</param>
-    protected virtual void OnPropertyChanged([CallerMemberName]string? propertyName = null) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-
-    /// <summary>
-    /// Cleans up the managed resources of the object.
-    /// </summary>
-    /// <param name="disposing">If it is getting called by the Dispose() method rather than a finalizer.</param>
-    protected virtual void Dispose(bool disposing)
-    {
-        if (!_disposedValue)
-        {
-            if (disposing)
-            {
-                _initSubject.Dispose();
-                _compositeDisposable.Dispose();
-                _deactivateSubject.OnNext(Unit.Default);
-            }
-
-            _disposedValue = true;
-        }
+        get => base.ViewModel;
+        set => base.ViewModel = value;
     }
 }

--- a/src/ReactiveUI.Blazor/ReactiveLayoutComponentBase.cs
+++ b/src/ReactiveUI.Blazor/ReactiveLayoutComponentBase.cs
@@ -4,13 +4,7 @@
 // See the LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Reactive;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
-using System.Runtime.CompilerServices;
-using Microsoft.AspNetCore.Components;
 
 namespace ReactiveUI.Blazor;
 
@@ -18,108 +12,8 @@ namespace ReactiveUI.Blazor;
 /// A base component for handling property changes and updating the blazer view appropriately.
 /// </summary>
 /// <typeparam name="T">The type of view model. Must support INotifyPropertyChanged.</typeparam>
-public class ReactiveLayoutComponentBase<T> : LayoutComponentBase, IViewFor<T>, INotifyPropertyChanged, ICanActivate, IDisposable
+[Obsolete("This class is deprecated. Use ReactiveComponentBase instead.")]
+public abstract class ReactiveLayoutComponentBase<T> : ReactiveComponentBase<T>
     where T : class, INotifyPropertyChanged
 {
-    private readonly Subject<Unit> _initSubject = new();
-
-    private T? _viewModel;
-
-    private bool _disposedValue; // To detect redundant calls
-
-    /// <inheritdoc />
-    public event PropertyChangedEventHandler? PropertyChanged;
-
-    /// <inheritdoc />
-    public T? ViewModel
-    {
-        get => _viewModel;
-        set
-        {
-            if (EqualityComparer<T?>.Default.Equals(_viewModel, value))
-            {
-                return;
-            }
-
-            _viewModel = value;
-            OnPropertyChanged();
-        }
-    }
-
-    /// <inheritdoc />
-    object? IViewFor.ViewModel
-    {
-        get => ViewModel;
-        set => ViewModel = (T?)value;
-    }
-
-    /// <inheritdoc />
-    public IObservable<Unit> Activated => _initSubject.AsObservable();
-
-    /// <inheritdoc />
-    public IObservable<Unit> Deactivated => Observable.Empty<Unit>();
-
-    /// <inheritdoc />
-    public void Dispose()
-    {
-        // Do not change this code. Put cleanup code in Dispose(bool disposing) below.
-        Dispose(true);
-        GC.SuppressFinalize(this);
-    }
-
-    /// <inheritdoc />
-    protected override void OnInitialized()
-    {
-        _initSubject.OnNext(Unit.Default);
-        base.OnInitialized();
-    }
-
-    /// <inheritdoc />
-    protected override void OnAfterRender(bool isFirstRender)
-    {
-        if (isFirstRender)
-        {
-            this.WhenAnyValue(x => x.ViewModel)
-                .Skip(1)
-                .WhereNotNull()
-                .Subscribe(_ => InvokeAsync(StateHasChanged));
-        }
-
-        this.WhenAnyValue(x => x.ViewModel)
-            .WhereNotNull()
-            .Select(x => Observable.FromEvent<PropertyChangedEventHandler, Unit>(
-                     eventHandler =>
-                     {
-                         void Handler(object? sender, PropertyChangedEventArgs e) => eventHandler(Unit.Default);
-                         return Handler;
-                     },
-                     eh => x.PropertyChanged += eh,
-                     eh => x.PropertyChanged -= eh))
-            .Switch()
-            .Do(_ => InvokeAsync(StateHasChanged))
-            .Subscribe();
-    }
-
-    /// <summary>
-    /// Invokes the property changed event.
-    /// </summary>
-    /// <param name="propertyName">The name of the property.</param>
-    protected virtual void OnPropertyChanged([CallerMemberName]string? propertyName = null) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-
-    /// <summary>
-    /// Cleans up the managed resources of the object.
-    /// </summary>
-    /// <param name="disposing">If it is getting called by the Dispose() method rather than a finalizer.</param>
-    protected virtual void Dispose(bool disposing)
-    {
-        if (!_disposedValue)
-        {
-            if (disposing)
-            {
-                _initSubject.Dispose();
-            }
-
-            _disposedValue = true;
-        }
-    }
 }


### PR DESCRIPTION
There are three classes affected:

- `ReactiveComponentBase`
- `ReactiveInjectableComponentBase`
- `ReactiveLayoutComponentBase`

The goal is to reduce code duplication between these three classes, as well as eliminating any behavioral differences that may not have been intentional. With that in mind, the changes in each class is outlined below.

# ReactiveComponentBase

This class is now the base class for others. Logically it hasn't changed much. A few methods were made `virtual` in order for them to be overridden in derived classes. Its main purpose now is to house shared logic that was previously duplicated between the other two classes.

Its implementation of `OnAfterRender()` was modified to use the more succinct implementation from `ReactiveLayoutComponentBase`.

# ReactiveInjectableComponentBase

Nearly 100% gutted. It now derives from `ReactiveComponentBase` and only overrides `ViewModel` in order to specify the `[Inject]` attribute.

# ReactiveLayoutComponentBase

I'll be completely honest, I have no idea what the purpose of this class is. I made many efforts to understand:

- `git log` to read the history of the file to make out its purpose.
- Read [certain pull requests][pr] on github that involve changes to this file.
- Ask various individuals on Slack
- Carefully reading the code and comparing it to the implementation of `ReactiveComponentBase`.

Despite these efforts, I failed to find any meaningful differences. Semantically the only difference I found was that it did not use a `CompositeDisposable` to be rid of its connections to the `ViewModel` on its destruction, but I assume this doesn't matter since it can safely assume ownership of the `ViewModel`.

Based on this, I have marked the class `[Obsolete]` to discourage users from using it and migrate them to `ReactiveComponentBase`. It has been kept as an empty class that implements `ReactiveComponentBase` only for backward compatibility.

[pr]: https://github.com/reactiveui/ReactiveUI/pull/2336
