### PR TITLE
Update WinForms to remove ControlObservable

### DIFF
--- a/src/ReactiveUI.Tests/Platforms/winforms/Mocks/FakeWinformViewModel.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/Mocks/FakeWinformViewModel.cs
@@ -3,6 +3,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.Windows.Forms;
+
 namespace ReactiveUI.Tests.Winforms;
 
 /// <summary>

--- a/src/ReactiveUI.Winforms/ActivationForViewFetcher.cs
+++ b/src/ReactiveUI.Winforms/ActivationForViewFetcher.cs
@@ -5,7 +5,6 @@
 
 using System.Globalization;
 using System.Reflection;
-using System.Windows.Forms;
 
 namespace ReactiveUI.Winforms;
 
@@ -87,12 +86,8 @@ public class ActivationForViewFetcher : IActivationForViewFetcher, IEnableLogger
         return Observable<bool>.Empty;
     }
 
-    private static bool GetIsDesignMode(Control control)
-    {
-        var isDesignMode = LicenseManager.UsageMode == LicenseUsageMode.Designtime || control.Site?.DesignMode == true || control.Parent?.Site?.DesignMode == true;
-
-        return isDesignMode;
-    }
+    private static bool GetIsDesignMode(Control control) =>
+        LicenseManager.UsageMode == LicenseUsageMode.Designtime || control.Site?.DesignMode == true || control.Parent?.Site?.DesignMode == true;
 
     private bool GetCachedIsDesignMode(Control control)
     {

--- a/src/ReactiveUI.Winforms/ContentControlBindingHook.cs
+++ b/src/ReactiveUI.Winforms/ContentControlBindingHook.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Windows.Forms;
-
 namespace ReactiveUI.Winforms;
 
 /// <summary>

--- a/src/ReactiveUI.Winforms/CreatesWinformsCommandBinding.cs
+++ b/src/ReactiveUI.Winforms/CreatesWinformsCommandBinding.cs
@@ -4,7 +4,6 @@
 // See the LICENSE file in the project root for full license information.
 
 using System.Reflection;
-using System.Windows.Forms;
 using System.Windows.Input;
 
 namespace ReactiveUI.Winforms;

--- a/src/ReactiveUI.Winforms/GlobalUsings.cs
+++ b/src/ReactiveUI.Winforms/GlobalUsings.cs
@@ -12,4 +12,5 @@ global using System.Reactive.Concurrency;
 global using System.Reactive.Disposables;
 global using System.Reactive.Linq;
 global using System.Threading;
+global using System.Windows.Forms;
 global using Splat;

--- a/src/ReactiveUI.Winforms/PanelSetMethodBindingConverter.cs
+++ b/src/ReactiveUI.Winforms/PanelSetMethodBindingConverter.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Windows.Forms;
-
 namespace ReactiveUI.Winforms;
 
 /// <summary>

--- a/src/ReactiveUI.Winforms/ReactiveUI.Winforms.csproj
+++ b/src/ReactiveUI.Winforms/ReactiveUI.Winforms.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="..\ReactiveUI.Wpf\Rx\**\*.cs" LinkBase="Rx" Exclude="..\ReactiveUI.Wpf\Rx\**\Dispatcher*.cs;..\ReactiveUI.Wpf\Rx\Internal\*.cs;..\ReactiveUI.Wpf\Rx\Concurrency\*.cs" />
+    <Compile Include="..\ReactiveUI.Wpf\Rx\**\*.cs" LinkBase="Rx" Exclude="..\ReactiveUI.Wpf\Rx\**\Dispatcher*.cs;..\ReactiveUI.Wpf\Rx\Internal\*.cs;..\ReactiveUI.Wpf\Rx\Concurrency\*.cs;..\ReactiveUI.Wpf\Rx\Linq\ControlObservable.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'net462' or $(TargetFramework.EndsWith('-windows10.0.17763.0'))">

--- a/src/ReactiveUI.Winforms/ReactiveUserControl.cs
+++ b/src/ReactiveUI.Winforms/ReactiveUserControl.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Windows.Forms;
-
 namespace ReactiveUI.Winforms;
 
 /// <summary>

--- a/src/ReactiveUI.Winforms/ReactiveUserControlNonGeneric.cs
+++ b/src/ReactiveUI.Winforms/ReactiveUserControlNonGeneric.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Windows.Forms;
-
 namespace ReactiveUI.Winforms;
 
 /// <summary>

--- a/src/ReactiveUI.Winforms/Registrations.cs
+++ b/src/ReactiveUI.Winforms/Registrations.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Windows.Forms;
-
 namespace ReactiveUI.Winforms;
 
 /// <summary>

--- a/src/ReactiveUI.Winforms/RoutedViewHost.cs
+++ b/src/ReactiveUI.Winforms/RoutedViewHost.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Windows.Forms;
-
 namespace ReactiveUI.Winforms;
 
 /// <summary>

--- a/src/ReactiveUI.Winforms/TableContentSetMethodBindingConverter.cs
+++ b/src/ReactiveUI.Winforms/TableContentSetMethodBindingConverter.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Windows.Forms;
-
 namespace ReactiveUI.Winforms;
 
 /// <summary>

--- a/src/ReactiveUI.Winforms/ViewModelViewHost.cs
+++ b/src/ReactiveUI.Winforms/ViewModelViewHost.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Windows.Forms;
-
 namespace ReactiveUI.Winforms;
 
 /// <summary>


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Fix for #3885 

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

#3885 

**What is the new behavior?**
<!-- If this is a feature change -->

This Removes ObserveOn and SubscribeOn extensions that are included with System.Reactive 6.0.1

**What might this PR break?**

None expected 

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

