### PR TITLE
Fix Global Usings One Per Project

### DIFF
--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -70,10 +70,6 @@
     <None Include="$(MSBuildThisFileDirectory)..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
-  <ItemGroup Condition="$(MSBuildProjectName.Contains('Fody')) != 'true'">
-    <Compile Include="$(MSBuildThisFileDirectory)GlobalUsings.cs" />
-  </ItemGroup>
-
   <ItemGroup>	
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.6.133" PrivateAssets="all" />	
     <PackageReference Include="stylecop.analyzers" Version="1.2.0-beta.507" PrivateAssets="all" />

--- a/src/ReactiveUI.AndroidSupport/GlobalUsings.cs
+++ b/src/ReactiveUI.AndroidSupport/GlobalUsings.cs
@@ -1,0 +1,16 @@
+// Copyright (c) 2023 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+global using global::Splat;
+global using global::System;
+global using global::System.Collections.Generic;
+global using global::System.ComponentModel;
+global using global::System.Diagnostics.CodeAnalysis;
+global using global::System.Linq;
+global using global::System.Reactive;
+global using global::System.Reactive.Linq;
+global using global::System.Reactive.Subjects;
+global using global::System.Reactive.Threading.Tasks;
+global using global::System.Threading.Tasks;

--- a/src/ReactiveUI.AndroidSupport/ReactiveAppCompatActivity.cs
+++ b/src/ReactiveUI.AndroidSupport/ReactiveAppCompatActivity.cs
@@ -3,9 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.ComponentModel;
-using System.Diagnostics.CodeAnalysis;
-
 using Android.App;
 using Android.Content;
 using Android.Runtime;

--- a/src/ReactiveUI.AndroidSupport/ReactiveDialogFragment.cs
+++ b/src/ReactiveUI.AndroidSupport/ReactiveDialogFragment.cs
@@ -3,9 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.ComponentModel;
-using System.Diagnostics.CodeAnalysis;
-
 namespace ReactiveUI.AndroidSupport;
 
 /// <summary>

--- a/src/ReactiveUI.AndroidSupport/ReactiveFragment.cs
+++ b/src/ReactiveUI.AndroidSupport/ReactiveFragment.cs
@@ -3,9 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.ComponentModel;
-using System.Diagnostics.CodeAnalysis;
-
 namespace ReactiveUI.AndroidSupport;
 
 /// <summary>

--- a/src/ReactiveUI.AndroidSupport/ReactiveFragmentActivity.cs
+++ b/src/ReactiveUI.AndroidSupport/ReactiveFragmentActivity.cs
@@ -3,9 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.ComponentModel;
-using System.Diagnostics.CodeAnalysis;
-
 using Android.App;
 using Android.Content;
 using Android.Support.V4.App;

--- a/src/ReactiveUI.AndroidSupport/ReactivePagerAdapter.cs
+++ b/src/ReactiveUI.AndroidSupport/ReactivePagerAdapter.cs
@@ -4,7 +4,6 @@
 // See the LICENSE file in the project root for full license information.
 
 using System.Collections.Specialized;
-using System.Diagnostics.CodeAnalysis;
 
 using Android.Support.V4.View;
 using Android.Views;

--- a/src/ReactiveUI.AndroidSupport/ReactivePreferenceFragment.cs
+++ b/src/ReactiveUI.AndroidSupport/ReactivePreferenceFragment.cs
@@ -3,9 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.ComponentModel;
-using System.Diagnostics.CodeAnalysis;
-
 using Android.Runtime;
 using Android.Support.V7.Preferences;
 

--- a/src/ReactiveUI.AndroidSupport/ReactiveRecyclerViewAdapter.cs
+++ b/src/ReactiveUI.AndroidSupport/ReactiveRecyclerViewAdapter.cs
@@ -4,7 +4,6 @@
 // See the LICENSE file in the project root for full license information.
 
 using System.Collections.Specialized;
-using System.Diagnostics.CodeAnalysis;
 
 using Android.Support.V7.Widget;
 using Android.Views;

--- a/src/ReactiveUI.AndroidSupport/ReactiveRecyclerViewViewHolder.cs
+++ b/src/ReactiveUI.AndroidSupport/ReactiveRecyclerViewViewHolder.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.ComponentModel;
-using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.Serialization;
 

--- a/src/ReactiveUI.AndroidX/GlobalUsings.cs
+++ b/src/ReactiveUI.AndroidX/GlobalUsings.cs
@@ -1,0 +1,16 @@
+// Copyright (c) 2023 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+global using global::Splat;
+global using global::System;
+global using global::System.Collections.Generic;
+global using global::System.ComponentModel;
+global using global::System.Diagnostics.CodeAnalysis;
+global using global::System.Linq;
+global using global::System.Reactive;
+global using global::System.Reactive.Linq;
+global using global::System.Reactive.Subjects;
+global using global::System.Reactive.Threading.Tasks;
+global using global::System.Threading.Tasks;

--- a/src/ReactiveUI.AndroidX/ReactiveAppCompatActivity.cs
+++ b/src/ReactiveUI.AndroidX/ReactiveAppCompatActivity.cs
@@ -3,9 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.ComponentModel;
-using System.Diagnostics.CodeAnalysis;
-
 using Android.App;
 using Android.Content;
 using Android.Runtime;

--- a/src/ReactiveUI.AndroidX/ReactiveDialogFragment.cs
+++ b/src/ReactiveUI.AndroidX/ReactiveDialogFragment.cs
@@ -3,9 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.ComponentModel;
-using System.Diagnostics.CodeAnalysis;
-
 namespace ReactiveUI.AndroidX;
 
 /// <summary>

--- a/src/ReactiveUI.AndroidX/ReactiveFragment.cs
+++ b/src/ReactiveUI.AndroidX/ReactiveFragment.cs
@@ -3,9 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.ComponentModel;
-using System.Diagnostics.CodeAnalysis;
-
 namespace ReactiveUI.AndroidX;
 
 /// <summary>

--- a/src/ReactiveUI.AndroidX/ReactiveFragmentActivity.cs
+++ b/src/ReactiveUI.AndroidX/ReactiveFragmentActivity.cs
@@ -3,9 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.ComponentModel;
-using System.Diagnostics.CodeAnalysis;
-
 using Android.App;
 using Android.Content;
 

--- a/src/ReactiveUI.AndroidX/ReactivePagerAdapter.cs
+++ b/src/ReactiveUI.AndroidX/ReactivePagerAdapter.cs
@@ -4,7 +4,6 @@
 // See the LICENSE file in the project root for full license information.
 
 using System.Collections.Specialized;
-using System.Diagnostics.CodeAnalysis;
 
 using Android.Views;
 

--- a/src/ReactiveUI.AndroidX/ReactivePreferenceFragment.cs
+++ b/src/ReactiveUI.AndroidX/ReactivePreferenceFragment.cs
@@ -3,9 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.ComponentModel;
-using System.Diagnostics.CodeAnalysis;
-
 using Android.Runtime;
 
 using AndroidX.Preference;

--- a/src/ReactiveUI.AndroidX/ReactiveRecyclerViewAdapter.cs
+++ b/src/ReactiveUI.AndroidX/ReactiveRecyclerViewAdapter.cs
@@ -4,7 +4,6 @@
 // See the LICENSE file in the project root for full license information.
 
 using System.Collections.Specialized;
-using System.Diagnostics.CodeAnalysis;
 
 using AndroidX.RecyclerView.Widget;
 

--- a/src/ReactiveUI.AndroidX/ReactiveRecyclerViewViewHolder.cs
+++ b/src/ReactiveUI.AndroidX/ReactiveRecyclerViewViewHolder.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.ComponentModel;
-using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.Serialization;
 

--- a/src/ReactiveUI.Blazor/GlobalUsings.cs
+++ b/src/ReactiveUI.Blazor/GlobalUsings.cs
@@ -1,0 +1,15 @@
+// Copyright (c) 2023 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+global using global::System;
+global using global::System.Collections.Generic;
+global using global::System.ComponentModel;
+global using global::System.Diagnostics.CodeAnalysis;
+global using global::System.Linq;
+global using global::System.Reactive;
+global using global::System.Reactive.Concurrency;
+global using global::System.Reactive.Disposables;
+global using global::System.Reactive.Linq;
+global using global::System.Reactive.Subjects;

--- a/src/ReactiveUI.Blazor/ReactiveComponentBase.cs
+++ b/src/ReactiveUI.Blazor/ReactiveComponentBase.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.ComponentModel;
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
 using Microsoft.AspNetCore.Components;

--- a/src/ReactiveUI.Blazor/ReactiveInjectableComponentBase.cs
+++ b/src/ReactiveUI.Blazor/ReactiveInjectableComponentBase.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.ComponentModel;
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
 using Microsoft.AspNetCore.Components;

--- a/src/ReactiveUI.Blazor/ReactiveLayoutComponentBase.cs
+++ b/src/ReactiveUI.Blazor/ReactiveLayoutComponentBase.cs
@@ -3,7 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.ComponentModel;
 using System.Runtime.CompilerServices;
 
 using Microsoft.AspNetCore.Components;

--- a/src/ReactiveUI.Blend/GlobalUsings.cs
+++ b/src/ReactiveUI.Blend/GlobalUsings.cs
@@ -1,0 +1,7 @@
+// Copyright (c) 2023 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+global using global::System;
+global using global::System.Reactive.Linq;

--- a/src/ReactiveUI.Drawing/GlobalUsings.cs
+++ b/src/ReactiveUI.Drawing/GlobalUsings.cs
@@ -1,0 +1,7 @@
+// Copyright (c) 2023 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+global using global::Splat;
+global using global::System;

--- a/src/ReactiveUI.Maui/GlobalUsings.cs
+++ b/src/ReactiveUI.Maui/GlobalUsings.cs
@@ -1,0 +1,17 @@
+// Copyright (c) 2023 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+global using global::Splat;
+global using global::System;
+global using global::System.ComponentModel;
+global using global::System.Linq;
+global using global::System.Linq.Expressions;
+global using global::System.Reactive;
+global using global::System.Reactive.Concurrency;
+global using global::System.Reactive.Disposables;
+global using global::System.Reactive.Linq;
+global using global::System.Reactive.Subjects;
+global using global::System.Threading;
+global using global::System.Threading.Tasks;

--- a/src/ReactiveUI.Splat.Tests/GlobalUsings.cs
+++ b/src/ReactiveUI.Splat.Tests/GlobalUsings.cs
@@ -1,0 +1,9 @@
+// Copyright (c) 2023 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+global using global::Splat;
+global using global::System.Collections.Generic;
+global using global::System.Linq;
+global using global::System.Reactive.Linq;

--- a/src/ReactiveUI.Testing.Tests/GlobalUsings.cs
+++ b/src/ReactiveUI.Testing.Tests/GlobalUsings.cs
@@ -1,0 +1,11 @@
+// Copyright (c) 2023 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+global using global::System;
+global using global::System.Collections.Generic;
+global using global::System.Reactive;
+global using global::System.Reactive.Linq;
+global using global::System.Reactive.Subjects;
+global using global::System.Threading.Tasks;

--- a/src/ReactiveUI.Testing.Tests/TestFixture.cs
+++ b/src/ReactiveUI.Testing.Tests/TestFixture.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Diagnostics.CodeAnalysis;
-
 namespace ReactiveUI.Testing.Tests
 {
     /// <summary>

--- a/src/ReactiveUI.Testing/GlobalUsings.cs
+++ b/src/ReactiveUI.Testing/GlobalUsings.cs
@@ -1,0 +1,12 @@
+// Copyright (c) 2023 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+global using global::System;
+global using global::System.Collections.Generic;
+global using global::System.Reactive;
+global using global::System.Reactive.Concurrency;
+global using global::System.Reactive.Disposables;
+global using global::System.Threading;
+global using global::System.Threading.Tasks;

--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.cs
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.cs
@@ -3,11 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Diagnostics.CodeAnalysis;
-
 using VerifyXunit;
-
-using Xunit;
 
 namespace ReactiveUI.Tests.API
 {

--- a/src/ReactiveUI.Tests/Activation/ActivatingViewModelTests.cs
+++ b/src/ReactiveUI.Tests/Activation/ActivatingViewModelTests.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using Xunit;
-
 namespace ReactiveUI.Tests
 {
     /// <summary>

--- a/src/ReactiveUI.Tests/Activation/ActivatingViewTests.cs
+++ b/src/ReactiveUI.Tests/Activation/ActivatingViewTests.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using Xunit;
-
 namespace ReactiveUI.Tests
 {
     /// <summary>

--- a/src/ReactiveUI.Tests/Activation/CanActivateViewFetcherTests.cs
+++ b/src/ReactiveUI.Tests/Activation/CanActivateViewFetcherTests.cs
@@ -7,8 +7,6 @@ using Microsoft.Reactive.Testing;
 
 using ReactiveUI.Tests.Winforms;
 
-using Xunit;
-
 namespace ReactiveUI.Tests
 {
     /// <summary>

--- a/src/ReactiveUI.Tests/Activation/ViewModelActivatorTests.cs
+++ b/src/ReactiveUI.Tests/Activation/ViewModelActivatorTests.cs
@@ -5,8 +5,6 @@
 
 using DynamicData;
 
-using Xunit;
-
 namespace ReactiveUI.Tests
 {
     /// <summary>

--- a/src/ReactiveUI.Tests/AutoPersist/AutoPersistCollectionTests.cs
+++ b/src/ReactiveUI.Tests/AutoPersist/AutoPersistCollectionTests.cs
@@ -9,8 +9,6 @@ using Microsoft.Reactive.Testing;
 
 using ReactiveUI.Testing;
 
-using Xunit;
-
 namespace ReactiveUI.Tests
 {
     /// <summary>

--- a/src/ReactiveUI.Tests/AutoPersist/AutoPersistHelperTest.cs
+++ b/src/ReactiveUI.Tests/AutoPersist/AutoPersistHelperTest.cs
@@ -7,8 +7,6 @@ using Microsoft.Reactive.Testing;
 
 using ReactiveUI.Testing;
 
-using Xunit;
-
 namespace ReactiveUI.Tests
 {
     /// <summary>

--- a/src/ReactiveUI.Tests/AwaiterTest.cs
+++ b/src/ReactiveUI.Tests/AwaiterTest.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using Xunit;
-
 namespace ReactiveUI.Tests
 {
     /// <summary>

--- a/src/ReactiveUI.Tests/BindingTypeConvertersTest.cs
+++ b/src/ReactiveUI.Tests/BindingTypeConvertersTest.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using Xunit;
-
 namespace ReactiveUI.Tests
 {
     /// <summary>

--- a/src/ReactiveUI.Tests/Commands/CombinedReactiveCommandTest.cs
+++ b/src/ReactiveUI.Tests/Commands/CombinedReactiveCommandTest.cs
@@ -9,8 +9,6 @@ using Microsoft.Reactive.Testing;
 
 using ReactiveUI.Testing;
 
-using Xunit;
-
 namespace ReactiveUI.Tests
 {
     /// <summary>

--- a/src/ReactiveUI.Tests/Commands/CreatesCommandBindingTests.cs
+++ b/src/ReactiveUI.Tests/Commands/CreatesCommandBindingTests.cs
@@ -3,10 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.ComponentModel;
-
-using Xunit;
-
 namespace ReactiveUI.Tests
 {
     /// <summary>

--- a/src/ReactiveUI.Tests/Comparers/OrderedComparerTests.cs
+++ b/src/ReactiveUI.Tests/Comparers/OrderedComparerTests.cs
@@ -5,8 +5,6 @@
 
 using System.Diagnostics;
 
-using Xunit;
-
 namespace ReactiveUI.Tests
 {
     /// <summary>

--- a/src/ReactiveUI.Tests/GlobalUsings.cs
+++ b/src/ReactiveUI.Tests/GlobalUsings.cs
@@ -1,0 +1,21 @@
+// Copyright (c) 2023 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+global using global::Splat;
+global using global::System;
+global using global::System.Collections.Generic;
+global using global::System.ComponentModel;
+global using global::System.Diagnostics.CodeAnalysis;
+global using global::System.Linq;
+global using global::System.Linq.Expressions;
+global using global::System.Reactive;
+global using global::System.Reactive.Concurrency;
+global using global::System.Reactive.Disposables;
+global using global::System.Reactive.Linq;
+global using global::System.Reactive.Subjects;
+global using global::System.Reactive.Threading.Tasks;
+global using global::System.Threading;
+global using global::System.Threading.Tasks;
+global using global::Xunit;

--- a/src/ReactiveUI.Tests/InteractionBinding/InteractionBinderImplementationTests.cs
+++ b/src/ReactiveUI.Tests/InteractionBinding/InteractionBinderImplementationTests.cs
@@ -5,8 +5,6 @@
 
 using FluentAssertions;
 
-using Xunit;
-
 namespace ReactiveUI.Tests
 {
     /// <summary>

--- a/src/ReactiveUI.Tests/InteractionsTest.cs
+++ b/src/ReactiveUI.Tests/InteractionsTest.cs
@@ -9,8 +9,6 @@ using Microsoft.Reactive.Testing;
 
 using ReactiveUI.Testing;
 
-using Xunit;
-
 namespace ReactiveUI.Tests
 {
     /// <summary>

--- a/src/ReactiveUI.Tests/Locator/DefaultViewLocatorTests.cs
+++ b/src/ReactiveUI.Tests/Locator/DefaultViewLocatorTests.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using Xunit;
-
 namespace ReactiveUI.Tests
 {
     /// <summary>

--- a/src/ReactiveUI.Tests/MessageBusTest.cs
+++ b/src/ReactiveUI.Tests/MessageBusTest.cs
@@ -9,8 +9,6 @@ using Microsoft.Reactive.Testing;
 
 using ReactiveUI.Testing;
 
-using Xunit;
-
 namespace ReactiveUI.Tests
 {
     /// <summary>

--- a/src/ReactiveUI.Tests/Mocks/Foo.cs
+++ b/src/ReactiveUI.Tests/Mocks/Foo.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) 2023 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace ReactiveUI.Tests.Mocks;
+
+public class Foo
+{
+    public Foo() => Value = 42;
+
+    public int Value { get; private set; }
+
+    public async Task<Unit> SetValueAsync(int value)
+    {
+        await RxApp.TaskpoolScheduler.Sleep(TimeSpan.FromMilliseconds(10));
+        Value = value;
+        return Unit.Default;
+    }
+}

--- a/src/ReactiveUI.Tests/Mocks/FooViewModel.cs
+++ b/src/ReactiveUI.Tests/Mocks/FooViewModel.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) 2023 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace ReactiveUI.Tests.Mocks;
+
+public class FooViewModel : ReactiveObject
+{
+    private int _setpoint;
+
+    public FooViewModel(Foo foo)
+    {
+        Foo = foo ?? throw new ArgumentNullException(nameof(foo));
+
+        this.WhenAnyValue(x => x.Setpoint)
+            ////.Skip(1) // Skip the initial value
+            .SelectMany(foo.SetValueAsync)
+            .Subscribe();
+    }
+
+    public int Setpoint { get => _setpoint; set => this.RaiseAndSetIfChanged(ref _setpoint, value); }
+
+    public Foo Foo { get; }
+}

--- a/src/ReactiveUI.Tests/ObservableAsPropertyHelper/ObservableAsPropertyHelperTest.cs
+++ b/src/ReactiveUI.Tests/ObservableAsPropertyHelper/ObservableAsPropertyHelperTest.cs
@@ -9,8 +9,6 @@ using Microsoft.Reactive.Testing;
 
 using ReactiveUI.Testing;
 
-using Xunit;
-
 namespace ReactiveUI.Tests
 {
     /// <summary>

--- a/src/ReactiveUI.Tests/ObservedChanged/NewGameViewModelTests.cs
+++ b/src/ReactiveUI.Tests/ObservedChanged/NewGameViewModelTests.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using Xunit;
-
 namespace ReactiveUI.Tests
 {
     /// <summary>

--- a/src/ReactiveUI.Tests/ObservedChanged/ObservedChangedMixinTest.cs
+++ b/src/ReactiveUI.Tests/ObservedChanged/ObservedChangedMixinTest.cs
@@ -7,8 +7,6 @@ using Microsoft.Reactive.Testing;
 
 using ReactiveUI.Testing;
 
-using Xunit;
-
 namespace ReactiveUI.Tests
 {
     /// <summary>

--- a/src/ReactiveUI.Tests/Platforms/common-gui/ObservableAsPropertyHelperModeTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/common-gui/ObservableAsPropertyHelperModeTests.cs
@@ -4,7 +4,6 @@
 // See the LICENSE file in the project root for full license information.
 
 using System.Diagnostics;
-using Xunit;
 
 namespace ReactiveUI.Tests
 {

--- a/src/ReactiveUI.Tests/Platforms/windows-xaml/Api/XamlApiApprovalTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/windows-xaml/Api/XamlApiApprovalTests.cs
@@ -3,10 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Diagnostics.CodeAnalysis;
-
-using Xunit;
-
 namespace ReactiveUI.Tests.Xaml
 {
     /// <summary>

--- a/src/ReactiveUI.Tests/Platforms/windows-xaml/CommandBindingImplementationTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/windows-xaml/CommandBindingImplementationTests.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using Xunit;
-
 #if NETFX_CORE
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;

--- a/src/ReactiveUI.Tests/Platforms/windows-xaml/DependencyObjectObservableForPropertyTest.cs
+++ b/src/ReactiveUI.Tests/Platforms/windows-xaml/DependencyObjectObservableForPropertyTest.cs
@@ -4,7 +4,6 @@
 // See the LICENSE file in the project root for full license information.
 
 using DynamicData;
-using Xunit;
 
 #if NETFX_CORE
 using Windows.UI.Xaml;

--- a/src/ReactiveUI.Tests/Platforms/windows-xaml/PropertyBindingTest.cs
+++ b/src/ReactiveUI.Tests/Platforms/windows-xaml/PropertyBindingTest.cs
@@ -8,8 +8,6 @@ using System.Globalization;
 
 using DynamicData.Binding;
 
-using Xunit;
-
 #if NETFX_CORE
 #else
 

--- a/src/ReactiveUI.Tests/Platforms/windows-xaml/RxAppDependencyObjectTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/windows-xaml/RxAppDependencyObjectTests.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using Xunit;
-
 namespace ReactiveUI.Tests.Xaml
 {
     /// <summary>

--- a/src/ReactiveUI.Tests/Platforms/windows-xaml/WhenAnyThroughDependencyObjectTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/windows-xaml/WhenAnyThroughDependencyObjectTests.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using Xunit;
-
 #if NETFX_CORE
 #else
 

--- a/src/ReactiveUI.Tests/Platforms/windows-xaml/XamlViewCommandTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/windows-xaml/XamlViewCommandTests.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using Xunit;
-
 #if NETFX_CORE
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Automation.Peers;

--- a/src/ReactiveUI.Tests/Platforms/windows-xaml/XamlViewDependencyResolverTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/windows-xaml/XamlViewDependencyResolverTests.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using Xunit;
-
 #if NETFX_CORE
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;

--- a/src/ReactiveUI.Tests/Platforms/winforms/API/WinformsApiApprovalTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/API/WinformsApiApprovalTests.cs
@@ -3,11 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Diagnostics.CodeAnalysis;
-
 using VerifyXunit;
-
-using Xunit;
 
 namespace ReactiveUI.Tests
 {

--- a/src/ReactiveUI.Tests/Platforms/winforms/ActivationTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/ActivationTests.cs
@@ -5,8 +5,6 @@
 
 using System.Windows.Forms;
 
-using Xunit;
-
 namespace ReactiveUI.Tests.Winforms
 {
     /// <summary>

--- a/src/ReactiveUI.Tests/Platforms/winforms/CommandBindingImplementationTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/CommandBindingImplementationTests.cs
@@ -5,7 +5,6 @@
 
 using System.Windows.Forms;
 using ReactiveUI.Testing;
-using Xunit;
 
 namespace ReactiveUI.Tests.Winforms
 {

--- a/src/ReactiveUI.Tests/Platforms/winforms/CommandBindingTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/CommandBindingTests.cs
@@ -7,8 +7,6 @@ using System.Windows.Forms;
 using ReactiveUI.Testing;
 using ReactiveUI.Winforms;
 
-using Xunit;
-
 namespace ReactiveUI.Tests.Winforms
 {
     /// <summary>

--- a/src/ReactiveUI.Tests/Platforms/winforms/DefaultPropertyBindingTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/DefaultPropertyBindingTests.cs
@@ -10,8 +10,6 @@ using DynamicData;
 
 using ReactiveUI.Winforms;
 
-using Xunit;
-
 namespace ReactiveUI.Tests.Winforms
 {
     /// <summary>

--- a/src/ReactiveUI.Tests/Platforms/winforms/Mocks/CustomClickableComponent.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/Mocks/CustomClickableComponent.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.ComponentModel;
-
 namespace ReactiveUI.Tests.Winforms
 {
     /// <summary>

--- a/src/ReactiveUI.Tests/Platforms/winforms/WinFormsRoutedViewHostTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/WinFormsRoutedViewHostTests.cs
@@ -5,8 +5,6 @@
 
 using System.Windows.Forms;
 
-using Xunit;
-
 using WinFormsRoutedViewHost = ReactiveUI.Winforms.RoutedControlHost;
 
 namespace ReactiveUI.Tests.Winforms

--- a/src/ReactiveUI.Tests/Platforms/winforms/WinFormsViewDependencyResolverTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/WinFormsViewDependencyResolverTests.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using Xunit;
-
 using FactAttribute = Xunit.WpfFactAttribute;
 
 namespace ReactiveUI.Tests.Winforms

--- a/src/ReactiveUI.Tests/Platforms/winforms/WinFormsViewModelViewHostTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/WinFormsViewModelViewHostTests.cs
@@ -5,8 +5,6 @@
 
 using System.Windows.Forms;
 
-using Xunit;
-
 using WinFormsViewModelViewHost = ReactiveUI.Winforms.ViewModelControlHost;
 
 namespace ReactiveUI.Tests.Winforms

--- a/src/ReactiveUI.Tests/Platforms/wpf/API/WpfApiApprovalTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/wpf/API/WpfApiApprovalTests.cs
@@ -3,11 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Diagnostics.CodeAnalysis;
-
 using VerifyXunit;
-
-using Xunit;
 
 namespace ReactiveUI.Tests.Wpf
 {

--- a/src/ReactiveUI.Tests/Platforms/wpf/WpfActiveContentTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/wpf/WpfActiveContentTests.cs
@@ -7,7 +7,6 @@ using System.Windows;
 
 using DynamicData;
 using ReactiveUI.Testing;
-using Xunit;
 
 namespace ReactiveUI.Tests.Wpf
 {

--- a/src/ReactiveUI.Tests/Platforms/wpf/WpfCommandBindingImplementationTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/wpf/WpfCommandBindingImplementationTests.cs
@@ -10,8 +10,6 @@ using System.Windows.Input;
 
 using FluentAssertions;
 
-using Xunit;
-
 using FactAttribute = Xunit.WpfFactAttribute;
 
 namespace ReactiveUI.Tests.Wpf

--- a/src/ReactiveUI.Tests/Platforms/wpf/WpfViewDependencyResolverTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/wpf/WpfViewDependencyResolverTests.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using Xunit;
-
 using FactAttribute = Xunit.WpfFactAttribute;
 
 namespace ReactiveUI.Tests.Wpf

--- a/src/ReactiveUI.Tests/RandomTests.cs
+++ b/src/ReactiveUI.Tests/RandomTests.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using Xunit;
-
 namespace ReactiveUI.Tests
 {
     public class RandomTests

--- a/src/ReactiveUI.Tests/ReactiveObject/ReactiveObjectTests.cs
+++ b/src/ReactiveUI.Tests/ReactiveObject/ReactiveObjectTests.cs
@@ -4,11 +4,8 @@
 // See the LICENSE file in the project root for full license information.
 
 using System.Collections;
-using System.ComponentModel;
 
 using DynamicData;
-
-using Xunit;
 
 namespace ReactiveUI.Tests
 {

--- a/src/ReactiveUI.Tests/Resolvers/DependencyResolverTests.cs
+++ b/src/ReactiveUI.Tests/Resolvers/DependencyResolverTests.cs
@@ -5,8 +5,6 @@
 
 using FluentAssertions;
 
-using Xunit;
-
 namespace ReactiveUI.Tests
 {
     public sealed class DependencyResolverTests

--- a/src/ReactiveUI.Tests/Resolvers/INPCObservableForPropertyTests.cs
+++ b/src/ReactiveUI.Tests/Resolvers/INPCObservableForPropertyTests.cs
@@ -3,10 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.ComponentModel;
 using System.Runtime.CompilerServices;
-
-using Xunit;
 
 namespace ReactiveUI.Tests
 {

--- a/src/ReactiveUI.Tests/Resolvers/PocoObservableForPropertyTests.cs
+++ b/src/ReactiveUI.Tests/Resolvers/PocoObservableForPropertyTests.cs
@@ -3,10 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.ComponentModel;
-
-using Xunit;
-
 namespace ReactiveUI.Tests
 {
     public class PocoObservableForPropertyTests

--- a/src/ReactiveUI.Tests/Routing/RoutableViewModelMixinTests.cs
+++ b/src/ReactiveUI.Tests/Routing/RoutableViewModelMixinTests.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using Xunit;
-
 namespace ReactiveUI.Tests
 {
     /// <summary>

--- a/src/ReactiveUI.Tests/Routing/RoutedViewHostTests.cs
+++ b/src/ReactiveUI.Tests/Routing/RoutedViewHostTests.cs
@@ -9,8 +9,6 @@ using DynamicData;
 
 using ReactiveUI.Tests.Wpf;
 
-using Xunit;
-
 namespace ReactiveUI.Tests
 {
     public class RoutedViewHostTests

--- a/src/ReactiveUI.Tests/Routing/RoutingStateTests.cs
+++ b/src/ReactiveUI.Tests/Routing/RoutingStateTests.cs
@@ -9,8 +9,6 @@ using Microsoft.Reactive.Testing;
 
 using ReactiveUI.Testing;
 
-using Xunit;
-
 namespace ReactiveUI.Tests
 {
     public class RoutingStateTests

--- a/src/ReactiveUI.Tests/Routing/ViewModelViewHostTests.cs
+++ b/src/ReactiveUI.Tests/Routing/ViewModelViewHostTests.cs
@@ -9,8 +9,6 @@ using DynamicData;
 
 using ReactiveUI.Tests.Wpf;
 
-using Xunit;
-
 namespace ReactiveUI.Tests
 {
     public class ViewModelViewHostTests

--- a/src/ReactiveUI.Tests/RxAppTest.cs
+++ b/src/ReactiveUI.Tests/RxAppTest.cs
@@ -5,8 +5,6 @@
 
 using System.Diagnostics;
 
-using Xunit;
-
 namespace ReactiveUI.Tests
 {
     /// <summary>

--- a/src/ReactiveUI.Tests/Suspension/SuspensionHostExtensionsTests.cs
+++ b/src/ReactiveUI.Tests/Suspension/SuspensionHostExtensionsTests.cs
@@ -5,8 +5,6 @@
 
 using FluentAssertions;
 
-using Xunit;
-
 namespace ReactiveUI.Tests.Suspension
 {
     public class SuspensionHostExtensionsTests

--- a/src/ReactiveUI.Tests/TestConfiguration.cs
+++ b/src/ReactiveUI.Tests/TestConfiguration.cs
@@ -3,6 +3,4 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using Xunit;
-
 [assembly: CollectionBehavior(DisableTestParallelization = true, MaxParallelThreads = 1)]

--- a/src/ReactiveUI.Tests/Utilities/ApiApprovalBase.cs
+++ b/src/ReactiveUI.Tests/Utilities/ApiApprovalBase.cs
@@ -3,7 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 

--- a/src/ReactiveUI.Tests/Utilities/EnumerableTestMixin.cs
+++ b/src/ReactiveUI.Tests/Utilities/EnumerableTestMixin.cs
@@ -5,8 +5,6 @@
 
 using System.Diagnostics;
 
-using Xunit;
-
 namespace ReactiveUI.Tests
 {
     public static class EnumerableTestMixin

--- a/src/ReactiveUI.Tests/Utilities/TestLogger.cs
+++ b/src/ReactiveUI.Tests/Utilities/TestLogger.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.ComponentModel;
-
 namespace ReactiveUI.Tests
 {
     public class TestLogger : ILogger

--- a/src/ReactiveUI.Tests/WaitForDispatcherSchedulerTests.cs
+++ b/src/ReactiveUI.Tests/WaitForDispatcherSchedulerTests.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using Xunit;
-
 namespace ReactiveUI.Tests
 {
     /// <summary>

--- a/src/ReactiveUI.Tests/WhenAny/Mockups/NonReactiveINPCObject.cs
+++ b/src/ReactiveUI.Tests/WhenAny/Mockups/NonReactiveINPCObject.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.ComponentModel;
-
 namespace ReactiveUI.Tests
 {
     public class NonReactiveINPCObject : INotifyPropertyChanged

--- a/src/ReactiveUI.Tests/WhenAny/ReactiveNotifyPropertyChangedMixinTest.cs
+++ b/src/ReactiveUI.Tests/WhenAny/ReactiveNotifyPropertyChangedMixinTest.cs
@@ -9,8 +9,6 @@ using Microsoft.Reactive.Testing;
 
 using ReactiveUI.Testing;
 
-using Xunit;
-
 namespace ReactiveUI.Tests
 {
     /// <summary>

--- a/src/ReactiveUI.Tests/WhenAny/WhenAnyObservableTests.cs
+++ b/src/ReactiveUI.Tests/WhenAny/WhenAnyObservableTests.cs
@@ -6,8 +6,6 @@
 using DynamicData;
 using DynamicData.Binding;
 
-using Xunit;
-
 namespace ReactiveUI.Tests
 {
     /// <summary>

--- a/src/ReactiveUI.WinUI/GlobalUsings.cs
+++ b/src/ReactiveUI.WinUI/GlobalUsings.cs
@@ -1,0 +1,13 @@
+// Copyright (c) 2023 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+global using global::Splat;
+global using global::System;
+global using global::System.Linq;
+global using global::System.Linq.Expressions;
+global using global::System.Reactive.Concurrency;
+global using global::System.Reactive.Disposables;
+global using global::System.Reactive.Linq;
+global using global::System.Threading;

--- a/src/ReactiveUI.Winforms/ActivationForViewFetcher.cs
+++ b/src/ReactiveUI.Winforms/ActivationForViewFetcher.cs
@@ -3,7 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.ComponentModel;
 using System.Globalization;
 using System.Reflection;
 using System.Windows.Forms;

--- a/src/ReactiveUI.Winforms/CreatesWinformsCommandBinding.cs
+++ b/src/ReactiveUI.Winforms/CreatesWinformsCommandBinding.cs
@@ -3,7 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.ComponentModel;
 using System.Reflection;
 using System.Windows.Forms;
 using System.Windows.Input;

--- a/src/ReactiveUI.Winforms/GlobalUsings.cs
+++ b/src/ReactiveUI.Winforms/GlobalUsings.cs
@@ -1,0 +1,15 @@
+// Copyright (c) 2023 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+global using global::Splat;
+global using global::System;
+global using global::System.Collections.Generic;
+global using global::System.ComponentModel;
+global using global::System.Linq;
+global using global::System.Linq.Expressions;
+global using global::System.Reactive.Concurrency;
+global using global::System.Reactive.Disposables;
+global using global::System.Reactive.Linq;
+global using global::System.Threading;

--- a/src/ReactiveUI.Winforms/ObservableCollectionChangedToListChangedTransformer.cs
+++ b/src/ReactiveUI.Winforms/ObservableCollectionChangedToListChangedTransformer.cs
@@ -4,7 +4,6 @@
 // See the LICENSE file in the project root for full license information.
 
 using System.Collections.Specialized;
-using System.ComponentModel;
 
 namespace ReactiveUI.Winforms;
 

--- a/src/ReactiveUI.Winforms/ReactiveUserControl.cs
+++ b/src/ReactiveUI.Winforms/ReactiveUserControl.cs
@@ -3,7 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.ComponentModel;
 using System.Windows.Forms;
 
 namespace ReactiveUI.Winforms;

--- a/src/ReactiveUI.Winforms/RoutedViewHost.cs
+++ b/src/ReactiveUI.Winforms/RoutedViewHost.cs
@@ -3,7 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.ComponentModel;
 using System.Windows.Forms;
 
 namespace ReactiveUI.Winforms;

--- a/src/ReactiveUI.Winforms/ViewModelViewHost.cs
+++ b/src/ReactiveUI.Winforms/ViewModelViewHost.cs
@@ -3,7 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.ComponentModel;
 using System.Windows.Forms;
 
 namespace ReactiveUI.Winforms;

--- a/src/ReactiveUI.Winforms/WinformsCreatesObservableForProperty.cs
+++ b/src/ReactiveUI.Winforms/WinformsCreatesObservableForProperty.cs
@@ -3,7 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.ComponentModel;
 using System.Reflection;
 
 namespace ReactiveUI.Winforms;

--- a/src/ReactiveUI.Wpf/DependencyObjectObservableForProperty.cs
+++ b/src/ReactiveUI.Wpf/DependencyObjectObservableForProperty.cs
@@ -3,7 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.ComponentModel;
 using System.Reflection;
 using System.Windows;
 

--- a/src/ReactiveUI.Wpf/GlobalUsings.cs
+++ b/src/ReactiveUI.Wpf/GlobalUsings.cs
@@ -1,0 +1,16 @@
+// Copyright (c) 2023 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+global using global::Splat;
+global using global::System;
+global using global::System.Collections.Generic;
+global using global::System.ComponentModel;
+global using global::System.Linq;
+global using global::System.Reactive;
+global using global::System.Reactive.Concurrency;
+global using global::System.Reactive.Disposables;
+global using global::System.Reactive.Linq;
+global using global::System.Reactive.Subjects;
+global using global::System.Threading;

--- a/src/ReactiveUI.Wpf/ReactiveUI.Wpf.csproj
+++ b/src/ReactiveUI.Wpf/ReactiveUI.Wpf.csproj
@@ -9,7 +9,6 @@
     <PackageId>ReactiveUI.WPF</PackageId>
     <UseWpf>true</UseWpf>
     <PackageTags>mvvm;reactiveui;rx;reactive extensions;observable;LINQ;events;frp;wpf;net;net472</PackageTags>
-    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ReactiveUI.XamForms.Tests/Activation/Mocks/FlyoutPageViewFlyout.xaml.cs
+++ b/src/ReactiveUI.XamForms.Tests/Activation/Mocks/FlyoutPageViewFlyout.xaml.cs
@@ -4,7 +4,6 @@
 // See the LICENSE file in the project root for full license information.
 
 using System.Collections.ObjectModel;
-using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using Xamarin.Forms;
 using Xamarin.Forms.Xaml;

--- a/src/ReactiveUI.XamForms.Tests/GlobalUsings.cs
+++ b/src/ReactiveUI.XamForms.Tests/GlobalUsings.cs
@@ -1,0 +1,11 @@
+// Copyright (c) 2023 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+global using global::Splat;
+global using global::System;
+global using global::System.ComponentModel;
+global using global::System.Reactive.Disposables;
+global using global::System.Reactive.Linq;
+global using global::System.Threading.Tasks;

--- a/src/ReactiveUI.XamForms/ActivationForViewFetcher.cs
+++ b/src/ReactiveUI.XamForms/ActivationForViewFetcher.cs
@@ -3,7 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.ComponentModel;
 using System.Reflection;
 
 using Xamarin.Forms;

--- a/src/ReactiveUI.XamForms/GlobalUsings.cs
+++ b/src/ReactiveUI.XamForms/GlobalUsings.cs
@@ -1,0 +1,15 @@
+// Copyright (c) 2023 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+global using global::Splat;
+global using global::System;
+global using global::System.ComponentModel;
+global using global::System.Diagnostics.CodeAnalysis;
+global using global::System.Linq;
+global using global::System.Reactive;
+global using global::System.Reactive.Disposables;
+global using global::System.Reactive.Linq;
+global using global::System.Reactive.Subjects;
+global using global::System.Reactive.Threading.Tasks;

--- a/src/ReactiveUI.XamForms/RoutedViewHost.cs
+++ b/src/ReactiveUI.XamForms/RoutedViewHost.cs
@@ -3,7 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
 using Xamarin.Forms;

--- a/src/ReactiveUI/GlobalUsings.cs
+++ b/src/ReactiveUI/GlobalUsings.cs
@@ -1,0 +1,20 @@
+// Copyright (c) 2023 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+global using global::Splat;
+global using global::System;
+global using global::System.Collections.Generic;
+global using global::System.ComponentModel;
+global using global::System.Diagnostics.CodeAnalysis;
+global using global::System.Linq;
+global using global::System.Linq.Expressions;
+global using global::System.Reactive;
+global using global::System.Reactive.Concurrency;
+global using global::System.Reactive.Disposables;
+global using global::System.Reactive.Linq;
+global using global::System.Reactive.Subjects;
+global using global::System.Reactive.Threading.Tasks;
+global using global::System.Threading;
+global using global::System.Threading.Tasks;

--- a/src/global.json
+++ b/src/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "version": "7.0",
+        "version": "7.0.400",
         "rollForward": "latestMinor",
         "allowPrerelease": true
     },


### PR DESCRIPTION
Issues with a single file where invalid usings exist.

<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Fix

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

A single GlobalUsing file is used

**What is the new behavior?**
<!-- If this is a feature change -->

Multiple GlobalUsing files are used to remove the issue where usings are included that are invalid for some projects

**What might this PR break?**

none expected

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

