### PR TITLE
Add Functions to handle Cancellation Token Tasks for ReactiveCommand

### DIFF
--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.DotNet6_0.verified.txt
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.DotNet6_0.verified.txt
@@ -814,6 +814,15 @@ namespace ReactiveUI
         public int GetAffinityForObjects(System.Type fromType, System.Type toType) { }
         public bool TryConvert(object? from, System.Type toType, object? conversionHint, out object result) { }
     }
+    public static class Signals
+    {
+        public static System.IObservable<T> FromAsync<T>(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task> actionAsync, System.Reactive.Concurrency.IScheduler? scheduler = null) { }
+        public static System.IObservable<T> FromValue<T>(System.Action<System.Threading.CancellationToken> actionAsync, System.Reactive.Concurrency.IScheduler? scheduler = null) { }
+        public static System.IObservable<T> FromValue<T>(System.Func<System.Threading.CancellationToken, T> actionAsync, System.Reactive.Concurrency.IScheduler? scheduler = null) { }
+        public static System.Threading.Tasks.Task HandleCancellation(this System.Threading.Tasks.Task asyncTask, System.Action? action = null) { }
+        public static System.Threading.Tasks.Task<TResult?> HandleCancellation<TResult>(this System.Threading.Tasks.Task<TResult> asyncTask, System.Action action) { }
+        public static T RunCancellationTask<T>(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task> execute, System.Threading.CancellationToken ct) { }
+    }
     [System.AttributeUsage(System.AttributeTargets.Class)]
     public sealed class SingleInstanceViewAttribute : System.Attribute
     {

--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.Net4_7.verified.txt
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.Net4_7.verified.txt
@@ -821,6 +821,15 @@ namespace ReactiveUI
         public int GetAffinityForObjects(System.Type fromType, System.Type toType) { }
         public bool TryConvert(object? from, System.Type toType, object? conversionHint, out object result) { }
     }
+    public static class Signals
+    {
+        public static System.IObservable<T> FromAsync<T>(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task> actionAsync, System.Reactive.Concurrency.IScheduler? scheduler = null) { }
+        public static System.IObservable<T> FromValue<T>(System.Action<System.Threading.CancellationToken> actionAsync, System.Reactive.Concurrency.IScheduler? scheduler = null) { }
+        public static System.IObservable<T> FromValue<T>(System.Func<System.Threading.CancellationToken, T> actionAsync, System.Reactive.Concurrency.IScheduler? scheduler = null) { }
+        public static System.Threading.Tasks.Task HandleCancellation(this System.Threading.Tasks.Task asyncTask, System.Action? action = null) { }
+        public static System.Threading.Tasks.Task<TResult?> HandleCancellation<TResult>(this System.Threading.Tasks.Task<TResult> asyncTask, System.Action action) { }
+        public static T RunCancellationTask<T>(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task> execute, System.Threading.CancellationToken ct) { }
+    }
     [System.AttributeUsage(System.AttributeTargets.Class)]
     public sealed class SingleInstanceViewAttribute : System.Attribute
     {

--- a/src/ReactiveUI/ReactiveCommand/ReactiveCommand.cs
+++ b/src/ReactiveUI/ReactiveCommand/ReactiveCommand.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Reactive;
 using System.Reactive.Concurrency;
 using System.Reactive.Disposables;
@@ -402,7 +403,7 @@ public static class ReactiveCommand
             throw new ArgumentNullException(nameof(execute));
         }
 
-        return CreateFromObservable(() => Observable.FromAsync(execute), canExecute, outputScheduler);
+        return CreateFromObservable(() => Signals.FromValue<TResult>(async ct => await execute(ct)), canExecute, outputScheduler);
     }
 
     /// <summary>
@@ -458,7 +459,10 @@ public static class ReactiveCommand
             throw new ArgumentNullException(nameof(execute));
         }
 
-        return CreateFromObservable(() => Observable.FromAsync(execute), canExecute, outputScheduler);
+        return CreateFromObservable(
+            () => Signals.FromAsync<Unit>(execute),
+            canExecute,
+            outputScheduler);
     }
 
     /// <summary>
@@ -530,7 +534,7 @@ public static class ReactiveCommand
         }
 
         return CreateFromObservable<TParam, TResult>(
-                                                     param => Observable.FromAsync(ct => execute(param, ct)),
+                                                     param => Signals.FromValue<TResult>(async ct => await execute(param, ct)!),
                                                      canExecute,
                                                      outputScheduler);
     }
@@ -598,7 +602,7 @@ public static class ReactiveCommand
         }
 
         return CreateFromObservable<TParam, Unit>(
-                                                  param => Observable.FromAsync(ct => execute(param, ct)),
+                                                  param => Signals.FromValue<Unit>(async ct => await execute(param, ct)),
                                                   canExecute,
                                                   outputScheduler);
     }
@@ -624,7 +628,7 @@ public static class ReactiveCommand
                     "StyleCop.CSharp.MaintainabilityRules",
                     "SA1402:FileMayOnlyContainASingleType",
                     Justification = "Same class just generic.")]
-public class ReactiveCommand<TParam, TResult> : ReactiveCommandBase<TParam, TResult>
+public partial class ReactiveCommand<TParam, TResult> : ReactiveCommandBase<TParam, TResult>
 {
     private readonly IObservable<bool> _canExecute;
     private readonly IDisposable _canExecuteSubscription;

--- a/src/ReactiveUI/ReactiveCommand/Signals.cs
+++ b/src/ReactiveUI/ReactiveCommand/Signals.cs
@@ -1,0 +1,280 @@
+﻿// Copyright (c) 2022 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Linq;
+using System.Reactive.Concurrency;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ReactiveUI;
+
+/// <summary>
+/// Signals.
+/// </summary>
+public static class Signals
+{
+    /// <summary>
+    /// Froms the asynchronous.
+    /// </summary>
+    /// <typeparam name="T">The type of the return value.</typeparam>
+    /// <param name="actionAsync">The action asynchronous.</param>
+    /// <param name="scheduler">The scheduler.</param>
+    /// <returns>An Observable of T.</returns>
+    public static IObservable<T> FromAsync<T>(Func<CancellationToken, Task> actionAsync, IScheduler? scheduler = null) =>
+        FromValue(ct => RunCancellationTask<T>(actionAsync, ct), scheduler);
+
+    /// <summary>
+    /// Froms the asynchronous.
+    /// </summary>
+    /// <typeparam name="T">The type of the return value.</typeparam>
+    /// <param name="actionAsync">The action asynchronous.</param>
+    /// <param name="scheduler">The scheduler.</param>
+    /// <returns>An Observable of T.</returns>
+    public static IObservable<T> FromValue<T>(Func<CancellationToken, T> actionAsync, IScheduler? scheduler = null)
+    {
+        var s = scheduler ?? CurrentThreadScheduler.Instance;
+        return Observable.Defer(() => Observable.Create<T>(
+            async obs =>
+            {
+                // CancelationToken
+                var src = new CancellationTokenSource();
+                var ct = src.Token;
+
+#pragma warning disable CA2008 // Do not create tasks without passing a TaskScheduler
+                var task = Task.Factory.StartNew<T>(
+                    () =>
+                    {
+                        try
+                        {
+                            return actionAsync(ct);
+                        }
+                        catch (OperationCanceledException oce)
+                        {
+                            // Catch the cancellation exception and pass it to the observer if not user handled.
+                            obs.OnError(oce);
+                        }
+                        catch (Exception ex)
+                        {
+                            // Catch the exception and pass it to the observer if not user handled.
+                            obs.OnError(ex);
+                        }
+
+                        return default!;
+                    },
+                    ct);
+#pragma warning restore CA2008 // Do not create tasks without passing a TaskScheduler
+                try
+                {
+                    var result = await task.WhenCancelled(ct);
+                    if (result != null)
+                    {
+                        obs.OnNext(result);
+                        obs.OnCompleted();
+                    }
+                }
+                catch (Exception ex)
+                {
+                    // Catch the exception and pass it to the observer if not user handled.
+                    obs.OnError(ex);
+                }
+
+                return Disposable.Create(() =>
+                         {
+                             ct.ThrowIfCancellationRequested();
+                             src.Cancel();
+                             src.Dispose();
+                         });
+            })).ObserveOn(s);
+    }
+
+    /// <summary>
+    /// Froms the asynchronous.
+    /// </summary>
+    /// <typeparam name="T">The type of the return value.</typeparam>
+    /// <param name="actionAsync">The action asynchronous.</param>
+    /// <param name="scheduler">The scheduler.</param>
+    /// <returns>An Observable of T.</returns>
+    public static IObservable<T> FromValue<T>(Action<CancellationToken> actionAsync, IScheduler? scheduler = null)
+    {
+        var s = scheduler ?? CurrentThreadScheduler.Instance;
+        return Observable.Defer(() => Observable.Create<T>(
+            async obs =>
+            {
+                // CancelationToken
+                var src = new CancellationTokenSource();
+                var ct = src.Token;
+
+#pragma warning disable CA2008 // Do not create tasks without passing a TaskScheduler
+                var task = Task.Factory.StartNew<T>(
+                    () =>
+                {
+                    try
+                    {
+                        actionAsync(ct);
+                    }
+                    catch (OperationCanceledException oce)
+                    {
+                        // Catch the cancellation exception and pass it to the observer if not user handled.
+                        obs.OnError(oce);
+                    }
+                    catch (Exception ex)
+                    {
+                        // Catch the exception and pass it to the observer if not user handled.
+                        obs.OnError(ex);
+                    }
+
+                    return default!;
+                },
+                    ct);
+#pragma warning restore CA2008 // Do not create tasks without passing a TaskScheduler
+
+                try
+                {
+                    var result = await task.WhenCancelled(ct);
+                    if (result != null)
+                    {
+                        obs.OnNext(result);
+                    }
+
+                    obs.OnCompleted();
+                }
+                catch (Exception ex)
+                {
+                    // Catch the exception and pass it to the observer if not user handled.
+                    obs.OnError(ex);
+                }
+
+                return Disposable.Create(() =>
+                {
+                    ct.ThrowIfCancellationRequested();
+                    src.Cancel();
+                    src.Dispose();
+                });
+            }).ObserveOn(s));
+    }
+
+    /// <summary>
+    /// Runs from asynchronous.
+    /// </summary>
+    /// <typeparam name="T">The return type.</typeparam>
+    /// <param name="execute">The execute.</param>
+    /// <param name="ct">The ct.</param>
+    /// <returns>A instance of type T.</returns>
+    public static T RunCancellationTask<T>(Func<CancellationToken, Task> execute, CancellationToken ct)
+    {
+        try
+        {
+#pragma warning disable CA2008 // Do not create tasks without passing a TaskScheduler
+            return Task.Factory.StartNew<T>(
+                () =>
+                {
+                    var task = execute(ct);
+                    try
+                    {
+                        task.HandleCancellation().Wait();
+                    }
+                    catch (AggregateException ae)
+                    {
+                        foreach (var ex in ae.InnerExceptions.Select(e => new Exception(e.Message, e)))
+                        {
+                            throw ex;
+                        }
+                    }
+                    catch (OperationCanceledException)
+                    {
+                    }
+                    catch (Exception)
+                    {
+                        throw;
+                    }
+
+                    return default!;
+                },
+                ct).Result;
+#pragma warning restore CA2008 // Do not create tasks without passing a TaskScheduler
+        }
+        catch (Exception ex)
+        {
+            if (ex is AggregateException ae)
+            {
+                foreach (var innerEx in ae.InnerExceptions.Select(e => new Exception(e.Message, e)))
+                {
+                    throw innerEx;
+                }
+            }
+
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Handles the cancellation.
+    /// </summary>
+    /// <param name="asyncTask">The asynchronous task.</param>
+    /// <param name="action">The action.</param>
+    /// <returns>A Task.</returns>
+    public static async Task HandleCancellation(this Task asyncTask, Action? action = null)
+    {
+        try
+        {
+            await asyncTask;
+        }
+        catch (OperationCanceledException)
+        {
+            action?.Invoke();
+        }
+    }
+
+    /// <summary>
+    /// Handles the cancellation.
+    /// </summary>
+    /// <typeparam name="TResult">The type of the result.</typeparam>
+    /// <param name="asyncTask">The asynchronous task.</param>
+    /// <param name="action">The action.</param>
+    /// <returns>A Task of TResult.</returns>
+    public static async Task<TResult?> HandleCancellation<TResult>(this Task<TResult> asyncTask, Action action)
+    {
+        try
+        {
+            if (asyncTask?.IsCanceled == false && !asyncTask.IsFaulted && !asyncTask.IsCompleted)
+            {
+                return await asyncTask;
+            }
+
+            action?.Invoke();
+        }
+        catch (OperationCanceledException)
+        {
+            action?.Invoke();
+        }
+
+        return default;
+    }
+
+    private static async Task<TResult> WhenCancelled<TResult>(this Task<TResult> asyncTask, CancellationToken cancellationToken)
+    {
+        var tcs = new TaskCompletionSource<TResult>();
+        cancellationToken.Register(() => tcs.TrySetCanceled(), useSynchronizationContext: false);
+        var cancellationTask = tcs.Task;
+
+        // Create a task that completes when either the async operation completes,
+        // or cancellation is requested.
+        var readyTask = await Task.WhenAny(asyncTask, cancellationTask);
+
+        // In case of cancellation, register a continuation to observe any unhandled.
+        // exceptions from the asynchronous operation (once it completes).
+        if (readyTask == cancellationTask)
+        {
+#pragma warning disable CA2008 // Do not create tasks without passing a TaskScheduler
+            await asyncTask.ContinueWith(_ => asyncTask.Exception, TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously);
+#pragma warning restore CA2008 // Do not create tasks without passing a TaskScheduler
+        }
+
+        return await readyTask;
+    }
+}


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Fix

**What is the current behaviour?**
<!-- You can also link to an open issue here. -->

ReactiveCommand does not support Cancellation tokens properly for CreateFromTask 

**What is the new behaviour?**
<!-- If this is a feature change -->

Issue with HandleNonSuccessAndDebuggerNotification needs resolving
Fix the issues with the base functions within RxUI due to issue with Observable.FromAsync

**What might this PR break?**

ReactiveCommand.CreateFromTask  with a cancellation token will operate differently

**Please check if the PR fulfils these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

