### PR TITLE
Marking Observable properties from ReactiveObject and ReactiveRecord …

### DIFF
--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.DotNet6_0.verified.txt
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.DotNet6_0.verified.txt
@@ -715,12 +715,18 @@ namespace ReactiveUI
     public class ReactiveObject : ReactiveUI.IHandleObservableErrors, ReactiveUI.IReactiveNotifyPropertyChanged<ReactiveUI.IReactiveObject>, ReactiveUI.IReactiveObject, Splat.IEnableLogger, System.ComponentModel.INotifyPropertyChanged, System.ComponentModel.INotifyPropertyChanging
     {
         public ReactiveObject() { }
+        [System.ComponentModel.Browsable(false)]
+        [System.ComponentModel.DataAnnotations.Display(AutoGenerateField=false, AutoGenerateFilter=false, Order=-1)]
         [System.Runtime.Serialization.IgnoreDataMember]
         [System.Text.Json.Serialization.JsonIgnore]
         public System.IObservable<ReactiveUI.IReactivePropertyChangedEventArgs<ReactiveUI.IReactiveObject>> Changed { get; }
+        [System.ComponentModel.Browsable(false)]
+        [System.ComponentModel.DataAnnotations.Display(AutoGenerateField=false, AutoGenerateFilter=false, Order=-1)]
         [System.Runtime.Serialization.IgnoreDataMember]
         [System.Text.Json.Serialization.JsonIgnore]
         public System.IObservable<ReactiveUI.IReactivePropertyChangedEventArgs<ReactiveUI.IReactiveObject>> Changing { get; }
+        [System.ComponentModel.Browsable(false)]
+        [System.ComponentModel.DataAnnotations.Display(AutoGenerateField=false, AutoGenerateFilter=false, Order=-1)]
         [System.Runtime.Serialization.IgnoreDataMember]
         [System.Text.Json.Serialization.JsonIgnore]
         public System.IObservable<System.Exception> ThrownExceptions { get; }
@@ -744,12 +750,18 @@ namespace ReactiveUI
     public class ReactiveRecord : ReactiveUI.IHandleObservableErrors, ReactiveUI.IReactiveNotifyPropertyChanged<ReactiveUI.IReactiveObject>, ReactiveUI.IReactiveObject, Splat.IEnableLogger, System.ComponentModel.INotifyPropertyChanged, System.ComponentModel.INotifyPropertyChanging, System.IEquatable<ReactiveUI.ReactiveRecord>
     {
         public ReactiveRecord() { }
+        [System.ComponentModel.Browsable(false)]
+        [System.ComponentModel.DataAnnotations.Display(AutoGenerateField=false, AutoGenerateFilter=false, Order=-1)]
         [System.Runtime.Serialization.IgnoreDataMember]
         [System.Text.Json.Serialization.JsonIgnore]
         public System.IObservable<ReactiveUI.IReactivePropertyChangedEventArgs<ReactiveUI.IReactiveObject>> Changed { get; }
+        [System.ComponentModel.Browsable(false)]
+        [System.ComponentModel.DataAnnotations.Display(AutoGenerateField=false, AutoGenerateFilter=false, Order=-1)]
         [System.Runtime.Serialization.IgnoreDataMember]
         [System.Text.Json.Serialization.JsonIgnore]
         public System.IObservable<ReactiveUI.IReactivePropertyChangedEventArgs<ReactiveUI.IReactiveObject>> Changing { get; }
+        [System.ComponentModel.Browsable(false)]
+        [System.ComponentModel.DataAnnotations.Display(AutoGenerateField=false, AutoGenerateFilter=false, Order=-1)]
         [System.Runtime.Serialization.IgnoreDataMember]
         [System.Text.Json.Serialization.JsonIgnore]
         public System.IObservable<System.Exception> ThrownExceptions { get; }

--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.DotNet7_0.verified.txt
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.DotNet7_0.verified.txt
@@ -715,12 +715,18 @@ namespace ReactiveUI
     public class ReactiveObject : ReactiveUI.IHandleObservableErrors, ReactiveUI.IReactiveNotifyPropertyChanged<ReactiveUI.IReactiveObject>, ReactiveUI.IReactiveObject, Splat.IEnableLogger, System.ComponentModel.INotifyPropertyChanged, System.ComponentModel.INotifyPropertyChanging
     {
         public ReactiveObject() { }
+        [System.ComponentModel.Browsable(false)]
+        [System.ComponentModel.DataAnnotations.Display(AutoGenerateField=false, AutoGenerateFilter=false, Order=-1)]
         [System.Runtime.Serialization.IgnoreDataMember]
         [System.Text.Json.Serialization.JsonIgnore]
         public System.IObservable<ReactiveUI.IReactivePropertyChangedEventArgs<ReactiveUI.IReactiveObject>> Changed { get; }
+        [System.ComponentModel.Browsable(false)]
+        [System.ComponentModel.DataAnnotations.Display(AutoGenerateField=false, AutoGenerateFilter=false, Order=-1)]
         [System.Runtime.Serialization.IgnoreDataMember]
         [System.Text.Json.Serialization.JsonIgnore]
         public System.IObservable<ReactiveUI.IReactivePropertyChangedEventArgs<ReactiveUI.IReactiveObject>> Changing { get; }
+        [System.ComponentModel.Browsable(false)]
+        [System.ComponentModel.DataAnnotations.Display(AutoGenerateField=false, AutoGenerateFilter=false, Order=-1)]
         [System.Runtime.Serialization.IgnoreDataMember]
         [System.Text.Json.Serialization.JsonIgnore]
         public System.IObservable<System.Exception> ThrownExceptions { get; }
@@ -744,12 +750,18 @@ namespace ReactiveUI
     public class ReactiveRecord : ReactiveUI.IHandleObservableErrors, ReactiveUI.IReactiveNotifyPropertyChanged<ReactiveUI.IReactiveObject>, ReactiveUI.IReactiveObject, Splat.IEnableLogger, System.ComponentModel.INotifyPropertyChanged, System.ComponentModel.INotifyPropertyChanging, System.IEquatable<ReactiveUI.ReactiveRecord>
     {
         public ReactiveRecord() { }
+        [System.ComponentModel.Browsable(false)]
+        [System.ComponentModel.DataAnnotations.Display(AutoGenerateField=false, AutoGenerateFilter=false, Order=-1)]
         [System.Runtime.Serialization.IgnoreDataMember]
         [System.Text.Json.Serialization.JsonIgnore]
         public System.IObservable<ReactiveUI.IReactivePropertyChangedEventArgs<ReactiveUI.IReactiveObject>> Changed { get; }
+        [System.ComponentModel.Browsable(false)]
+        [System.ComponentModel.DataAnnotations.Display(AutoGenerateField=false, AutoGenerateFilter=false, Order=-1)]
         [System.Runtime.Serialization.IgnoreDataMember]
         [System.Text.Json.Serialization.JsonIgnore]
         public System.IObservable<ReactiveUI.IReactivePropertyChangedEventArgs<ReactiveUI.IReactiveObject>> Changing { get; }
+        [System.ComponentModel.Browsable(false)]
+        [System.ComponentModel.DataAnnotations.Display(AutoGenerateField=false, AutoGenerateFilter=false, Order=-1)]
         [System.Runtime.Serialization.IgnoreDataMember]
         [System.Text.Json.Serialization.JsonIgnore]
         public System.IObservable<System.Exception> ThrownExceptions { get; }

--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.DotNet8_0.verified.txt
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.DotNet8_0.verified.txt
@@ -715,12 +715,18 @@ namespace ReactiveUI
     public class ReactiveObject : ReactiveUI.IHandleObservableErrors, ReactiveUI.IReactiveNotifyPropertyChanged<ReactiveUI.IReactiveObject>, ReactiveUI.IReactiveObject, Splat.IEnableLogger, System.ComponentModel.INotifyPropertyChanged, System.ComponentModel.INotifyPropertyChanging
     {
         public ReactiveObject() { }
+        [System.ComponentModel.Browsable(false)]
+        [System.ComponentModel.DataAnnotations.Display(AutoGenerateField=false, AutoGenerateFilter=false, Order=-1)]
         [System.Runtime.Serialization.IgnoreDataMember]
         [System.Text.Json.Serialization.JsonIgnore]
         public System.IObservable<ReactiveUI.IReactivePropertyChangedEventArgs<ReactiveUI.IReactiveObject>> Changed { get; }
+        [System.ComponentModel.Browsable(false)]
+        [System.ComponentModel.DataAnnotations.Display(AutoGenerateField=false, AutoGenerateFilter=false, Order=-1)]
         [System.Runtime.Serialization.IgnoreDataMember]
         [System.Text.Json.Serialization.JsonIgnore]
         public System.IObservable<ReactiveUI.IReactivePropertyChangedEventArgs<ReactiveUI.IReactiveObject>> Changing { get; }
+        [System.ComponentModel.Browsable(false)]
+        [System.ComponentModel.DataAnnotations.Display(AutoGenerateField=false, AutoGenerateFilter=false, Order=-1)]
         [System.Runtime.Serialization.IgnoreDataMember]
         [System.Text.Json.Serialization.JsonIgnore]
         public System.IObservable<System.Exception> ThrownExceptions { get; }
@@ -744,12 +750,18 @@ namespace ReactiveUI
     public class ReactiveRecord : ReactiveUI.IHandleObservableErrors, ReactiveUI.IReactiveNotifyPropertyChanged<ReactiveUI.IReactiveObject>, ReactiveUI.IReactiveObject, Splat.IEnableLogger, System.ComponentModel.INotifyPropertyChanged, System.ComponentModel.INotifyPropertyChanging, System.IEquatable<ReactiveUI.ReactiveRecord>
     {
         public ReactiveRecord() { }
+        [System.ComponentModel.Browsable(false)]
+        [System.ComponentModel.DataAnnotations.Display(AutoGenerateField=false, AutoGenerateFilter=false, Order=-1)]
         [System.Runtime.Serialization.IgnoreDataMember]
         [System.Text.Json.Serialization.JsonIgnore]
         public System.IObservable<ReactiveUI.IReactivePropertyChangedEventArgs<ReactiveUI.IReactiveObject>> Changed { get; }
+        [System.ComponentModel.Browsable(false)]
+        [System.ComponentModel.DataAnnotations.Display(AutoGenerateField=false, AutoGenerateFilter=false, Order=-1)]
         [System.Runtime.Serialization.IgnoreDataMember]
         [System.Text.Json.Serialization.JsonIgnore]
         public System.IObservable<ReactiveUI.IReactivePropertyChangedEventArgs<ReactiveUI.IReactiveObject>> Changing { get; }
+        [System.ComponentModel.Browsable(false)]
+        [System.ComponentModel.DataAnnotations.Display(AutoGenerateField=false, AutoGenerateFilter=false, Order=-1)]
         [System.Runtime.Serialization.IgnoreDataMember]
         [System.Text.Json.Serialization.JsonIgnore]
         public System.IObservable<System.Exception> ThrownExceptions { get; }

--- a/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.Net4_7.verified.txt
+++ b/src/ReactiveUI.Tests/API/ApiApprovalTests.ReactiveUI.Net4_7.verified.txt
@@ -720,12 +720,18 @@ namespace ReactiveUI
     public class ReactiveObject : ReactiveUI.IHandleObservableErrors, ReactiveUI.IReactiveNotifyPropertyChanged<ReactiveUI.IReactiveObject>, ReactiveUI.IReactiveObject, Splat.IEnableLogger, System.ComponentModel.INotifyPropertyChanged, System.ComponentModel.INotifyPropertyChanging
     {
         public ReactiveObject() { }
+        [System.ComponentModel.Browsable(false)]
+        [System.ComponentModel.DataAnnotations.Display(AutoGenerateField=false, AutoGenerateFilter=false, Order=-1)]
         [System.Runtime.Serialization.IgnoreDataMember]
         [System.Text.Json.Serialization.JsonIgnore]
         public System.IObservable<ReactiveUI.IReactivePropertyChangedEventArgs<ReactiveUI.IReactiveObject>> Changed { get; }
+        [System.ComponentModel.Browsable(false)]
+        [System.ComponentModel.DataAnnotations.Display(AutoGenerateField=false, AutoGenerateFilter=false, Order=-1)]
         [System.Runtime.Serialization.IgnoreDataMember]
         [System.Text.Json.Serialization.JsonIgnore]
         public System.IObservable<ReactiveUI.IReactivePropertyChangedEventArgs<ReactiveUI.IReactiveObject>> Changing { get; }
+        [System.ComponentModel.Browsable(false)]
+        [System.ComponentModel.DataAnnotations.Display(AutoGenerateField=false, AutoGenerateFilter=false, Order=-1)]
         [System.Runtime.Serialization.IgnoreDataMember]
         [System.Text.Json.Serialization.JsonIgnore]
         public System.IObservable<System.Exception> ThrownExceptions { get; }
@@ -749,12 +755,18 @@ namespace ReactiveUI
     public class ReactiveRecord : ReactiveUI.IHandleObservableErrors, ReactiveUI.IReactiveNotifyPropertyChanged<ReactiveUI.IReactiveObject>, ReactiveUI.IReactiveObject, Splat.IEnableLogger, System.ComponentModel.INotifyPropertyChanged, System.ComponentModel.INotifyPropertyChanging, System.IEquatable<ReactiveUI.ReactiveRecord>
     {
         public ReactiveRecord() { }
+        [System.ComponentModel.Browsable(false)]
+        [System.ComponentModel.DataAnnotations.Display(AutoGenerateField=false, AutoGenerateFilter=false, Order=-1)]
         [System.Runtime.Serialization.IgnoreDataMember]
         [System.Text.Json.Serialization.JsonIgnore]
         public System.IObservable<ReactiveUI.IReactivePropertyChangedEventArgs<ReactiveUI.IReactiveObject>> Changed { get; }
+        [System.ComponentModel.Browsable(false)]
+        [System.ComponentModel.DataAnnotations.Display(AutoGenerateField=false, AutoGenerateFilter=false, Order=-1)]
         [System.Runtime.Serialization.IgnoreDataMember]
         [System.Text.Json.Serialization.JsonIgnore]
         public System.IObservable<ReactiveUI.IReactivePropertyChangedEventArgs<ReactiveUI.IReactiveObject>> Changing { get; }
+        [System.ComponentModel.Browsable(false)]
+        [System.ComponentModel.DataAnnotations.Display(AutoGenerateField=false, AutoGenerateFilter=false, Order=-1)]
         [System.Runtime.Serialization.IgnoreDataMember]
         [System.Text.Json.Serialization.JsonIgnore]
         public System.IObservable<System.Exception> ThrownExceptions { get; }

--- a/src/ReactiveUI/GlobalUsings.cs
+++ b/src/ReactiveUI/GlobalUsings.cs
@@ -8,7 +8,9 @@ global using global::System;
 global using global::System.Collections.Generic;
 global using global::System.Collections.ObjectModel;
 global using global::System.ComponentModel;
+#if !MONO
 global using global::System.ComponentModel.DataAnnotations;
+#endif
 global using global::System.Diagnostics.CodeAnalysis;
 global using global::System.Linq;
 global using global::System.Linq.Expressions;

--- a/src/ReactiveUI/GlobalUsings.cs
+++ b/src/ReactiveUI/GlobalUsings.cs
@@ -8,6 +8,7 @@ global using global::System;
 global using global::System.Collections.Generic;
 global using global::System.Collections.ObjectModel;
 global using global::System.ComponentModel;
+global using global::System.ComponentModel.DataAnnotations;
 global using global::System.Diagnostics.CodeAnalysis;
 global using global::System.Linq;
 global using global::System.Linq.Expressions;

--- a/src/ReactiveUI/ReactiveObject/ReactiveObject.cs
+++ b/src/ReactiveUI/ReactiveObject/ReactiveObject.cs
@@ -72,22 +72,28 @@ public class ReactiveObject : IReactiveNotifyPropertyChanged<IReactiveObject>, I
     /// <inheritdoc />
     [IgnoreDataMember]
     [JsonIgnore]
+#if !MONO
     [Browsable(false)]
     [Display(Order = -1, AutoGenerateField = false, AutoGenerateFilter = false)]
+#endif
     public IObservable<IReactivePropertyChangedEventArgs<IReactiveObject>> Changing => _changing.Value;
 
     /// <inheritdoc />
     [IgnoreDataMember]
     [JsonIgnore]
+#if !MONO
     [Browsable(false)]
     [Display(Order = -1, AutoGenerateField = false, AutoGenerateFilter = false)]
+#endif
     public IObservable<IReactivePropertyChangedEventArgs<IReactiveObject>> Changed => _changed.Value;
 
     /// <inheritdoc/>
     [IgnoreDataMember]
     [JsonIgnore]
+#if !MONO
     [Browsable(false)]
     [Display(Order = -1, AutoGenerateField = false, AutoGenerateFilter = false)]
+#endif
     public IObservable<Exception> ThrownExceptions => _thrownExceptions.Value;
 
     /// <inheritdoc/>

--- a/src/ReactiveUI/ReactiveObject/ReactiveObject.cs
+++ b/src/ReactiveUI/ReactiveObject/ReactiveObject.cs
@@ -72,16 +72,19 @@ public class ReactiveObject : IReactiveNotifyPropertyChanged<IReactiveObject>, I
     /// <inheritdoc />
     [IgnoreDataMember]
     [JsonIgnore]
+    [Browsable(false), Display(Order = -1, AutoGenerateField = false, AutoGenerateFilter = false)]
     public IObservable<IReactivePropertyChangedEventArgs<IReactiveObject>> Changing => _changing.Value;
 
     /// <inheritdoc />
     [IgnoreDataMember]
     [JsonIgnore]
+    [Browsable(false), Display(Order = -1, AutoGenerateField = false, AutoGenerateFilter = false)]
     public IObservable<IReactivePropertyChangedEventArgs<IReactiveObject>> Changed => _changed.Value;
 
     /// <inheritdoc/>
     [IgnoreDataMember]
     [JsonIgnore]
+    [Browsable(false), Display(Order = -1, AutoGenerateField = false, AutoGenerateFilter = false)]
     public IObservable<Exception> ThrownExceptions => _thrownExceptions.Value;
 
     /// <inheritdoc/>

--- a/src/ReactiveUI/ReactiveObject/ReactiveObject.cs
+++ b/src/ReactiveUI/ReactiveObject/ReactiveObject.cs
@@ -72,19 +72,22 @@ public class ReactiveObject : IReactiveNotifyPropertyChanged<IReactiveObject>, I
     /// <inheritdoc />
     [IgnoreDataMember]
     [JsonIgnore]
-    [Browsable(false), Display(Order = -1, AutoGenerateField = false, AutoGenerateFilter = false)]
+    [Browsable(false)]
+    [Display(Order = -1, AutoGenerateField = false, AutoGenerateFilter = false)]
     public IObservable<IReactivePropertyChangedEventArgs<IReactiveObject>> Changing => _changing.Value;
 
     /// <inheritdoc />
     [IgnoreDataMember]
     [JsonIgnore]
-    [Browsable(false), Display(Order = -1, AutoGenerateField = false, AutoGenerateFilter = false)]
+    [Browsable(false)]
+    [Display(Order = -1, AutoGenerateField = false, AutoGenerateFilter = false)]
     public IObservable<IReactivePropertyChangedEventArgs<IReactiveObject>> Changed => _changed.Value;
 
     /// <inheritdoc/>
     [IgnoreDataMember]
     [JsonIgnore]
-    [Browsable(false), Display(Order = -1, AutoGenerateField = false, AutoGenerateFilter = false)]
+    [Browsable(false)]
+    [Display(Order = -1, AutoGenerateField = false, AutoGenerateFilter = false)]
     public IObservable<Exception> ThrownExceptions => _thrownExceptions.Value;
 
     /// <inheritdoc/>

--- a/src/ReactiveUI/ReactiveObject/ReactiveRecord.cs
+++ b/src/ReactiveUI/ReactiveObject/ReactiveRecord.cs
@@ -72,21 +72,24 @@ public record ReactiveRecord : IReactiveNotifyPropertyChanged<IReactiveObject>, 
     /// <inheritdoc />
     [IgnoreDataMember]
     [JsonIgnore]
-    [Browsable(false), Display(Order = -1, AutoGenerateField = false, AutoGenerateFilter = false)]
+    [Browsable(false)]
+    [Display(Order = -1, AutoGenerateField = false, AutoGenerateFilter = false)]
     public IObservable<IReactivePropertyChangedEventArgs<IReactiveObject>> Changing => // TODO: Create Test
         _changing.Value;
 
     /// <inheritdoc />
     [IgnoreDataMember]
     [JsonIgnore]
-    [Browsable(false), Display(Order = -1, AutoGenerateField = false, AutoGenerateFilter = false)]
+    [Browsable(false)]
+    [Display(Order = -1, AutoGenerateField = false, AutoGenerateFilter = false)]
     public IObservable<IReactivePropertyChangedEventArgs<IReactiveObject>> Changed => // TODO: Create Test
         _changed.Value;
 
     /// <inheritdoc/>
     [IgnoreDataMember]
     [JsonIgnore]
-    [Browsable(false), Display(Order = -1, AutoGenerateField = false, AutoGenerateFilter = false)]
+    [Browsable(false)]
+    [Display(Order = -1, AutoGenerateField = false, AutoGenerateFilter = false)]
     public IObservable<Exception> ThrownExceptions => _thrownExceptions.Value;
 
     /// <inheritdoc/>

--- a/src/ReactiveUI/ReactiveObject/ReactiveRecord.cs
+++ b/src/ReactiveUI/ReactiveObject/ReactiveRecord.cs
@@ -72,18 +72,21 @@ public record ReactiveRecord : IReactiveNotifyPropertyChanged<IReactiveObject>, 
     /// <inheritdoc />
     [IgnoreDataMember]
     [JsonIgnore]
+    [Browsable(false), Display(Order = -1, AutoGenerateField = false, AutoGenerateFilter = false)]
     public IObservable<IReactivePropertyChangedEventArgs<IReactiveObject>> Changing => // TODO: Create Test
         _changing.Value;
 
     /// <inheritdoc />
     [IgnoreDataMember]
     [JsonIgnore]
+    [Browsable(false), Display(Order = -1, AutoGenerateField = false, AutoGenerateFilter = false)]
     public IObservable<IReactivePropertyChangedEventArgs<IReactiveObject>> Changed => // TODO: Create Test
         _changed.Value;
 
     /// <inheritdoc/>
     [IgnoreDataMember]
     [JsonIgnore]
+    [Browsable(false), Display(Order = -1, AutoGenerateField = false, AutoGenerateFilter = false)]
     public IObservable<Exception> ThrownExceptions => _thrownExceptions.Value;
 
     /// <inheritdoc/>

--- a/src/ReactiveUI/ReactiveObject/ReactiveRecord.cs
+++ b/src/ReactiveUI/ReactiveObject/ReactiveRecord.cs
@@ -72,24 +72,30 @@ public record ReactiveRecord : IReactiveNotifyPropertyChanged<IReactiveObject>, 
     /// <inheritdoc />
     [IgnoreDataMember]
     [JsonIgnore]
+#if !MONO
     [Browsable(false)]
     [Display(Order = -1, AutoGenerateField = false, AutoGenerateFilter = false)]
+#endif
     public IObservable<IReactivePropertyChangedEventArgs<IReactiveObject>> Changing => // TODO: Create Test
         _changing.Value;
 
     /// <inheritdoc />
     [IgnoreDataMember]
     [JsonIgnore]
+#if !MONO
     [Browsable(false)]
     [Display(Order = -1, AutoGenerateField = false, AutoGenerateFilter = false)]
+#endif
     public IObservable<IReactivePropertyChangedEventArgs<IReactiveObject>> Changed => // TODO: Create Test
         _changed.Value;
 
     /// <inheritdoc/>
     [IgnoreDataMember]
     [JsonIgnore]
+#if !MONO
     [Browsable(false)]
     [Display(Order = -1, AutoGenerateField = false, AutoGenerateFilter = false)]
+#endif
     public IObservable<Exception> ThrownExceptions => _thrownExceptions.Value;
 
     /// <inheritdoc/>

--- a/src/ReactiveUI/ReactiveUI.csproj
+++ b/src/ReactiveUI/ReactiveUI.csproj
@@ -36,6 +36,7 @@
     <Compile Include="Platforms\netstandard2.0\**\*.cs" />
     <Compile Include="Platforms\shared\**\*.cs" />
     <PackageReference Include="System.ComponentModel" Version="4.3.0" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Diagnostics.Contracts" Version="4.3.0" />
     <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
@@ -106,6 +107,7 @@
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) or '$(TargetFramework)' == 'net6.0' or '$(TargetFramework)' == 'net7.0' or '$(TargetFramework)' == 'net8.0' or $(TargetFramework.EndsWith('-windows10.0.17763.0')) or $(TargetFramework.EndsWith('-windows10.0.19041.0')) ">
     <Compile Include="Platforms\net\**\*.cs" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('uap')) ">
@@ -130,7 +132,6 @@
   <ItemGroup>
     <PackageReference Include="Splat" Version="14.*" />
     <PackageReference Include="DynamicData" Version="8.*" />
-    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Text.Json" Version="8.0.0" />
   </ItemGroup>
 

--- a/src/ReactiveUI/ReactiveUI.csproj
+++ b/src/ReactiveUI/ReactiveUI.csproj
@@ -36,6 +36,7 @@
     <Compile Include="Platforms\netstandard2.0\**\*.cs" />
     <Compile Include="Platforms\shared\**\*.cs" />
     <PackageReference Include="System.ComponentModel" Version="4.3.0" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Diagnostics.Contracts" Version="4.3.0" />
     <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
@@ -130,7 +131,6 @@
   <ItemGroup>
     <PackageReference Include="Splat" Version="14.*" />
     <PackageReference Include="DynamicData" Version="8.*" />
-    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Text.Json" Version="8.0.0" />
   </ItemGroup>
 

--- a/src/ReactiveUI/ReactiveUI.csproj
+++ b/src/ReactiveUI/ReactiveUI.csproj
@@ -36,7 +36,6 @@
     <Compile Include="Platforms\netstandard2.0\**\*.cs" />
     <Compile Include="Platforms\shared\**\*.cs" />
     <PackageReference Include="System.ComponentModel" Version="4.3.0" />
-    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Diagnostics.Contracts" Version="4.3.0" />
     <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
@@ -131,6 +130,7 @@
   <ItemGroup>
     <PackageReference Include="Splat" Version="14.*" />
     <PackageReference Include="DynamicData" Version="8.*" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Text.Json" Version="8.0.0" />
   </ItemGroup>
 

--- a/src/ReactiveUI/ReactiveUI.csproj
+++ b/src/ReactiveUI/ReactiveUI.csproj
@@ -130,6 +130,7 @@
   <ItemGroup>
     <PackageReference Include="Splat" Version="14.*" />
     <PackageReference Include="DynamicData" Version="8.*" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Text.Json" Version="8.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
…as no browsable, no displayable, no autogenerateable and no autofilterable for Winforms control databindings (and possibly for WPF controls too)

Fixes #3694 

**What kind of change does this PR introduce?**
Assign new attributes on Observable properties for better hiding from Winforms/WPF


**What is the current behavior?**
Those properties are autogenerated as controls


**What is the new behavior?**
Those properties are ignored as controls



**What might this PR break?**


**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

