### PR TITLE
Improve exception handling in property binder

### DIFF
--- a/src/ReactiveUI.sln
+++ b/src/ReactiveUI.sln
@@ -1,6 +1,6 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# 17
+# Visual Studio Version 17
 VisualStudioVersion = 17.0.31825.309
 MinimumVisualStudioVersion = 16.0.31613.86
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{BD9762CF-E104-481C-96A6-26E624B86283}"


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

closes #4003 

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

#4003 

**What is the new behavior?**
<!-- If this is a feature change -->

Refactored BindTo to wrap inner exceptions in TargetInvocationException for better error reporting. Also made minor code cleanups and added missing using directives.

**What might this PR break?**

users will experience unhandled exceptions if invalid read-only bindings exist i.e. a binding is set to TwoWay for a read only property.

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

