### PR TITLE
Refactor ViewModel change subscriptions in Blazor components

### DIFF
--- a/src/ReactiveUI.Blazor/ReactiveComponentBase.cs
+++ b/src/ReactiveUI.Blazor/ReactiveComponentBase.cs
@@ -97,15 +97,15 @@ public class ReactiveComponentBase<T> : ComponentBase, IViewFor<T>, INotifyPrope
 
             viewModelChanged
                 .Select(x =>
-                            Observable
-                                .FromEvent<PropertyChangedEventHandler?, Unit>(
-                                                                               eventHandler =>
-                                                                               {
-                                                                                   void Handler(object? sender, PropertyChangedEventArgs e) => eventHandler(Unit.Default);
-                                                                                   return Handler;
-                                                                               },
-                                                                               eh => x.PropertyChanged += eh,
-                                                                               eh => x.PropertyChanged -= eh))
+                    Observable
+                        .FromEvent<PropertyChangedEventHandler?, Unit>(
+                            eventHandler =>
+                            {
+                                void Handler(object? sender, PropertyChangedEventArgs e) => eventHandler(Unit.Default);
+                                return Handler;
+                            },
+                            eh => x.PropertyChanged += eh,
+                            eh => x.PropertyChanged -= eh))
                 .Switch()
                 .Subscribe(_ => InvokeAsync(StateHasChanged))
                 .DisposeWith(_compositeDisposable);

--- a/src/ReactiveUI.Blazor/ReactiveInjectableComponentBase.cs
+++ b/src/ReactiveUI.Blazor/ReactiveInjectableComponentBase.cs
@@ -98,15 +98,15 @@ public class ReactiveInjectableComponentBase<T> : ComponentBase, IViewFor<T>, IN
 
             viewModelChanged
                 .Select(x =>
-                            Observable
-                                .FromEvent<PropertyChangedEventHandler, Unit>(
-                                                                              eventHandler =>
-                                                                              {
-                                                                                  void Handler(object? sender, PropertyChangedEventArgs e) => eventHandler(Unit.Default);
-                                                                                  return Handler;
-                                                                              },
-                                                                              eh => x.PropertyChanged += eh,
-                                                                              eh => x.PropertyChanged -= eh))
+                    Observable
+                        .FromEvent<PropertyChangedEventHandler, Unit>(
+                            eventHandler =>
+                            {
+                                void Handler(object? sender, PropertyChangedEventArgs e) => eventHandler(Unit.Default);
+                                return Handler;
+                            },
+                            eh => x.PropertyChanged += eh,
+                            eh => x.PropertyChanged -= eh))
                 .Switch()
                 .Subscribe(_ => InvokeAsync(StateHasChanged))
                 .DisposeWith(_compositeDisposable);

--- a/src/ReactiveUI.Blazor/ReactiveLayoutComponentBase.cs
+++ b/src/ReactiveUI.Blazor/ReactiveLayoutComponentBase.cs
@@ -84,34 +84,40 @@ public class ReactiveLayoutComponentBase<T> : LayoutComponentBase, IViewFor<T>, 
     {
         if (isFirstRender)
         {
-            this.WhenAnyValue(x => x.ViewModel)
-                .Skip(1)
-                .WhereNotNull()
+            var viewModelChanged =
+                this.WhenAnyValue(x => x.ViewModel)
+                    .WhereNotNull()
+                    .Publish()
+                    .RefCount(2);
+
+            viewModelChanged
+                .Subscribe(_ => InvokeAsync(StateHasChanged))
+                .DisposeWith(_compositeDisposable);
+
+            viewModelChanged
+                .Select(x =>
+                    Observable
+                        .FromEvent<PropertyChangedEventHandler, Unit>(
+                            eventHandler =>
+                            {
+                                void Handler(object? sender, PropertyChangedEventArgs e) => eventHandler(Unit.Default);
+                                return Handler;
+                            },
+                            eh => x.PropertyChanged += eh,
+                            eh => x.PropertyChanged -= eh))
+                .Switch()
                 .Subscribe(_ => InvokeAsync(StateHasChanged))
                 .DisposeWith(_compositeDisposable);
         }
 
-        this.WhenAnyValue(x => x.ViewModel)
-            .WhereNotNull()
-            .Select(x => Observable.FromEvent<PropertyChangedEventHandler, Unit>(
-                     eventHandler =>
-                     {
-                         void Handler(object? sender, PropertyChangedEventArgs e) => eventHandler(Unit.Default);
-                         return Handler;
-                     },
-                     eh => x.PropertyChanged += eh,
-                     eh => x.PropertyChanged -= eh))
-            .Switch()
-            .Do(_ => InvokeAsync(StateHasChanged))
-            .Subscribe()
-            .DisposeWith(_compositeDisposable);
+        base.OnAfterRender(isFirstRender);
     }
 
     /// <summary>
     /// Invokes the property changed event.
     /// </summary>
     /// <param name="propertyName">The name of the property.</param>
-    protected virtual void OnPropertyChanged([CallerMemberName]string? propertyName = null) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    protected virtual void OnPropertyChanged([CallerMemberName] string? propertyName = null) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
 
     /// <summary>
     /// Cleans up the managed resources of the object.


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Bug Fix for #4068

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

#4068

**What is the new behavior?**
<!-- If this is a feature change -->

Consolidated and streamlined the logic for subscribing to ViewModel changes and property changes in ReactiveComponentBase, ReactiveInjectableComponentBase, and ReactiveLayoutComponentBase. This improves code readability and consistency across the components by using a shared pattern for handling ViewModel and property change notifications.

Closes #4068 

**What might this PR break?**

None expected

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

