### PR TITLE
Support for generic -windows targets in ReactiveUI.WPF (#3558)

### DIFF
--- a/src/ReactiveUI.Wpf/ReactiveUI.Wpf.csproj
+++ b/src/ReactiveUI.Wpf/ReactiveUI.Wpf.csproj
@@ -3,8 +3,9 @@
     <!--
     Added 19041 target as a workaround for System.Reactive targeting net5.0-windows10.0.19041.0
     When 19041 is selected by the end user it causes the DispatcherScheduler in System.Reactive to be exposed and used.
+    Added generic "*-windows" target workaround to include missing DispatcherScheduler from System.Reactive, in the same fashion 17763 is fixed. This allows inclusion of ReactiveUI.WPF in 3rd party libraries targeting generic netX.X-windows 
     -->
-    <TargetFrameworks>net462;net472;net48;net6.0-windows10.0.17763.0;net7.0-windows10.0.17763.0;net6.0-windows10.0.19041.0;net7.0-windows10.0.19041.0</TargetFrameworks>
+    <TargetFrameworks>net462;net472;net48;net6.0-windows;net7.0-windows;net6.0-windows10.0.17763.0;net7.0-windows10.0.17763.0;net6.0-windows10.0.19041.0;net7.0-windows10.0.19041.0</TargetFrameworks>
     <PackageDescription>Contains the ReactiveUI platform specific extensions for Windows Presentation Foundation (WPF)</PackageDescription>
     <PackageId>ReactiveUI.WPF</PackageId>
     <UseWpf>true</UseWpf>
@@ -26,7 +27,7 @@
     <Compile Include="..\ReactiveUI.Uwp\Rx\Linq\**\*.cs" LinkBase="Rx" Exclude="..\ReactiveUI.Uwp\Rx\Linq\*Observable.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition=" $(TargetFramework) == 'net462' or $(TargetFramework) == 'net6.0-windows10.0.17763.0' or $(TargetFramework) == 'net7.0-windows10.0.17763.0' ">
+  <ItemGroup Condition=" $(TargetFramework) == 'net462' or $(TargetFramework.EndsWith('windows')) or $(TargetFramework.EndsWith('windows10.0.17763.0'))">
     <Compile Include="..\ReactiveUI.Uwp\Rx\Concurrency\DispatcherScheduler.cs" LinkBase="Rx" />
     <Compile Include="..\ReactiveUI.Uwp\Rx\Linq\DispatcherObservable.cs" LinkBase="Rx" />
   </ItemGroup>


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Feature: Adding support for generic -windows targets

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

WPF applications require an OS version specific target. This forces the hand of develoeprs and 3rd party library makers. 

#3557 
#3558

**What is the new behavior?**
<!-- If this is a feature change -->

WPF application targeting net6.0-windows and net7.0-windows can use ReactiveUI.WPF. Also 3rd party libraries for WPF using ReactiveUI.WPF internally can expose the target frameworks.

**What might this PR break?**

Nothing really, it just adds more targets, existing targets are unaffected. 

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


The integration tests do not contain any dotnet builds as it is, so nothing to expand upon, we can upgrade those tests if you like. I did test the fix in my own WPF app. 

**Other information**:

