### PR TITLE
feature: Allow InvokeCommand to use IReactiveCommand<T, TResult>

### DIFF
--- a/src/ReactiveUI/ReactiveCommand/ReactiveCommandMixins.cs
+++ b/src/ReactiveUI/ReactiveCommand/ReactiveCommandMixins.cs
@@ -51,10 +51,10 @@ public static class ReactiveCommandMixins
     /// <param name="command">The command to be executed.</param>
     /// <returns>An object that when disposes, disconnects the Observable
     /// from the command.</returns>
-    public static IDisposable InvokeCommand<T, TResult>(this IObservable<T> item, ReactiveCommandBase<T, TResult>? command) =>
+    public static IDisposable InvokeCommand<T, TResult>(this IObservable<T> item, IReactiveCommand<T, TResult>? command) =>
         command is null
             ? throw new ArgumentNullException(nameof(command))
-            : WithLatestFromFixed(item, command.CanExecute, (value, canExecute) => new InvokeCommandInfo<ReactiveCommandBase<T, TResult>, T>(command, canExecute, value))
+            : WithLatestFromFixed(item, command.CanExecute, (value, canExecute) => new InvokeCommandInfo<IReactiveCommand<T, TResult>, T>(command, canExecute, value))
               .Where(ii => ii.CanExecute)
               .SelectMany(ii => command.Execute(ii.Value).Catch(Observable<TResult>.Empty))
               .Subscribe();


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Use interface intead of implementation.

**What is the current behavior?**

InvokeCommand **cannot** be used with instances of `IReactiveCommand<T, TResult>`

**What is the new behavior?**

InvokeCommand **can** be used with instances of `IReactiveCommand<T, TResult>`

**What might this PR break?**

Nothing.


**Please check if the PR fulfills these requirements**
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

**Other information**:
Minor change. Should be fine.

