### PR TITLE
Fix to enable use of DynamicData 9.0

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -8,7 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="coverlet.msbuild" Version="6.0.2" />
-    <PackageVersion Include="DynamicData" Version="8.4.1" />
+    <PackageVersion Include="DynamicData" Version="9.0.1" />
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
     <PackageVersion Include="JetBrains.DotMemoryUnit" Version="3.2.20220510" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />

--- a/src/ReactiveUI/Routing/RoutingState.cs
+++ b/src/ReactiveUI/Routing/RoutingState.cs
@@ -125,6 +125,6 @@ public class RoutingState : ReactiveObject
              return Navigate.Execute(vm);
          });
 
-        CurrentViewModel = Observable.Defer(() => Observable.Return(NavigationStack.LastOrDefault()!)).Concat(NavigationChanged.Select(_ => NavigationStack.LastOrDefault()!));
+        CurrentViewModel = NavigationChanged.Select(_ => NavigationStack.LastOrDefault()!);
     }
 }


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

fix

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

ReactiveUI 20.1.1 includes DynamicData 8
DynamicData 9 has an update to the Observable Change Set which introduces a default value, this results in a mismatch in count between V8 and V9

**What is the new behavior?**
<!-- If this is a feature change -->

the default value has been removed from the RoutingState CurrentViewModel

**What might this PR break?**

Execution should match previous versions

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

