### PR TITLE
Fix MAUI RoutedViewHost Navigation

### DIFF
--- a/src/ReactiveUI.Maui/RoutedViewHost.cs
+++ b/src/ReactiveUI.Maui/RoutedViewHost.cs
@@ -76,6 +76,7 @@ public class RoutedViewHost : NavigationPage, IActivatableView, IEnableLogger
 
             Router?
                 .Navigate
+                .Where(_ => Navigation.NavigationStack.Count != Router.NavigationStack.Count)
                 .ObserveOn(RxApp.MainThreadScheduler)
                 .SelectMany(_ => PagesForViewModel(Router.GetCurrentViewModel()))
                 .SelectMany(async page =>


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix

**What is the current behavior?**
<!-- You can also link to an open issue here. -->
#3640 When 'RoutedViewHost' is activated, it calls 'SyncNavigationStacksAsync', which pushes a page for the current ViewModel. However, the Router.Navigate subscription is also triggered, creating and pushing a new page for the same ViewModel.

**What is the new behavior?**
<!-- If this is a feature change -->
To fix this, I filtered Navigate to execute the action only when the NavigationStacks have different sizes, since it seems that is what the Navigate subscription was supposed to do anyway. I think this makes the subsequent call to SyncNavigationStacksAsync() useless. Should I remove it?

**What might this PR break?**
RoutedViewHost Navigate subscription.


**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
I was informed that there were no tests for MAUI and no documentation seemed to be present either.
