### PR TITLE
Fix For Maui Navigation cast Type A to Type B

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "19.3",
+  "version": "19.4",
   "publicReleaseRefSpec": [
     "^refs/heads/master$", // we release out of master
     "^refs/heads/main$",


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Fix for #3563

**What is the current behaviour?**
<!-- You can also link to an open issue here. -->

After clearing the Navigation stack, when Navigating using PopToRoot or NavigateBack an exception occurs in InvalidateCurrentViewModel trying to cast Type A to Type B

**What is the new behaviour?**
<!-- If this is a feature change -->

Handlers are added to synchronise the navigation stacks and ignore incompatible viewmodels

**What might this PR break?**

None expected as this issue must have been an underlying issue and would have crashed the end application

**Please check if the PR fulfils these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
