### PR TITLE
breaking: Add a interface to IInteraction

### DIFF
--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.DotNet6_0.verified.txt
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.DotNet6_0.verified.txt
@@ -218,12 +218,25 @@ namespace ReactiveUI
     }
     public interface IInteractionBinderImplementation : Splat.IEnableLogger
     {
-        System.IDisposable BindInteraction<TViewModel, TView, TInput, TOutput>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, ReactiveUI.Interaction<TInput, TOutput>>> propertyName, System.Func<ReactiveUI.InteractionContext<TInput, TOutput>, System.Threading.Tasks.Task> handler)
+        System.IDisposable BindInteraction<TViewModel, TView, TInput, TOutput>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, ReactiveUI.IInteraction<TInput, TOutput>>> propertyName, System.Func<ReactiveUI.IInteractionContext<TInput, TOutput>, System.Threading.Tasks.Task> handler)
             where TViewModel :  class
             where TView :  class, ReactiveUI.IViewFor;
-        System.IDisposable BindInteraction<TViewModel, TView, TInput, TOutput, TDontCare>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, ReactiveUI.Interaction<TInput, TOutput>>> propertyName, System.Func<ReactiveUI.InteractionContext<TInput, TOutput>, System.IObservable<TDontCare>> handler)
+        System.IDisposable BindInteraction<TViewModel, TView, TInput, TOutput, TDontCare>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, ReactiveUI.IInteraction<TInput, TOutput>>> propertyName, System.Func<ReactiveUI.IInteractionContext<TInput, TOutput>, System.IObservable<TDontCare>> handler)
             where TViewModel :  class
             where TView :  class, ReactiveUI.IViewFor;
+    }
+    public interface IInteractionContext<out TInput, in TOutput>
+    {
+        TInput Input { get; }
+        bool IsHandled { get; }
+        void SetOutput(TOutput output);
+    }
+    public interface IInteraction<TInput, TOutput>
+    {
+        System.IObservable<TOutput> Handle(TInput input);
+        System.IDisposable RegisterHandler(System.Action<ReactiveUI.IInteractionContext<TInput, TOutput>> handler);
+        System.IDisposable RegisterHandler(System.Func<ReactiveUI.IInteractionContext<TInput, TOutput>, System.Threading.Tasks.Task> handler);
+        System.IDisposable RegisterHandler<TDontCare>(System.Func<ReactiveUI.IInteractionContext<TInput, TOutput>, System.IObservable<TDontCare>> handler);
     }
     public interface IMessageBus : Splat.IEnableLogger
     {
@@ -245,6 +258,10 @@ namespace ReactiveUI
         System.Linq.Expressions.Expression? Expression { get; }
         TSender Sender { get; }
         TValue Value { get; }
+    }
+    public interface IOutputContext<out TInput, TOutput> : ReactiveUI.IInteractionContext<TInput, TOutput>
+    {
+        TOutput GetOutput();
     }
     public interface IPlatformOperations
     {
@@ -383,37 +400,38 @@ namespace ReactiveUI
     public class InteractionBinderImplementation : ReactiveUI.IInteractionBinderImplementation, Splat.IEnableLogger
     {
         public InteractionBinderImplementation() { }
-        public System.IDisposable BindInteraction<TViewModel, TView, TInput, TOutput>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, ReactiveUI.Interaction<TInput, TOutput>>> propertyName, System.Func<ReactiveUI.InteractionContext<TInput, TOutput>, System.Threading.Tasks.Task> handler)
+        public System.IDisposable BindInteraction<TViewModel, TView, TInput, TOutput>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, ReactiveUI.IInteraction<TInput, TOutput>>> propertyName, System.Func<ReactiveUI.IInteractionContext<TInput, TOutput>, System.Threading.Tasks.Task> handler)
             where TViewModel :  class
             where TView :  class, ReactiveUI.IViewFor { }
-        public System.IDisposable BindInteraction<TViewModel, TView, TInput, TOutput, TDontCare>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, ReactiveUI.Interaction<TInput, TOutput>>> propertyName, System.Func<ReactiveUI.InteractionContext<TInput, TOutput>, System.IObservable<TDontCare>> handler)
+        public System.IDisposable BindInteraction<TViewModel, TView, TInput, TOutput, TDontCare>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, ReactiveUI.IInteraction<TInput, TOutput>>> propertyName, System.Func<ReactiveUI.IInteractionContext<TInput, TOutput>, System.IObservable<TDontCare>> handler)
             where TViewModel :  class
             where TView :  class, ReactiveUI.IViewFor { }
     }
     public static class InteractionBindingMixins
     {
-        public static System.IDisposable BindInteraction<TViewModel, TView, TInput, TOutput>(this TView view, TViewModel? viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, ReactiveUI.Interaction<TInput, TOutput>>> propertyName, System.Func<ReactiveUI.InteractionContext<TInput, TOutput>, System.Threading.Tasks.Task> handler)
+        public static System.IDisposable BindInteraction<TViewModel, TView, TInput, TOutput>(this TView view, TViewModel? viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, ReactiveUI.IInteraction<TInput, TOutput>>> propertyName, System.Func<ReactiveUI.IInteractionContext<TInput, TOutput>, System.Threading.Tasks.Task> handler)
             where TViewModel :  class
             where TView :  class, ReactiveUI.IViewFor { }
-        public static System.IDisposable BindInteraction<TViewModel, TView, TInput, TOutput, TDontCare>(this TView view, TViewModel? viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, ReactiveUI.Interaction<TInput, TOutput>>> propertyName, System.Func<ReactiveUI.InteractionContext<TInput, TOutput>, System.IObservable<TDontCare>> handler)
+        public static System.IDisposable BindInteraction<TViewModel, TView, TInput, TOutput, TDontCare>(this TView view, TViewModel? viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, ReactiveUI.IInteraction<TInput, TOutput>>> propertyName, System.Func<ReactiveUI.IInteractionContext<TInput, TOutput>, System.IObservable<TDontCare>> handler)
             where TViewModel :  class
             where TView :  class, ReactiveUI.IViewFor { }
     }
-    public sealed class InteractionContext<TInput, TOutput>
+    public sealed class InteractionContext<TInput, TOutput> : ReactiveUI.IInteractionContext<TInput, TOutput>, ReactiveUI.IOutputContext<TInput, TOutput>
     {
         public TInput Input { get; }
         public bool IsHandled { get; }
         public TOutput GetOutput() { }
         public void SetOutput(TOutput output) { }
     }
-    public class Interaction<TInput, TOutput>
+    public class Interaction<TInput, TOutput> : ReactiveUI.IInteraction<TInput, TOutput>
     {
         public Interaction(System.Reactive.Concurrency.IScheduler? handlerScheduler = null) { }
-        protected System.Func<ReactiveUI.InteractionContext<TInput, TOutput>, System.IObservable<System.Reactive.Unit>>[] GetHandlers() { }
+        protected virtual ReactiveUI.IOutputContext<TInput, TOutput> GenerateContext(TInput input) { }
+        protected System.Func<ReactiveUI.IInteractionContext<TInput, TOutput>, System.IObservable<System.Reactive.Unit>>[] GetHandlers() { }
         public virtual System.IObservable<TOutput> Handle(TInput input) { }
-        public System.IDisposable RegisterHandler(System.Action<ReactiveUI.InteractionContext<TInput, TOutput>> handler) { }
-        public System.IDisposable RegisterHandler(System.Func<ReactiveUI.InteractionContext<TInput, TOutput>, System.Threading.Tasks.Task> handler) { }
-        public System.IDisposable RegisterHandler<TDontCare>(System.Func<ReactiveUI.InteractionContext<TInput, TOutput>, System.IObservable<TDontCare>> handler) { }
+        public System.IDisposable RegisterHandler(System.Action<ReactiveUI.IInteractionContext<TInput, TOutput>> handler) { }
+        public System.IDisposable RegisterHandler(System.Func<ReactiveUI.IInteractionContext<TInput, TOutput>, System.Threading.Tasks.Task> handler) { }
+        public System.IDisposable RegisterHandler<TDontCare>(System.Func<ReactiveUI.IInteractionContext<TInput, TOutput>, System.IObservable<TDontCare>> handler) { }
     }
     public class LongToStringTypeConverter : ReactiveUI.IBindingTypeConverter, Splat.IEnableLogger
     {

--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.DotNet7_0.verified.txt
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.DotNet7_0.verified.txt
@@ -218,12 +218,25 @@ namespace ReactiveUI
     }
     public interface IInteractionBinderImplementation : Splat.IEnableLogger
     {
-        System.IDisposable BindInteraction<TViewModel, TView, TInput, TOutput>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, ReactiveUI.Interaction<TInput, TOutput>>> propertyName, System.Func<ReactiveUI.InteractionContext<TInput, TOutput>, System.Threading.Tasks.Task> handler)
+        System.IDisposable BindInteraction<TViewModel, TView, TInput, TOutput>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, ReactiveUI.IInteraction<TInput, TOutput>>> propertyName, System.Func<ReactiveUI.IInteractionContext<TInput, TOutput>, System.Threading.Tasks.Task> handler)
             where TViewModel :  class
             where TView :  class, ReactiveUI.IViewFor;
-        System.IDisposable BindInteraction<TViewModel, TView, TInput, TOutput, TDontCare>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, ReactiveUI.Interaction<TInput, TOutput>>> propertyName, System.Func<ReactiveUI.InteractionContext<TInput, TOutput>, System.IObservable<TDontCare>> handler)
+        System.IDisposable BindInteraction<TViewModel, TView, TInput, TOutput, TDontCare>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, ReactiveUI.IInteraction<TInput, TOutput>>> propertyName, System.Func<ReactiveUI.IInteractionContext<TInput, TOutput>, System.IObservable<TDontCare>> handler)
             where TViewModel :  class
             where TView :  class, ReactiveUI.IViewFor;
+    }
+    public interface IInteractionContext<out TInput, in TOutput>
+    {
+        TInput Input { get; }
+        bool IsHandled { get; }
+        void SetOutput(TOutput output);
+    }
+    public interface IInteraction<TInput, TOutput>
+    {
+        System.IObservable<TOutput> Handle(TInput input);
+        System.IDisposable RegisterHandler(System.Action<ReactiveUI.IInteractionContext<TInput, TOutput>> handler);
+        System.IDisposable RegisterHandler(System.Func<ReactiveUI.IInteractionContext<TInput, TOutput>, System.Threading.Tasks.Task> handler);
+        System.IDisposable RegisterHandler<TDontCare>(System.Func<ReactiveUI.IInteractionContext<TInput, TOutput>, System.IObservable<TDontCare>> handler);
     }
     public interface IMessageBus : Splat.IEnableLogger
     {
@@ -245,6 +258,10 @@ namespace ReactiveUI
         System.Linq.Expressions.Expression? Expression { get; }
         TSender Sender { get; }
         TValue Value { get; }
+    }
+    public interface IOutputContext<out TInput, TOutput> : ReactiveUI.IInteractionContext<TInput, TOutput>
+    {
+        TOutput GetOutput();
     }
     public interface IPlatformOperations
     {
@@ -383,37 +400,38 @@ namespace ReactiveUI
     public class InteractionBinderImplementation : ReactiveUI.IInteractionBinderImplementation, Splat.IEnableLogger
     {
         public InteractionBinderImplementation() { }
-        public System.IDisposable BindInteraction<TViewModel, TView, TInput, TOutput>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, ReactiveUI.Interaction<TInput, TOutput>>> propertyName, System.Func<ReactiveUI.InteractionContext<TInput, TOutput>, System.Threading.Tasks.Task> handler)
+        public System.IDisposable BindInteraction<TViewModel, TView, TInput, TOutput>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, ReactiveUI.IInteraction<TInput, TOutput>>> propertyName, System.Func<ReactiveUI.IInteractionContext<TInput, TOutput>, System.Threading.Tasks.Task> handler)
             where TViewModel :  class
             where TView :  class, ReactiveUI.IViewFor { }
-        public System.IDisposable BindInteraction<TViewModel, TView, TInput, TOutput, TDontCare>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, ReactiveUI.Interaction<TInput, TOutput>>> propertyName, System.Func<ReactiveUI.InteractionContext<TInput, TOutput>, System.IObservable<TDontCare>> handler)
+        public System.IDisposable BindInteraction<TViewModel, TView, TInput, TOutput, TDontCare>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, ReactiveUI.IInteraction<TInput, TOutput>>> propertyName, System.Func<ReactiveUI.IInteractionContext<TInput, TOutput>, System.IObservable<TDontCare>> handler)
             where TViewModel :  class
             where TView :  class, ReactiveUI.IViewFor { }
     }
     public static class InteractionBindingMixins
     {
-        public static System.IDisposable BindInteraction<TViewModel, TView, TInput, TOutput>(this TView view, TViewModel? viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, ReactiveUI.Interaction<TInput, TOutput>>> propertyName, System.Func<ReactiveUI.InteractionContext<TInput, TOutput>, System.Threading.Tasks.Task> handler)
+        public static System.IDisposable BindInteraction<TViewModel, TView, TInput, TOutput>(this TView view, TViewModel? viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, ReactiveUI.IInteraction<TInput, TOutput>>> propertyName, System.Func<ReactiveUI.IInteractionContext<TInput, TOutput>, System.Threading.Tasks.Task> handler)
             where TViewModel :  class
             where TView :  class, ReactiveUI.IViewFor { }
-        public static System.IDisposable BindInteraction<TViewModel, TView, TInput, TOutput, TDontCare>(this TView view, TViewModel? viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, ReactiveUI.Interaction<TInput, TOutput>>> propertyName, System.Func<ReactiveUI.InteractionContext<TInput, TOutput>, System.IObservable<TDontCare>> handler)
+        public static System.IDisposable BindInteraction<TViewModel, TView, TInput, TOutput, TDontCare>(this TView view, TViewModel? viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, ReactiveUI.IInteraction<TInput, TOutput>>> propertyName, System.Func<ReactiveUI.IInteractionContext<TInput, TOutput>, System.IObservable<TDontCare>> handler)
             where TViewModel :  class
             where TView :  class, ReactiveUI.IViewFor { }
     }
-    public sealed class InteractionContext<TInput, TOutput>
+    public sealed class InteractionContext<TInput, TOutput> : ReactiveUI.IInteractionContext<TInput, TOutput>, ReactiveUI.IOutputContext<TInput, TOutput>
     {
         public TInput Input { get; }
         public bool IsHandled { get; }
         public TOutput GetOutput() { }
         public void SetOutput(TOutput output) { }
     }
-    public class Interaction<TInput, TOutput>
+    public class Interaction<TInput, TOutput> : ReactiveUI.IInteraction<TInput, TOutput>
     {
         public Interaction(System.Reactive.Concurrency.IScheduler? handlerScheduler = null) { }
-        protected System.Func<ReactiveUI.InteractionContext<TInput, TOutput>, System.IObservable<System.Reactive.Unit>>[] GetHandlers() { }
+        protected virtual ReactiveUI.IOutputContext<TInput, TOutput> GenerateContext(TInput input) { }
+        protected System.Func<ReactiveUI.IInteractionContext<TInput, TOutput>, System.IObservable<System.Reactive.Unit>>[] GetHandlers() { }
         public virtual System.IObservable<TOutput> Handle(TInput input) { }
-        public System.IDisposable RegisterHandler(System.Action<ReactiveUI.InteractionContext<TInput, TOutput>> handler) { }
-        public System.IDisposable RegisterHandler(System.Func<ReactiveUI.InteractionContext<TInput, TOutput>, System.Threading.Tasks.Task> handler) { }
-        public System.IDisposable RegisterHandler<TDontCare>(System.Func<ReactiveUI.InteractionContext<TInput, TOutput>, System.IObservable<TDontCare>> handler) { }
+        public System.IDisposable RegisterHandler(System.Action<ReactiveUI.IInteractionContext<TInput, TOutput>> handler) { }
+        public System.IDisposable RegisterHandler(System.Func<ReactiveUI.IInteractionContext<TInput, TOutput>, System.Threading.Tasks.Task> handler) { }
+        public System.IDisposable RegisterHandler<TDontCare>(System.Func<ReactiveUI.IInteractionContext<TInput, TOutput>, System.IObservable<TDontCare>> handler) { }
     }
     public class LongToStringTypeConverter : ReactiveUI.IBindingTypeConverter, Splat.IEnableLogger
     {

--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.Net4_7.verified.txt
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.Net4_7.verified.txt
@@ -216,14 +216,27 @@ namespace ReactiveUI
     }
     public interface IInteractionBinderImplementation : Splat.IEnableLogger
     {
-        System.IDisposable BindInteraction<TViewModel, TView, TInput, TOutput>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, ReactiveUI.Interaction<TInput, TOutput>>> propertyName, System.Func<ReactiveUI.InteractionContext<TInput, TOutput>, System.Threading.Tasks.Task> handler)
+        System.IDisposable BindInteraction<TViewModel, TView, TInput, TOutput>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, ReactiveUI.IInteraction<TInput, TOutput>>> propertyName, System.Func<ReactiveUI.IInteractionContext<TInput, TOutput>, System.Threading.Tasks.Task> handler)
             where TViewModel :  class
             where TView :  class, ReactiveUI.IViewFor
         ;
-        System.IDisposable BindInteraction<TViewModel, TView, TInput, TOutput, TDontCare>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, ReactiveUI.Interaction<TInput, TOutput>>> propertyName, System.Func<ReactiveUI.InteractionContext<TInput, TOutput>, System.IObservable<TDontCare>> handler)
+        System.IDisposable BindInteraction<TViewModel, TView, TInput, TOutput, TDontCare>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, ReactiveUI.IInteraction<TInput, TOutput>>> propertyName, System.Func<ReactiveUI.IInteractionContext<TInput, TOutput>, System.IObservable<TDontCare>> handler)
             where TViewModel :  class
             where TView :  class, ReactiveUI.IViewFor
         ;
+    }
+    public interface IInteractionContext<out TInput, in TOutput>
+    {
+        TInput Input { get; }
+        bool IsHandled { get; }
+        void SetOutput(TOutput output);
+    }
+    public interface IInteraction<TInput, TOutput>
+    {
+        System.IObservable<TOutput> Handle(TInput input);
+        System.IDisposable RegisterHandler(System.Action<ReactiveUI.IInteractionContext<TInput, TOutput>> handler);
+        System.IDisposable RegisterHandler(System.Func<ReactiveUI.IInteractionContext<TInput, TOutput>, System.Threading.Tasks.Task> handler);
+        System.IDisposable RegisterHandler<TDontCare>(System.Func<ReactiveUI.IInteractionContext<TInput, TOutput>, System.IObservable<TDontCare>> handler);
     }
     public interface IMessageBus : Splat.IEnableLogger
     {
@@ -245,6 +258,10 @@ namespace ReactiveUI
         System.Linq.Expressions.Expression? Expression { get; }
         TSender Sender { get; }
         TValue Value { get; }
+    }
+    public interface IOutputContext<out TInput, TOutput> : ReactiveUI.IInteractionContext<TInput, TOutput>
+    {
+        TOutput GetOutput();
     }
     public interface IPlatformOperations
     {
@@ -388,37 +405,38 @@ namespace ReactiveUI
     public class InteractionBinderImplementation : ReactiveUI.IInteractionBinderImplementation, Splat.IEnableLogger
     {
         public InteractionBinderImplementation() { }
-        public System.IDisposable BindInteraction<TViewModel, TView, TInput, TOutput>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, ReactiveUI.Interaction<TInput, TOutput>>> propertyName, System.Func<ReactiveUI.InteractionContext<TInput, TOutput>, System.Threading.Tasks.Task> handler)
+        public System.IDisposable BindInteraction<TViewModel, TView, TInput, TOutput>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, ReactiveUI.IInteraction<TInput, TOutput>>> propertyName, System.Func<ReactiveUI.IInteractionContext<TInput, TOutput>, System.Threading.Tasks.Task> handler)
             where TViewModel :  class
             where TView :  class, ReactiveUI.IViewFor { }
-        public System.IDisposable BindInteraction<TViewModel, TView, TInput, TOutput, TDontCare>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, ReactiveUI.Interaction<TInput, TOutput>>> propertyName, System.Func<ReactiveUI.InteractionContext<TInput, TOutput>, System.IObservable<TDontCare>> handler)
+        public System.IDisposable BindInteraction<TViewModel, TView, TInput, TOutput, TDontCare>(TViewModel? viewModel, TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, ReactiveUI.IInteraction<TInput, TOutput>>> propertyName, System.Func<ReactiveUI.IInteractionContext<TInput, TOutput>, System.IObservable<TDontCare>> handler)
             where TViewModel :  class
             where TView :  class, ReactiveUI.IViewFor { }
     }
     public static class InteractionBindingMixins
     {
-        public static System.IDisposable BindInteraction<TViewModel, TView, TInput, TOutput>(this TView view, TViewModel? viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, ReactiveUI.Interaction<TInput, TOutput>>> propertyName, System.Func<ReactiveUI.InteractionContext<TInput, TOutput>, System.Threading.Tasks.Task> handler)
+        public static System.IDisposable BindInteraction<TViewModel, TView, TInput, TOutput>(this TView view, TViewModel? viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, ReactiveUI.IInteraction<TInput, TOutput>>> propertyName, System.Func<ReactiveUI.IInteractionContext<TInput, TOutput>, System.Threading.Tasks.Task> handler)
             where TViewModel :  class
             where TView :  class, ReactiveUI.IViewFor { }
-        public static System.IDisposable BindInteraction<TViewModel, TView, TInput, TOutput, TDontCare>(this TView view, TViewModel? viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, ReactiveUI.Interaction<TInput, TOutput>>> propertyName, System.Func<ReactiveUI.InteractionContext<TInput, TOutput>, System.IObservable<TDontCare>> handler)
+        public static System.IDisposable BindInteraction<TViewModel, TView, TInput, TOutput, TDontCare>(this TView view, TViewModel? viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, ReactiveUI.IInteraction<TInput, TOutput>>> propertyName, System.Func<ReactiveUI.IInteractionContext<TInput, TOutput>, System.IObservable<TDontCare>> handler)
             where TViewModel :  class
             where TView :  class, ReactiveUI.IViewFor { }
     }
-    public sealed class InteractionContext<TInput, TOutput>
+    public sealed class InteractionContext<TInput, TOutput> : ReactiveUI.IInteractionContext<TInput, TOutput>, ReactiveUI.IOutputContext<TInput, TOutput>
     {
         public TInput Input { get; }
         public bool IsHandled { get; }
         public TOutput GetOutput() { }
         public void SetOutput(TOutput output) { }
     }
-    public class Interaction<TInput, TOutput>
+    public class Interaction<TInput, TOutput> : ReactiveUI.IInteraction<TInput, TOutput>
     {
         public Interaction(System.Reactive.Concurrency.IScheduler? handlerScheduler = null) { }
-        protected System.Func<ReactiveUI.InteractionContext<TInput, TOutput>, System.IObservable<System.Reactive.Unit>>[] GetHandlers() { }
+        protected virtual ReactiveUI.IOutputContext<TInput, TOutput> GenerateContext(TInput input) { }
+        protected System.Func<ReactiveUI.IInteractionContext<TInput, TOutput>, System.IObservable<System.Reactive.Unit>>[] GetHandlers() { }
         public virtual System.IObservable<TOutput> Handle(TInput input) { }
-        public System.IDisposable RegisterHandler(System.Action<ReactiveUI.InteractionContext<TInput, TOutput>> handler) { }
-        public System.IDisposable RegisterHandler(System.Func<ReactiveUI.InteractionContext<TInput, TOutput>, System.Threading.Tasks.Task> handler) { }
-        public System.IDisposable RegisterHandler<TDontCare>(System.Func<ReactiveUI.InteractionContext<TInput, TOutput>, System.IObservable<TDontCare>> handler) { }
+        public System.IDisposable RegisterHandler(System.Action<ReactiveUI.IInteractionContext<TInput, TOutput>> handler) { }
+        public System.IDisposable RegisterHandler(System.Func<ReactiveUI.IInteractionContext<TInput, TOutput>, System.Threading.Tasks.Task> handler) { }
+        public System.IDisposable RegisterHandler<TDontCare>(System.Func<ReactiveUI.IInteractionContext<TInput, TOutput>, System.IObservable<TDontCare>> handler) { }
     }
     public class LongToStringTypeConverter : ReactiveUI.IBindingTypeConverter, Splat.IEnableLogger
     {

--- a/src/ReactiveUI.Tests/InteractionsTest.cs
+++ b/src/ReactiveUI.Tests/InteractionsTest.cs
@@ -26,9 +26,9 @@ namespace ReactiveUI.Tests
         {
             var interaction = new Interaction<Unit, Unit>();
 
-            Assert.Throws<ArgumentNullException>(() => interaction.RegisterHandler((Action<InteractionContext<Unit, Unit>>)null!));
+            Assert.Throws<ArgumentNullException>(() => interaction.RegisterHandler((Action<IInteractionContext<Unit, Unit>>)null!));
             Assert.Throws<ArgumentNullException>(() => interaction.RegisterHandler(null!));
-            Assert.Throws<ArgumentNullException>(() => interaction.RegisterHandler((Func<InteractionContext<Unit, Unit>, IObservable<Unit>>)null!));
+            Assert.Throws<ArgumentNullException>(() => interaction.RegisterHandler((Func<IInteractionContext<Unit, Unit>, IObservable<Unit>>)null!));
         }
 
         /// <summary>
@@ -77,7 +77,7 @@ namespace ReactiveUI.Tests
 
             interaction.RegisterHandler(context =>
             {
-                var output = context.GetOutput();
+                var output = ((InteractionContext<Unit, Unit>)context).GetOutput();
             });
 
             var ex = Assert.Throws<InvalidOperationException>(() => interaction.Handle(Unit.Default).Subscribe());

--- a/src/ReactiveUI/Bindings/Interaction/IInteractionBinderImplementation.cs
+++ b/src/ReactiveUI/Bindings/Interaction/IInteractionBinderImplementation.cs
@@ -11,7 +11,7 @@ namespace ReactiveUI;
 public interface IInteractionBinderImplementation : IEnableLogger
 {
     /// <summary>
-    /// Binds the <see cref="Interaction{TInput, TOutput}"/> on a ViewModel to the specified handler.
+    /// Binds the <see cref="IInteraction{TInput, TOutput}"/> on a ViewModel to the specified handler.
     /// </summary>
     /// <param name="viewModel">The view model to bind to.</param>
     /// <param name="view">The view to bind to.</param>
@@ -25,13 +25,13 @@ public interface IInteractionBinderImplementation : IEnableLogger
     IDisposable BindInteraction<TViewModel, TView, TInput, TOutput>(
         TViewModel? viewModel,
         TView view,
-        Expression<Func<TViewModel, Interaction<TInput, TOutput>>> propertyName,
-        Func<InteractionContext<TInput, TOutput>, Task> handler)
+        Expression<Func<TViewModel, IInteraction<TInput, TOutput>>> propertyName,
+        Func<IInteractionContext<TInput, TOutput>, Task> handler)
         where TViewModel : class
         where TView : class, IViewFor;
 
     /// <summary>
-    /// Binds the <see cref="Interaction{TInput, TOutput}"/> on a ViewModel to the specified handler.
+    /// Binds the <see cref="IInteraction{TInput, TOutput}"/> on a ViewModel to the specified handler.
     /// </summary>
     /// <param name="viewModel">The view model to bind to.</param>
     /// <param name="view">The view to bind to.</param>
@@ -46,8 +46,8 @@ public interface IInteractionBinderImplementation : IEnableLogger
     IDisposable BindInteraction<TViewModel, TView, TInput, TOutput, TDontCare>(
         TViewModel? viewModel,
         TView view,
-        Expression<Func<TViewModel, Interaction<TInput, TOutput>>> propertyName,
-        Func<InteractionContext<TInput, TOutput>, IObservable<TDontCare>> handler)
+        Expression<Func<TViewModel, IInteraction<TInput, TOutput>>> propertyName,
+        Func<IInteractionContext<TInput, TOutput>, IObservable<TDontCare>> handler)
         where TViewModel : class
         where TView : class, IViewFor;
 }

--- a/src/ReactiveUI/Bindings/Interaction/InteractionBinderImplementation.cs
+++ b/src/ReactiveUI/Bindings/Interaction/InteractionBinderImplementation.cs
@@ -14,10 +14,10 @@ public class InteractionBinderImplementation : IInteractionBinderImplementation
     public IDisposable BindInteraction<TViewModel, TView, TInput, TOutput>(
         TViewModel? viewModel,
         TView view,
-        Expression<Func<TViewModel, Interaction<TInput, TOutput>>> propertyName,
-        Func<InteractionContext<TInput, TOutput>, Task> handler) // TODO: Create Test
-        where TViewModel : class
-        where TView : class, IViewFor
+        Expression<Func<TViewModel, IInteraction<TInput, TOutput>>> propertyName,
+        Func<IInteractionContext<TInput, TOutput>, Task> handler) // TODO: Create Test
+            where TViewModel : class
+            where TView : class, IViewFor
     {
         if (propertyName is null)
         {
@@ -31,7 +31,7 @@ public class InteractionBinderImplementation : IInteractionBinderImplementation
 
         var vmExpression = Reflection.Rewrite(propertyName.Body);
 
-        var source = Reflection.ViewModelWhenAnyValue(viewModel, view, vmExpression).Cast<Interaction<TInput, TOutput>>();
+        var source = Reflection.ViewModelWhenAnyValue(viewModel, view, vmExpression).Cast<IInteraction<TInput, TOutput>>();
 
         var interactionDisposable = new SerialDisposable();
 
@@ -46,10 +46,10 @@ public class InteractionBinderImplementation : IInteractionBinderImplementation
     public IDisposable BindInteraction<TViewModel, TView, TInput, TOutput, TDontCare>(
         TViewModel? viewModel,
         TView view,
-        Expression<Func<TViewModel, Interaction<TInput, TOutput>>> propertyName,
-        Func<InteractionContext<TInput, TOutput>, IObservable<TDontCare>> handler) // TODO: Create Test
-        where TViewModel : class
-        where TView : class, IViewFor
+        Expression<Func<TViewModel, IInteraction<TInput, TOutput>>> propertyName,
+        Func<IInteractionContext<TInput, TOutput>, IObservable<TDontCare>> handler) // TODO: Create Test
+            where TViewModel : class
+            where TView : class, IViewFor
     {
         if (propertyName is null)
         {
@@ -63,7 +63,7 @@ public class InteractionBinderImplementation : IInteractionBinderImplementation
 
         var vmExpression = Reflection.Rewrite(propertyName.Body);
 
-        var source = Reflection.ViewModelWhenAnyValue(viewModel, view, vmExpression).Cast<Interaction<TInput, TOutput>>();
+        var source = Reflection.ViewModelWhenAnyValue(viewModel, view, vmExpression).Cast<IInteraction<TInput, TOutput>>();
 
         var interactionDisposable = new SerialDisposable();
 

--- a/src/ReactiveUI/Bindings/Interaction/InteractionBindingMixins.cs
+++ b/src/ReactiveUI/Bindings/Interaction/InteractionBindingMixins.cs
@@ -10,16 +10,12 @@ namespace ReactiveUI;
 /// </summary>
 public static class InteractionBindingMixins
 {
-    private static readonly IInteractionBinderImplementation _binderImplementation;
+    private static readonly InteractionBinderImplementation _binderImplementation = new();
 
-    static InteractionBindingMixins()
-    {
-        RxApp.EnsureInitialized();
-        _binderImplementation = new InteractionBinderImplementation();
-    }
+    static InteractionBindingMixins() => RxApp.EnsureInitialized();
 
     /// <summary>
-    /// Binds the <see cref="Interaction{TInput, TOutput}"/> on a ViewModel to the specified handler.
+    /// Binds the <see cref="IInteraction{TInput, TOutput}"/> on a ViewModel to the specified handler.
     /// </summary>
     /// <param name="view">The view to bind to.</param>
     /// <param name="viewModel">The view model to bind to.</param>
@@ -33,18 +29,18 @@ public static class InteractionBindingMixins
     public static IDisposable BindInteraction<TViewModel, TView, TInput, TOutput>(
         this TView view,
         TViewModel? viewModel,
-        Expression<Func<TViewModel, Interaction<TInput, TOutput>>> propertyName,
-        Func<InteractionContext<TInput, TOutput>, Task> handler)
-        where TViewModel : class
-        where TView : class, IViewFor =>
+        Expression<Func<TViewModel, IInteraction<TInput, TOutput>>> propertyName,
+        Func<IInteractionContext<TInput, TOutput>, Task> handler)
+            where TViewModel : class
+            where TView : class, IViewFor =>
         _binderImplementation.BindInteraction(
-                                              viewModel,
-                                              view,
-                                              propertyName,
-                                              handler);
+                viewModel,
+                view,
+                propertyName,
+                handler);
 
     /// <summary>
-    /// Binds the <see cref="Interaction{TInput, TOutput}"/> on a ViewModel to the specified handler.
+    /// Binds the <see cref="IInteraction{TInput, TOutput}"/> on a ViewModel to the specified handler.
     /// </summary>
     /// <param name="view">The view to bind to.</param>
     /// <param name="viewModel">The view model to bind to.</param>
@@ -59,13 +55,13 @@ public static class InteractionBindingMixins
     public static IDisposable BindInteraction<TViewModel, TView, TInput, TOutput, TDontCare>(
         this TView view,
         TViewModel? viewModel,
-        Expression<Func<TViewModel, Interaction<TInput, TOutput>>> propertyName,
-        Func<InteractionContext<TInput, TOutput>, IObservable<TDontCare>> handler)
-        where TViewModel : class
-        where TView : class, IViewFor =>
+        Expression<Func<TViewModel, IInteraction<TInput, TOutput>>> propertyName,
+        Func<IInteractionContext<TInput, TOutput>, IObservable<TDontCare>> handler)
+            where TViewModel : class
+            where TView : class, IViewFor =>
         _binderImplementation.BindInteraction(
-                                              viewModel,
-                                              view,
-                                              propertyName,
-                                              handler);
+            viewModel,
+            view,
+            propertyName,
+            handler);
 }

--- a/src/ReactiveUI/Interactions/IInteraction.cs
+++ b/src/ReactiveUI/Interactions/IInteraction.cs
@@ -1,0 +1,101 @@
+﻿// Copyright (c) 2023 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace ReactiveUI;
+
+/// <summary>
+/// Represents an interaction between collaborating application components.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Interactions allow collaborating components in an application to ask each other questions. Typically,
+/// interactions allow a view model to get the user's confirmation from the view before proceeding with
+/// some operation. The view provides the interaction's confirmation interface in a handler registered
+/// for the interaction.
+/// </para>
+/// <para>
+/// Interactions have both an input and an output. Interaction inputs and outputs use generic type parameters.
+/// The interaction's input provides handlers the information they require to ask a question. The handler
+/// then provides the interaction with an output as the answer to the question.
+/// </para>
+/// </remarks>
+/// <typeparam name="TInput">
+/// The interaction's input type.
+/// </typeparam>
+/// <typeparam name="TOutput">
+/// The interaction's output type.
+/// </typeparam>
+public interface IInteraction<TInput, TOutput>
+{
+    /// <summary>
+    /// Registers a synchronous interaction handler.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This overload of <c>RegisterHandler</c> is only useful if the handler can handle the interaction
+    /// immediately. That is, it does not need to wait for the user or some other collaborating component.
+    /// </para>
+    /// </remarks>
+    /// <param name="handler">
+    /// The handler.
+    /// </param>
+    /// <returns>
+    /// A disposable which, when disposed, will unregister the handler.
+    /// </returns>
+    IDisposable RegisterHandler(Action<IInteractionContext<TInput, TOutput>> handler);
+
+    /// <summary>
+    /// Registers a task-based asynchronous interaction handler.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This overload of <c>RegisterHandler</c> is useful if the handler needs to perform some asynchronous
+    /// operation, such as displaying a dialog and waiting for the user's response.
+    /// </para>
+    /// </remarks>
+    /// <param name="handler">
+    /// The handler.
+    /// </param>
+    /// <returns>
+    /// A disposable which, when disposed, will unregister the handler.
+    /// </returns>
+    IDisposable RegisterHandler(Func<IInteractionContext<TInput, TOutput>, Task> handler);
+
+    /// <summary>
+    /// Registers an observable-based asynchronous interaction handler.
+    /// </summary>
+    /// <typeparam name="TDontCare">The signal type.</typeparam>
+    /// <remarks>
+    /// <para>
+    /// This overload of <c>RegisterHandler</c> is useful if the handler needs to perform some asynchronous
+    /// operation, such as displaying a dialog and waiting for the user's response.
+    /// </para>
+    /// </remarks>
+    /// <param name="handler">
+    /// The handler.
+    /// </param>
+    /// <returns>
+    /// A disposable which, when disposed, will unregister the handler.
+    /// </returns>
+    IDisposable RegisterHandler<TDontCare>(Func<IInteractionContext<TInput, TOutput>, IObservable<TDontCare>> handler);
+
+    /// <summary>
+    /// Handles an interaction and asynchronously returns the result.
+    /// </summary>
+    /// <param name="input">
+    /// The input for the interaction.
+    /// </param>
+    /// <remarks>
+    /// <para>
+    /// This method passes the interaction in turn to its registered handlers in reverse order of registration
+    /// until one of them handles the interaction. If the interaction remains unhandled after all
+    /// its registered handlers have executed, an <see cref="UnhandledInteractionException{TInput, TOutput}"/> is thrown.
+    /// </para>
+    /// </remarks>
+    /// <returns>
+    /// An observable that ticks when the interaction completes.
+    /// </returns>
+    IObservable<TOutput> Handle(TInput input);
+}

--- a/src/ReactiveUI/Interactions/IInteractionContext.cs
+++ b/src/ReactiveUI/Interactions/IInteractionContext.cs
@@ -21,22 +21,17 @@ namespace ReactiveUI;
 /// <typeparam name="TOutput">
 /// The type of the interaction's output.
 /// </typeparam>
-public sealed class InteractionContext<TInput, TOutput> : IInteractionContext<TInput, TOutput>
+public interface IInteractionContext<out TInput, in TOutput>
 {
-    private TOutput _output = default!;
-    private int _outputSet;
-
-    internal InteractionContext(TInput input) => Input = input;
-
     /// <summary>
     /// Gets the input for the interaction.
     /// </summary>
-    public TInput Input { get; }
+    TInput Input { get; }
 
     /// <summary>
     /// Gets a value indicating whether the interaction is handled. That is, whether the output has been set.
     /// </summary>
-    public bool IsHandled => _outputSet == 1;
+    bool IsHandled { get; }
 
     /// <summary>
     /// Sets the output for the interaction.
@@ -44,35 +39,5 @@ public sealed class InteractionContext<TInput, TOutput> : IInteractionContext<TI
     /// <param name="output">
     /// The output.
     /// </param>
-    /// <exception cref="InvalidOperationException">
-    /// If the output has already been set.
-    /// </exception>
-    public void SetOutput(TOutput output)
-    {
-        if (Interlocked.CompareExchange(ref _outputSet, 1, 0) != 0)
-        {
-            throw new InvalidOperationException("Output has already been set.");
-        }
-
-        _output = output;
-    }
-
-    /// <summary>
-    /// Gets the output of the interaction.
-    /// </summary>
-    /// <returns>
-    /// The output.
-    /// </returns>
-    /// <exception cref="InvalidOperationException">
-    /// If the output has not been set.
-    /// </exception>
-    public TOutput GetOutput()
-    {
-        if (_outputSet == 0)
-        {
-            throw new InvalidOperationException("Output has not been set.");
-        }
-
-        return _output;
-    }
+    void SetOutput(TOutput output);
 }

--- a/src/ReactiveUI/Interactions/IOutputContext.cs
+++ b/src/ReactiveUI/Interactions/IOutputContext.cs
@@ -10,7 +10,7 @@ namespace ReactiveUI;
 /// </summary>
 /// <typeparam name="TInput">The input.</typeparam>
 /// <typeparam name="TOutput">The output.</typeparam>
-public interface IOutputContext<TInput, TOutput> : IInteractionContext<TInput, TOutput>
+public interface IOutputContext<out TInput, TOutput> : IInteractionContext<TInput, TOutput>
 {
     /// <summary>
     /// Gets the output of the interaction.

--- a/src/ReactiveUI/Interactions/IOutputContext.cs
+++ b/src/ReactiveUI/Interactions/IOutputContext.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) 2023 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace ReactiveUI;
+
+/// <summary>
+/// Gives the ability to get the output.
+/// </summary>
+/// <typeparam name="TInput">The input.</typeparam>
+/// <typeparam name="TOutput">The output.</typeparam>
+public interface IOutputContext<TInput, TOutput> : IInteractionContext<TInput, TOutput>
+{
+    /// <summary>
+    /// Gets the output of the interaction.
+    /// </summary>
+    /// <returns>
+    /// The output.
+    /// </returns>
+    /// <exception cref="InvalidOperationException">
+    /// If the output has not been set.
+    /// </exception>
+    TOutput GetOutput();
+}

--- a/src/ReactiveUI/Interactions/Interaction.cs
+++ b/src/ReactiveUI/Interactions/Interaction.cs
@@ -39,10 +39,10 @@ namespace ReactiveUI;
 /// <typeparam name="TOutput">
 /// The interaction's output type.
 /// </typeparam>
-public class Interaction<TInput, TOutput>
+public class Interaction<TInput, TOutput> : IInteraction<TInput, TOutput>
 {
-    private readonly IList<Func<InteractionContext<TInput, TOutput>, IObservable<Unit>>> _handlers;
-    private readonly object _sync;
+    private readonly List<Func<IInteractionContext<TInput, TOutput>, IObservable<Unit>>> _handlers = new();
+    private readonly object _sync = new();
     private readonly IScheduler _handlerScheduler;
 
     /// <summary>
@@ -51,29 +51,10 @@ public class Interaction<TInput, TOutput>
     /// <param name="handlerScheduler">
     /// The scheduler to use when invoking handlers, which defaults to <c>CurrentThreadScheduler.Instance</c> if <see langword="null"/>.
     /// </param>
-    public Interaction(IScheduler? handlerScheduler = null)
-    {
-        _handlers = new List<Func<InteractionContext<TInput, TOutput>, IObservable<Unit>>>();
-        _sync = new object();
-        _handlerScheduler = handlerScheduler ?? CurrentThreadScheduler.Instance;
-    }
+    public Interaction(IScheduler? handlerScheduler = null) => _handlerScheduler ??= CurrentThreadScheduler.Instance;
 
-    /// <summary>
-    /// Registers a synchronous interaction handler.
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    /// This overload of <c>RegisterHandler</c> is only useful if the handler can handle the interaction
-    /// immediately. That is, it does not need to wait for the user or some other collaborating component.
-    /// </para>
-    /// </remarks>
-    /// <param name="handler">
-    /// The handler.
-    /// </param>
-    /// <returns>
-    /// A disposable which, when disposed, will unregister the handler.
-    /// </returns>
-    public IDisposable RegisterHandler(Action<InteractionContext<TInput, TOutput>> handler)
+    /// <inheritdoc/>
+    public IDisposable RegisterHandler(Action<IInteractionContext<TInput, TOutput>> handler)
     {
         if (handler is null)
         {
@@ -87,22 +68,8 @@ public class Interaction<TInput, TOutput>
         });
     }
 
-    /// <summary>
-    /// Registers a task-based asynchronous interaction handler.
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    /// This overload of <c>RegisterHandler</c> is useful if the handler needs to perform some asynchronous
-    /// operation, such as displaying a dialog and waiting for the user's response.
-    /// </para>
-    /// </remarks>
-    /// <param name="handler">
-    /// The handler.
-    /// </param>
-    /// <returns>
-    /// A disposable which, when disposed, will unregister the handler.
-    /// </returns>
-    public IDisposable RegisterHandler(Func<InteractionContext<TInput, TOutput>, Task> handler)
+    /// <inheritdoc />
+    public IDisposable RegisterHandler(Func<IInteractionContext<TInput, TOutput>, Task> handler)
     {
         if (handler is null)
         {
@@ -112,70 +79,39 @@ public class Interaction<TInput, TOutput>
         return RegisterHandler(interaction => handler(interaction).ToObservable());
     }
 
-    /// <summary>
-    /// Registers an observable-based asynchronous interaction handler.
-    /// </summary>
-    /// <typeparam name="TDontCare">The signal type.</typeparam>
-    /// <remarks>
-    /// <para>
-    /// This overload of <c>RegisterHandler</c> is useful if the handler needs to perform some asynchronous
-    /// operation, such as displaying a dialog and waiting for the user's response.
-    /// </para>
-    /// </remarks>
-    /// <param name="handler">
-    /// The handler.
-    /// </param>
-    /// <returns>
-    /// A disposable which, when disposed, will unregister the handler.
-    /// </returns>
-    public IDisposable RegisterHandler<TDontCare>(Func<InteractionContext<TInput, TOutput>, IObservable<TDontCare>> handler)
+    /// <inheritdoc />
+    public IDisposable RegisterHandler<TDontCare>(Func<IInteractionContext<TInput, TOutput>, IObservable<TDontCare>> handler)
     {
         if (handler is null)
         {
             throw new ArgumentNullException(nameof(handler));
         }
 
-        IObservable<Unit> ContentHandler(InteractionContext<TInput, TOutput> context) => handler(context).Select(_ => Unit.Default);
+        IObservable<Unit> ContentHandler(IInteractionContext<TInput, TOutput> context) => handler(context).Select(_ => Unit.Default);
 
         AddHandler(ContentHandler);
         return Disposable.Create(() => RemoveHandler(ContentHandler));
     }
 
-    /// <summary>
-    /// Handles an interaction and asynchronously returns the result.
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    /// This method passes the interaction in turn to its registered handlers in reverse order of registration
-    /// until one of them handles the interaction. If the interaction remains unhandled after all
-    /// its registered handlers have executed, an <see cref="UnhandledInteractionException{TInput, TOutput}"/> is thrown.
-    /// </para>
-    /// </remarks>
-    /// <param name="input">
-    /// The input for the interaction.
-    /// </param>
-    /// <returns>
-    /// An observable that ticks when the interaction completes.
-    /// </returns>
-    /// <exception cref="UnhandledInteractionException{TInput, TOutput}">Thrown when no handler handles the interaction.</exception>
+    /// <inheritdoc />
     public virtual IObservable<TOutput> Handle(TInput input)
     {
         var context = new InteractionContext<TInput, TOutput>(input);
 
         return GetHandlers()
-               .Reverse()
-               .ToObservable()
-               .ObserveOn(_handlerScheduler)
-               .Select(handler => Observable.Defer(() => handler(context)))
-               .Concat()
-               .TakeWhile(_ => !context.IsHandled)
-               .IgnoreElements()
-               .Select(_ => default(TOutput)!)
-               .Concat(
-                       Observable.Defer(
-                                        () => context.IsHandled
-                                                  ? Observable.Return(context.GetOutput())
-                                                  : Observable.Throw<TOutput>(new UnhandledInteractionException<TInput, TOutput>(this, input))));
+            .Reverse()
+            .ToObservable()
+            .ObserveOn(_handlerScheduler)
+            .Select(handler => Observable.Defer(() => handler(context)))
+            .Concat()
+            .TakeWhile(_ => !context.IsHandled)
+            .IgnoreElements()
+            .Select(_ => default(TOutput)!)
+            .Concat(
+                Observable.Defer(
+                    () => context.IsHandled
+                        ? Observable.Return(context.GetOutput())
+                        : Observable.Throw<TOutput>(new UnhandledInteractionException<TInput, TOutput>(this, input))));
     }
 
     /// <summary>
@@ -184,7 +120,7 @@ public class Interaction<TInput, TOutput>
     /// <returns>
     /// All registered handlers.
     /// </returns>
-    protected Func<InteractionContext<TInput, TOutput>, IObservable<Unit>>[] GetHandlers()
+    protected Func<IInteractionContext<TInput, TOutput>, IObservable<Unit>>[] GetHandlers()
     {
         lock (_sync)
         {
@@ -192,7 +128,7 @@ public class Interaction<TInput, TOutput>
         }
     }
 
-    private void AddHandler(Func<InteractionContext<TInput, TOutput>, IObservable<Unit>> handler)
+    private void AddHandler(Func<IInteractionContext<TInput, TOutput>, IObservable<Unit>> handler)
     {
         lock (_sync)
         {
@@ -200,7 +136,7 @@ public class Interaction<TInput, TOutput>
         }
     }
 
-    private void RemoveHandler(Func<InteractionContext<TInput, TOutput>, IObservable<Unit>> handler)
+    private void RemoveHandler(Func<IInteractionContext<TInput, TOutput>, IObservable<Unit>> handler)
     {
         lock (_sync)
         {

--- a/src/ReactiveUI/Interactions/Interaction.cs
+++ b/src/ReactiveUI/Interactions/Interaction.cs
@@ -96,7 +96,7 @@ public class Interaction<TInput, TOutput> : IInteraction<TInput, TOutput>
     /// <inheritdoc />
     public virtual IObservable<TOutput> Handle(TInput input)
     {
-        var context = new InteractionContext<TInput, TOutput>(input);
+        var context = GenerateContext(input);
 
         return GetHandlers()
             .Reverse()

--- a/src/ReactiveUI/Interactions/Interaction.cs
+++ b/src/ReactiveUI/Interactions/Interaction.cs
@@ -128,6 +128,13 @@ public class Interaction<TInput, TOutput> : IInteraction<TInput, TOutput>
         }
     }
 
+    /// <summary>
+    /// Gets a interaction context which is used to provide information about the interaction.
+    /// </summary>
+    /// <param name="input">The input that is being passed in.</param>
+    /// <returns>The interaction context.</returns>
+    protected virtual IInteractionContext<TInput, TOutput> GenerateContext(TInput input) => new InteractionContext<TInput, TOutput>(input);
+
     private void AddHandler(Func<IInteractionContext<TInput, TOutput>, IObservable<Unit>> handler)
     {
         lock (_sync)

--- a/src/ReactiveUI/Interactions/Interaction.cs
+++ b/src/ReactiveUI/Interactions/Interaction.cs
@@ -51,7 +51,7 @@ public class Interaction<TInput, TOutput> : IInteraction<TInput, TOutput>
     /// <param name="handlerScheduler">
     /// The scheduler to use when invoking handlers, which defaults to <c>CurrentThreadScheduler.Instance</c> if <see langword="null"/>.
     /// </param>
-    public Interaction(IScheduler? handlerScheduler = null) => _handlerScheduler ??= CurrentThreadScheduler.Instance;
+    public Interaction(IScheduler? handlerScheduler = null) => _handlerScheduler = handlerScheduler ?? CurrentThreadScheduler.Instance;
 
     /// <inheritdoc/>
     public IDisposable RegisterHandler(Action<IInteractionContext<TInput, TOutput>> handler)

--- a/src/ReactiveUI/Interactions/Interaction.cs
+++ b/src/ReactiveUI/Interactions/Interaction.cs
@@ -133,7 +133,7 @@ public class Interaction<TInput, TOutput> : IInteraction<TInput, TOutput>
     /// </summary>
     /// <param name="input">The input that is being passed in.</param>
     /// <returns>The interaction context.</returns>
-    protected virtual IInteractionContext<TInput, TOutput> GenerateContext(TInput input) => new InteractionContext<TInput, TOutput>(input);
+    protected virtual IOutputContext<TInput, TOutput> GenerateContext(TInput input) => new InteractionContext<TInput, TOutput>(input);
 
     private void AddHandler(Func<IInteractionContext<TInput, TOutput>, IObservable<Unit>> handler)
     {

--- a/src/ReactiveUI/Interactions/InteractionContext.cs
+++ b/src/ReactiveUI/Interactions/InteractionContext.cs
@@ -21,32 +21,20 @@ namespace ReactiveUI;
 /// <typeparam name="TOutput">
 /// The type of the interaction's output.
 /// </typeparam>
-public sealed class InteractionContext<TInput, TOutput> : IInteractionContext<TInput, TOutput>
+public sealed class InteractionContext<TInput, TOutput> : IOutputContext<TInput, TOutput>
 {
     private TOutput _output = default!;
     private int _outputSet;
 
     internal InteractionContext(TInput input) => Input = input;
 
-    /// <summary>
-    /// Gets the input for the interaction.
-    /// </summary>
+    /// <inheritdoc />
     public TInput Input { get; }
 
-    /// <summary>
-    /// Gets a value indicating whether the interaction is handled. That is, whether the output has been set.
-    /// </summary>
+    /// <inheritdoc />
     public bool IsHandled => _outputSet == 1;
 
-    /// <summary>
-    /// Sets the output for the interaction.
-    /// </summary>
-    /// <param name="output">
-    /// The output.
-    /// </param>
-    /// <exception cref="InvalidOperationException">
-    /// If the output has already been set.
-    /// </exception>
+    /// <inheritdoc />
     public void SetOutput(TOutput output)
     {
         if (Interlocked.CompareExchange(ref _outputSet, 1, 0) != 0)
@@ -57,15 +45,7 @@ public sealed class InteractionContext<TInput, TOutput> : IInteractionContext<TI
         _output = output;
     }
 
-    /// <summary>
-    /// Gets the output of the interaction.
-    /// </summary>
-    /// <returns>
-    /// The output.
-    /// </returns>
-    /// <exception cref="InvalidOperationException">
-    /// If the output has not been set.
-    /// </exception>
+    /// <inheritdoc />
     public TOutput GetOutput()
     {
         if (_outputSet == 0)


### PR DESCRIPTION
On the interface `IInteractionContext` the `GetOutput()` is no longer accessible. You can still cast the concrete class. This enforces strict requirements

Since `Interaction` generated the `InteractionContext` there should be minimal changes to users unless they use `GetOutput` on the context. The `GetOutput` is on another interface used internally to get the output value. 

There is now support for providing your own context's by overriding the protected method `GenerateContext` on the `Interaction` class. 