### PR TITLE
Fix NavigateAndReset navigation for Maui

### DIFF
--- a/src/ReactiveUI.Maui/RoutedViewHost.cs
+++ b/src/ReactiveUI.Maui/RoutedViewHost.cs
@@ -15,7 +15,7 @@ namespace ReactiveUI.Maui;
 /// </summary>
 /// <seealso cref="NavigationPage" />
 /// <seealso cref="IActivatableView" />
-public class RoutedViewHost : NavigationPage, IActivatableView, IEnableLogger
+public partial class RoutedViewHost : NavigationPage, IActivatableView, IEnableLogger
 {
     /// <summary>
     /// The router bindable property.
@@ -76,7 +76,7 @@ public class RoutedViewHost : NavigationPage, IActivatableView, IEnableLogger
 
             Router?
                 .Navigate
-                .Where(_ => Navigation.NavigationStack.Count != Router.NavigationStack.Count)
+                .Where(_ => StacksAreDifferent())
                 .ObserveOn(RxApp.MainThreadScheduler)
                 .SelectMany(_ => PagesForViewModel(Router.GetCurrentViewModel()))
                 .SelectMany(async page =>


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Fix
closes #3820 

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

#3820 

**What is the new behavior?**
<!-- If this is a feature change -->

Changed RoutedViewHost to be a partial class to allow splitting its implementation. 
Refactored navigation stack comparison to use the StacksAreDifferent() method for improved clarity and maintainability.

**What might this PR break?**

If currently calling NavigateAndReset at startup may cause navigation to end up in a different place.

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

