### PR TITLE
Update : Remove Requirements for the Latest WinUI SDK in Maui

### DIFF
--- a/src/ReactiveUI.Maui/ReactiveUI.Maui.csproj
+++ b/src/ReactiveUI.Maui/ReactiveUI.Maui.csproj
@@ -12,10 +12,6 @@
 	<PropertyGroup Condition="$(TargetFramework.EndsWith('-windows10.0.19041.0'))">
 		<DefineConstants>$(DefineConstants);WINUI_TARGET;</DefineConstants>
 	</PropertyGroup>
-
-  <ItemGroup Condition="$(TargetFramework.EndsWith('-windows10.0.19041.0'))">
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.3.230602002" />
-  </ItemGroup>
   
 	<ItemGroup>
 		<ProjectReference Include="..\ReactiveUI\ReactiveUI.csproj" />


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Update

**What is the current behaviour?**
<!-- You can also link to an open issue here. -->

There is a possibility that we could use functionality that is not available on the end users target by importing a newer SDK than the target we use.

**What is the new behaviour?**
<!-- If this is a feature change -->

By removing the latest SDK we will automatically fall back to our target framework 19041 this will ensure that we don't use components that are not compatible with older versions of windows 10 whilst enabling the end user a simple means of using the library with the SDK automatically being by the IDE selecting the correct SDK based upon the end users Target choices

**What might this PR break?**

None expected, those who have already added the newer SDK's can continue to do so

**Please check if the PR fulfils these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

