### PR TITLE
Do not reference System.Text.Json for .NET 8+

### DIFF
--- a/src/ReactiveUI/ReactiveUI.csproj
+++ b/src/ReactiveUI/ReactiveUI.csproj
@@ -58,10 +58,12 @@
     <Compile Include="Platforms\net\**\*.cs" />
     <PackageReference Include="System.ComponentModel.Annotations" />
   </ItemGroup>
+  <ItemGroup Condition="$(TargetFramework.StartsWith('netstandard')) or $(TargetFramework.StartsWith('net4'))">
+    <PackageReference Include="System.Text.Json" />
+  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Splat" />
     <PackageReference Include="DynamicData" />
-    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
   <ItemGroup>
     <None Update="VariadicTemplates.tt" Generator="TextTemplatingFileGenerator" LastGenOutput="VariadicTemplates.cs" />


### PR DESCRIPTION
https://github.com/reactiveui/ReactiveUI/pull/3933 mistakenly removed the target framework condition for STJ. Referencing the STJ package on .NET 8+ causes the STJ source generator to run twice, resulting in build errors. See https://github.com/dotnet/wpf/issues/8943.

<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Bug fix

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

Build errors for projects referencing ReactiveUI and using STJ source generation at the same time.

**What is the new behavior?**
<!-- If this is a feature change -->

No build errors.

**What might this PR break?**



**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

