### PR TITLE
Fix issue in ReactiveUI.Wpf when windows10.0.19041 is selected at runtime by end user

### DIFF
--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -52,7 +52,7 @@
     <PackageReference Include="Microsoft.Reactive.Testing" Version="5.0.0" />
     <PackageReference Include="PublicApiGenerator" Version="10.3.0" />
     <PackageReference Include="coverlet.msbuild" Version="3.2.0" PrivateAssets="All" />
-    <PackageReference Include="Verify.Xunit" Version="19.9.3" />
+    <PackageReference Include="Verify.Xunit" Version="19.10.0" />
   </ItemGroup>
   
   <ItemGroup Condition="'$(IsTestProject)' != 'true'">

--- a/src/ReactiveUI.Maui/ReactiveUI.Maui.csproj
+++ b/src/ReactiveUI.Maui/ReactiveUI.Maui.csproj
@@ -16,9 +16,7 @@
 	</PropertyGroup>
 
 	<ItemGroup Condition="$(TargetFramework.StartsWith('net6.0-windows10')) or $(TargetFramework.StartsWith('net7.0-windows10'))">
-		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.2.230118.102" />
-	</ItemGroup>
-  <ItemGroup Condition="$(TargetFramework.StartsWith('net6.0-windows10'))">
+		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.2.230217.4" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.755" />
   </ItemGroup>
 	<ItemGroup>

--- a/src/ReactiveUI.WinUI/ReactiveUI.WinUI.csproj
+++ b/src/ReactiveUI.WinUI/ReactiveUI.WinUI.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.2.230118.102" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.2.230217.4" />
   </ItemGroup>
 
   <!-- Workaround for https://github.com/microsoft/WindowsAppSDK/issues/1217 

--- a/src/ReactiveUI.Wpf/ReactiveUI.Wpf.csproj
+++ b/src/ReactiveUI.Wpf/ReactiveUI.Wpf.csproj
@@ -1,10 +1,15 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
-    <TargetFrameworks>net462;net472;net48;net6.0-windows10.0.17763.0;net7.0-windows10.0.17763.0</TargetFrameworks>
+    <!--
+    Added 19041 target as a workaround for System.Reactive targeting net5.0-windows10.0.19041.0
+    When 19041 is selected by the end user it causes the DispatcherScheduler in System.Reactive to be exposed and used.
+    -->
+    <TargetFrameworks>net462;net472;net48;net6.0-windows10.0.17763.0;net7.0-windows10.0.17763.0;net6.0-windows10.0.19041.0;net7.0-windows10.0.19041.0</TargetFrameworks>
     <PackageDescription>Contains the ReactiveUI platform specific extensions for Windows Presentation Foundation (WPF)</PackageDescription>
     <PackageId>ReactiveUI.WPF</PackageId>
     <UseWpf>true</UseWpf>
     <PackageTags>mvvm;reactiveui;rx;reactive extensions;observable;LINQ;events;frp;wpf;net;net472</PackageTags>
+    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>
@@ -16,9 +21,12 @@
     <None Include="..\ReactiveUI.Uwp\Rx\**\*.cs" LinkBase="Rx" />
   </ItemGroup>
 
-  <ItemGroup Condition=" $(TargetFramework.StartsWith('net6.0-windows')) or $(TargetFramework.StartsWith('net7.0-windows')) or $(TargetFramework) == 'net462' ">
-    <Compile Include="..\ReactiveUI.Uwp\Rx\Concurrency\DispatcherScheduler.cs" LinkBase="Rx" />
+  <ItemGroup Condition=" $(TargetFramework) == 'net462' or $(TargetFramework.StartsWith('net6.0-windows')) or $(TargetFramework.StartsWith('net7.0-windows')) ">
     <Compile Include="..\ReactiveUI.Uwp\Rx\Internal\Constants.cs" LinkBase="Rx" />
     <Compile Include="..\ReactiveUI.Uwp\Rx\Linq\**\*.cs" LinkBase="Rx" Exclude="..\ReactiveUI.Uwp\Rx\Linq\ControlObservable.cs" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" $(TargetFramework) == 'net462' or $(TargetFramework) == 'net6.0-windows10.0.17763.0' or $(TargetFramework) == 'net7.0-windows10.0.17763.0' ">
+    <Compile Include="..\ReactiveUI.Uwp\Rx\Concurrency\DispatcherScheduler.cs" LinkBase="Rx" />
   </ItemGroup>
 </Project>

--- a/src/global.json
+++ b/src/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "version": "6.0",
+        "version": "7.0",
         "rollForward": "latestMinor",
         "allowPrerelease": true
     },


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Fix for #3493

**What is the current behaviour?**
<!-- You can also link to an open issue here. -->

Works on all targets except windows10.0.19041

**What is the new behaviour?**
<!-- If this is a feature change -->

Works on all targets
Added windows10.0.19041.0 target as a workaround for System.Reactive targeting net5.0-windows10.0.19041.0
When windows10.0.19041.0 is selected by the end user it causes the DispatcherScheduler in System.Reactive to be exposed and used.

**What might this PR break?**

none expected

**Please check if the PR fulfils these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

