### PR TITLE
Feature: Add ReactiveUI.Maui.Plugins.Popup

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -19,6 +19,7 @@
     <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.3233" />
     <PackageVersion Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.77" />
     <PackageVersion Include="Mocks.Maui" Version="1.1.4" />
+    <PackageVersion Include="Mopups" Version="1.3.1" />
     <PackageVersion Include="Nerdbank.GitVersioning" Version="3.6.133" />
     <PackageVersion Include="PublicApiGenerator" Version="11.1.0" />
     <PackageVersion Include="Reactive.Wasm" Version="2.1.2" />

--- a/src/ReactiveUI.Maui.Plugins.Popup/INavigationMixins.cs
+++ b/src/ReactiveUI.Maui.Plugins.Popup/INavigationMixins.cs
@@ -1,0 +1,118 @@
+﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Reactive;
+using System.Reactive.Linq;
+using Mopups.Events;
+using Mopups.Pages;
+using Mopups.Services;
+
+namespace ReactiveUI.Maui.Plugins.Popup;
+
+/// <summary>
+/// INavigation Mixins.
+/// </summary>
+public static class INavigationMixins
+{
+    /// <summary>
+    /// Pops all popup.
+    /// </summary>
+    /// <param name="navigation">The navigation.</param>
+    /// <param name="animate">if set to <c>true</c> [animate].</param>
+    /// <returns>An Observable of Unit.</returns>
+    public static IObservable<Unit> PopAllPopup(this INavigation navigation, bool animate = true) =>
+               Observable.FromAsync(async _ => await MopupService.Instance.PopAllAsync(animate).ConfigureAwait(false));
+
+    /// <summary>
+    /// Pops the popup.
+    /// </summary>
+    /// <param name="navigation">The navigation.</param>
+    /// <param name="animate">if set to <c>true</c> [animate].</param>
+    /// <returns>An Observable of Unit.</returns>
+    public static IObservable<Unit> PopPopup(this INavigation navigation, bool animate = true) =>
+        Observable.FromAsync(async _ => await MopupService.Instance.PopAsync(animate).ConfigureAwait(false));
+
+    /// <summary>
+    /// Pushes the popup.
+    /// </summary>
+    /// <typeparam name="T">The Type of Popup Page.</typeparam>
+    /// <param name="navigation">The navigation.</param>
+    /// <param name="page">The popup page.</param>
+    /// <param name="animate">if set to <c>true</c> [animate].</param>
+    /// <returns>An Observable of Unit.</returns>
+    public static IObservable<Unit> PushPopup<T>(this INavigation navigation, T page, bool animate = true)
+        where T : PopupPage => Observable.FromAsync(async _ => await MopupService.Instance.PushAsync(page, animate).ConfigureAwait(false));
+
+    /// <summary>
+    /// Removes the popup page.
+    /// </summary>
+    /// <typeparam name="T">The Type of Popup Page.</typeparam>
+    /// <param name="navigation">The navigation.</param>
+    /// <param name="page">The popup page.</param>
+    /// <param name="animate">if set to <c>true</c> [animate].</param>
+    /// <returns>An Observable of Unit.</returns>
+    public static IObservable<Unit> RemovePopupPage<T>(this INavigation navigation, T page, bool animate = true)
+        where T : PopupPage => Observable.FromAsync(async _ => await MopupService.Instance.RemovePageAsync(page, animate).ConfigureAwait(false));
+
+    /// <summary>
+    /// Poppings the specified service.
+    /// </summary>
+    /// <param name="navigation">The service.</param>
+    /// <returns>A PopupNavigationEventArgs.</returns>
+    public static IObservable<PopupNavigationEventArgs> PoppingObservable(this INavigation navigation) =>
+        Observable.FromEvent<EventHandler<PopupNavigationEventArgs>, PopupNavigationEventArgs>(
+                    handler =>
+                    {
+                        void EventHandler(object? sender, PopupNavigationEventArgs args) => handler(args);
+                        return EventHandler;
+                    },
+                    x => MopupService.Instance.Popping += x,
+                    x => MopupService.Instance.Popping -= x);
+
+    /// <summary>
+    /// Poppeds the observable.
+    /// </summary>
+    /// <param name="navigation">The service.</param>
+    /// <returns>A PopupNavigationEventArgs.</returns>
+    public static IObservable<PopupNavigationEventArgs> PoppedObservable(this INavigation navigation) =>
+        Observable.FromEvent<EventHandler<PopupNavigationEventArgs>, PopupNavigationEventArgs>(
+                    handler =>
+                    {
+                        void EventHandler(object? sender, PopupNavigationEventArgs args) => handler(args);
+                        return EventHandler;
+                    },
+                    x => MopupService.Instance.Popped += x,
+                    x => MopupService.Instance.Popped -= x);
+
+    /// <summary>
+    /// Pushings the observable.
+    /// </summary>
+    /// <param name="navigation">The service.</param>
+    /// <returns>A PopupNavigationEventArgs.</returns>
+    public static IObservable<PopupNavigationEventArgs> PushingObservable(this INavigation navigation) =>
+        Observable.FromEvent<EventHandler<PopupNavigationEventArgs>, PopupNavigationEventArgs>(
+                    handler =>
+                    {
+                        void EventHandler(object? sender, PopupNavigationEventArgs args) => handler(args);
+                        return EventHandler;
+                    },
+                    x => MopupService.Instance.Pushing += x,
+                    x => MopupService.Instance.Pushing -= x);
+
+    /// <summary>
+    /// Pusheds the observable.
+    /// </summary>
+    /// <param name="navigation">The service.</param>
+    /// <returns>A PopupNavigationEventArgs.</returns>
+    public static IObservable<PopupNavigationEventArgs> PushedObservable(this INavigation navigation) =>
+        Observable.FromEvent<EventHandler<PopupNavigationEventArgs>, PopupNavigationEventArgs>(
+                    handler =>
+                    {
+                        void EventHandler(object? sender, PopupNavigationEventArgs args) => handler(args);
+                        return EventHandler;
+                    },
+                    x => MopupService.Instance.Pushed += x,
+                    x => MopupService.Instance.Pushed -= x);
+}

--- a/src/ReactiveUI.Maui.Plugins.Popup/IPopupNavigationMixins.cs
+++ b/src/ReactiveUI.Maui.Plugins.Popup/IPopupNavigationMixins.cs
@@ -1,0 +1,118 @@
+﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Reactive;
+using System.Reactive.Linq;
+using Mopups.Events;
+using Mopups.Interfaces;
+using Mopups.Pages;
+
+namespace ReactiveUI.Maui.Plugins.Popup;
+
+/// <summary>
+/// IPopupNavigation Mixins.
+/// </summary>
+public static class IPopupNavigationMixins
+{
+    /// <summary>
+    /// Pops all popup.
+    /// </summary>
+    /// <param name="service">The navigation.</param>
+    /// <param name="animate">if set to <c>true</c> [animate].</param>
+    /// <returns>An Observable of Unit.</returns>
+    public static IObservable<Unit> PopAllPopup(this IPopupNavigation service, bool animate = true) =>
+               Observable.FromAsync(async _ => await service.PopAllAsync(animate).ConfigureAwait(false));
+
+    /// <summary>
+    /// Pops the popup.
+    /// </summary>
+    /// <param name="service">The navigation.</param>
+    /// <param name="animate">if set to <c>true</c> [animate].</param>
+    /// <returns>An Observable of Unit.</returns>
+    public static IObservable<Unit> PopPopup(this IPopupNavigation service, bool animate = true) =>
+        Observable.FromAsync(async _ => await service.PopAsync(animate).ConfigureAwait(false));
+
+    /// <summary>
+    /// Pushes the popup.
+    /// </summary>
+    /// <typeparam name="T">The Type of Popup Page.</typeparam>
+    /// <param name="service">The navigation.</param>
+    /// <param name="page">The popup page.</param>
+    /// <param name="animate">if set to <c>true</c> [animate].</param>
+    /// <returns>An Observable of Unit.</returns>
+    public static IObservable<Unit> PushPopup<T>(this IPopupNavigation service, T page, bool animate = true)
+        where T : PopupPage => Observable.FromAsync(async _ => await service.PushAsync(page, animate).ConfigureAwait(false));
+
+    /// <summary>
+    /// Removes the popup page.
+    /// </summary>
+    /// <typeparam name="T">The Type of Popup Page.</typeparam>
+    /// <param name="service">The navigation.</param>
+    /// <param name="page">The popup page.</param>
+    /// <param name="animate">if set to <c>true</c> [animate].</param>
+    /// <returns>An Observable of Unit.</returns>
+    public static IObservable<Unit> RemovePopupPage<T>(this IPopupNavigation service, T page, bool animate = true)
+        where T : PopupPage => Observable.FromAsync(async _ => await service.RemovePageAsync(page, animate).ConfigureAwait(false));
+
+    /// <summary>
+    /// Poppings the specified service.
+    /// </summary>
+    /// <param name="service">The service.</param>
+    /// <returns>A PopupNavigationEventArgs.</returns>
+    public static IObservable<PopupNavigationEventArgs> PoppingObservable(this IPopupNavigation service) =>
+        Observable.FromEvent<EventHandler<PopupNavigationEventArgs>, PopupNavigationEventArgs>(
+                    handler =>
+                    {
+                        void EventHandler(object? sender, PopupNavigationEventArgs args) => handler(args);
+                        return EventHandler;
+                    },
+                    x => service.Popping += x,
+                    x => service.Popping -= x);
+
+    /// <summary>
+    /// Poppeds the observable.
+    /// </summary>
+    /// <param name="service">The service.</param>
+    /// <returns>A PopupNavigationEventArgs.</returns>
+    public static IObservable<PopupNavigationEventArgs> PoppedObservable(this IPopupNavigation service) =>
+        Observable.FromEvent<EventHandler<PopupNavigationEventArgs>, PopupNavigationEventArgs>(
+                    handler =>
+                    {
+                        void EventHandler(object? sender, PopupNavigationEventArgs args) => handler(args);
+                        return EventHandler;
+                    },
+                    x => service.Popped += x,
+                    x => service.Popped -= x);
+
+    /// <summary>
+    /// Pushings the observable.
+    /// </summary>
+    /// <param name="service">The service.</param>
+    /// <returns>A PopupNavigationEventArgs.</returns>
+    public static IObservable<PopupNavigationEventArgs> PushingObservable(this IPopupNavigation service) =>
+        Observable.FromEvent<EventHandler<PopupNavigationEventArgs>, PopupNavigationEventArgs>(
+                    handler =>
+                    {
+                        void EventHandler(object? sender, PopupNavigationEventArgs args) => handler(args);
+                        return EventHandler;
+                    },
+                    x => service.Pushing += x,
+                    x => service.Pushing -= x);
+
+    /// <summary>
+    /// Pusheds the observable.
+    /// </summary>
+    /// <param name="service">The service.</param>
+    /// <returns>A PopupNavigationEventArgs.</returns>
+    public static IObservable<PopupNavigationEventArgs> PushedObservable(this IPopupNavigation service) =>
+        Observable.FromEvent<EventHandler<PopupNavigationEventArgs>, PopupNavigationEventArgs>(
+                    handler =>
+                    {
+                        void EventHandler(object? sender, PopupNavigationEventArgs args) => handler(args);
+                        return EventHandler;
+                    },
+                    x => service.Pushed += x,
+                    x => service.Pushed -= x);
+}

--- a/src/ReactiveUI.Maui.Plugins.Popup/MauiAppBuilderMixins.cs
+++ b/src/ReactiveUI.Maui.Plugins.Popup/MauiAppBuilderMixins.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Mopups.Hosting;
+using ReactiveUI;
+using ReactiveUI.Maui.Plugins.Popup;
+using Splat;
+
+namespace Microsoft.Maui.Hosting;
+
+/// <summary>
+/// INavigation Mixins.
+/// </summary>
+public static class MauiAppBuilderMixins
+{
+    /// <summary>
+    /// Registers all the default registrations that are needed by the Splat module.
+    /// Initialize resolvers with the default ReactiveUI types.
+    /// Configures ReactiveUI Maui Mopups.
+    /// </summary>
+    /// <param name="builder">The builder.</param>
+    /// <returns>MauiAppBuilder.</returns>
+    public static MauiAppBuilder ConfigureReactiveUIPopup(this MauiAppBuilder builder)
+    {
+        builder.ConfigureMopups();
+        var resolver = Locator.CurrentMutable;
+        resolver.InitializeSplat();
+        resolver.InitializeReactiveUI(RegistrationNamespace.Maui);
+        return builder;
+    }
+
+    /// <summary>
+    /// Configures the reactive UI mopups.
+    /// </summary>
+    /// <param name="builder">The builder.</param>
+    /// <param name="backPressHandler">The back press handler.</param>
+    /// <returns>MauiAppBuilder.</returns>
+    public static MauiAppBuilder ConfigureReactiveUIPopup(this MauiAppBuilder builder, Action? backPressHandler)
+    {
+        builder.ConfigureMopups(backPressHandler);
+        var resolver = Locator.CurrentMutable;
+        resolver.InitializeSplat();
+        resolver.InitializeReactiveUI(RegistrationNamespace.Maui);
+        return builder;
+    }
+}

--- a/src/ReactiveUI.Maui.Plugins.Popup/ReactivePopupPage.cs
+++ b/src/ReactiveUI.Maui.Plugins.Popup/ReactivePopupPage.cs
@@ -1,0 +1,81 @@
+﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Reactive;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using Mopups.Pages;
+
+namespace ReactiveUI.Maui.Plugins.Popup;
+
+/// <summary>
+/// Base Popup page for that implements <see cref="IViewFor"/>.
+/// </summary>
+public abstract class ReactivePopupPage : PopupPage, IViewFor
+{
+    /// <summary>
+    /// The view model property.
+    /// </summary>
+    public static readonly BindableProperty ViewModelProperty = BindableProperty.Create(
+        nameof(ViewModel),
+        typeof(object),
+        typeof(IViewFor<object>),
+        default,
+        BindingMode.OneWay,
+        propertyChanged: OnViewModelChanged);
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ReactivePopupPage"/> class.
+    /// </summary>
+    protected ReactivePopupPage() => BackgroundClick =
+            Observable.FromEvent<EventHandler, Unit>(
+                    handler =>
+                    {
+                        void EventHandler(object? sender, EventArgs args) => handler(Unit.Default);
+                        return EventHandler;
+                    },
+                    x => BackgroundClicked += x,
+                    x => BackgroundClicked -= x)
+                .Select(_ => Unit.Default);
+
+    /// <summary>
+    /// Gets or sets the background click observable signal.
+    /// </summary>
+    /// <value>The background click.</value>
+    public IObservable<Unit> BackgroundClick { get; protected set; }
+
+    /// <summary>
+    /// Gets or sets the ViewModel to display.
+    /// </summary>
+    public object? ViewModel
+    {
+        get => GetValue(ViewModelProperty);
+        set => SetValue(ViewModelProperty, value);
+    }
+
+    /// <summary>
+    /// Gets the control binding disposable.
+    /// </summary>
+    protected CompositeDisposable ControlBindings { get; } = [];
+
+    /// <summary>
+    /// Called when [view model changed].
+    /// </summary>
+    /// <param name="bindableObject">The bindable object.</param>
+    /// <param name="oldValue">The old value.</param>
+    /// <param name="newValue">The new value.</param>
+    protected static void OnViewModelChanged(BindableObject bindableObject, object oldValue, object newValue)
+    {
+        ArgumentNullException.ThrowIfNull(bindableObject);
+        bindableObject.BindingContext = newValue;
+    }
+
+    /// <inheritdoc/>
+    protected override void OnBindingContextChanged()
+    {
+        base.OnBindingContextChanged();
+        ViewModel = BindingContext;
+    }
+}

--- a/src/ReactiveUI.Maui.Plugins.Popup/ReactivePopupPage{TViewModel}.cs
+++ b/src/ReactiveUI.Maui.Plugins.Popup/ReactivePopupPage{TViewModel}.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace ReactiveUI.Maui.Plugins.Popup;
+
+/// <summary>
+/// Base Popup page for that implements <see cref="IViewFor"/>.
+/// </summary>
+/// <typeparam name="TViewModel">The view model type.</typeparam>
+public abstract class ReactivePopupPage<TViewModel> : ReactivePopupPage, IViewFor<TViewModel>
+    where TViewModel : class
+{
+    /// <summary>
+    /// The view model property.
+    /// </summary>
+    public static new readonly BindableProperty ViewModelProperty = BindableProperty.Create(
+         nameof(ViewModel),
+         typeof(TViewModel),
+         typeof(ReactivePopupPage<TViewModel>),
+         default(TViewModel),
+         BindingMode.OneWay,
+         propertyChanged: OnViewModelChanged);
+
+    /// <summary>
+    /// Gets or sets the ViewModel to display.
+    /// </summary>
+    public new TViewModel? ViewModel
+    {
+        get => (TViewModel?)GetValue(ViewModelProperty);
+        set => SetValue(ViewModelProperty, value);
+    }
+
+    /// <inheritdoc/>
+    protected override void OnBindingContextChanged()
+    {
+        base.OnBindingContextChanged();
+        ViewModel = BindingContext as TViewModel;
+    }
+}

--- a/src/ReactiveUI.Maui.Plugins.Popup/ReactiveUI.Maui.Plugins.Popup.csproj
+++ b/src/ReactiveUI.Maui.Plugins.Popup/ReactiveUI.Maui.Plugins.Popup.csproj
@@ -1,0 +1,29 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFrameworks>net8.0;net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
+    <PackageDescription>Contains the ReactiveUI platform specific extensions for Microsoft Maui Popup</PackageDescription>
+    <PackageTags>mvvm;reactiveui;rx;reactive extensions;observable;LINQ;events;frp;maui;android;ios;mac;windows;net;popup</PackageTags>
+		<UseMaui>true</UseMaui>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+
+		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">11.0</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">13.1</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
+		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
+		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
+	</PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Maui.Controls" />
+    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" />
+    <PackageReference Include="Mopups" />
+  </ItemGroup>
+
+	<ItemGroup>
+	  <ProjectReference Include="..\ReactiveUI.Maui\ReactiveUI.Maui.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/src/ReactiveUI.sln
+++ b/src/ReactiveUI.sln
@@ -1,4 +1,3 @@
-﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31825.309
@@ -47,6 +46,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ReactiveUI.Maui", "Reactive
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ReactiveUI.WinUI", "ReactiveUI.WinUI\ReactiveUI.WinUI.csproj", "{4FF9F04B-928E-47B6-836F-546B584F597C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReactiveUI.Maui.Plugins.Popup", "ReactiveUI.Maui.Plugins.Popup\ReactiveUI.Maui.Plugins.Popup.csproj", "{A3E5D49F-00ED-4C9F-AB14-BDF6998D1F23}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -75,6 +76,22 @@ Global
 		{464CB812-F99F-401B-BE4C-E8F0515CD19D}.Release|x64.Build.0 = Release|Any CPU
 		{464CB812-F99F-401B-BE4C-E8F0515CD19D}.Release|x86.ActiveCfg = Release|Any CPU
 		{464CB812-F99F-401B-BE4C-E8F0515CD19D}.Release|x86.Build.0 = Release|Any CPU
+		{A3E5D49F-00ED-4C9F-AB14-BDF6998D1F23}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A3E5D49F-00ED-4C9F-AB14-BDF6998D1F23}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A3E5D49F-00ED-4C9F-AB14-BDF6998D1F23}.Debug|arm64.ActiveCfg = Debug|Any CPU
+		{A3E5D49F-00ED-4C9F-AB14-BDF6998D1F23}.Debug|arm64.Build.0 = Debug|Any CPU
+		{A3E5D49F-00ED-4C9F-AB14-BDF6998D1F23}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A3E5D49F-00ED-4C9F-AB14-BDF6998D1F23}.Debug|x64.Build.0 = Debug|Any CPU
+		{A3E5D49F-00ED-4C9F-AB14-BDF6998D1F23}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A3E5D49F-00ED-4C9F-AB14-BDF6998D1F23}.Debug|x86.Build.0 = Debug|Any CPU
+		{A3E5D49F-00ED-4C9F-AB14-BDF6998D1F23}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A3E5D49F-00ED-4C9F-AB14-BDF6998D1F23}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A3E5D49F-00ED-4C9F-AB14-BDF6998D1F23}.Release|arm64.ActiveCfg = Release|Any CPU
+		{A3E5D49F-00ED-4C9F-AB14-BDF6998D1F23}.Release|arm64.Build.0 = Release|Any CPU
+		{A3E5D49F-00ED-4C9F-AB14-BDF6998D1F23}.Release|x64.ActiveCfg = Release|Any CPU
+		{A3E5D49F-00ED-4C9F-AB14-BDF6998D1F23}.Release|x64.Build.0 = Release|Any CPU
+		{A3E5D49F-00ED-4C9F-AB14-BDF6998D1F23}.Release|x86.ActiveCfg = Release|Any CPU
+		{A3E5D49F-00ED-4C9F-AB14-BDF6998D1F23}.Release|x86.Build.0 = Release|Any CPU
 		{DDF89A7A-5CC9-4243-98E4-462860D5D963}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{DDF89A7A-5CC9-4243-98E4-462860D5D963}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DDF89A7A-5CC9-4243-98E4-462860D5D963}.Debug|arm64.ActiveCfg = Debug|Any CPU


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Feature

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

A version of Popups existed previously RxUI.Plugins.Pop - this was based on Xamarin.Forms

**What is the new behavior?**
<!-- If this is a feature change -->

ReactiveUI.Maui.Plugins.Popup has been added.
Use ConfigureReactiveUIPopup() with MauiAppBuilder to initialise ReactiveUI.Maui.Plugins.Popup

The following methods are available

	PopAllPopup
	PopPopup
	PushPopup
	RemovePopupPage

The Following Observable Events are available

	PoppingObservable
	PoppedObservable
	PushingObservable
	PushedObservable

**What might this PR break?**



**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

