### PR TITLE
Replace dead URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Install the following packages to start building your own ReactiveUI app. <b>Not
 
 [Blaz]: https://www.nuget.org/packages/ReactiveUI.Blazor/
 [BlazBadge]: https://img.shields.io/nuget/v/ReactiveUI.Blazor.svg
-[BlazDoc]: https://www.reactiveui.net/blog/2020/07/article-blazor-compelling-example
+[BlazDoc]: https://www.reactiveui.net/docs/getting-started/installation/blazor
 
 [Ava]: https://www.nuget.org/packages/Avalonia.ReactiveUI/
 [AvaBadge]: https://img.shields.io/nuget/v/Avalonia.ReactiveUI.svg


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

It fixes the URL, in the documentation, to be consistent with [ReactiveUI.Blazor](https://www.reactiveui.net/docs/getting-started/installation/blazor) found in [Getting Started](https://www.reactiveui.net/docs/getting-started/installation/blazor) instead of [the dead URL](https://www.reactiveui.net/blog/2020/07/article-blazor-compelling-example).

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

Following the current URL, It leads to 404 Response.


**What is the new behavior?**
<!-- If this is a feature change -->

The URL leads to existing and relevant page.

**What might this PR break?**

None that I know.

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:

N/A