### PR TITLE
Fix stop oaph omitting inappropriately 

### DIFF
--- a/src/ReactiveUI.Tests/ObservableAsPropertyHelper/ObservableAsPropertyHelperTest.cs
+++ b/src/ReactiveUI.Tests/ObservableAsPropertyHelper/ObservableAsPropertyHelperTest.cs
@@ -290,10 +290,62 @@ public class ObservableAsPropertyHelperTest
         Assert.Equal(42, result);
     }
 
-    /// <summary>
-    /// Tests that Observable As Property Helpers initial value should emit initial value.
-    /// </summary>
-    /// <param name="initialValue">The initial value.</param>
+    /// <summary>Test that Observable As Property Helpers defers subscription with initial function value doesn't call on changed when subscribed.</summary>
+    /// <param name = "initialValue" >The initial value.</param>
+    [Theory]
+    [InlineData(default(int))]
+    [InlineData(42)]
+    public void OAPHDeferSubscriptionWithInitialFuncValueNotCallOnChangedWhenSubscribed(int initialValue)
+    {
+        var observable = Observable.Empty<int>();
+
+        var wasOnChangingCalled = false;
+        Action<int> onChanging = v => wasOnChangingCalled = true;
+        var wasOnChangedCalled = false;
+        Action<int> onChanged = v => wasOnChangedCalled = true;
+
+        var fixture = new ObservableAsPropertyHelper<int>(observable, onChanged, onChanging, () => initialValue, true);
+
+        Assert.False(fixture.IsSubscribed);
+        Assert.False(wasOnChangingCalled);
+        Assert.False(wasOnChangedCalled);
+
+        var result = fixture.Value;
+
+        Assert.True(fixture.IsSubscribed);
+        Assert.False(wasOnChangingCalled);
+        Assert.False(wasOnChangedCalled);
+        Assert.Equal(initialValue, result);
+    }
+
+    /// <summary>Test that Observable As Property Helpers defers subscription with initial function value doesn't call on changed when source provides initial value after subscription.</summary>
+    /// <param name = "initialValue" >The initial value.</param>
+    [Theory]
+    [InlineData(default(int))]
+    [InlineData(42)]
+    public void OAPHDeferSubscriptionWithInitialFuncValueNotCallOnChangedWhenSourceProvidesInitialValue(int initialValue)
+    {
+        var observable = new Subject<int>();
+
+        var wasOnChangingCalled = false;
+        Action<int> onChanging = v => wasOnChangingCalled = true;
+        var wasOnChangedCalled = false;
+        Action<int> onChanged = v => wasOnChangedCalled = true;
+
+        var fixture = new ObservableAsPropertyHelper<int>(observable, onChanged, onChanging, () => initialValue, true);
+
+        var result = fixture.Value;
+
+        Assert.Equal(initialValue, result);
+
+        observable.OnNext(initialValue);
+
+        Assert.False(wasOnChangingCalled);
+        Assert.False(wasOnChangedCalled);
+    }
+
+    /// <summary>Tests that Observable As Property Helpers initial value should emit initial value.</summary>
+    /// <param name = "initialValue" >The initial value.</param>
     [Theory]
     [InlineData(default(int))]
     [InlineData(42)]

--- a/src/ReactiveUI/ObservableForProperty/ObservableAsPropertyHelper.cs
+++ b/src/ReactiveUI/ObservableForProperty/ObservableAsPropertyHelper.cs
@@ -154,21 +154,23 @@ public sealed class ObservableAsPropertyHelper<T> : IHandleObservableErrors, IDi
                            ex => _thrownExceptions.Value.OnNext(ex))
                 .DisposeWith(_disposable);
 
-        _getInitialValue = getInitialValue!;
+        _getInitialValue = getInitialValue ??= () => default(T?);
 
         if (deferSubscription)
         {
             // Although there are no subscribers yet, we should skip all the values that are equal getInitialValue() instead of equal default(T?) because
-            // default(T?) is never accessable anyway when subscriptions are deferred. We're going to assume that the current value is {getInitialValue()} even
+            // default(T?) is never accessible anyway when subscriptions are deferred. We're going to assume that the current value is getInitialValue() even
             // if it hasn't been evaluated yet
-            Source = observable.SkipWhile(x => EqualityComparer<T>.Default.Equals(x, getInitialValue() /* Don't use field to avoid capturing this */))
+            Source = observable.SkipWhile(x => EqualityComparer<T?>.Default.Equals(x, getInitialValue() /* Don't use field to avoid capturing this */))
                                .DistinctUntilChanged();
         }
         else
         {
             _lastValue = _getInitialValue();
-            Source = observable.StartWith(_lastValue).DistinctUntilChanged();
-            Source.Subscribe(_subject).DisposeWith(_disposable);
+            Source = observable.StartWith(_lastValue)
+                               .DistinctUntilChanged();
+            Source.Subscribe(_subject)
+                  .DisposeWith(_disposable);
             _activated = 1;
         }
     }


### PR DESCRIPTION
Fixes #3682

<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->



**What is the current behavior?**
<!-- You can also link to an open issue here. -->

**What is the new behavior?**
<!-- If this is a feature change -->

For deferred subscriptions in OAPH 2 changes where made:

- On first `Value` access INPC is no longer emitted while the `Value` is still the initial value.

- After accessing `Value` for the first time, INPC is no longer emitted if the value produced from source is the same as the initial value


**What might this PR break?**
I don't think anything will break. It doesn't make sense for any UI framework to subscribe to INPC without reading the initial value anyway.


**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:

