### PR TITLE
Fix Blazor ViewModelActivation

### DIFF
--- a/src/ReactiveUI.Blazor/ReactiveComponentBase.cs
+++ b/src/ReactiveUI.Blazor/ReactiveComponentBase.cs
@@ -74,7 +74,7 @@ public class ReactiveComponentBase<T> : ComponentBase, IViewFor<T>, INotifyPrope
             Activated.Subscribe(_ => avm.Activator.Activate()).DisposeWith(_compositeDisposable);
             Deactivated.Subscribe(_ => avm.Activator.Deactivate());
         }
-        
+
         _initSubject.OnNext(Unit.Default);
         base.OnInitialized();
     }

--- a/src/ReactiveUI.Blazor/ReactiveComponentBase.cs
+++ b/src/ReactiveUI.Blazor/ReactiveComponentBase.cs
@@ -70,6 +70,11 @@ public class ReactiveComponentBase<T> : ComponentBase, IViewFor<T>, INotifyPrope
     protected override void OnInitialized()
     {
         _initSubject.OnNext(Unit.Default);
+        if (ViewModel is IActivatableViewModel avm)
+        {
+            Activated.Subscribe(_ => avm.Activator.Activate()).DisposeWith(_compositeDisposable);
+            Deactivated.Subscribe(_ => avm.Activator.Deactivate());
+        }
         base.OnInitialized();
     }
 

--- a/src/ReactiveUI.Blazor/ReactiveComponentBase.cs
+++ b/src/ReactiveUI.Blazor/ReactiveComponentBase.cs
@@ -69,12 +69,13 @@ public class ReactiveComponentBase<T> : ComponentBase, IViewFor<T>, INotifyPrope
     /// <inheritdoc />
     protected override void OnInitialized()
     {
-        _initSubject.OnNext(Unit.Default);
         if (ViewModel is IActivatableViewModel avm)
         {
             Activated.Subscribe(_ => avm.Activator.Activate()).DisposeWith(_compositeDisposable);
             Deactivated.Subscribe(_ => avm.Activator.Deactivate());
         }
+        
+        _initSubject.OnNext(Unit.Default);
         base.OnInitialized();
     }
 

--- a/src/ReactiveUI.Blazor/ReactiveInjectableComponentBase.cs
+++ b/src/ReactiveUI.Blazor/ReactiveInjectableComponentBase.cs
@@ -69,12 +69,12 @@ public class ReactiveInjectableComponentBase<T> : ComponentBase, IViewFor<T>, IN
     /// <inheritdoc />
     protected override void OnInitialized()
     {
-        _initSubject.OnNext(Unit.Default);
         if (ViewModel is IActivatableViewModel avm)
         {
             Activated.Subscribe(_ => avm.Activator.Activate()).DisposeWith(_compositeDisposable);
             Deactivated.Subscribe(_ => avm.Activator.Deactivate());
         }
+        _initSubject.OnNext(Unit.Default);
 
         base.OnInitialized();
     }

--- a/src/ReactiveUI.Blazor/ReactiveInjectableComponentBase.cs
+++ b/src/ReactiveUI.Blazor/ReactiveInjectableComponentBase.cs
@@ -74,6 +74,7 @@ public class ReactiveInjectableComponentBase<T> : ComponentBase, IViewFor<T>, IN
             Activated.Subscribe(_ => avm.Activator.Activate()).DisposeWith(_compositeDisposable);
             Deactivated.Subscribe(_ => avm.Activator.Deactivate());
         }
+
         _initSubject.OnNext(Unit.Default);
 
         base.OnInitialized();

--- a/src/ReactiveUI.Blazor/ReactiveLayoutComponentBase.cs
+++ b/src/ReactiveUI.Blazor/ReactiveLayoutComponentBase.cs
@@ -86,7 +86,8 @@ public class ReactiveLayoutComponentBase<T> : LayoutComponentBase, IViewFor<T>, 
             this.WhenAnyValue(x => x.ViewModel)
                 .Skip(1)
                 .WhereNotNull()
-                .Subscribe(_ => InvokeAsync(StateHasChanged));
+                .Subscribe(_ => InvokeAsync(StateHasChanged))
+                .DisposeWith(_compositeDisposable);
         }
 
         this.WhenAnyValue(x => x.ViewModel)
@@ -101,7 +102,8 @@ public class ReactiveLayoutComponentBase<T> : LayoutComponentBase, IViewFor<T>, 
                      eh => x.PropertyChanged -= eh))
             .Switch()
             .Do(_ => InvokeAsync(StateHasChanged))
-            .Subscribe();
+            .Subscribe()
+            .DisposeWith(_compositeDisposable);
     }
 
     /// <summary>

--- a/src/ReactiveUI.Blazor/ReactiveLayoutComponentBase.cs
+++ b/src/ReactiveUI.Blazor/ReactiveLayoutComponentBase.cs
@@ -72,6 +72,7 @@ public class ReactiveLayoutComponentBase<T> : LayoutComponentBase, IViewFor<T>, 
             Activated.Subscribe(_ => avm.Activator.Activate()).DisposeWith(_compositeDisposable);
             Deactivated.Subscribe(_ => avm.Activator.Deactivate());
         }
+
         _initSubject.OnNext(Unit.Default);
         base.OnInitialized();
     }


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix. Current implementation did increase RefCount under ViewModelActivator once, but decrement it twice on deactivation. So the ViewModel was bricked if it was used as Scoped, or Singleton and would never activate again.


**What is the current behavior?**
<!-- You can also link to an open issue here. -->
Fixed behavior


**What is the new behavior?**
<!-- If this is a feature change -->



**What might this PR break?**
Should only fix


**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

