### PR TITLE
housekeeping: add global usings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,7 +2,7 @@
 * text=auto
 
 # Text files that should be normalized to LF in odb.
-*.cs     text eol=lf diff=csharp
+*.cs     text diff=csharp
 *.xaml   text
 *.config text
 *.c      text
@@ -35,8 +35,8 @@
 *.pdb    binary
 *.sdf    binary
 *.7z     binary
-# Generated file should just use CRLF, it's fiiine
-SolutionInfo.cs text eol=crlf diff=csharp
+
+# lfs files
 *.mht filter=lfs diff=lfs merge=lfs -text
 *.ppam filter=lfs diff=lfs merge=lfs -text
 *.wmv filter=lfs diff=lfs merge=lfs -text

--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -70,6 +70,10 @@
     <None Include="$(MSBuildThisFileDirectory)..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
+  <ItemGroup Condition="$(MSBuildProjectName.Contains('Fody')) != 'true'">
+    <Compile Include="$(MSBuildThisFileDirectory)GlobalUsings.cs" />
+  </ItemGroup>
+
   <ItemGroup>	
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.6.133" PrivateAssets="all" />	
     <PackageReference Include="stylecop.analyzers" Version="1.2.0-beta.507" PrivateAssets="all" />

--- a/src/GlobalUsings.cs
+++ b/src/GlobalUsings.cs
@@ -1,0 +1,20 @@
+// Copyright (c) 2023 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+global using global::Splat;
+global using global::System;
+global using global::System.Collections.Generic;
+global using global::System.ComponentModel;
+global using global::System.Diagnostics.CodeAnalysis;
+global using global::System.Linq;
+global using global::System.Linq.Expressions;
+global using global::System.Reactive;
+global using global::System.Reactive.Concurrency;
+global using global::System.Reactive.Disposables;
+global using global::System.Reactive.Linq;
+global using global::System.Reactive.Subjects;
+global using global::System.Reactive.Threading.Tasks;
+global using global::System.Threading;
+global using global::System.Threading.Tasks;

--- a/src/ReactiveUI.AndroidSupport/ControlFetcherMixin.cs
+++ b/src/ReactiveUI.AndroidSupport/ControlFetcherMixin.cs
@@ -3,9 +3,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using Android.Views;
+
 using static ReactiveUI.ControlFetcherMixin;
+
 using Fragment = Android.Support.V4.App.Fragment;
 
 namespace ReactiveUI.AndroidSupport;

--- a/src/ReactiveUI.AndroidSupport/ReactiveAppCompatActivity.cs
+++ b/src/ReactiveUI.AndroidSupport/ReactiveAppCompatActivity.cs
@@ -3,14 +3,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
-using System.Reactive;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
-using System.Reactive.Threading.Tasks;
-using System.Threading.Tasks;
+
 using Android.App;
 using Android.Content;
 using Android.Runtime;

--- a/src/ReactiveUI.AndroidSupport/ReactiveDialogFragment.cs
+++ b/src/ReactiveUI.AndroidSupport/ReactiveDialogFragment.cs
@@ -3,12 +3,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
-using System.Reactive;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
 
 namespace ReactiveUI.AndroidSupport;
 

--- a/src/ReactiveUI.AndroidSupport/ReactiveFragment.cs
+++ b/src/ReactiveUI.AndroidSupport/ReactiveFragment.cs
@@ -3,12 +3,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
-using System.Reactive;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
 
 namespace ReactiveUI.AndroidSupport;
 

--- a/src/ReactiveUI.AndroidSupport/ReactiveFragmentActivity.cs
+++ b/src/ReactiveUI.AndroidSupport/ReactiveFragmentActivity.cs
@@ -3,14 +3,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
-using System.Reactive;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
-using System.Reactive.Threading.Tasks;
-using System.Threading.Tasks;
+
 using Android.App;
 using Android.Content;
 using Android.Support.V4.App;

--- a/src/ReactiveUI.AndroidSupport/ReactivePagerAdapter.cs
+++ b/src/ReactiveUI.AndroidSupport/ReactivePagerAdapter.cs
@@ -3,16 +3,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
+
 using Android.Support.V4.View;
 using Android.Views;
+
 using DynamicData;
 using DynamicData.Binding;
-using Splat;
+
 using Object = Java.Lang.Object;
 
 namespace ReactiveUI.AndroidSupport;

--- a/src/ReactiveUI.AndroidSupport/ReactivePreferenceFragment.cs
+++ b/src/ReactiveUI.AndroidSupport/ReactivePreferenceFragment.cs
@@ -3,12 +3,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
-using System.Reactive;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
+
 using Android.Runtime;
 using Android.Support.V7.Preferences;
 

--- a/src/ReactiveUI.AndroidSupport/ReactiveRecyclerViewAdapter.cs
+++ b/src/ReactiveUI.AndroidSupport/ReactiveRecyclerViewAdapter.cs
@@ -3,13 +3,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
+
 using Android.Support.V7.Widget;
 using Android.Views;
+
 using DynamicData;
 using DynamicData.Binding;
 

--- a/src/ReactiveUI.AndroidSupport/ReactiveRecyclerViewViewHolder.cs
+++ b/src/ReactiveUI.AndroidSupport/ReactiveRecyclerViewViewHolder.cs
@@ -3,15 +3,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Reactive;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
 using System.Reflection;
 using System.Runtime.Serialization;
+
 using Android.Support.V7.Widget;
 using Android.Views;
 

--- a/src/ReactiveUI.AndroidX/ControlFetcherMixin.cs
+++ b/src/ReactiveUI.AndroidX/ControlFetcherMixin.cs
@@ -3,9 +3,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using Android.Views;
+
 using static ReactiveUI.ControlFetcherMixin;
+
 using Fragment = AndroidX.Fragment.App.Fragment;
 
 namespace ReactiveUI.AndroidX;

--- a/src/ReactiveUI.AndroidX/ReactiveAppCompatActivity.cs
+++ b/src/ReactiveUI.AndroidX/ReactiveAppCompatActivity.cs
@@ -3,17 +3,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
-using System.Reactive;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
-using System.Reactive.Threading.Tasks;
-using System.Threading.Tasks;
+
 using Android.App;
 using Android.Content;
 using Android.Runtime;
+
 using AndroidX.AppCompat.App;
 
 namespace ReactiveUI.AndroidX;

--- a/src/ReactiveUI.AndroidX/ReactiveDialogFragment.cs
+++ b/src/ReactiveUI.AndroidX/ReactiveDialogFragment.cs
@@ -3,12 +3,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
-using System.Reactive;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
 
 namespace ReactiveUI.AndroidX;
 

--- a/src/ReactiveUI.AndroidX/ReactiveFragment.cs
+++ b/src/ReactiveUI.AndroidX/ReactiveFragment.cs
@@ -3,12 +3,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
-using System.Reactive;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
 
 namespace ReactiveUI.AndroidX;
 

--- a/src/ReactiveUI.AndroidX/ReactiveFragmentActivity.cs
+++ b/src/ReactiveUI.AndroidX/ReactiveFragmentActivity.cs
@@ -3,16 +3,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
-using System.Reactive;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
-using System.Reactive.Threading.Tasks;
-using System.Threading.Tasks;
+
 using Android.App;
 using Android.Content;
+
 using AndroidX.Fragment.App;
 
 namespace ReactiveUI.AndroidX;

--- a/src/ReactiveUI.AndroidX/ReactivePagerAdapter.cs
+++ b/src/ReactiveUI.AndroidX/ReactivePagerAdapter.cs
@@ -3,16 +3,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
+
 using Android.Views;
+
 using AndroidX.ViewPager.Widget;
+
 using DynamicData;
 using DynamicData.Binding;
-using Splat;
+
 using Object = Java.Lang.Object;
 
 namespace ReactiveUI.AndroidX;

--- a/src/ReactiveUI.AndroidX/ReactivePreferenceFragment.cs
+++ b/src/ReactiveUI.AndroidX/ReactivePreferenceFragment.cs
@@ -3,13 +3,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
-using System.Reactive;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
+
 using Android.Runtime;
+
 using AndroidX.Preference;
 
 namespace ReactiveUI.AndroidX;

--- a/src/ReactiveUI.AndroidX/ReactiveRecyclerViewAdapter.cs
+++ b/src/ReactiveUI.AndroidX/ReactiveRecyclerViewAdapter.cs
@@ -3,12 +3,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
+
 using AndroidX.RecyclerView.Widget;
+
 using DynamicData;
 using DynamicData.Binding;
 

--- a/src/ReactiveUI.AndroidX/ReactiveRecyclerViewViewHolder.cs
+++ b/src/ReactiveUI.AndroidX/ReactiveRecyclerViewViewHolder.cs
@@ -3,16 +3,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Reactive;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
 using System.Reflection;
 using System.Runtime.Serialization;
+
 using Android.Views;
+
 using AndroidX.RecyclerView.Widget;
 
 namespace ReactiveUI.AndroidX;

--- a/src/ReactiveUI.Blazor/ReactiveComponentBase.cs
+++ b/src/ReactiveUI.Blazor/ReactiveComponentBase.cs
@@ -3,15 +3,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
-using System.Reactive;
-using System.Reactive.Disposables;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
 using System.Runtime.CompilerServices;
+
 using Microsoft.AspNetCore.Components;
 
 namespace ReactiveUI.Blazor;

--- a/src/ReactiveUI.Blazor/ReactiveInjectableComponentBase.cs
+++ b/src/ReactiveUI.Blazor/ReactiveInjectableComponentBase.cs
@@ -3,15 +3,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
-using System.Reactive;
-using System.Reactive.Disposables;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
 using System.Runtime.CompilerServices;
+
 using Microsoft.AspNetCore.Components;
 
 namespace ReactiveUI.Blazor;

--- a/src/ReactiveUI.Blazor/ReactiveLayoutComponentBase.cs
+++ b/src/ReactiveUI.Blazor/ReactiveLayoutComponentBase.cs
@@ -3,13 +3,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Reactive;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
 using System.Runtime.CompilerServices;
+
 using Microsoft.AspNetCore.Components;
 
 namespace ReactiveUI.Blazor;

--- a/src/ReactiveUI.Blazor/Registrations.cs
+++ b/src/ReactiveUI.Blazor/Registrations.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Reactive.Concurrency;
 using System.Reactive.PlatformServices;
 
 namespace ReactiveUI.Blazor;

--- a/src/ReactiveUI.Blend/FollowObservableStateBehavior.cs
+++ b/src/ReactiveUI.Blend/FollowObservableStateBehavior.cs
@@ -3,9 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Reactive.Linq;
-
 #if NETFX_CORE
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;

--- a/src/ReactiveUI.Blend/Platforms/net4/ObservableTrigger.cs
+++ b/src/ReactiveUI.Blend/Platforms/net4/ObservableTrigger.cs
@@ -3,9 +3,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Reactive.Linq;
 using System.Windows;
+
 using Microsoft.Xaml.Behaviors;
 
 namespace ReactiveUI.Blend;

--- a/src/ReactiveUI.Drawing/Registrations.cs
+++ b/src/ReactiveUI.Drawing/Registrations.cs
@@ -3,9 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using Splat;
-
 namespace ReactiveUI.Drawing;
 
 /// <summary>

--- a/src/ReactiveUI.Maui/ActivationForViewFetcher.cs
+++ b/src/ReactiveUI.Maui/ActivationForViewFetcher.cs
@@ -3,11 +3,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Reactive.Linq;
 using System.Reflection;
 #if WINUI_TARGET
 using Microsoft.UI.Xaml;
+
 using Windows.Foundation;
 #endif
 

--- a/src/ReactiveUI.Maui/AutoSuspendHelper.cs
+++ b/src/ReactiveUI.Maui/AutoSuspendHelper.cs
@@ -3,12 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Reactive;
-using System.Reactive.Disposables;
-using System.Reactive.Subjects;
-using Splat;
-
 namespace ReactiveUI.Maui;
 
 /// <summary>

--- a/src/ReactiveUI.Maui/Common/AutoDataTemplateBindingHook.cs
+++ b/src/ReactiveUI.Maui/Common/AutoDataTemplateBindingHook.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Markup;

--- a/src/ReactiveUI.Maui/Common/BooleanToVisibilityHint.cs
+++ b/src/ReactiveUI.Maui/Common/BooleanToVisibilityHint.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-
 namespace ReactiveUI
 {
     /// <summary>

--- a/src/ReactiveUI.Maui/Common/BooleanToVisibilityTypeConverter.cs
+++ b/src/ReactiveUI.Maui/Common/BooleanToVisibilityTypeConverter.cs
@@ -3,7 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 #if WINUI_TARGET
 using Microsoft.UI.Xaml;
 #else

--- a/src/ReactiveUI.Maui/Common/ReactiveUserControl.cs
+++ b/src/ReactiveUI.Maui/Common/ReactiveUserControl.cs
@@ -6,6 +6,7 @@
 #if WINUI_TARGET
 using System;
 using System.Diagnostics.CodeAnalysis;
+
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 

--- a/src/ReactiveUI.Maui/Common/RoutedViewHost.cs
+++ b/src/ReactiveUI.Maui/Common/RoutedViewHost.cs
@@ -4,15 +4,9 @@
 // See the LICENSE file in the project root for full license information.
 
 #if WINUI_TARGET
-using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Reactive.Linq;
 using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Controls;
+
 using ReactiveUI;
-using Splat;
 
 namespace ReactiveUI
 {

--- a/src/ReactiveUI.Maui/Common/ViewModelViewHost.cs
+++ b/src/ReactiveUI.Maui/Common/ViewModelViewHost.cs
@@ -9,8 +9,10 @@ using System.Diagnostics.CodeAnalysis;
 using System.Reactive;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
+
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+
 using Splat;
 
 namespace ReactiveUI

--- a/src/ReactiveUI.Maui/DisableAnimationAttribute.cs
+++ b/src/ReactiveUI.Maui/DisableAnimationAttribute.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-
 namespace ReactiveUI.Maui;
 
 /// <summary>

--- a/src/ReactiveUI.Maui/ReactiveShellContent.cs
+++ b/src/ReactiveUI.Maui/ReactiveShellContent.cs
@@ -3,9 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using Microsoft.Maui.Controls;
-using Splat;
 
 namespace ReactiveUI.Maui;
 

--- a/src/ReactiveUI.Maui/Registrations.cs
+++ b/src/ReactiveUI.Maui/Registrations.cs
@@ -3,13 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-
-#if WINUI_TARGET
-using System.Reactive.Concurrency;
-using Splat;
-#endif
-
 #if IS_WINUI
 namespace ReactiveUI.WinUI;
 #endif

--- a/src/ReactiveUI.Maui/RoutedViewHost.cs
+++ b/src/ReactiveUI.Maui/RoutedViewHost.cs
@@ -3,16 +3,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Specialized;
-using System.Reactive;
-using System.Reactive.Concurrency;
-using System.Reactive.Disposables;
-using System.Reactive.Linq;
 using System.Reflection;
-using System.Threading.Tasks;
+
 using Microsoft.Maui.Controls;
-using Splat;
 
 namespace ReactiveUI.Maui;
 

--- a/src/ReactiveUI.Maui/ViewModelViewHost.cs
+++ b/src/ReactiveUI.Maui/ViewModelViewHost.cs
@@ -3,10 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Reactive.Linq;
 using Microsoft.Maui.Controls;
-using Splat;
 
 namespace ReactiveUI.Maui;
 

--- a/src/ReactiveUI.Maui/WinUI/DependencyObjectObservableForProperty.cs
+++ b/src/ReactiveUI.Maui/WinUI/DependencyObjectObservableForProperty.cs
@@ -10,7 +10,9 @@ using System.Linq.Expressions;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reflection;
+
 using Microsoft.UI.Xaml;
+
 using Splat;
 
 namespace ReactiveUI

--- a/src/ReactiveUI.Maui/WinUI/TransitioningContentControl.Empty.cs
+++ b/src/ReactiveUI.Maui/WinUI/TransitioningContentControl.Empty.cs
@@ -5,6 +5,7 @@
 
 #if WINUI_TARGET
 using System.Diagnostics.CodeAnalysis;
+
 using Microsoft.UI.Xaml.Controls;
 
 namespace ReactiveUI;

--- a/src/ReactiveUI.Splat.Tests/SplatAdapterTests.cs
+++ b/src/ReactiveUI.Splat.Tests/SplatAdapterTests.cs
@@ -3,17 +3,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using Autofac;
+
 using DryIoc;
 
 using FluentAssertions;
 
 using Ninject;
 
-using Splat;
 using Splat.Autofac;
 using Splat.DryIoc;
 using Splat.Ninject;
@@ -34,7 +31,7 @@ namespace ReactiveUI.Splat.Tests
         public void DryIocDependencyResolver_Should_Register_ReactiveUI_BindingTypeConverters()
         {
             // Invoke RxApp which initializes the ReactiveUI platform.
-            var container = new Container();
+            var container = new DryIoc.Container();
             container.UseDryIocDependencyResolver();
             Locator.CurrentMutable.InitializeReactiveUI();
 
@@ -52,7 +49,7 @@ namespace ReactiveUI.Splat.Tests
         public void DryIocDependencyResolver_Should_Register_ReactiveUI_CreatesCommandBinding()
         {
             // Invoke RxApp which initializes the ReactiveUI platform.
-            var container = new Container();
+            var container = new DryIoc.Container();
             container.UseDryIocDependencyResolver();
             Locator.CurrentMutable.InitializeReactiveUI();
 

--- a/src/ReactiveUI.Testing.Tests/TestFixture.cs
+++ b/src/ReactiveUI.Testing.Tests/TestFixture.cs
@@ -3,7 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
 namespace ReactiveUI.Testing.Tests

--- a/src/ReactiveUI.Testing.Tests/TestFixtureBuilder.cs
+++ b/src/ReactiveUI.Testing.Tests/TestFixtureBuilder.cs
@@ -3,9 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-
 namespace ReactiveUI.Testing.Tests
 {
     /// <summary>

--- a/src/ReactiveUI.Testing.Tests/TestFixtureBuilderExtensionTests.cs
+++ b/src/ReactiveUI.Testing.Tests/TestFixtureBuilderExtensionTests.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Collections.Generic;
-
 using FluentAssertions;
 
 using Xunit;

--- a/src/ReactiveUI.Testing/IBuilderExtensions.cs
+++ b/src/ReactiveUI.Testing/IBuilderExtensions.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Collections.Generic;
-
 namespace ReactiveUI.Testing;
 #pragma warning disable SA1402, SA1649, CA1040
 /// <summary>

--- a/src/ReactiveUI.Testing/MessageBusExtensions.cs
+++ b/src/ReactiveUI.Testing/MessageBusExtensions.cs
@@ -3,10 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Reactive.Disposables;
-using System.Threading;
-
 namespace ReactiveUI.Testing;
 
 /// <summary>

--- a/src/ReactiveUI.Testing/SchedulerExtensions.cs
+++ b/src/ReactiveUI.Testing/SchedulerExtensions.cs
@@ -3,12 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Reactive;
-using System.Reactive.Concurrency;
-using System.Reactive.Disposables;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Reactive.Testing;
 
 namespace ReactiveUI.Testing;

--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.cs
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.cs
@@ -3,9 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Threading.Tasks;
 
 using VerifyXunit;
 

--- a/src/ReactiveUI.Tests/Activation/ActivatingView.cs
+++ b/src/ReactiveUI.Tests/Activation/ActivatingView.cs
@@ -3,11 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Reactive;
-using System.Reactive.Disposables;
-using System.Reactive.Subjects;
-
 namespace ReactiveUI.Tests
 {
     /// <summary>

--- a/src/ReactiveUI.Tests/Activation/ActivatingViewFetcher.cs
+++ b/src/ReactiveUI.Tests/Activation/ActivatingViewFetcher.cs
@@ -3,9 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Reactive.Linq;
-
 namespace ReactiveUI.Tests
 {
     /// <summary>

--- a/src/ReactiveUI.Tests/Activation/ActivatingViewModel.cs
+++ b/src/ReactiveUI.Tests/Activation/ActivatingViewModel.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Reactive.Disposables;
-
 namespace ReactiveUI.Tests
 {
     /// <summary>

--- a/src/ReactiveUI.Tests/Activation/ActivatingViewTests.cs
+++ b/src/ReactiveUI.Tests/Activation/ActivatingViewTests.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Reactive;
-using Splat;
 using Xunit;
 
 namespace ReactiveUI.Tests

--- a/src/ReactiveUI.Tests/Activation/CanActivateViewFetcherTests.cs
+++ b/src/ReactiveUI.Tests/Activation/CanActivateViewFetcherTests.cs
@@ -3,12 +3,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Reactive;
-using System.Reactive.Linq;
-using System.Threading.Tasks;
 using Microsoft.Reactive.Testing;
+
 using ReactiveUI.Tests.Winforms;
+
 using Xunit;
 
 namespace ReactiveUI.Tests

--- a/src/ReactiveUI.Tests/Activation/DerivedActivatingViewModel.cs
+++ b/src/ReactiveUI.Tests/Activation/DerivedActivatingViewModel.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Reactive.Disposables;
-
 namespace ReactiveUI.Tests
 {
     /// <summary>

--- a/src/ReactiveUI.Tests/Activation/ViewModelActivatorTests.cs
+++ b/src/ReactiveUI.Tests/Activation/ViewModelActivatorTests.cs
@@ -3,9 +3,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Reactive.Concurrency;
 using DynamicData;
+
 using Xunit;
 
 namespace ReactiveUI.Tests

--- a/src/ReactiveUI.Tests/AutoPersist/AutoPersistCollectionTests.cs
+++ b/src/ReactiveUI.Tests/AutoPersist/AutoPersistCollectionTests.cs
@@ -3,13 +3,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Reactive;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
 using DynamicData.Binding;
+
 using Microsoft.Reactive.Testing;
+
 using ReactiveUI.Testing;
+
 using Xunit;
 
 namespace ReactiveUI.Tests

--- a/src/ReactiveUI.Tests/AutoPersist/AutoPersistHelperTest.cs
+++ b/src/ReactiveUI.Tests/AutoPersist/AutoPersistHelperTest.cs
@@ -3,12 +3,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Reactive;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
 using Microsoft.Reactive.Testing;
+
 using ReactiveUI.Testing;
+
 using Xunit;
 
 namespace ReactiveUI.Tests

--- a/src/ReactiveUI.Tests/AwaiterTest.cs
+++ b/src/ReactiveUI.Tests/AwaiterTest.cs
@@ -3,13 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reactive.Linq;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace ReactiveUI.Tests

--- a/src/ReactiveUI.Tests/Commands/CombinedReactiveCommandTest.cs
+++ b/src/ReactiveUI.Tests/Commands/CombinedReactiveCommandTest.cs
@@ -3,15 +3,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Reactive;
-using System.Reactive.Concurrency;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
-using System.Threading.Tasks;
 using DynamicData;
+
 using Microsoft.Reactive.Testing;
+
 using ReactiveUI.Testing;
+
 using Xunit;
 
 namespace ReactiveUI.Tests

--- a/src/ReactiveUI.Tests/Commands/CreatesCommandBindingTests.cs
+++ b/src/ReactiveUI.Tests/Commands/CreatesCommandBindingTests.cs
@@ -4,7 +4,7 @@
 // See the LICENSE file in the project root for full license information.
 
 using System.ComponentModel;
-using System.Reactive.Linq;
+
 using Xunit;
 
 namespace ReactiveUI.Tests

--- a/src/ReactiveUI.Tests/Commands/Mocks/FakeCommand.cs
+++ b/src/ReactiveUI.Tests/Commands/Mocks/FakeCommand.cs
@@ -3,7 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.Windows.Input;
 
 namespace ReactiveUI.Tests

--- a/src/ReactiveUI.Tests/Commands/Mocks/ReactiveCommandHolder.cs
+++ b/src/ReactiveUI.Tests/Commands/Mocks/ReactiveCommandHolder.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Reactive;
-
 namespace ReactiveUI.Tests
 {
     /// <summary>

--- a/src/ReactiveUI.Tests/Commands/ReactiveCommandTest.cs
+++ b/src/ReactiveUI.Tests/Commands/ReactiveCommandTest.cs
@@ -3,18 +3,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Reactive;
-using System.Reactive.Concurrency;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
-using System.Threading;
-using System.Threading.Tasks;
 using System.Windows.Input;
+
 using DynamicData;
+
 using Microsoft.Reactive.Testing;
+
 using ReactiveUI.Testing;
+
 using Xunit;
 
 namespace ReactiveUI.Tests

--- a/src/ReactiveUI.Tests/Comparers/OrderedComparerTests.cs
+++ b/src/ReactiveUI.Tests/Comparers/OrderedComparerTests.cs
@@ -3,10 +3,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
+
 using Xunit;
 
 namespace ReactiveUI.Tests

--- a/src/ReactiveUI.Tests/InteractionBinding/InteractionBinderImplementationTests.cs
+++ b/src/ReactiveUI.Tests/InteractionBinding/InteractionBinderImplementationTests.cs
@@ -3,12 +3,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Reactive;
-using System.Reactive.Linq;
-using System.Reactive.Threading.Tasks;
-using System.Threading.Tasks;
 using FluentAssertions;
+
 using Xunit;
 
 namespace ReactiveUI.Tests

--- a/src/ReactiveUI.Tests/InteractionsTest.cs
+++ b/src/ReactiveUI.Tests/InteractionsTest.cs
@@ -3,14 +3,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Reactive;
-using System.Reactive.Concurrency;
-using System.Reactive.Linq;
-using System.Threading.Tasks;
 using DynamicData;
+
 using Microsoft.Reactive.Testing;
+
 using ReactiveUI.Testing;
+
 using Xunit;
 
 namespace ReactiveUI.Tests

--- a/src/ReactiveUI.Tests/Locator/DefaultViewLocatorTests.cs
+++ b/src/ReactiveUI.Tests/Locator/DefaultViewLocatorTests.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using Splat;
 using Xunit;
 
 namespace ReactiveUI.Tests

--- a/src/ReactiveUI.Tests/Locator/Mocks/FooThatThrowsView.cs
+++ b/src/ReactiveUI.Tests/Locator/Mocks/FooThatThrowsView.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-
 namespace ReactiveUI.Tests
 {
     /// <summary>

--- a/src/ReactiveUI.Tests/Locator/Mocks/IBarViewModel.cs
+++ b/src/ReactiveUI.Tests/Locator/Mocks/IBarViewModel.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Diagnostics.CodeAnalysis;
-
 namespace ReactiveUI.Tests
 {
     /// <summary>

--- a/src/ReactiveUI.Tests/Locator/Mocks/IFooViewModel.cs
+++ b/src/ReactiveUI.Tests/Locator/Mocks/IFooViewModel.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Diagnostics.CodeAnalysis;
-
 namespace ReactiveUI.Tests
 {
     /// <summary>

--- a/src/ReactiveUI.Tests/Locator/Mocks/IStrangeInterfaceNotFollowingConvention.cs
+++ b/src/ReactiveUI.Tests/Locator/Mocks/IStrangeInterfaceNotFollowingConvention.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Diagnostics.CodeAnalysis;
-
 namespace ReactiveUI.Tests
 {
     /// <summary>

--- a/src/ReactiveUI.Tests/MessageBusTest.cs
+++ b/src/ReactiveUI.Tests/MessageBusTest.cs
@@ -3,14 +3,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Reactive.Concurrency;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
-using System.Threading;
 using DynamicData;
+
 using Microsoft.Reactive.Testing;
+
 using ReactiveUI.Testing;
+
 using Xunit;
 
 namespace ReactiveUI.Tests

--- a/src/ReactiveUI.Tests/Mocks/CommandBindViewModel.cs
+++ b/src/ReactiveUI.Tests/Mocks/CommandBindViewModel.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Reactive;
-
 namespace ReactiveUI.Tests
 {
     /// <summary>

--- a/src/ReactiveUI.Tests/Mocks/FakeNestedViewModel.cs
+++ b/src/ReactiveUI.Tests/Mocks/FakeNestedViewModel.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Reactive;
-
 namespace ReactiveUI.Tests
 {
     /// <summary>

--- a/src/ReactiveUI.Tests/Mocks/FakeViewModel.cs
+++ b/src/ReactiveUI.Tests/Mocks/FakeViewModel.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Reactive;
-
 namespace ReactiveUI.Tests
 {
     /// <summary>

--- a/src/ReactiveUI.Tests/Mocks/MockBindListView.cs
+++ b/src/ReactiveUI.Tests/Mocks/MockBindListView.cs
@@ -4,8 +4,6 @@
 // See the LICENSE file in the project root for full license information.
 
 using System.IO;
-using System.Reactive.Disposables;
-using System.Reactive.Linq;
 using System.Text;
 using System.Windows;
 using System.Windows.Controls;

--- a/src/ReactiveUI.Tests/Mocks/MockBindListViewModel.cs
+++ b/src/ReactiveUI.Tests/Mocks/MockBindListViewModel.cs
@@ -3,12 +3,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.ObjectModel;
-using System.Linq;
-using System.Reactive;
-using System.Reactive.Concurrency;
-using System.Reactive.Linq;
+
 using DynamicData;
 
 namespace ReactiveUI.Tests

--- a/src/ReactiveUI.Tests/ObservableAsPropertyHelper/Mocks/OAPHIndexerTestFixture.cs
+++ b/src/ReactiveUI.Tests/ObservableAsPropertyHelper/Mocks/OAPHIndexerTestFixture.cs
@@ -3,9 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Diagnostics.CodeAnalysis;
-using System.Reactive.Linq;
-
 namespace ReactiveUI.Tests
 {
     /// <summary>

--- a/src/ReactiveUI.Tests/ObservableAsPropertyHelper/ObservableAsPropertyHelperTest.cs
+++ b/src/ReactiveUI.Tests/ObservableAsPropertyHelper/ObservableAsPropertyHelperTest.cs
@@ -3,16 +3,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reactive.Concurrency;
-using System.Reactive.Disposables;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
 using DynamicData;
+
 using Microsoft.Reactive.Testing;
+
 using ReactiveUI.Testing;
+
 using Xunit;
 
 namespace ReactiveUI.Tests

--- a/src/ReactiveUI.Tests/ObservedChanged/Mocks/NewGameViewModel.cs
+++ b/src/ReactiveUI.Tests/ObservedChanged/Mocks/NewGameViewModel.cs
@@ -3,10 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Linq;
-using System.Reactive;
-using System.Reactive.Linq;
 using DynamicData.Binding;
 
 namespace ReactiveUI.Tests

--- a/src/ReactiveUI.Tests/ObservedChanged/NewGameViewModelTests.cs
+++ b/src/ReactiveUI.Tests/ObservedChanged/NewGameViewModelTests.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Linq;
 using Xunit;
 
 namespace ReactiveUI.Tests

--- a/src/ReactiveUI.Tests/ObservedChanged/ObservedChangedMixinTest.cs
+++ b/src/ReactiveUI.Tests/ObservedChanged/ObservedChangedMixinTest.cs
@@ -3,13 +3,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq.Expressions;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
 using Microsoft.Reactive.Testing;
+
 using ReactiveUI.Testing;
+
 using Xunit;
 
 namespace ReactiveUI.Tests

--- a/src/ReactiveUI.Tests/Platforms/common-gui/Mocks/RaceConditionFixture.cs
+++ b/src/ReactiveUI.Tests/Platforms/common-gui/Mocks/RaceConditionFixture.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Reactive.Linq;
-
 namespace ReactiveUI.Tests
 {
     /// <summary>

--- a/src/ReactiveUI.Tests/Platforms/common-gui/Mocks/RaceConditionNameOfFixture.cs
+++ b/src/ReactiveUI.Tests/Platforms/common-gui/Mocks/RaceConditionNameOfFixture.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Reactive.Linq;
-
 namespace ReactiveUI.Tests
 {
     /// <summary>

--- a/src/ReactiveUI.Tests/Platforms/common-gui/ProductionMode.cs
+++ b/src/ReactiveUI.Tests/Platforms/common-gui/ProductionMode.cs
@@ -3,10 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Reactive.Disposables;
-using Splat;
-
 namespace ReactiveUI.Tests
 {
     /// <summary>

--- a/src/ReactiveUI.Tests/Platforms/windows-xaml/Api/XamlApiApprovalTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/windows-xaml/Api/XamlApiApprovalTests.cs
@@ -3,9 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Threading.Tasks;
 
 using Xunit;
 

--- a/src/ReactiveUI.Tests/Platforms/windows-xaml/CommandBindingImplementationTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/windows-xaml/CommandBindingImplementationTests.cs
@@ -3,17 +3,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
 using Xunit;
 
 #if NETFX_CORE
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 #else
-using System.Windows.Controls;
-using System.Windows.Input;
 using FactAttribute = Xunit.WpfFactAttribute;
 #endif
 

--- a/src/ReactiveUI.Tests/Platforms/windows-xaml/DependencyObjectObservableForPropertyTest.cs
+++ b/src/ReactiveUI.Tests/Platforms/windows-xaml/DependencyObjectObservableForPropertyTest.cs
@@ -3,12 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Linq.Expressions;
-using System.Reactive.Linq;
-
 using DynamicData;
 using Xunit;
 

--- a/src/ReactiveUI.Tests/Platforms/windows-xaml/Mocks/CommandBindView.cs
+++ b/src/ReactiveUI.Tests/Platforms/windows-xaml/Mocks/CommandBindView.cs
@@ -3,13 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows;
-
 #if NETFX_CORE
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;

--- a/src/ReactiveUI.Tests/Platforms/windows-xaml/Mocks/CustomClickButton.cs
+++ b/src/ReactiveUI.Tests/Platforms/windows-xaml/Mocks/CustomClickButton.cs
@@ -3,13 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows;
-
 #if NETFX_CORE
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;

--- a/src/ReactiveUI.Tests/Platforms/windows-xaml/Mocks/DepObjFixture.cs
+++ b/src/ReactiveUI.Tests/Platforms/windows-xaml/Mocks/DepObjFixture.cs
@@ -3,18 +3,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
 
 #if NETFX_CORE
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 #else
-using System.Windows.Controls;
 #endif
 
 namespace ReactiveUI.Tests.Xaml

--- a/src/ReactiveUI.Tests/Platforms/windows-xaml/Mocks/DerivedDepObjFixture.cs
+++ b/src/ReactiveUI.Tests/Platforms/windows-xaml/Mocks/DerivedDepObjFixture.cs
@@ -3,11 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
 
 #if NETFX_CORE

--- a/src/ReactiveUI.Tests/Platforms/windows-xaml/Mocks/FakeView.cs
+++ b/src/ReactiveUI.Tests/Platforms/windows-xaml/Mocks/FakeView.cs
@@ -3,12 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 #if NETFX_CORE
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;

--- a/src/ReactiveUI.Tests/Platforms/windows-xaml/Mocks/PropertyBindFakeControl.cs
+++ b/src/ReactiveUI.Tests/Platforms/windows-xaml/Mocks/PropertyBindFakeControl.cs
@@ -3,11 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
 
 #if NETFX_CORE

--- a/src/ReactiveUI.Tests/Platforms/windows-xaml/Mocks/PropertyBindView.cs
+++ b/src/ReactiveUI.Tests/Platforms/windows-xaml/Mocks/PropertyBindView.cs
@@ -3,11 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
 
 #if NETFX_CORE

--- a/src/ReactiveUI.Tests/Platforms/windows-xaml/Mocks/ReactiveObjectCommandBindView.cs
+++ b/src/ReactiveUI.Tests/Platforms/windows-xaml/Mocks/ReactiveObjectCommandBindView.cs
@@ -3,13 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows;
-
 #if NETFX_CORE
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;

--- a/src/ReactiveUI.Tests/Platforms/windows-xaml/PropertyBindingTest.cs
+++ b/src/ReactiveUI.Tests/Platforms/windows-xaml/PropertyBindingTest.cs
@@ -3,19 +3,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections;
 using System.Globalization;
-using System.Linq;
-using System.Reactive;
-using System.Reactive.Concurrency;
-using System.Reactive.Disposables;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
-using System.Windows;
-using DynamicData;
+
 using DynamicData.Binding;
-using ReactiveUI.Tests.Wpf;
+
 using Xunit;
 
 #if NETFX_CORE

--- a/src/ReactiveUI.Tests/Platforms/windows-xaml/RxAppDependencyObjectTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/windows-xaml/RxAppDependencyObjectTests.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Linq;
-using Splat;
 using Xunit;
 
 namespace ReactiveUI.Tests.Xaml

--- a/src/ReactiveUI.Tests/Platforms/windows-xaml/Utilities/DispatcherUtilities.cs
+++ b/src/ReactiveUI.Tests/Platforms/windows-xaml/Utilities/DispatcherUtilities.cs
@@ -3,13 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 #if !NETFX_CORE
 using System.Windows.Threading;
 #endif

--- a/src/ReactiveUI.Tests/Platforms/windows-xaml/WhenAnyThroughDependencyObjectTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/windows-xaml/WhenAnyThroughDependencyObjectTests.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using Xunit;
 
 #if NETFX_CORE

--- a/src/ReactiveUI.Tests/Platforms/windows-xaml/XamlViewCommandTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/windows-xaml/XamlViewCommandTests.cs
@@ -3,9 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Reactive.Linq;
-
 using Xunit;
 
 #if NETFX_CORE
@@ -19,7 +16,6 @@ using Windows.UI.Xaml.Markup;
 using System.Windows.Automation.Peers;
 using System.Windows.Automation.Provider;
 using System.Windows.Controls;
-using System.Windows.Controls.Primitives;
 using FactAttribute = Xunit.WpfFactAttribute;
 #endif
 

--- a/src/ReactiveUI.Tests/Platforms/windows-xaml/XamlViewDependencyResolverTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/windows-xaml/XamlViewDependencyResolverTests.cs
@@ -3,12 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Splat;
 using Xunit;
 
 #if NETFX_CORE

--- a/src/ReactiveUI.Tests/Platforms/winforms/API/WinformsApiApprovalTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/API/WinformsApiApprovalTests.cs
@@ -3,9 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Threading.Tasks;
 
 using VerifyXunit;
 

--- a/src/ReactiveUI.Tests/Platforms/winforms/ActivationTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/ActivationTests.cs
@@ -3,9 +3,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Runtime.InteropServices;
 using System.Windows.Forms;
+
 using Xunit;
 
 namespace ReactiveUI.Tests.Winforms

--- a/src/ReactiveUI.Tests/Platforms/winforms/CommandBindingImplementationTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/CommandBindingImplementationTests.cs
@@ -3,8 +3,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.Windows.Forms;
+
 using Xunit;
 
 namespace ReactiveUI.Tests.Winforms

--- a/src/ReactiveUI.Tests/Platforms/winforms/CommandBindingTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/CommandBindingTests.cs
@@ -3,12 +3,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
-using System.Threading.Tasks;
 using System.Windows.Forms;
+
 using ReactiveUI.Winforms;
+
 using Xunit;
 
 namespace ReactiveUI.Tests.Winforms

--- a/src/ReactiveUI.Tests/Platforms/winforms/DefaultPropertyBindingTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/DefaultPropertyBindingTests.cs
@@ -3,15 +3,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Linq.Expressions;
-using System.Reactive.Concurrency;
-using System.Reactive.Disposables;
 using System.Windows.Forms;
+
 using DynamicData;
+
 using ReactiveUI.Winforms;
+
 using Xunit;
 
 namespace ReactiveUI.Tests.Winforms

--- a/src/ReactiveUI.Tests/Platforms/winforms/Mocks/CustomClickableComponent.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/Mocks/CustomClickableComponent.cs
@@ -3,7 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.ComponentModel;
 
 namespace ReactiveUI.Tests.Winforms

--- a/src/ReactiveUI.Tests/Platforms/winforms/Mocks/CustomClickableControl.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/Mocks/CustomClickableControl.cs
@@ -3,7 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.Windows.Forms;
 
 namespace ReactiveUI.Tests.Winforms

--- a/src/ReactiveUI.Tests/Platforms/winforms/Mocks/ExampleView.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/Mocks/ExampleView.cs
@@ -3,12 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace ReactiveUI.Tests.Winforms
 {
     /// <summary>

--- a/src/ReactiveUI.Tests/Platforms/winforms/Mocks/FakeViewLocator.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/Mocks/FakeViewLocator.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-
 namespace ReactiveUI.Tests.Winforms
 {
     internal class FakeViewLocator : IViewLocator

--- a/src/ReactiveUI.Tests/Platforms/winforms/Mocks/FakeViewModel.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/Mocks/FakeViewModel.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Reactive;
-
 namespace ReactiveUI.Tests.Winforms
 {
     /// <summary>

--- a/src/ReactiveUI.Tests/Platforms/winforms/Mocks/TestForm.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/Mocks/TestForm.cs
@@ -3,10 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Reactive;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
 using System.Windows.Forms;
 
 namespace ReactiveUI.Tests.Winforms

--- a/src/ReactiveUI.Tests/Platforms/winforms/Mocks/ThirdPartyControl.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/Mocks/ThirdPartyControl.cs
@@ -3,7 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.Windows.Forms;
 
 namespace AThirdPartyNamespace

--- a/src/ReactiveUI.Tests/Platforms/winforms/Mocks/WinformCommandBindViewModel.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/Mocks/WinformCommandBindViewModel.cs
@@ -3,9 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Reactive;
-using System.Reactive.Concurrency;
-
 namespace ReactiveUI.Tests.Winforms
 {
     public class WinformCommandBindViewModel : ReactiveObject

--- a/src/ReactiveUI.Tests/Platforms/winforms/WinFormsRoutedViewHostTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/WinFormsRoutedViewHostTests.cs
@@ -3,10 +3,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Linq;
 using System.Windows.Forms;
-using ReactiveUI;
-using ReactiveUI.Winforms;
+
 using Xunit;
 
 using WinFormsRoutedViewHost = ReactiveUI.Winforms.RoutedControlHost;

--- a/src/ReactiveUI.Tests/Platforms/winforms/WinFormsViewDependencyResolverTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/WinFormsViewDependencyResolverTests.cs
@@ -3,12 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Splat;
 using Xunit;
 
 using FactAttribute = Xunit.WpfFactAttribute;

--- a/src/ReactiveUI.Tests/Platforms/winforms/WinFormsViewModelViewHostTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/WinFormsViewModelViewHostTests.cs
@@ -3,9 +3,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Linq;
 using System.Windows.Forms;
-using ReactiveUI.Winforms;
+
 using Xunit;
 
 using WinFormsViewModelViewHost = ReactiveUI.Winforms.ViewModelControlHost;

--- a/src/ReactiveUI.Tests/Platforms/wpf/API/WpfApiApprovalTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/wpf/API/WpfApiApprovalTests.cs
@@ -3,12 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 using VerifyXunit;
 

--- a/src/ReactiveUI.Tests/Platforms/wpf/Mocks/CanExecuteMock/AlwaysFalseModeDetector.cs
+++ b/src/ReactiveUI.Tests/Platforms/wpf/Mocks/CanExecuteMock/AlwaysFalseModeDetector.cs
@@ -3,9 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using ReactiveUI;
-using Splat;
-
 namespace ReactiveUI.Tests.Wpf
 {
     /// <summary>

--- a/src/ReactiveUI.Tests/Platforms/wpf/Mocks/CanExecuteMock/LiveModeDetector.cs
+++ b/src/ReactiveUI.Tests/Platforms/wpf/Mocks/CanExecuteMock/LiveModeDetector.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using Splat;
-
 namespace ReactiveUI.Tests.Wpf
 {
     public static class LiveModeDetector

--- a/src/ReactiveUI.Tests/Platforms/wpf/Mocks/CommandBindingViewModel.cs
+++ b/src/ReactiveUI.Tests/Platforms/wpf/Mocks/CommandBindingViewModel.cs
@@ -3,12 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Reactive;
-using System.Reactive.Concurrency;
-using System.Threading;
-using System.Threading.Tasks;
-
 namespace ReactiveUI.Tests.Wpf
 {
     public class CommandBindingViewModel : ReactiveObject

--- a/src/ReactiveUI.Tests/Platforms/wpf/Mocks/WpfActiveContentApp.cs
+++ b/src/ReactiveUI.Tests/Platforms/wpf/Mocks/WpfActiveContentApp.cs
@@ -3,7 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.Windows;
 
 namespace ReactiveUI.Tests.Wpf

--- a/src/ReactiveUI.Tests/Platforms/wpf/Mocks/WpfActiveContentFixture.cs
+++ b/src/ReactiveUI.Tests/Platforms/wpf/Mocks/WpfActiveContentFixture.cs
@@ -3,9 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 using System.Windows.Threading;
 
 namespace ReactiveUI.Tests.Wpf

--- a/src/ReactiveUI.Tests/Platforms/wpf/WpfActivationForViewFetcherTest.cs
+++ b/src/ReactiveUI.Tests/Platforms/wpf/WpfActivationForViewFetcherTest.cs
@@ -3,12 +3,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Reactive.Concurrency;
 using System.Windows;
 
 using DynamicData;
-using Xunit;
 
 using FactAttribute = Xunit.WpfFactAttribute;
 

--- a/src/ReactiveUI.Tests/Platforms/wpf/WpfActiveContentTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/wpf/WpfActiveContentTests.cs
@@ -3,13 +3,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Reactive.Disposables;
-using System.Reactive.Linq;
-using System.Threading.Tasks;
 using System.Windows;
+
 using DynamicData;
-using Splat;
+
 using Xunit;
 
 namespace ReactiveUI.Tests.Wpf

--- a/src/ReactiveUI.Tests/Platforms/wpf/WpfCommandBindingImplementationTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/wpf/WpfCommandBindingImplementationTests.cs
@@ -3,16 +3,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
 using System.Reflection;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+
 using FluentAssertions;
-using Splat;
+
 using Xunit;
+
 using FactAttribute = Xunit.WpfFactAttribute;
 
 namespace ReactiveUI.Tests.Wpf

--- a/src/ReactiveUI.Tests/Platforms/wpf/WpfViewDependencyResolverTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/wpf/WpfViewDependencyResolverTests.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using Splat;
 using Xunit;
 
 using FactAttribute = Xunit.WpfFactAttribute;

--- a/src/ReactiveUI.Tests/RandomTests.cs
+++ b/src/ReactiveUI.Tests/RandomTests.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using Splat;
 using Xunit;
 
 namespace ReactiveUI.Tests

--- a/src/ReactiveUI.Tests/ReactiveObject/Mocks/AccountService.cs
+++ b/src/ReactiveUI.Tests/ReactiveObject/Mocks/AccountService.cs
@@ -3,9 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-
 namespace ReactiveUI.Tests
 {
     /// <summary>

--- a/src/ReactiveUI.Tests/ReactiveObject/Mocks/OaphNameOfTestFixture.cs
+++ b/src/ReactiveUI.Tests/ReactiveObject/Mocks/OaphNameOfTestFixture.cs
@@ -3,7 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Reactive.Linq;
 using System.Runtime.Serialization;
 
 namespace ReactiveUI.Tests

--- a/src/ReactiveUI.Tests/ReactiveObject/Mocks/OaphTestFixture.cs
+++ b/src/ReactiveUI.Tests/ReactiveObject/Mocks/OaphTestFixture.cs
@@ -3,7 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Reactive.Linq;
 using System.Runtime.Serialization;
 
 namespace ReactiveUI.Tests

--- a/src/ReactiveUI.Tests/ReactiveObject/Mocks/ProjectService.cs
+++ b/src/ReactiveUI.Tests/ReactiveObject/Mocks/ProjectService.cs
@@ -3,9 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-
 namespace ReactiveUI.Tests
 {
     /// <summary>

--- a/src/ReactiveUI.Tests/ReactiveObject/Mocks/TestFixture.cs
+++ b/src/ReactiveUI.Tests/ReactiveObject/Mocks/TestFixture.cs
@@ -3,9 +3,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.Serialization;
+
 using DynamicData.Binding;
 
 namespace ReactiveUI.Tests

--- a/src/ReactiveUI.Tests/ReactiveObject/ReactiveObjectTests.cs
+++ b/src/ReactiveUI.Tests/ReactiveObject/ReactiveObjectTests.cs
@@ -3,14 +3,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
-using System.Reactive.Concurrency;
-using System.Reactive.Linq;
+
 using DynamicData;
+
 using Xunit;
 
 namespace ReactiveUI.Tests

--- a/src/ReactiveUI.Tests/Resolvers/DependencyResolverTests.cs
+++ b/src/ReactiveUI.Tests/Resolvers/DependencyResolverTests.cs
@@ -3,13 +3,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-
 using FluentAssertions;
 
-using Splat;
 using Xunit;
 
 namespace ReactiveUI.Tests

--- a/src/ReactiveUI.Tests/Resolvers/INPCObservableForPropertyTests.cs
+++ b/src/ReactiveUI.Tests/Resolvers/INPCObservableForPropertyTests.cs
@@ -3,11 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq.Expressions;
-using System.Reactive.Linq;
 using System.Runtime.CompilerServices;
 
 using Xunit;

--- a/src/ReactiveUI.Tests/Resolvers/PocoObservableForPropertyTests.cs
+++ b/src/ReactiveUI.Tests/Resolvers/PocoObservableForPropertyTests.cs
@@ -3,13 +3,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
-using System.Linq.Expressions;
-using FluentAssertions;
-using Splat;
+
 using Xunit;
 
 namespace ReactiveUI.Tests

--- a/src/ReactiveUI.Tests/Routing/Mocks/TestView.cs
+++ b/src/ReactiveUI.Tests/Routing/Mocks/TestView.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using Splat;
-
 namespace ReactiveUI.Tests
 {
     public class TestView : ReactiveUserControl<TestViewModel>, IScreen

--- a/src/ReactiveUI.Tests/Routing/RoutableViewModelMixinTests.cs
+++ b/src/ReactiveUI.Tests/Routing/RoutableViewModelMixinTests.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Reactive.Disposables;
 using Xunit;
 
 namespace ReactiveUI.Tests

--- a/src/ReactiveUI.Tests/Routing/RoutedViewHostTests.cs
+++ b/src/ReactiveUI.Tests/Routing/RoutedViewHostTests.cs
@@ -3,12 +3,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Reactive.Concurrency;
 using System.Windows;
+
 using DynamicData;
+
 using ReactiveUI.Tests.Wpf;
-using Splat;
+
 using Xunit;
 
 namespace ReactiveUI.Tests

--- a/src/ReactiveUI.Tests/Routing/RoutingStateTests.cs
+++ b/src/ReactiveUI.Tests/Routing/RoutingStateTests.cs
@@ -3,14 +3,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Linq;
-using System.Reactive.Concurrency;
-using System.Reactive.Linq;
-using System.Threading.Tasks;
 using DynamicData;
+
 using Microsoft.Reactive.Testing;
+
 using ReactiveUI.Testing;
+
 using Xunit;
 
 namespace ReactiveUI.Tests

--- a/src/ReactiveUI.Tests/Routing/ViewModelViewHostTests.cs
+++ b/src/ReactiveUI.Tests/Routing/ViewModelViewHostTests.cs
@@ -3,12 +3,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Reactive.Concurrency;
 using System.Windows;
+
 using DynamicData;
+
 using ReactiveUI.Tests.Wpf;
-using Splat;
+
 using Xunit;
 
 namespace ReactiveUI.Tests

--- a/src/ReactiveUI.Tests/RxAppTest.cs
+++ b/src/ReactiveUI.Tests/RxAppTest.cs
@@ -4,7 +4,7 @@
 // See the LICENSE file in the project root for full license information.
 
 using System.Diagnostics;
-using System.Reactive.Concurrency;
+
 using Xunit;
 
 namespace ReactiveUI.Tests

--- a/src/ReactiveUI.Tests/Suspension/SuspensionHostExtensionsTests.cs
+++ b/src/ReactiveUI.Tests/Suspension/SuspensionHostExtensionsTests.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-
 using FluentAssertions;
 
 using Xunit;

--- a/src/ReactiveUI.Tests/Utilities/ApiApprovalBase.cs
+++ b/src/ReactiveUI.Tests/Utilities/ApiApprovalBase.cs
@@ -3,15 +3,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Threading.Tasks;
 
 using PublicApiGenerator;
-
-using VerifyTests;
 
 using VerifyXunit;
 

--- a/src/ReactiveUI.Tests/Utilities/CompatMixins.cs
+++ b/src/ReactiveUI.Tests/Utilities/CompatMixins.cs
@@ -3,10 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-
 namespace ReactiveUI.Tests
 {
     internal static class CompatMixins

--- a/src/ReactiveUI.Tests/Utilities/CountingTestScheduler.cs
+++ b/src/ReactiveUI.Tests/Utilities/CountingTestScheduler.cs
@@ -3,10 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Reactive.Concurrency;
-
 namespace ReactiveUI.Tests
 {
     public class CountingTestScheduler : IScheduler

--- a/src/ReactiveUI.Tests/Utilities/EnumerableTestMixin.cs
+++ b/src/ReactiveUI.Tests/Utilities/EnumerableTestMixin.cs
@@ -3,10 +3,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
+
 using Xunit;
 
 namespace ReactiveUI.Tests

--- a/src/ReactiveUI.Tests/Utilities/JsonHelper.cs
+++ b/src/ReactiveUI.Tests/Utilities/JsonHelper.cs
@@ -3,7 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.IO;
 using System.Text;
 

--- a/src/ReactiveUI.Tests/Utilities/TestLogger.cs
+++ b/src/ReactiveUI.Tests/Utilities/TestLogger.cs
@@ -3,10 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using Splat;
 
 namespace ReactiveUI.Tests
 {

--- a/src/ReactiveUI.Tests/Utilities/UseInvariantCulture.cs
+++ b/src/ReactiveUI.Tests/Utilities/UseInvariantCulture.cs
@@ -5,7 +5,6 @@
 
 using System.Globalization;
 using System.Reflection;
-using System.Threading;
 
 using Xunit.Sdk;
 

--- a/src/ReactiveUI.Tests/WaitForDispatcherSchedulerTests.cs
+++ b/src/ReactiveUI.Tests/WaitForDispatcherSchedulerTests.cs
@@ -3,10 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Reactive.Concurrency;
-using System.Reactive.Disposables;
-
 using Xunit;
 
 namespace ReactiveUI.Tests

--- a/src/ReactiveUI.Tests/WhenAny/Mockups/HostTestFixture.cs
+++ b/src/ReactiveUI.Tests/WhenAny/Mockups/HostTestFixture.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Reactive.Linq;
-
 namespace ReactiveUI.Tests
 {
     /// <summary>

--- a/src/ReactiveUI.Tests/WhenAny/ReactiveNotifyPropertyChangedMixinTest.cs
+++ b/src/ReactiveUI.Tests/WhenAny/ReactiveNotifyPropertyChangedMixinTest.cs
@@ -3,17 +3,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Linq.Expressions;
-using System.Reactive;
-using System.Reactive.Concurrency;
-using System.Reactive.Linq;
-using System.Threading;
 using DynamicData;
+
 using Microsoft.Reactive.Testing;
+
 using ReactiveUI.Testing;
+
 using Xunit;
 
 namespace ReactiveUI.Tests

--- a/src/ReactiveUI.Tests/WhenAny/TestWhenAnyObsViewModel.cs
+++ b/src/ReactiveUI.Tests/WhenAny/TestWhenAnyObsViewModel.cs
@@ -3,9 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Reactive.Concurrency;
-using System.Reactive.Linq;
 using DynamicData;
 using DynamicData.Binding;
 

--- a/src/ReactiveUI.Tests/WhenAny/WhenAnyObservableTests.cs
+++ b/src/ReactiveUI.Tests/WhenAny/WhenAnyObservableTests.cs
@@ -3,15 +3,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reactive;
-using System.Reactive.Concurrency;
-using System.Reactive.Linq;
-using System.Threading.Tasks;
 using DynamicData;
 using DynamicData.Binding;
+
 using Xunit;
 
 namespace ReactiveUI.Tests

--- a/src/ReactiveUI.Winforms/ActivationForViewFetcher.cs
+++ b/src/ReactiveUI.Winforms/ActivationForViewFetcher.cs
@@ -3,13 +3,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.ComponentModel;
 using System.Globalization;
-using System.Reactive.Linq;
 using System.Reflection;
 using System.Windows.Forms;
-using Splat;
 
 namespace ReactiveUI.Winforms;
 

--- a/src/ReactiveUI.Winforms/ContentControlBindingHook.cs
+++ b/src/ReactiveUI.Winforms/ContentControlBindingHook.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Linq;
 using System.Windows.Forms;
 
 namespace ReactiveUI.Winforms;

--- a/src/ReactiveUI.Winforms/CreatesWinformsCommandBinding.cs
+++ b/src/ReactiveUI.Winforms/CreatesWinformsCommandBinding.cs
@@ -3,12 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
-using System.Reactive.Disposables;
-using System.Reactive.Linq;
 using System.Reflection;
 using System.Windows.Forms;
 using System.Windows.Input;

--- a/src/ReactiveUI.Winforms/ObservableCollectionChangedToListChangedTransformer.cs
+++ b/src/ReactiveUI.Winforms/ObservableCollectionChangedToListChangedTransformer.cs
@@ -3,10 +3,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
-using System.Linq;
 
 namespace ReactiveUI.Winforms;
 

--- a/src/ReactiveUI.Winforms/PanelSetMethodBindingConverter.cs
+++ b/src/ReactiveUI.Winforms/PanelSetMethodBindingConverter.cs
@@ -3,9 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Windows.Forms;
 
 namespace ReactiveUI.Winforms;

--- a/src/ReactiveUI.Winforms/Registrations.cs
+++ b/src/ReactiveUI.Winforms/Registrations.cs
@@ -3,11 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Reactive.Concurrency;
 using System.Windows.Forms;
-
-using Splat;
 
 namespace ReactiveUI.Winforms;
 

--- a/src/ReactiveUI.Winforms/RoutedViewHost.cs
+++ b/src/ReactiveUI.Winforms/RoutedViewHost.cs
@@ -3,10 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.ComponentModel;
-using System.Reactive.Disposables;
-using System.Reactive.Linq;
 using System.Windows.Forms;
 
 namespace ReactiveUI.Winforms;

--- a/src/ReactiveUI.Winforms/TableContentSetMethodBindingConverter.cs
+++ b/src/ReactiveUI.Winforms/TableContentSetMethodBindingConverter.cs
@@ -3,9 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Windows.Forms;
 
 namespace ReactiveUI.Winforms;

--- a/src/ReactiveUI.Winforms/ViewModelViewHost.cs
+++ b/src/ReactiveUI.Winforms/ViewModelViewHost.cs
@@ -3,11 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Reactive.Disposables;
-using System.Reactive.Linq;
 using System.Windows.Forms;
 
 namespace ReactiveUI.Winforms;

--- a/src/ReactiveUI.Winforms/WinformsCreatesObservableForProperty.cs
+++ b/src/ReactiveUI.Winforms/WinformsCreatesObservableForProperty.cs
@@ -3,16 +3,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.ComponentModel;
-using System.Linq;
-using System.Linq.Expressions;
-using System.Reactive.Disposables;
-using System.Reactive.Linq;
 using System.Reflection;
-using System.Windows.Forms;
-
-using Splat;
 
 namespace ReactiveUI.Winforms;
 

--- a/src/ReactiveUI.Wpf/ActivationForViewFetcher.cs
+++ b/src/ReactiveUI.Wpf/ActivationForViewFetcher.cs
@@ -3,11 +3,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Reactive.Linq;
 using System.Reflection;
 using System.Windows;
-using System.Windows.Threading;
 
 namespace ReactiveUI;
 

--- a/src/ReactiveUI.Wpf/AutoSuspendHelper.cs
+++ b/src/ReactiveUI.Wpf/AutoSuspendHelper.cs
@@ -3,13 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Reactive;
-using System.Reactive.Disposables;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
 using System.Windows;
-using Splat;
 
 namespace ReactiveUI;
 

--- a/src/ReactiveUI.Wpf/Common/AutoDataTemplateBindingHook.cs
+++ b/src/ReactiveUI.Wpf/Common/AutoDataTemplateBindingHook.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Markup;

--- a/src/ReactiveUI.Wpf/Common/BooleanToVisibilityHint.cs
+++ b/src/ReactiveUI.Wpf/Common/BooleanToVisibilityHint.cs
@@ -3,9 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Diagnostics.CodeAnalysis;
-
 #if HAS_UNO
 namespace ReactiveUI.Uno
 #else

--- a/src/ReactiveUI.Wpf/Common/BooleanToVisibilityTypeConverter.cs
+++ b/src/ReactiveUI.Wpf/Common/BooleanToVisibilityTypeConverter.cs
@@ -7,7 +7,6 @@
 using Microsoft.Maui;
 
 #endif
-using System;
 #if HAS_WINUI
 using Microsoft.UI.Xaml;
 #elif NETFX_CORE || HAS_UNO

--- a/src/ReactiveUI.Wpf/Common/PlatformOperations.cs
+++ b/src/ReactiveUI.Wpf/Common/PlatformOperations.cs
@@ -3,12 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 #if HAS_UNO
 namespace ReactiveUI.Uno
 #else

--- a/src/ReactiveUI.Wpf/Common/ReactivePage.cs
+++ b/src/ReactiveUI.Wpf/Common/ReactivePage.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Diagnostics.CodeAnalysis;
 #if HAS_MAUI
 using Microsoft.Maui.Controls;
 

--- a/src/ReactiveUI.Wpf/Common/ReactiveUserControl.cs
+++ b/src/ReactiveUI.Wpf/Common/ReactiveUserControl.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Diagnostics.CodeAnalysis;
 #if HAS_WINUI
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;

--- a/src/ReactiveUI.Wpf/Common/RoutedViewHost.cs
+++ b/src/ReactiveUI.Wpf/Common/RoutedViewHost.cs
@@ -3,13 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Reactive.Linq;
 using ReactiveUI;
-using Splat;
 
 #if HAS_WINUI
 using Microsoft.UI.Xaml;
@@ -21,7 +15,6 @@ using Windows.UI.Xaml.Controls;
 #else
 
 using System.Windows;
-using System.Windows.Controls;
 
 #endif
 

--- a/src/ReactiveUI.Wpf/Common/ViewModelViewHost.cs
+++ b/src/ReactiveUI.Wpf/Common/ViewModelViewHost.cs
@@ -3,13 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Diagnostics.CodeAnalysis;
-using System.Reactive;
-using System.Reactive.Disposables;
-using System.Reactive.Linq;
-using Splat;
-
 #if HAS_WINUI
 
 using Microsoft.UI.Xaml;
@@ -24,7 +17,6 @@ using Windows.UI.Xaml.Controls;
 #else
 
 using System.Windows;
-using System.Windows.Controls;
 
 #endif
 

--- a/src/ReactiveUI.Wpf/DependencyObjectObservableForProperty.cs
+++ b/src/ReactiveUI.Wpf/DependencyObjectObservableForProperty.cs
@@ -3,14 +3,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.ComponentModel;
-using System.Linq;
-using System.Reactive.Disposables;
-using System.Reactive.Linq;
 using System.Reflection;
 using System.Windows;
-using Splat;
 
 namespace ReactiveUI;
 

--- a/src/ReactiveUI.Wpf/Registrations.cs
+++ b/src/ReactiveUI.Wpf/Registrations.cs
@@ -3,10 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Reactive.Concurrency;
-using Splat;
-
 namespace ReactiveUI.Wpf;
 
 /// <summary>

--- a/src/ReactiveUI.Wpf/TransitioningContentControl.cs
+++ b/src/ReactiveUI.Wpf/TransitioningContentControl.cs
@@ -3,10 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reactive.Linq;
 using System.Runtime.CompilerServices;
 using System.Windows;
 using System.Windows.Controls;

--- a/src/ReactiveUI.XamForms.Tests/Activation/ActivatingReactivePagesTests.cs
+++ b/src/ReactiveUI.XamForms.Tests/Activation/ActivatingReactivePagesTests.cs
@@ -6,8 +6,9 @@
 using ReactiveUI.XamForms;
 using ReactiveUI.XamForms.Tests.Activation;
 using ReactiveUI.XamForms.Tests.Activation.Mocks;
-using Splat;
+
 using Xamarin.Forms;
+
 using Xunit;
 
 namespace ReactiveUI.Tests

--- a/src/ReactiveUI.XamForms.Tests/Activation/Mocks/App.xaml.cs
+++ b/src/ReactiveUI.XamForms.Tests/Activation/Mocks/App.xaml.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using Xamarin.Forms;
-
 namespace ReactiveUI.XamForms.Tests.Activation
 {
     /// <summary>

--- a/src/ReactiveUI.XamForms.Tests/Activation/Mocks/AppShell.xaml.cs
+++ b/src/ReactiveUI.XamForms.Tests/Activation/Mocks/AppShell.xaml.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Reactive.Disposables;
-
 namespace ReactiveUI.XamForms.Tests.Activation
 {
     /// <summary>

--- a/src/ReactiveUI.XamForms.Tests/Activation/Mocks/AppShellViewModel.cs
+++ b/src/ReactiveUI.XamForms.Tests/Activation/Mocks/AppShellViewModel.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Reactive.Disposables;
-
 namespace ReactiveUI.XamForms.Tests.Activation
 {
     /// <summary>

--- a/src/ReactiveUI.XamForms.Tests/Activation/Mocks/ApplicationFixture.cs
+++ b/src/ReactiveUI.XamForms.Tests/Activation/Mocks/ApplicationFixture.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using Splat;
 using Xamarin.Forms;
 using Xamarin.Forms.Mocks;
 

--- a/src/ReactiveUI.XamForms.Tests/Activation/Mocks/CarouselPageView.cs
+++ b/src/ReactiveUI.XamForms.Tests/Activation/Mocks/CarouselPageView.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Reactive.Disposables;
-
 namespace ReactiveUI.XamForms.Tests.Activation
 {
     /// <summary>

--- a/src/ReactiveUI.XamForms.Tests/Activation/Mocks/CarouselPageViewModel.cs
+++ b/src/ReactiveUI.XamForms.Tests/Activation/Mocks/CarouselPageViewModel.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Reactive.Disposables;
-
 namespace ReactiveUI.XamForms.Tests.Activation
 {
     /// <summary>

--- a/src/ReactiveUI.XamForms.Tests/Activation/Mocks/ContentPageView.cs
+++ b/src/ReactiveUI.XamForms.Tests/Activation/Mocks/ContentPageView.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Reactive.Disposables;
-
 namespace ReactiveUI.XamForms.Tests.Activation
 {
     /// <summary>

--- a/src/ReactiveUI.XamForms.Tests/Activation/Mocks/ContentPageViewModel.cs
+++ b/src/ReactiveUI.XamForms.Tests/Activation/Mocks/ContentPageViewModel.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Reactive.Disposables;
-
 namespace ReactiveUI.XamForms.Tests.Activation
 {
     /// <summary>

--- a/src/ReactiveUI.XamForms.Tests/Activation/Mocks/FlyOutPageViewModel.cs
+++ b/src/ReactiveUI.XamForms.Tests/Activation/Mocks/FlyOutPageViewModel.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Reactive.Disposables;
-
 namespace ReactiveUI.XamForms.Tests.Activation
 {
     /// <summary>

--- a/src/ReactiveUI.XamForms.Tests/Activation/Mocks/FlyoutPageView.xaml.cs
+++ b/src/ReactiveUI.XamForms.Tests/Activation/Mocks/FlyoutPageView.xaml.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Reactive.Disposables;
 using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 

--- a/src/ReactiveUI.XamForms.Tests/Activation/Mocks/FlyoutPageViewFlyoutMenuItem.cs
+++ b/src/ReactiveUI.XamForms.Tests/Activation/Mocks/FlyoutPageViewFlyoutMenuItem.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-
 namespace ReactiveUI.XamForms.Tests.Activation.Mocks
 {
     /// <summary>

--- a/src/ReactiveUI.XamForms.Tests/Activation/Mocks/ShellView.cs
+++ b/src/ReactiveUI.XamForms.Tests/Activation/Mocks/ShellView.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Reactive.Disposables;
-
 namespace ReactiveUI.XamForms.Tests.Activation
 {
     /// <summary>

--- a/src/ReactiveUI.XamForms.Tests/Activation/Mocks/ShellViewModel.cs
+++ b/src/ReactiveUI.XamForms.Tests/Activation/Mocks/ShellViewModel.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Reactive.Disposables;
-
 namespace ReactiveUI.XamForms.Tests.Activation
 {
     /// <summary>

--- a/src/ReactiveUI.XamForms.Tests/Activation/Mocks/TabbedPageView.cs
+++ b/src/ReactiveUI.XamForms.Tests/Activation/Mocks/TabbedPageView.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Reactive.Disposables;
-
 namespace ReactiveUI.XamForms.Tests.Activation
 {
     /// <summary>

--- a/src/ReactiveUI.XamForms.Tests/Activation/Mocks/TabbedPageViewModel.cs
+++ b/src/ReactiveUI.XamForms.Tests/Activation/Mocks/TabbedPageViewModel.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Reactive.Disposables;
-
 namespace ReactiveUI.XamForms.Tests.Activation
 {
     /// <summary>

--- a/src/ReactiveUI.XamForms.Tests/Mocks/ChildViewModel.cs
+++ b/src/ReactiveUI.XamForms.Tests/Mocks/ChildViewModel.cs
@@ -3,10 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-
-using Splat;
-
 namespace ReactiveUI.XamForms.Tests.Mocks
 {
     /// <summary>

--- a/src/ReactiveUI.XamForms.Tests/Mocks/MainViewModel.cs
+++ b/src/ReactiveUI.XamForms.Tests/Mocks/MainViewModel.cs
@@ -3,10 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-
-using Splat;
-
 namespace ReactiveUI.XamForms.Tests.Mocks
 {
     /// <summary>

--- a/src/ReactiveUI.XamForms.Tests/Mocks/NavigationViewModel.cs
+++ b/src/ReactiveUI.XamForms.Tests/Mocks/NavigationViewModel.cs
@@ -3,12 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Reactive;
-using System.Reactive.Linq;
-
-using Splat;
-
 namespace ReactiveUI.XamForms.Tests.Mocks
 {
     /// <summary>

--- a/src/ReactiveUI.XamForms.Tests/RoutedViewHostTest.cs
+++ b/src/ReactiveUI.XamForms.Tests/RoutedViewHostTest.cs
@@ -3,11 +3,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Reactive.Linq;
-using System.Threading.Tasks;
 using ReactiveUI.XamForms.Tests.Mocks;
-using Splat;
+
 using Xunit;
 
 namespace ReactiveUI.XamForms.Tests

--- a/src/ReactiveUI.XamForms/ActivationForViewFetcher.cs
+++ b/src/ReactiveUI.XamForms/ActivationForViewFetcher.cs
@@ -3,10 +3,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.ComponentModel;
-using System.Reactive.Linq;
 using System.Reflection;
+
 using Xamarin.Forms;
 
 namespace ReactiveUI.XamForms;

--- a/src/ReactiveUI.XamForms/AutoSuspendHelper.cs
+++ b/src/ReactiveUI.XamForms/AutoSuspendHelper.cs
@@ -3,12 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Reactive;
-using System.Reactive.Disposables;
-using System.Reactive.Subjects;
-using Splat;
-
 namespace ReactiveUI.XamForms;
 
 /// <summary>

--- a/src/ReactiveUI.XamForms/DisableAnimationAttribute.cs
+++ b/src/ReactiveUI.XamForms/DisableAnimationAttribute.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-
 namespace ReactiveUI.XamForms;
 
 /// <summary>

--- a/src/ReactiveUI.XamForms/ReactiveMasterDetailPage.cs
+++ b/src/ReactiveUI.XamForms/ReactiveMasterDetailPage.cs
@@ -3,7 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using Xamarin.Forms;
 
 namespace ReactiveUI.XamForms;

--- a/src/ReactiveUI.XamForms/ReactiveShellContent.cs
+++ b/src/ReactiveUI.XamForms/ReactiveShellContent.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using Splat;
 using Xamarin.Forms;
 
 namespace ReactiveUI.XamForms;

--- a/src/ReactiveUI.XamForms/Registrations.cs
+++ b/src/ReactiveUI.XamForms/Registrations.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-
 namespace ReactiveUI.XamForms;
 
 /// <summary>

--- a/src/ReactiveUI.XamForms/RoutedViewHost.cs
+++ b/src/ReactiveUI.XamForms/RoutedViewHost.cs
@@ -3,14 +3,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Reactive;
-using System.Reactive.Disposables;
-using System.Reactive.Linq;
-using System.Reactive.Threading.Tasks;
 using System.Reflection;
-using Splat;
+
 using Xamarin.Forms;
 
 namespace ReactiveUI.XamForms;

--- a/src/ReactiveUI.XamForms/ViewModelViewHost.cs
+++ b/src/ReactiveUI.XamForms/ViewModelViewHost.cs
@@ -3,9 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Reactive.Linq;
-using Splat;
 using Xamarin.Forms;
 
 namespace ReactiveUI.XamForms;

--- a/src/ReactiveUI.sln
+++ b/src/ReactiveUI.sln
@@ -9,6 +9,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Directory.build.props = Directory.build.props
 		Directory.build.targets = Directory.build.targets
 		global.json = global.json
+		GlobalUsings.cs = GlobalUsings.cs
 		stylecop.json = stylecop.json
 		..\version.json = ..\version.json
 	EndProjectSection

--- a/src/ReactiveUI/Activation/CanActivateViewFetcher.cs
+++ b/src/ReactiveUI/Activation/CanActivateViewFetcher.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Reactive.Linq;
 using System.Reflection;
 
 namespace ReactiveUI;

--- a/src/ReactiveUI/Activation/IActivationForViewFetcher.cs
+++ b/src/ReactiveUI/Activation/IActivationForViewFetcher.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-
 namespace ReactiveUI;
 
 /// <summary>

--- a/src/ReactiveUI/Activation/ViewForMixins.cs
+++ b/src/ReactiveUI/Activation/ViewForMixins.cs
@@ -3,13 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
-using System.Reactive.Disposables;
-using System.Reactive.Linq;
-using Splat;
 
 namespace ReactiveUI;
 

--- a/src/ReactiveUI/Activation/ViewModelActivator.cs
+++ b/src/ReactiveUI/Activation/ViewModelActivator.cs
@@ -3,14 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reactive;
-using System.Reactive.Disposables;
-using System.Reactive.Subjects;
-using System.Threading;
-
 namespace ReactiveUI;
 
 /// <summary>

--- a/src/ReactiveUI/Bindings/Command/CommandBinder.cs
+++ b/src/ReactiveUI/Bindings/Command/CommandBinder.cs
@@ -3,10 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Linq.Expressions;
 using System.Windows.Input;
-using Splat;
 
 namespace ReactiveUI;
 

--- a/src/ReactiveUI/Bindings/Command/CommandBinderImplementation.cs
+++ b/src/ReactiveUI/Bindings/Command/CommandBinderImplementation.cs
@@ -3,13 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Linq;
-using System.Linq.Expressions;
-using System.Reactive;
-using System.Reactive.Disposables;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
 using System.Windows.Input;
 
 namespace ReactiveUI;

--- a/src/ReactiveUI/Bindings/Command/CommandBinderImplementationMixins.cs
+++ b/src/ReactiveUI/Bindings/Command/CommandBinderImplementationMixins.cs
@@ -3,9 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Linq.Expressions;
-using System.Reactive.Linq;
 using System.Windows.Input;
 
 namespace ReactiveUI;

--- a/src/ReactiveUI/Bindings/Command/CreatesCommandBinding.cs
+++ b/src/ReactiveUI/Bindings/Command/CreatesCommandBinding.cs
@@ -3,11 +3,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Linq;
 using System.Reflection;
 using System.Windows.Input;
-using Splat;
 
 namespace ReactiveUI;
 #pragma warning disable RCS1102 // Make class static. Used as base class.

--- a/src/ReactiveUI/Bindings/Command/CreatesCommandBindingViaCommandParameter.cs
+++ b/src/ReactiveUI/Bindings/Command/CreatesCommandBindingViaCommandParameter.cs
@@ -3,9 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Linq;
-using System.Reactive.Disposables;
 using System.Reflection;
 using System.Windows.Input;
 

--- a/src/ReactiveUI/Bindings/Command/CreatesCommandBindingViaEvent.cs
+++ b/src/ReactiveUI/Bindings/Command/CreatesCommandBindingViaEvent.cs
@@ -3,11 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reactive.Disposables;
-using System.Reactive.Linq;
 using System.Reflection;
 using System.Windows.Input;
 

--- a/src/ReactiveUI/Bindings/Command/ICommandBinderImplementation.cs
+++ b/src/ReactiveUI/Bindings/Command/ICommandBinderImplementation.cs
@@ -3,10 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Linq.Expressions;
 using System.Windows.Input;
-using Splat;
 
 namespace ReactiveUI;
 

--- a/src/ReactiveUI/Bindings/Command/RelayCommand.cs
+++ b/src/ReactiveUI/Bindings/Command/RelayCommand.cs
@@ -3,7 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.Windows.Input;
 
 namespace ReactiveUI;

--- a/src/ReactiveUI/Bindings/Converter/ByteToStringTypeConverter.cs
+++ b/src/ReactiveUI/Bindings/Converter/ByteToStringTypeConverter.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-
 namespace ReactiveUI;
 
 /// <summary>

--- a/src/ReactiveUI/Bindings/Converter/DecimalToStringTypeConverter.cs
+++ b/src/ReactiveUI/Bindings/Converter/DecimalToStringTypeConverter.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-
 namespace ReactiveUI;
 
 /// <summary>

--- a/src/ReactiveUI/Bindings/Converter/DoubleToStringTypeConverter.cs
+++ b/src/ReactiveUI/Bindings/Converter/DoubleToStringTypeConverter.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-
 namespace ReactiveUI;
 
 /// <summary>

--- a/src/ReactiveUI/Bindings/Converter/EqualityTypeConverter.cs
+++ b/src/ReactiveUI/Bindings/Converter/EqualityTypeConverter.cs
@@ -3,10 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Linq;
 using System.Reflection;
-using Splat;
 
 namespace ReactiveUI;
 

--- a/src/ReactiveUI/Bindings/Converter/IntegerToStringTypeConverter.cs
+++ b/src/ReactiveUI/Bindings/Converter/IntegerToStringTypeConverter.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-
 namespace ReactiveUI;
 
 /// <summary>

--- a/src/ReactiveUI/Bindings/Converter/LongToStringTypeConverter.cs
+++ b/src/ReactiveUI/Bindings/Converter/LongToStringTypeConverter.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-
 namespace ReactiveUI;
 
 /// <summary>

--- a/src/ReactiveUI/Bindings/Converter/NullableByteToStringTypeConverter.cs
+++ b/src/ReactiveUI/Bindings/Converter/NullableByteToStringTypeConverter.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-
 namespace ReactiveUI;
 
 /// <summary>

--- a/src/ReactiveUI/Bindings/Converter/NullableDecimalToStringTypeConverter.cs
+++ b/src/ReactiveUI/Bindings/Converter/NullableDecimalToStringTypeConverter.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-
 namespace ReactiveUI;
 
 /// <summary>

--- a/src/ReactiveUI/Bindings/Converter/NullableDoubleToStringTypeConverter.cs
+++ b/src/ReactiveUI/Bindings/Converter/NullableDoubleToStringTypeConverter.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-
 namespace ReactiveUI;
 
 /// <summary>

--- a/src/ReactiveUI/Bindings/Converter/NullableIntegerToStringTypeConverter.cs
+++ b/src/ReactiveUI/Bindings/Converter/NullableIntegerToStringTypeConverter.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-
 namespace ReactiveUI;
 
 /// <summary>

--- a/src/ReactiveUI/Bindings/Converter/NullableLongToStringTypeConverter.cs
+++ b/src/ReactiveUI/Bindings/Converter/NullableLongToStringTypeConverter.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-
 namespace ReactiveUI;
 
 /// <summary>

--- a/src/ReactiveUI/Bindings/Converter/NullableShortToStringTypeConverter.cs
+++ b/src/ReactiveUI/Bindings/Converter/NullableShortToStringTypeConverter.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-
 namespace ReactiveUI;
 
 /// <summary>

--- a/src/ReactiveUI/Bindings/Converter/NullableSingleToStringTypeConverter.cs
+++ b/src/ReactiveUI/Bindings/Converter/NullableSingleToStringTypeConverter.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-
 namespace ReactiveUI;
 
 /// <summary>

--- a/src/ReactiveUI/Bindings/Converter/ShortToStringTypeConverter.cs
+++ b/src/ReactiveUI/Bindings/Converter/ShortToStringTypeConverter.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-
 namespace ReactiveUI;
 
 /// <summary>

--- a/src/ReactiveUI/Bindings/Converter/SingleToStringTypeConverter.cs
+++ b/src/ReactiveUI/Bindings/Converter/SingleToStringTypeConverter.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-
 namespace ReactiveUI;
 
 /// <summary>

--- a/src/ReactiveUI/Bindings/Converter/StringConverter.cs
+++ b/src/ReactiveUI/Bindings/Converter/StringConverter.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-
 namespace ReactiveUI;
 
 /// <summary>

--- a/src/ReactiveUI/Bindings/IBindingTypeConverter.cs
+++ b/src/ReactiveUI/Bindings/IBindingTypeConverter.cs
@@ -3,9 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using Splat;
-
 namespace ReactiveUI;
 
 /// <summary>

--- a/src/ReactiveUI/Bindings/ISetMethodBindingConverter.cs
+++ b/src/ReactiveUI/Bindings/ISetMethodBindingConverter.cs
@@ -3,9 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using Splat;
-
 namespace ReactiveUI;
 
 /// <summary>

--- a/src/ReactiveUI/Bindings/Interaction/IInteractionBinderImplementation.cs
+++ b/src/ReactiveUI/Bindings/Interaction/IInteractionBinderImplementation.cs
@@ -3,11 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Linq.Expressions;
-using System.Threading.Tasks;
-using Splat;
-
 namespace ReactiveUI;
 
 /// <summary>

--- a/src/ReactiveUI/Bindings/Interaction/InteractionBinderImplementation.cs
+++ b/src/ReactiveUI/Bindings/Interaction/InteractionBinderImplementation.cs
@@ -3,13 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Linq.Expressions;
-using System.Reactive.Disposables;
-using System.Reactive.Linq;
-using System.Threading.Tasks;
-using Splat;
-
 namespace ReactiveUI;
 
 /// <summary>

--- a/src/ReactiveUI/Bindings/Interaction/InteractionBindingMixins.cs
+++ b/src/ReactiveUI/Bindings/Interaction/InteractionBindingMixins.cs
@@ -3,10 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Linq.Expressions;
-using System.Threading.Tasks;
-
 namespace ReactiveUI;
 
 /// <summary>

--- a/src/ReactiveUI/Bindings/Property/IPropertyBinderImplementation.cs
+++ b/src/ReactiveUI/Bindings/Property/IPropertyBinderImplementation.cs
@@ -3,11 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Linq.Expressions;
-
-using Splat;
-
 namespace ReactiveUI;
 
 /// <summary>

--- a/src/ReactiveUI/Bindings/Property/PropertyBinderImplementation.cs
+++ b/src/ReactiveUI/Bindings/Property/PropertyBinderImplementation.cs
@@ -3,18 +3,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
-using System.Linq;
-using System.Linq.Expressions;
-using System.Reactive.Disposables;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
-
-using Splat;
 
 namespace ReactiveUI;
 

--- a/src/ReactiveUI/Bindings/Property/PropertyBindingMixins.cs
+++ b/src/ReactiveUI/Bindings/Property/PropertyBindingMixins.cs
@@ -3,10 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Linq.Expressions;
-using System.Reactive;
-
 namespace ReactiveUI;
 
 /// <summary>

--- a/src/ReactiveUI/Bindings/Reactive/IReactiveBinding.cs
+++ b/src/ReactiveUI/Bindings/Reactive/IReactiveBinding.cs
@@ -3,9 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Linq.Expressions;
-
 namespace ReactiveUI;
 
 /// <summary>

--- a/src/ReactiveUI/Bindings/Reactive/ReactiveBinding.cs
+++ b/src/ReactiveUI/Bindings/Reactive/ReactiveBinding.cs
@@ -3,9 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Linq.Expressions;
-
 namespace ReactiveUI;
 
 internal class ReactiveBinding<TView, TValue> : IReactiveBinding<TView, TValue>

--- a/src/ReactiveUI/Comparers/ChainedComparer.cs
+++ b/src/ReactiveUI/Comparers/ChainedComparer.cs
@@ -3,9 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-
 namespace ReactiveUI;
 
 internal sealed class ChainedComparer<T> : IComparer<T>

--- a/src/ReactiveUI/Comparers/ComparerChainingExtensions.cs
+++ b/src/ReactiveUI/Comparers/ComparerChainingExtensions.cs
@@ -3,9 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-
 namespace ReactiveUI;
 
 /// <summary>

--- a/src/ReactiveUI/Comparers/IComparerBuilder.cs
+++ b/src/ReactiveUI/Comparers/IComparerBuilder.cs
@@ -3,9 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-
 namespace ReactiveUI;
 
 /// <summary>

--- a/src/ReactiveUI/Comparers/OrderedComparer.cs
+++ b/src/ReactiveUI/Comparers/OrderedComparer.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
 namespace ReactiveUI;

--- a/src/ReactiveUI/EventHandlers/LocalizableAttribute.cs
+++ b/src/ReactiveUI/EventHandlers/LocalizableAttribute.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-
 #if PORTABLE || NETFX_CORE || ANDROID
 namespace ReactiveUI
 {

--- a/src/ReactiveUI/Expression/ExpressionRewriter.cs
+++ b/src/ReactiveUI/Expression/ExpressionRewriter.cs
@@ -3,13 +3,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
 using System.Text;
-using System.Threading.Tasks;
 
 namespace ReactiveUI;
 

--- a/src/ReactiveUI/Expression/Reflection.cs
+++ b/src/ReactiveUI/Expression/Reflection.cs
@@ -3,16 +3,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Diagnostics.Contracts;
-using System.Linq;
-using System.Linq.Expressions;
-using System.Reactive.Linq;
 using System.Reflection;
 using System.Text;
-using Splat;
 
 namespace ReactiveUI;
 

--- a/src/ReactiveUI/Interactions/Interaction.cs
+++ b/src/ReactiveUI/Interactions/Interaction.cs
@@ -3,16 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reactive;
-using System.Reactive.Concurrency;
-using System.Reactive.Disposables;
-using System.Reactive.Linq;
-using System.Reactive.Threading.Tasks;
-using System.Threading.Tasks;
-
 namespace ReactiveUI;
 
 /// <summary>

--- a/src/ReactiveUI/Interactions/InteractionContext.cs
+++ b/src/ReactiveUI/Interactions/InteractionContext.cs
@@ -3,9 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Threading;
-
 namespace ReactiveUI;
 
 /// <summary>

--- a/src/ReactiveUI/Interactions/UnhandledInteractionException.cs
+++ b/src/ReactiveUI/Interactions/UnhandledInteractionException.cs
@@ -3,7 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.Runtime.Serialization;
 
 namespace ReactiveUI;

--- a/src/ReactiveUI/Interfaces/ICanActivate.cs
+++ b/src/ReactiveUI/Interfaces/ICanActivate.cs
@@ -3,9 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Reactive;
-
 namespace ReactiveUI;
 
 /// <summary>

--- a/src/ReactiveUI/Interfaces/ICreatesCommandBinding.cs
+++ b/src/ReactiveUI/Interfaces/ICreatesCommandBinding.cs
@@ -3,7 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.Windows.Input;
 
 namespace ReactiveUI;

--- a/src/ReactiveUI/Interfaces/ICreatesObservableForProperty.cs
+++ b/src/ReactiveUI/Interfaces/ICreatesObservableForProperty.cs
@@ -3,10 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Linq.Expressions;
-using Splat;
-
 namespace ReactiveUI;
 
 /// <summary>

--- a/src/ReactiveUI/Interfaces/IHandleObservableErrors.cs
+++ b/src/ReactiveUI/Interfaces/IHandleObservableErrors.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-
 namespace ReactiveUI;
 
 /// <summary>

--- a/src/ReactiveUI/Interfaces/IMessageBus.cs
+++ b/src/ReactiveUI/Interfaces/IMessageBus.cs
@@ -3,10 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Reactive.Concurrency;
-using Splat;
-
 namespace ReactiveUI;
 
 /// <summary>

--- a/src/ReactiveUI/Interfaces/IObservedChange.cs
+++ b/src/ReactiveUI/Interfaces/IObservedChange.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Linq.Expressions;
-
 namespace ReactiveUI;
 
 /// <summary>

--- a/src/ReactiveUI/Interfaces/IPropertyBindingHook.cs
+++ b/src/ReactiveUI/Interfaces/IPropertyBindingHook.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-
 namespace ReactiveUI;
 
 /// <summary>

--- a/src/ReactiveUI/Interfaces/IReactiveNotifyPropertyChanged.cs
+++ b/src/ReactiveUI/Interfaces/IReactiveNotifyPropertyChanged.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-
 namespace ReactiveUI;
 
 /// <summary>

--- a/src/ReactiveUI/Interfaces/ISuspensionDriver.cs
+++ b/src/ReactiveUI/Interfaces/ISuspensionDriver.cs
@@ -3,9 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Reactive;
-
 namespace ReactiveUI;
 
 /// <summary>

--- a/src/ReactiveUI/Interfaces/ISuspensionHost.cs
+++ b/src/ReactiveUI/Interfaces/ISuspensionHost.cs
@@ -3,9 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Reactive;
-
 namespace ReactiveUI;
 /* Nicked from http://caliburnmicro.codeplex.com/wikipage?title=Working%20with%20Windows%20Phone%207%20v1.1
  *

--- a/src/ReactiveUI/Interfaces/IViewLocator.cs
+++ b/src/ReactiveUI/Interfaces/IViewLocator.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using Splat;
-
 namespace ReactiveUI;
 
 /// <summary>

--- a/src/ReactiveUI/Interfaces/IWantsToRegisterStuff.cs
+++ b/src/ReactiveUI/Interfaces/IWantsToRegisterStuff.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-
 namespace ReactiveUI;
 
 /// <summary>

--- a/src/ReactiveUI/Interfaces/ObservedChange.cs
+++ b/src/ReactiveUI/Interfaces/ObservedChange.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Linq.Expressions;
-
 namespace ReactiveUI;
 
 /// <summary>

--- a/src/ReactiveUI/Legacy/CollectionDebugView.cs
+++ b/src/ReactiveUI/Legacy/CollectionDebugView.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 
 namespace ReactiveUI.Legacy;

--- a/src/ReactiveUI/Legacy/RefcountDisposeWrapper.cs
+++ b/src/ReactiveUI/Legacy/RefcountDisposeWrapper.cs
@@ -3,9 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Threading;
-
 namespace ReactiveUI.Legacy;
 
 internal sealed class RefcountDisposeWrapper

--- a/src/ReactiveUI/Mixins/AutoPersistHelper.cs
+++ b/src/ReactiveUI/Mixins/AutoPersistHelper.cs
@@ -3,21 +3,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
-using System.Linq;
-using System.Reactive;
-using System.Reactive.Concurrency;
-using System.Reactive.Disposables;
-using System.Reactive.Linq;
 using System.Reflection;
 using System.Runtime.Serialization;
 
 using DynamicData;
 using DynamicData.Binding;
-using Splat;
 
 namespace ReactiveUI;
 

--- a/src/ReactiveUI/Mixins/ChangeSetMixin.cs
+++ b/src/ReactiveUI/Mixins/ChangeSetMixin.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Reactive.Linq;
 using DynamicData;
 
 namespace ReactiveUI;

--- a/src/ReactiveUI/Mixins/CompatMixins.cs
+++ b/src/ReactiveUI/Mixins/CompatMixins.cs
@@ -3,10 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-
 namespace ReactiveUI;
 
 internal static class CompatMixins

--- a/src/ReactiveUI/Mixins/DependencyResolverMixins.cs
+++ b/src/ReactiveUI/Mixins/DependencyResolverMixins.cs
@@ -3,13 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
-using Splat;
 
 namespace ReactiveUI;
 

--- a/src/ReactiveUI/Mixins/ExpressionMixins.cs
+++ b/src/ReactiveUI/Mixins/ExpressionMixins.cs
@@ -3,11 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
 using System.Text;
 

--- a/src/ReactiveUI/Mixins/ObservableLoggingMixin.cs
+++ b/src/ReactiveUI/Mixins/ObservableLoggingMixin.cs
@@ -3,10 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.Globalization;
-using System.Reactive.Linq;
-using Splat;
 
 namespace ReactiveUI;
 

--- a/src/ReactiveUI/Mixins/ObservableMixins.cs
+++ b/src/ReactiveUI/Mixins/ObservableMixins.cs
@@ -3,9 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Reactive.Linq;
-
 namespace ReactiveUI;
 
 /// <summary>

--- a/src/ReactiveUI/Mixins/ObservedChangedMixin.cs
+++ b/src/ReactiveUI/Mixins/ObservedChangedMixin.cs
@@ -3,10 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Linq.Expressions;
-using System.Reactive.Linq;
-
 namespace ReactiveUI;
 
 /// <summary>

--- a/src/ReactiveUI/Mixins/PreserveAttribute.cs
+++ b/src/ReactiveUI/Mixins/PreserveAttribute.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-
 namespace ReactiveUI;
 
 [AttributeUsage(AttributeTargets.All)]

--- a/src/ReactiveUI/Mixins/ReactiveNotifyPropertyChangedMixin.cs
+++ b/src/ReactiveUI/Mixins/ReactiveNotifyPropertyChangedMixin.cs
@@ -3,13 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Linq.Expressions;
-using System.Reactive.Linq;
-using Splat;
-
 namespace ReactiveUI;
 
 /// <summary>

--- a/src/ReactiveUI/ObservableForProperty/INPCObservableForProperty.cs
+++ b/src/ReactiveUI/ObservableForProperty/INPCObservableForProperty.cs
@@ -3,11 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.ComponentModel;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq.Expressions;
-using System.Reactive.Linq;
 using System.Reflection;
 
 namespace ReactiveUI;

--- a/src/ReactiveUI/ObservableForProperty/IROObservableForProperty.cs
+++ b/src/ReactiveUI/ObservableForProperty/IROObservableForProperty.cs
@@ -3,9 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Linq.Expressions;
-using System.Reactive.Linq;
 using System.Reflection;
 
 namespace ReactiveUI;

--- a/src/ReactiveUI/ObservableForProperty/OAPHCreationHelperMixin.cs
+++ b/src/ReactiveUI/ObservableForProperty/OAPHCreationHelperMixin.cs
@@ -3,10 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Linq.Expressions;
-using System.Reactive.Concurrency;
-
 namespace ReactiveUI;
 
 /// <summary>

--- a/src/ReactiveUI/ObservableForProperty/ObservableAsPropertyHelper.cs
+++ b/src/ReactiveUI/ObservableForProperty/ObservableAsPropertyHelper.cs
@@ -3,15 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Diagnostics.Contracts;
-using System.Reactive.Concurrency;
-using System.Reactive.Disposables;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
-using System.Threading;
-using Splat;
-
 namespace ReactiveUI;
 
 /// <summary>

--- a/src/ReactiveUI/ObservableForProperty/POCOObservableForProperty.cs
+++ b/src/ReactiveUI/ObservableForProperty/POCOObservableForProperty.cs
@@ -3,12 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Linq.Expressions;
-using System.Reactive.Linq;
-using Splat;
 
 namespace ReactiveUI;
 

--- a/src/ReactiveUI/ObservableFuncMixins.cs
+++ b/src/ReactiveUI/ObservableFuncMixins.cs
@@ -3,10 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Linq.Expressions;
-using System.Reactive.Linq;
-
 namespace ReactiveUI;
 
 /// <summary>

--- a/src/ReactiveUI/PlatformRegistrationManager.cs
+++ b/src/ReactiveUI/PlatformRegistrationManager.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-
 namespace ReactiveUI;
 
 /// <summary>

--- a/src/ReactiveUI/Platforms/android/AndroidCommandBinders.cs
+++ b/src/ReactiveUI/Platforms/android/AndroidCommandBinders.cs
@@ -3,9 +3,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Linq.Expressions;
 using System.Reflection;
+
 using Android.Views;
 
 namespace ReactiveUI;

--- a/src/ReactiveUI/Platforms/android/AndroidObservableForWidgets.cs
+++ b/src/ReactiveUI/Platforms/android/AndroidObservableForWidgets.cs
@@ -3,17 +3,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Linq.Expressions;
-using System.Reactive.Linq;
 using System.Runtime.Versioning;
+
 using Android.OS;
 using Android.Text;
 using Android.Views;
 using Android.Widget;
+
 using Observable = System.Reactive.Linq.Observable;
 
 namespace ReactiveUI;

--- a/src/ReactiveUI/Platforms/android/AutoSuspendHelper.cs
+++ b/src/ReactiveUI/Platforms/android/AutoSuspendHelper.cs
@@ -3,17 +3,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Linq;
-using System.Reactive;
-using System.Reactive.Disposables;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
-
 using Android.App;
 using Android.OS;
-
-using Splat;
 
 namespace ReactiveUI;
 

--- a/src/ReactiveUI/Platforms/android/BundleSuspensionDriver.cs
+++ b/src/ReactiveUI/Platforms/android/BundleSuspensionDriver.cs
@@ -3,10 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.IO;
-using System.Reactive;
-using System.Reactive.Linq;
 using System.Runtime.Serialization.Formatters.Binary;
 
 namespace ReactiveUI;

--- a/src/ReactiveUI/Platforms/android/ContextExtensions.cs
+++ b/src/ReactiveUI/Platforms/android/ContextExtensions.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Reactive.Linq;
 using Android.Content;
 using Android.OS;
 

--- a/src/ReactiveUI/Platforms/android/ControlFetcherMixin.cs
+++ b/src/ReactiveUI/Platforms/android/ControlFetcherMixin.cs
@@ -3,12 +3,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+
 using Android.App;
 using Android.Views;
 

--- a/src/ReactiveUI/Platforms/android/FlexibleCommandBinder.cs
+++ b/src/ReactiveUI/Platforms/android/FlexibleCommandBinder.cs
@@ -3,11 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reactive.Disposables;
-using System.Reactive.Linq;
 using System.Reflection;
 using System.Windows.Input;
 

--- a/src/ReactiveUI/Platforms/android/HandlerScheduler.cs
+++ b/src/ReactiveUI/Platforms/android/HandlerScheduler.cs
@@ -3,16 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reactive;
-using System.Reactive.Concurrency;
-using System.Reactive.Disposables;
-using Android.App;
 using Android.OS;
-using ReactiveUI;
-using Splat;
 
 namespace ReactiveUI;
 

--- a/src/ReactiveUI/Platforms/android/IgnoreResourceAttribute.cs
+++ b/src/ReactiveUI/Platforms/android/IgnoreResourceAttribute.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-
 namespace ReactiveUI;
 
 /// <summary>

--- a/src/ReactiveUI/Platforms/android/JavaHolder.cs
+++ b/src/ReactiveUI/Platforms/android/JavaHolder.cs
@@ -3,10 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Text;
 
 using Object = Java.Lang.Object;
 

--- a/src/ReactiveUI/Platforms/android/LayoutViewHost.cs
+++ b/src/ReactiveUI/Platforms/android/LayoutViewHost.cs
@@ -3,11 +3,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Diagnostics.CodeAnalysis;
 using Android.Content;
 using Android.Views;
-using Splat;
 
 namespace ReactiveUI;
 

--- a/src/ReactiveUI/Platforms/android/LinkerOverrides.cs
+++ b/src/ReactiveUI/Platforms/android/LinkerOverrides.cs
@@ -3,17 +3,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.Versioning;
-using System.Text;
 
-using Android.App;
-using Android.Content;
-using Android.OS;
-using Android.Runtime;
-using Android.Views;
 using Android.Widget;
 
 namespace ReactiveUI;

--- a/src/ReactiveUI/Platforms/android/ObjectExtension.cs
+++ b/src/ReactiveUI/Platforms/android/ObjectExtension.cs
@@ -3,7 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using Object = Java.Lang.Object;
 
 namespace ReactiveUI;

--- a/src/ReactiveUI/Platforms/android/PlatformOperations.cs
+++ b/src/ReactiveUI/Platforms/android/PlatformOperations.cs
@@ -3,7 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using Android.App;
 using Android.Content;
 using Android.Views;

--- a/src/ReactiveUI/Platforms/android/PlatformRegistrations.cs
+++ b/src/ReactiveUI/Platforms/android/PlatformRegistrations.cs
@@ -3,10 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Reactive.Concurrency;
-using Splat;
-
 namespace ReactiveUI;
 
 /// <summary>

--- a/src/ReactiveUI/Platforms/android/ReactiveActivity.cs
+++ b/src/ReactiveUI/Platforms/android/ReactiveActivity.cs
@@ -3,15 +3,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Reactive;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
-using System.Reactive.Threading.Tasks;
-using System.Threading.Tasks;
+
 using Android.App;
 using Android.Content;
 using Android.Runtime;

--- a/src/ReactiveUI/Platforms/android/ReactiveFragment.cs
+++ b/src/ReactiveUI/Platforms/android/ReactiveFragment.cs
@@ -3,13 +3,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
-using System.Reactive;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
 using System.Runtime.Versioning;
+
 using Android.App;
 using Android.Runtime;
 

--- a/src/ReactiveUI/Platforms/android/ReactivePreferenceActivity.cs
+++ b/src/ReactiveUI/Platforms/android/ReactivePreferenceActivity.cs
@@ -3,15 +3,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
-using System.Reactive;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
-using System.Reactive.Threading.Tasks;
 using System.Runtime.Versioning;
-using System.Threading.Tasks;
+
 using Android.App;
 using Android.Content;
 using Android.Preferences;

--- a/src/ReactiveUI/Platforms/android/ReactivePreferenceFragment.cs
+++ b/src/ReactiveUI/Platforms/android/ReactivePreferenceFragment.cs
@@ -3,13 +3,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
-using System.Reactive;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
 using System.Runtime.Versioning;
+
 using Android.Preferences;
 using Android.Runtime;
 

--- a/src/ReactiveUI/Platforms/android/ReactiveViewHost.cs
+++ b/src/ReactiveUI/Platforms/android/ReactiveViewHost.cs
@@ -3,12 +3,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Reflection;
 using System.Runtime.Serialization;
+
 using Android.Content;
 using Android.Views;
 

--- a/src/ReactiveUI/Platforms/android/SharedPreferencesExtensions.cs
+++ b/src/ReactiveUI/Platforms/android/SharedPreferencesExtensions.cs
@@ -3,9 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Reactive.Disposables;
-using System.Reactive.Linq;
 using Android.Content;
 
 namespace ReactiveUI;

--- a/src/ReactiveUI/Platforms/android/UsbManagerExtensions.cs
+++ b/src/ReactiveUI/Platforms/android/UsbManagerExtensions.cs
@@ -3,10 +3,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Reactive.Disposables;
-using System.Reactive.Linq;
 using System.Runtime.Versioning;
+
 using Android.App;
 using Android.Content;
 using Android.Hardware.Usb;

--- a/src/ReactiveUI/Platforms/android/ViewCommandExtensions.cs
+++ b/src/ReactiveUI/Platforms/android/ViewCommandExtensions.cs
@@ -3,12 +3,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reactive.Disposables;
-using System.Text;
 using System.Windows.Input;
+
 using Android.Views;
 
 namespace ReactiveUI;

--- a/src/ReactiveUI/Platforms/android/WireUpResourceAttribute.cs
+++ b/src/ReactiveUI/Platforms/android/WireUpResourceAttribute.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-
 namespace ReactiveUI;
 
 /// <summary>

--- a/src/ReactiveUI/Platforms/apple-common/AppSupportJsonSuspensionDriver.cs
+++ b/src/ReactiveUI/Platforms/apple-common/AppSupportJsonSuspensionDriver.cs
@@ -3,11 +3,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.IO;
-using System.Reactive;
-using System.Reactive.Linq;
 using System.Runtime.Serialization.Formatters.Binary;
+
 using Foundation;
 
 namespace ReactiveUI;

--- a/src/ReactiveUI/Platforms/apple-common/BlockObserveValueDelegate.cs
+++ b/src/ReactiveUI/Platforms/apple-common/BlockObserveValueDelegate.cs
@@ -3,7 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using Foundation;
 
 namespace ReactiveUI;

--- a/src/ReactiveUI/Platforms/apple-common/Converters/DateTimeNSDateConverter.cs
+++ b/src/ReactiveUI/Platforms/apple-common/Converters/DateTimeNSDateConverter.cs
@@ -3,7 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using Foundation;
 
 namespace ReactiveUI;

--- a/src/ReactiveUI/Platforms/apple-common/IndexNormalizer.cs
+++ b/src/ReactiveUI/Platforms/apple-common/IndexNormalizer.cs
@@ -3,10 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 
 namespace ReactiveUI;
 

--- a/src/ReactiveUI/Platforms/apple-common/KVOObservableForProperty.cs
+++ b/src/ReactiveUI/Platforms/apple-common/KVOObservableForProperty.cs
@@ -3,16 +3,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.Globalization;
-using System.Linq;
-using System.Linq.Expressions;
-using System.Reactive.Disposables;
-using System.Reactive.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
+
 using Foundation;
-using Splat;
 
 namespace ReactiveUI;
 

--- a/src/ReactiveUI/Platforms/apple-common/NSRunloopScheduler.cs
+++ b/src/ReactiveUI/Platforms/apple-common/NSRunloopScheduler.cs
@@ -3,11 +3,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Reactive.Concurrency;
-using System.Reactive.Disposables;
 using CoreFoundation;
+
 using Foundation;
+
 using NSAction = System.Action;
 
 namespace ReactiveUI;

--- a/src/ReactiveUI/Platforms/apple-common/ObservableForPropertyBase.cs
+++ b/src/ReactiveUI/Platforms/apple-common/ObservableForPropertyBase.cs
@@ -3,12 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Linq.Expressions;
-using System.Reactive.Disposables;
-using System.Reactive.Linq;
 using Foundation;
 
 #if UIKIT

--- a/src/ReactiveUI/Platforms/apple-common/ReactiveControl.cs
+++ b/src/ReactiveUI/Platforms/apple-common/ReactiveControl.cs
@@ -3,13 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
-using System.Reactive;
-using System.Reactive.Concurrency;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
 using CoreGraphics;
 using Foundation;
 

--- a/src/ReactiveUI/Platforms/apple-common/ReactiveImageView.cs
+++ b/src/ReactiveUI/Platforms/apple-common/ReactiveImageView.cs
@@ -3,18 +3,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
-using System.Reactive;
-using System.Reactive.Concurrency;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
 using CoreGraphics;
 using Foundation;
 
 #if UIKIT
-using UIKit;
 using NSImage = UIKit.UIImage;
 using NSImageView = UIKit.UIImageView;
 using NSView = UIKit.UIView;

--- a/src/ReactiveUI/Platforms/apple-common/ReactiveSplitViewController.cs
+++ b/src/ReactiveUI/Platforms/apple-common/ReactiveSplitViewController.cs
@@ -3,18 +3,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.ComponentModel;
-using System.Diagnostics.CodeAnalysis;
-using System.Reactive;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
 using Foundation;
 
 #if UIKIT
-using UIKit;
 using NSSplitViewController = UIKit.UISplitViewController;
-using NSView = UIKit.UIView;
 #else
 using AppKit;
 #endif

--- a/src/ReactiveUI/Platforms/apple-common/ReactiveView.cs
+++ b/src/ReactiveUI/Platforms/apple-common/ReactiveView.cs
@@ -3,18 +3,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.ComponentModel;
-using System.Diagnostics.CodeAnalysis;
-using System.Reactive;
-using System.Reactive.Concurrency;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
 using CoreGraphics;
 using Foundation;
 
 #if UIKIT
-using UIKit;
 using NSView = UIKit.UIView;
 #else
 using AppKit;

--- a/src/ReactiveUI/Platforms/apple-common/ReactiveViewController.cs
+++ b/src/ReactiveUI/Platforms/apple-common/ReactiveViewController.cs
@@ -3,17 +3,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.ComponentModel;
-using System.Diagnostics.CodeAnalysis;
-using System.Reactive;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
 using Foundation;
 
 #if UIKIT
-using UIKit;
-using NSView = UIKit.UIView;
 using NSViewController = UIKit.UIViewController;
 #else
 using AppKit;

--- a/src/ReactiveUI/Platforms/apple-common/TargetActionCommandBinder.cs
+++ b/src/ReactiveUI/Platforms/apple-common/TargetActionCommandBinder.cs
@@ -3,11 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Reactive.Disposables;
-using System.Reactive.Linq;
 using System.Reflection;
 using System.Windows.Input;
 using Foundation;

--- a/src/ReactiveUI/Platforms/apple-common/UIViewControllerMixins.cs
+++ b/src/ReactiveUI/Platforms/apple-common/UIViewControllerMixins.cs
@@ -3,16 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.ComponentModel;
-using System.Diagnostics.CodeAnalysis;
-using System.Reactive;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
-using Foundation;
-
 #if UIKIT
-using UIKit;
 using NSView = UIKit.UIView;
 using NSViewController = UIKit.UIViewController;
 #else

--- a/src/ReactiveUI/Platforms/apple-common/ViewModelViewHost.cs
+++ b/src/ReactiveUI/Platforms/apple-common/ViewModelViewHost.cs
@@ -3,14 +3,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Diagnostics.CodeAnalysis;
-using System.Reactive.Disposables;
-using System.Reactive.Linq;
-
 #if UIKIT
 using UIKit;
-using NSView = UIKit.UIView;
 using NSViewController = UIKit.UIViewController;
 #else
 using AppKit;

--- a/src/ReactiveUI/Platforms/ios/LinkerOverrides.cs
+++ b/src/ReactiveUI/Platforms/ios/LinkerOverrides.cs
@@ -3,7 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using UIKit;
 
 namespace ReactiveUI.Cocoa;

--- a/src/ReactiveUI/Platforms/ios/UIKitCommandBinders.cs
+++ b/src/ReactiveUI/Platforms/ios/UIKitCommandBinders.cs
@@ -3,8 +3,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.Reflection;
+
 using UIKit;
 
 namespace ReactiveUI;

--- a/src/ReactiveUI/Platforms/ios/UIKitObservableForProperty.cs
+++ b/src/ReactiveUI/Platforms/ios/UIKitObservableForProperty.cs
@@ -3,7 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using UIKit;
 
 namespace ReactiveUI;

--- a/src/ReactiveUI/Platforms/mac/AppKitObservableForProperty.cs
+++ b/src/ReactiveUI/Platforms/mac/AppKitObservableForProperty.cs
@@ -3,7 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using AppKit;
 
 namespace ReactiveUI;

--- a/src/ReactiveUI/Platforms/mac/AutoSuspendHelper.cs
+++ b/src/ReactiveUI/Platforms/mac/AutoSuspendHelper.cs
@@ -3,15 +3,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Reactive;
-using System.Reactive.Concurrency;
-using System.Reactive.Disposables;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
 using AppKit;
+
 using Foundation;
-using Splat;
 
 namespace ReactiveUI;
 

--- a/src/ReactiveUI/Platforms/mac/PlatformRegistrations.cs
+++ b/src/ReactiveUI/Platforms/mac/PlatformRegistrations.cs
@@ -3,10 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Reactive.Concurrency;
-using Splat;
-
 namespace ReactiveUI;
 
 /// <summary>

--- a/src/ReactiveUI/Platforms/mac/ReactiveWindowController.cs
+++ b/src/ReactiveUI/Platforms/mac/ReactiveWindowController.cs
@@ -3,11 +3,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.ComponentModel;
-using System.Reactive;
-using System.Reactive.Subjects;
+
 using AppKit;
+
 using Foundation;
 
 namespace ReactiveUI;

--- a/src/ReactiveUI/Platforms/netstandard2.0/PlatformRegistrations.cs
+++ b/src/ReactiveUI/Platforms/netstandard2.0/PlatformRegistrations.cs
@@ -3,10 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Reactive.Concurrency;
-using Splat;
-
 namespace ReactiveUI;
 
 /// <summary>

--- a/src/ReactiveUI/Platforms/tizen/EcoreMainloopScheduler.cs
+++ b/src/ReactiveUI/Platforms/tizen/EcoreMainloopScheduler.cs
@@ -3,9 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Reactive.Concurrency;
-using System.Reactive.Disposables;
 using ElmSharp;
 
 namespace ReactiveUI;

--- a/src/ReactiveUI/Platforms/tizen/PlatformRegistrations.cs
+++ b/src/ReactiveUI/Platforms/tizen/PlatformRegistrations.cs
@@ -3,10 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Reactive.Concurrency;
-using Splat;
-
 namespace ReactiveUI;
 
 /// <summary>

--- a/src/ReactiveUI/Platforms/tvos/LinkerOverrides.cs
+++ b/src/ReactiveUI/Platforms/tvos/LinkerOverrides.cs
@@ -3,7 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using UIKit;
 
 namespace ReactiveUI.Cocoa;

--- a/src/ReactiveUI/Platforms/tvos/UIKitCommandBinders.cs
+++ b/src/ReactiveUI/Platforms/tvos/UIKitCommandBinders.cs
@@ -3,8 +3,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.Reflection;
+
 using UIKit;
 
 namespace ReactiveUI;

--- a/src/ReactiveUI/Platforms/tvos/UIKitObservableForProperty.cs
+++ b/src/ReactiveUI/Platforms/tvos/UIKitObservableForProperty.cs
@@ -3,7 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using UIKit;
 
 namespace ReactiveUI;

--- a/src/ReactiveUI/Platforms/uikit-common/AutoSuspendHelper.cs
+++ b/src/ReactiveUI/Platforms/uikit-common/AutoSuspendHelper.cs
@@ -3,16 +3,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reactive;
-using System.Reactive.Disposables;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
 using Foundation;
-using Splat;
+
 using UIKit;
+
 using NSAction = System.Action;
 
 namespace ReactiveUI;

--- a/src/ReactiveUI/Platforms/uikit-common/CollectionViewSectionInformation.cs
+++ b/src/ReactiveUI/Platforms/uikit-common/CollectionViewSectionInformation.cs
@@ -3,10 +3,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Specialized;
 using System.Diagnostics.CodeAnalysis;
+
 using Foundation;
+
 using UIKit;
 
 namespace ReactiveUI;

--- a/src/ReactiveUI/Platforms/uikit-common/CommonReactiveSource.cs
+++ b/src/ReactiveUI/Platforms/uikit-common/CommonReactiveSource.cs
@@ -3,22 +3,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Diagnostics;
 using System.Globalization;
-using System.Linq;
-using System.Reactive;
-using System.Reactive.Concurrency;
-using System.Reactive.Disposables;
-using System.Reactive.Linq;
-using System.Threading;
+
 using DynamicData;
 using DynamicData.Binding;
+
 using Foundation;
-using Splat;
 
 namespace ReactiveUI;
 

--- a/src/ReactiveUI/Platforms/uikit-common/FlexibleCommandBinder.cs
+++ b/src/ReactiveUI/Platforms/uikit-common/FlexibleCommandBinder.cs
@@ -3,13 +3,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reactive.Disposables;
-using System.Reactive.Linq;
 using System.Reflection;
 using System.Windows.Input;
+
 using UIKit;
 
 namespace ReactiveUI;

--- a/src/ReactiveUI/Platforms/uikit-common/ISectionInformation.cs
+++ b/src/ReactiveUI/Platforms/uikit-common/ISectionInformation.cs
@@ -3,8 +3,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Specialized;
+
 using Foundation;
 
 namespace ReactiveUI;

--- a/src/ReactiveUI/Platforms/uikit-common/IUICollViewAdapter.cs
+++ b/src/ReactiveUI/Platforms/uikit-common/IUICollViewAdapter.cs
@@ -3,7 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using Foundation;
 
 namespace ReactiveUI;

--- a/src/ReactiveUI/Platforms/uikit-common/PlatformRegistrations.cs
+++ b/src/ReactiveUI/Platforms/uikit-common/PlatformRegistrations.cs
@@ -3,10 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Reactive.Concurrency;
-using Splat;
-
 namespace ReactiveUI;
 
 /// <summary>

--- a/src/ReactiveUI/Platforms/uikit-common/ReactiveCollectionReusableView.cs
+++ b/src/ReactiveUI/Platforms/uikit-common/ReactiveCollectionReusableView.cs
@@ -3,14 +3,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
-using System.Reactive;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
+
 using CoreGraphics;
+
 using Foundation;
+
 using UIKit;
 
 namespace ReactiveUI;

--- a/src/ReactiveUI/Platforms/uikit-common/ReactiveCollectionView.cs
+++ b/src/ReactiveUI/Platforms/uikit-common/ReactiveCollectionView.cs
@@ -3,15 +3,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
-using System.Reactive;
-using System.Reactive.Concurrency;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
+
 using CoreGraphics;
+
 using Foundation;
+
 using UIKit;
 
 namespace ReactiveUI;

--- a/src/ReactiveUI/Platforms/uikit-common/ReactiveCollectionViewCell.cs
+++ b/src/ReactiveUI/Platforms/uikit-common/ReactiveCollectionViewCell.cs
@@ -3,15 +3,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
-using System.Reactive;
-using System.Reactive.Concurrency;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
+
 using CoreGraphics;
+
 using Foundation;
+
 using UIKit;
 
 namespace ReactiveUI;

--- a/src/ReactiveUI/Platforms/uikit-common/ReactiveCollectionViewController.cs
+++ b/src/ReactiveUI/Platforms/uikit-common/ReactiveCollectionViewController.cs
@@ -3,13 +3,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
-using System.Reactive;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
+
 using Foundation;
+
 using UIKit;
 
 namespace ReactiveUI;

--- a/src/ReactiveUI/Platforms/uikit-common/ReactiveCollectionViewSource.cs
+++ b/src/ReactiveUI/Platforms/uikit-common/ReactiveCollectionViewSource.cs
@@ -3,12 +3,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
-using System.Reactive.Subjects;
+
 using Foundation;
+
 using UIKit;
 
 namespace ReactiveUI;

--- a/src/ReactiveUI/Platforms/uikit-common/ReactiveCollectionViewSourceExtensions.cs
+++ b/src/ReactiveUI/Platforms/uikit-common/ReactiveCollectionViewSourceExtensions.cs
@@ -3,13 +3,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using System.Collections.Specialized;
-using System.Linq;
-using System.Reactive.Disposables;
-using System.Reactive.Linq;
+
 using Foundation;
+
 using UIKit;
 
 namespace ReactiveUI;

--- a/src/ReactiveUI/Platforms/uikit-common/ReactiveNavigationController.cs
+++ b/src/ReactiveUI/Platforms/uikit-common/ReactiveNavigationController.cs
@@ -3,13 +3,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
-using System.Reactive;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
+
 using Foundation;
+
 using UIKit;
 
 namespace ReactiveUI;

--- a/src/ReactiveUI/Platforms/uikit-common/ReactivePageViewController.cs
+++ b/src/ReactiveUI/Platforms/uikit-common/ReactivePageViewController.cs
@@ -3,13 +3,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
-using System.Reactive;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
+
 using Foundation;
+
 using UIKit;
 
 namespace ReactiveUI;

--- a/src/ReactiveUI/Platforms/uikit-common/ReactiveTabBarController.cs
+++ b/src/ReactiveUI/Platforms/uikit-common/ReactiveTabBarController.cs
@@ -3,13 +3,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
-using System.Reactive;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
+
 using Foundation;
+
 using UIKit;
 
 namespace ReactiveUI;

--- a/src/ReactiveUI/Platforms/uikit-common/ReactiveTableView.cs
+++ b/src/ReactiveUI/Platforms/uikit-common/ReactiveTableView.cs
@@ -3,15 +3,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
-using System.Reactive;
-using System.Reactive.Concurrency;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
+
 using CoreGraphics;
+
 using Foundation;
+
 using UIKit;
 
 namespace ReactiveUI;

--- a/src/ReactiveUI/Platforms/uikit-common/ReactiveTableViewCell.cs
+++ b/src/ReactiveUI/Platforms/uikit-common/ReactiveTableViewCell.cs
@@ -3,15 +3,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
-using System.Reactive;
-using System.Reactive.Concurrency;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
+
 using CoreGraphics;
+
 using Foundation;
+
 using UIKit;
 
 namespace ReactiveUI;

--- a/src/ReactiveUI/Platforms/uikit-common/ReactiveTableViewController.cs
+++ b/src/ReactiveUI/Platforms/uikit-common/ReactiveTableViewController.cs
@@ -3,13 +3,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
-using System.Reactive;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
+
 using Foundation;
+
 using NSTableViewController = UIKit.UITableViewController;
 using NSTableViewStyle = UIKit.UITableViewStyle;
 

--- a/src/ReactiveUI/Platforms/uikit-common/ReactiveTableViewSource.cs
+++ b/src/ReactiveUI/Platforms/uikit-common/ReactiveTableViewSource.cs
@@ -3,15 +3,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
-using System.Reactive.Subjects;
 
 using Foundation;
 
-using ObjCRuntime;
 using UIKit;
 
 namespace ReactiveUI;

--- a/src/ReactiveUI/Platforms/uikit-common/ReactiveTableViewSourceExtensions.cs
+++ b/src/ReactiveUI/Platforms/uikit-common/ReactiveTableViewSourceExtensions.cs
@@ -3,12 +3,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using System.Collections.Specialized;
-using System.Reactive.Disposables;
-using System.Reactive.Linq;
+
 using Foundation;
+
 using UIKit;
 
 namespace ReactiveUI;

--- a/src/ReactiveUI/Platforms/uikit-common/RoutedViewHost.cs
+++ b/src/ReactiveUI/Platforms/uikit-common/RoutedViewHost.cs
@@ -3,12 +3,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Specialized;
 using System.Diagnostics.CodeAnalysis;
-using System.Reactive.Disposables;
-using System.Reactive.Linq;
+
 using DynamicData.Binding;
+
 using NSViewController = UIKit.UIViewController;
 
 namespace ReactiveUI;

--- a/src/ReactiveUI/Platforms/uikit-common/TableSectionHeader.cs
+++ b/src/ReactiveUI/Platforms/uikit-common/TableSectionHeader.cs
@@ -3,7 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using UIKit;
 
 namespace ReactiveUI;

--- a/src/ReactiveUI/Platforms/uikit-common/TableSectionInformation.cs
+++ b/src/ReactiveUI/Platforms/uikit-common/TableSectionInformation.cs
@@ -3,10 +3,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Specialized;
 using System.Diagnostics.CodeAnalysis;
+
 using Foundation;
+
 using UIKit;
 
 namespace ReactiveUI;

--- a/src/ReactiveUI/Platforms/uikit-common/UICollectionViewAdapter.cs
+++ b/src/ReactiveUI/Platforms/uikit-common/UICollectionViewAdapter.cs
@@ -3,13 +3,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.Diagnostics;
-using System.Reactive.Concurrency;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
+
 using Foundation;
+
 using UIKit;
+
 using NSAction = System.Action;
 
 namespace ReactiveUI;

--- a/src/ReactiveUI/Platforms/uikit-common/UIControlCommandExtensions.cs
+++ b/src/ReactiveUI/Platforms/uikit-common/UIControlCommandExtensions.cs
@@ -3,9 +3,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Reactive.Disposables;
 using System.Windows.Input;
+
 using UIKit;
 
 namespace ReactiveUI;

--- a/src/ReactiveUI/Platforms/uikit-common/UITableViewAdapter.cs
+++ b/src/ReactiveUI/Platforms/uikit-common/UITableViewAdapter.cs
@@ -3,12 +3,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.Diagnostics;
-using System.Reactive.Concurrency;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
+
 using Foundation;
+
 using UIKit;
 
 namespace ReactiveUI;

--- a/src/ReactiveUI/Platforms/xamarin-common/ComponentModelTypeConverter.cs
+++ b/src/ReactiveUI/Platforms/xamarin-common/ComponentModelTypeConverter.cs
@@ -3,9 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.ComponentModel;
-using Splat;
 
 namespace ReactiveUI;
 

--- a/src/ReactiveUI/ReactiveCommand/CombinedReactiveCommand.cs
+++ b/src/ReactiveUI/ReactiveCommand/CombinedReactiveCommand.cs
@@ -3,12 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reactive.Concurrency;
-using System.Reactive.Linq;
-
 namespace ReactiveUI;
 
 /// <summary>

--- a/src/ReactiveUI/ReactiveCommand/IReactiveCommand.cs
+++ b/src/ReactiveUI/ReactiveCommand/IReactiveCommand.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-
 namespace ReactiveUI;
 
 /// <summary>

--- a/src/ReactiveUI/ReactiveCommand/ReactiveCommand.cs
+++ b/src/ReactiveUI/ReactiveCommand/ReactiveCommand.cs
@@ -3,17 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Reactive;
-using System.Reactive.Concurrency;
-using System.Reactive.Disposables;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
-using System.Reactive.Threading.Tasks;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace ReactiveUI;
 

--- a/src/ReactiveUI/ReactiveCommand/ReactiveCommandBase.cs
+++ b/src/ReactiveUI/ReactiveCommand/ReactiveCommandBase.cs
@@ -3,9 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Reactive.Concurrency;
-using System.Reactive.Linq;
 using System.Windows.Input;
 
 namespace ReactiveUI;

--- a/src/ReactiveUI/ReactiveCommand/ReactiveCommandMixins.cs
+++ b/src/ReactiveUI/ReactiveCommand/ReactiveCommandMixins.cs
@@ -3,10 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Linq.Expressions;
-using System.Reactive;
-using System.Reactive.Linq;
 using System.Windows.Input;
 
 namespace ReactiveUI;

--- a/src/ReactiveUI/ReactiveObject/IReactiveObject.cs
+++ b/src/ReactiveUI/ReactiveObject/IReactiveObject.cs
@@ -4,7 +4,6 @@
 // See the LICENSE file in the project root for full license information.
 
 using System.ComponentModel;
-using Splat;
 
 namespace ReactiveUI;
 

--- a/src/ReactiveUI/ReactiveObject/IReactiveObjectExtensions.cs
+++ b/src/ReactiveUI/ReactiveObject/IReactiveObjectExtensions.cs
@@ -3,16 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Reactive;
-using System.Reactive.Concurrency;
-using System.Reactive.Disposables;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
 using System.Runtime.CompilerServices;
-using System.Threading;
-using Splat;
 
 namespace ReactiveUI;
 

--- a/src/ReactiveUI/ReactiveObject/ReactiveObject.cs
+++ b/src/ReactiveUI/ReactiveObject/ReactiveObject.cs
@@ -3,11 +3,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.ComponentModel;
-using System.Reactive;
 using System.Runtime.Serialization;
-using System.Threading;
 
 namespace ReactiveUI;
 

--- a/src/ReactiveUI/ReactiveObject/ReactiveRecord.cs
+++ b/src/ReactiveUI/ReactiveObject/ReactiveRecord.cs
@@ -3,11 +3,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.ComponentModel;
-using System.Reactive;
 using System.Runtime.Serialization;
-using System.Threading;
 
 namespace ReactiveUI;
 

--- a/src/ReactiveUI/Registration/Registrations.cs
+++ b/src/ReactiveUI/Registration/Registrations.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-
 namespace ReactiveUI;
 
 /// <summary>

--- a/src/ReactiveUI/Routing/MessageBus.cs
+++ b/src/ReactiveUI/Routing/MessageBus.cs
@@ -3,13 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Reactive.Concurrency;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
-using Splat;
 
 namespace ReactiveUI;
 

--- a/src/ReactiveUI/Routing/RoutableViewModelMixin.cs
+++ b/src/ReactiveUI/Routing/RoutableViewModelMixin.cs
@@ -3,11 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Linq;
-using System.Reactive;
-using System.Reactive.Linq;
-
 using DynamicData;
 
 namespace ReactiveUI;

--- a/src/ReactiveUI/Routing/RoutingState.cs
+++ b/src/ReactiveUI/Routing/RoutingState.cs
@@ -3,13 +3,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.ObjectModel;
-using System.Linq;
-using System.Reactive;
-using System.Reactive.Concurrency;
-using System.Reactive.Linq;
 using System.Runtime.Serialization;
+
 using DynamicData;
 using DynamicData.Binding;
 #pragma warning disable 8618

--- a/src/ReactiveUI/Routing/RoutingStateMixins.cs
+++ b/src/ReactiveUI/Routing/RoutingStateMixins.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Linq;
-
 namespace ReactiveUI;
 
 /// <summary>

--- a/src/ReactiveUI/RxApp.cs
+++ b/src/ReactiveUI/RxApp.cs
@@ -3,13 +3,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
-using System.Reactive;
-using System.Reactive.Concurrency;
 using System.Runtime.CompilerServices;
-using Splat;
 
 namespace ReactiveUI;
 

--- a/src/ReactiveUI/Scheduler/ScheduledSubject.cs
+++ b/src/ReactiveUI/Scheduler/ScheduledSubject.cs
@@ -3,13 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Reactive.Concurrency;
-using System.Reactive.Disposables;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
-using System.Threading;
-
 namespace ReactiveUI;
 
 /// <summary>

--- a/src/ReactiveUI/Scheduler/WaitForDispatcherScheduler.cs
+++ b/src/ReactiveUI/Scheduler/WaitForDispatcherScheduler.cs
@@ -3,9 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Reactive.Concurrency;
-
 namespace ReactiveUI;
 
 /// <summary>

--- a/src/ReactiveUI/Suspension/DummySuspensionDriver.cs
+++ b/src/ReactiveUI/Suspension/DummySuspensionDriver.cs
@@ -3,10 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Reactive;
-using System.Reactive.Linq;
-
 namespace ReactiveUI;
 
 /// <summary>

--- a/src/ReactiveUI/Suspension/SuspensionHost.cs
+++ b/src/ReactiveUI/Suspension/SuspensionHost.cs
@@ -3,11 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Reactive;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
-
 namespace ReactiveUI;
 
 /// <summary>

--- a/src/ReactiveUI/Suspension/SuspensionHostExtensions.cs
+++ b/src/ReactiveUI/Suspension/SuspensionHostExtensions.cs
@@ -3,13 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Reactive;
-using System.Reactive.Disposables;
-using System.Reactive.Linq;
-using System.Threading;
-using Splat;
-
 namespace ReactiveUI;
 
 /// <summary>

--- a/src/ReactiveUI/UnhandledErrorException.cs
+++ b/src/ReactiveUI/UnhandledErrorException.cs
@@ -3,7 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.Runtime.Serialization;
 
 namespace ReactiveUI;

--- a/src/ReactiveUI/View/DefaultViewLocator.cs
+++ b/src/ReactiveUI/View/DefaultViewLocator.cs
@@ -3,11 +3,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Reflection;
-using Splat;
 
 namespace ReactiveUI;
 

--- a/src/ReactiveUI/View/SingleInstanceViewAttribute.cs
+++ b/src/ReactiveUI/View/SingleInstanceViewAttribute.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-
 namespace ReactiveUI;
 
 /// <summary>

--- a/src/ReactiveUI/View/ViewContractAttribute.cs
+++ b/src/ReactiveUI/View/ViewContractAttribute.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-
 namespace ReactiveUI;
 
 /// <summary>

--- a/src/ReactiveUI/View/ViewLocator.cs
+++ b/src/ReactiveUI/View/ViewLocator.cs
@@ -3,9 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.Diagnostics.CodeAnalysis;
-using Splat;
 
 namespace ReactiveUI;
 

--- a/src/ReactiveUI/View/ViewLocatorNotFoundException.cs
+++ b/src/ReactiveUI/View/ViewLocatorNotFoundException.cs
@@ -3,7 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.Runtime.Serialization;
 
 namespace ReactiveUI;


### PR DESCRIPTION
* Start using Global Usings. With we have net472 projects I'm not using implicit usings. Just including common using statements used throughout all the projects. Excluding Fody since they have custom requirements.
* Git now will store files in platform specific format
