### PR TITLE
Add AOT reflection warnings for .NET 6+ methods

### DIFF
--- a/src/ReactiveUI/Expression/Reflection.cs
+++ b/src/ReactiveUI/Expression/Reflection.cs
@@ -395,6 +395,10 @@ public static class Reflection
         return method.IsStatic;
     }
 
+#if NET6_0_OR_GREATER
+    [RequiresDynamicCode("The method uses reflection and will not work in AOT environments.")]
+    [RequiresUnreferencedCode("The method uses reflection and will not work in AOT environments.")]
+#endif
     internal static IObservable<object> ViewModelWhenAnyValue<TView, TViewModel>(TViewModel? viewModel, TView view, Expression? expression)
         where TView : class, IViewFor
         where TViewModel : class =>

--- a/src/ReactiveUI/Interfaces/ISuspensionDriver.cs
+++ b/src/ReactiveUI/Interfaces/ISuspensionDriver.cs
@@ -37,5 +37,9 @@ public interface ISuspensionDriver
     /// Invalidates the application state (i.e. deletes it from disk).
     /// </summary>
     /// <returns>A completed observable.</returns>
+#if NET6_0_OR_GREATER
+    [RequiresDynamicCode("The method uses reflection and will not work in AOT environments.")]
+    [RequiresUnreferencedCode("The method uses reflection and will not work in AOT environments.")]
+#endif
     IObservable<Unit> InvalidateState();
 }

--- a/src/ReactiveUI/Mixins/AutoPersistHelper.cs
+++ b/src/ReactiveUI/Mixins/AutoPersistHelper.cs
@@ -22,8 +22,8 @@ public static class AutoPersistHelper
 {
     private static readonly MemoizingMRUCache<Type, Dictionary<string, bool>> _persistablePropertiesCache = new(
      static (type, _) => type.GetTypeInfo().DeclaredProperties
-                      .Where(x => x.CustomAttributes.Any(y => typeof(DataMemberAttribute).GetTypeInfo().IsAssignableFrom(y.AttributeType.GetTypeInfo())))
-                      .ToDictionary(k => k.Name, _ => true),
+                               .Where(x => x.CustomAttributes.Any(y => typeof(DataMemberAttribute).GetTypeInfo().IsAssignableFrom(y.AttributeType.GetTypeInfo())))
+                               .ToDictionary(k => k.Name, _ => true),
      RxApp.SmallCacheLimit);
 
     private static readonly MemoizingMRUCache<Type, bool> _dataContractCheckCache = new(
@@ -49,6 +49,10 @@ public static class AutoPersistHelper
     /// it is possible that it will never be saved.
     /// </param>
     /// <returns>A Disposable to disable automatic persistence.</returns>
+#if NET6_0_OR_GREATER
+    [RequiresDynamicCode("The method uses reflection and will not work in AOT environments.")]
+    [RequiresUnreferencedCode("The method uses reflection and will not work in AOT environments.")]
+#endif
     public static IDisposable AutoPersist<T>(this T @this, Func<T, IObservable<Unit>> doPersist, TimeSpan? interval = null)
         where T : IReactiveObject =>
         @this.AutoPersist(doPersist, Observable<Unit>.Never, interval);
@@ -76,6 +80,10 @@ public static class AutoPersistHelper
     /// it is possible that it will never be saved.
     /// </param>
     /// <returns>A Disposable to disable automatic persistence.</returns>
+#if NET6_0_OR_GREATER
+    [RequiresDynamicCode("The method uses reflection and will not work in AOT environments.")]
+    [RequiresUnreferencedCode("The method uses reflection and will not work in AOT environments.")]
+#endif
     public static IDisposable AutoPersist<T, TDontCare>(this T @this, Func<T, IObservable<Unit>> doPersist, IObservable<TDontCare> manualSaveSignal, TimeSpan? interval = null)
         where T : IReactiveObject
     {
@@ -127,6 +135,10 @@ public static class AutoPersistHelper
     /// it is possible that it will never be saved.
     /// </param>
     /// <returns>A Disposable to disable automatic persistence.</returns>
+#if NET6_0_OR_GREATER
+    [RequiresDynamicCode("The method uses reflection and will not work in AOT environments.")]
+    [RequiresUnreferencedCode("The method uses reflection and will not work in AOT environments.")]
+#endif
     public static IDisposable AutoPersistCollection<TItem>(this ObservableCollection<TItem> @this, Func<TItem, IObservable<Unit>> doPersist, TimeSpan? interval = null) // TODO: Create Test
         where TItem : IReactiveObject =>
         AutoPersistCollection(@this, doPersist, Observable<Unit>.Never, interval);
@@ -151,6 +163,10 @@ public static class AutoPersistHelper
     /// it is possible that it will never be saved.
     /// </param>
     /// <returns>A Disposable to disable automatic persistence.</returns>
+#if NET6_0_OR_GREATER
+    [RequiresDynamicCode("The method uses reflection and will not work in AOT environments.")]
+    [RequiresUnreferencedCode("The method uses reflection and will not work in AOT environments.")]
+#endif
     public static IDisposable AutoPersistCollection<TItem, TDontCare>(this ObservableCollection<TItem> @this, Func<TItem, IObservable<Unit>> doPersist, IObservable<TDontCare> manualSaveSignal, TimeSpan? interval = null)
         where TItem : IReactiveObject =>
         AutoPersistCollection<TItem, ObservableCollection<TItem>, TDontCare>(@this, doPersist, manualSaveSignal, interval);
@@ -175,6 +191,10 @@ public static class AutoPersistHelper
     /// it is possible that it will never be saved.
     /// </param>
     /// <returns>A Disposable to disable automatic persistence.</returns>
+#if NET6_0_OR_GREATER
+    [RequiresDynamicCode("The method uses reflection and will not work in AOT environments.")]
+    [RequiresUnreferencedCode("The method uses reflection and will not work in AOT environments.")]
+#endif
     public static IDisposable AutoPersistCollection<TItem, TDontCare>(this ReadOnlyObservableCollection<TItem> @this, Func<TItem, IObservable<Unit>> doPersist, IObservable<TDontCare> manualSaveSignal, TimeSpan? interval = null) // TODO: Create Test
         where TItem : IReactiveObject =>
         AutoPersistCollection<TItem, ReadOnlyObservableCollection<TItem>, TDontCare>(@this, doPersist, manualSaveSignal, interval);
@@ -200,6 +220,10 @@ public static class AutoPersistHelper
     /// it is possible that it will never be saved.
     /// </param>
     /// <returns>A Disposable to disable automatic persistence.</returns>
+#if NET6_0_OR_GREATER
+    [RequiresDynamicCode("The method uses reflection and will not work in AOT environments.")]
+    [RequiresUnreferencedCode("The method uses reflection and will not work in AOT environments.")]
+#endif
     public static IDisposable AutoPersistCollection<TItem, TCollection, TDontCare>(this TCollection @this, Func<TItem, IObservable<Unit>> doPersist, IObservable<TDontCare> manualSaveSignal, TimeSpan? interval = null) // TODO: Create Test
         where TItem : IReactiveObject
         where TCollection : INotifyCollectionChanged, IEnumerable<TItem>

--- a/src/ReactiveUI/Platforms/android/BundleSuspensionDriver.cs
+++ b/src/ReactiveUI/Platforms/android/BundleSuspensionDriver.cs
@@ -11,10 +11,6 @@ namespace ReactiveUI;
 /// <summary>
 /// Loads and saves state to persistent storage.
 /// </summary>
-#if NET6_0_OR_GREATER
-[RequiresDynamicCode("The method uses reflection and will not work in AOT environments.")]
-[RequiresUnreferencedCode("The method uses reflection and will not work in AOT environments.")]
-#endif
 public class BundleSuspensionDriver : ISuspensionDriver
 {
     /// <inheritdoc/>
@@ -71,6 +67,10 @@ public class BundleSuspensionDriver : ISuspensionDriver
     }
 
     /// <inheritdoc/>
+#if NET6_0_OR_GREATER
+    [RequiresDynamicCode("The method uses reflection and will not work in AOT environments.")]
+    [RequiresUnreferencedCode("The method uses reflection and will not work in AOT environments.")]
+#endif
     public IObservable<Unit> InvalidateState() // TODO: Create Test
     {
         try

--- a/src/ReactiveUI/Platforms/android/ControlFetcherMixin.cs
+++ b/src/ReactiveUI/Platforms/android/ControlFetcherMixin.cs
@@ -17,10 +17,6 @@ namespace ReactiveUI;
 /// Fragments via property names, similar to Butter Knife, as well as allows
 /// you to fetch controls manually.
 /// </summary>
-#if NET6_0_OR_GREATER
-[RequiresDynamicCode("The method uses reflection and will not work in AOT environments.")]
-[RequiresUnreferencedCode("The method uses reflection and will not work in AOT environments.")]
-#endif
 public static partial class ControlFetcherMixin
 {
     private static readonly ConcurrentDictionary<Assembly, Dictionary<string, int>> _controlIds = new();
@@ -47,6 +43,10 @@ public static partial class ControlFetcherMixin
     /// <param name="assembly">The assembly containing the user-defined view.</param>
     /// <param name="propertyName">The property.</param>
     /// <returns>The return view.</returns>
+#if NET6_0_OR_GREATER
+    [RequiresDynamicCode("The method uses reflection and will not work in AOT environments.")]
+    [RequiresUnreferencedCode("The method uses reflection and will not work in AOT environments.")]
+#endif
     public static View? GetControl(this View view, Assembly assembly, [CallerMemberName] string? propertyName = null) // TODO: Create Test
         => GetCachedControl(propertyName, view, () => view.FindViewById(GetControlIdByName(assembly, propertyName)));
 
@@ -55,6 +55,10 @@ public static partial class ControlFetcherMixin
     /// </summary>
     /// <param name="layoutHost">The layout view host.</param>
     /// <param name="resolveMembers">The resolve members.</param>
+#if NET6_0_OR_GREATER
+    [RequiresDynamicCode("The method uses reflection and will not work in AOT environments.")]
+    [RequiresUnreferencedCode("The method uses reflection and will not work in AOT environments.")]
+#endif
     public static void WireUpControls(this ILayoutViewHost layoutHost, ResolveStrategy resolveMembers = ResolveStrategy.Implicit) // TODO: Create Test
     {
         ArgumentNullException.ThrowIfNull(layoutHost);
@@ -80,6 +84,10 @@ public static partial class ControlFetcherMixin
     /// </summary>
     /// <param name="view">The view.</param>
     /// <param name="resolveMembers">The resolve members.</param>
+#if NET6_0_OR_GREATER
+    [RequiresDynamicCode("The method uses reflection and will not work in AOT environments.")]
+    [RequiresUnreferencedCode("The method uses reflection and will not work in AOT environments.")]
+#endif
     public static void WireUpControls(this View view, ResolveStrategy resolveMembers = ResolveStrategy.Implicit) // TODO: Create Test
     {
         ArgumentNullException.ThrowIfNull(view);
@@ -111,6 +119,10 @@ public static partial class ControlFetcherMixin
     /// <param name="fragment">The fragment.</param>
     /// <param name="inflatedView">The inflated view.</param>
     /// <param name="resolveMembers">The resolve members.</param>
+#if NET6_0_OR_GREATER
+    [RequiresDynamicCode("The method uses reflection and will not work in AOT environments.")]
+    [RequiresUnreferencedCode("The method uses reflection and will not work in AOT environments.")]
+#endif
     public static void WireUpControls(this Fragment fragment, View inflatedView, ResolveStrategy resolveMembers = ResolveStrategy.Implicit) // TODO: Create Test
     {
         ArgumentNullException.ThrowIfNull(fragment);
@@ -140,6 +152,10 @@ public static partial class ControlFetcherMixin
     /// </summary>
     /// <param name="activity">The Activity.</param>
     /// <param name="resolveMembers">The resolve members.</param>
+#if NET6_0_OR_GREATER
+    [RequiresDynamicCode("The method uses reflection and will not work in AOT environments.")]
+    [RequiresUnreferencedCode("The method uses reflection and will not work in AOT environments.")]
+#endif
     public static void WireUpControls(this Activity activity, ResolveStrategy resolveMembers = ResolveStrategy.Implicit) // TODO: Create Test
     {
         ArgumentNullException.ThrowIfNull(activity);

--- a/src/ReactiveUI/Platforms/android/PlatformRegistrations.cs
+++ b/src/ReactiveUI/Platforms/android/PlatformRegistrations.cs
@@ -9,10 +9,6 @@ namespace ReactiveUI;
 /// Android platform registrations.
 /// </summary>
 /// <seealso cref="ReactiveUI.IWantsToRegisterStuff" />
-#if NET6_0_OR_GREATER
-[RequiresDynamicCode("The method uses reflection and will not work in AOT environments.")]
-[RequiresUnreferencedCode("The method uses reflection and will not work in AOT environments.")]
-#endif
 public class PlatformRegistrations : IWantsToRegisterStuff
 {
     /// <inheritdoc/>

--- a/src/ReactiveUI/Platforms/apple-common/AppSupportJsonSuspensionDriver.cs
+++ b/src/ReactiveUI/Platforms/apple-common/AppSupportJsonSuspensionDriver.cs
@@ -12,10 +12,6 @@ namespace ReactiveUI;
 /// <summary>
 /// Loads and saves state to persistent storage.
 /// </summary>
-#if NET6_0_OR_GREATER
-[RequiresDynamicCode("The method uses reflection and will not work in AOT environments.")]
-[RequiresUnreferencedCode("The method uses reflection and will not work in AOT environments.")]
-#endif
 public class AppSupportJsonSuspensionDriver : ISuspensionDriver
 {
     /// <inheritdoc/>
@@ -68,6 +64,10 @@ public class AppSupportJsonSuspensionDriver : ISuspensionDriver
     }
 
     /// <inheritdoc/>
+#if NET6_0_OR_GREATER
+    [RequiresDynamicCode("The method uses reflection and will not work in AOT environments.")]
+    [RequiresUnreferencedCode("The method uses reflection and will not work in AOT environments.")]
+#endif
     public IObservable<Unit> InvalidateState()
     {
         try

--- a/src/ReactiveUI/Platforms/mac/PlatformRegistrations.cs
+++ b/src/ReactiveUI/Platforms/mac/PlatformRegistrations.cs
@@ -9,10 +9,6 @@ namespace ReactiveUI;
 /// Mac platform registrations.
 /// </summary>
 /// <seealso cref="ReactiveUI.IWantsToRegisterStuff" />
-#if NET6_0_OR_GREATER
-[RequiresDynamicCode("The method uses reflection and will not work in AOT environments.")]
-[RequiresUnreferencedCode("The method uses reflection and will not work in AOT environments.")]
-#endif
 public class PlatformRegistrations : IWantsToRegisterStuff
 {
     /// <inheritdoc/>

--- a/src/ReactiveUI/Platforms/net/PlatformRegistrations.cs
+++ b/src/ReactiveUI/Platforms/net/PlatformRegistrations.cs
@@ -10,10 +10,6 @@ namespace ReactiveUI;
 /// .NET Framework platform registrations.
 /// </summary>
 /// <seealso cref="ReactiveUI.IWantsToRegisterStuff" />
-#if NET6_0_OR_GREATER
-[RequiresDynamicCode("The method uses reflection and will not work in AOT environments.")]
-[RequiresUnreferencedCode("The method uses reflection and will not work in AOT environments.")]
-#endif
 public class PlatformRegistrations : IWantsToRegisterStuff
 {
     /// <inheritdoc/>

--- a/src/ReactiveUI/Platforms/uikit-common/PlatformRegistrations.cs
+++ b/src/ReactiveUI/Platforms/uikit-common/PlatformRegistrations.cs
@@ -9,10 +9,6 @@ namespace ReactiveUI;
 /// UIKit platform registrations.
 /// </summary>
 /// <seealso cref="ReactiveUI.IWantsToRegisterStuff" />
-#if NET6_0_OR_GREATER
-[RequiresDynamicCode("The method uses reflection and will not work in AOT environments.")]
-[RequiresUnreferencedCode("The method uses reflection and will not work in AOT environments.")]
-#endif
 public class PlatformRegistrations : IWantsToRegisterStuff
 {
     /// <inheritdoc/>

--- a/src/ReactiveUI/ReactiveCommand/ReactiveCommand.cs
+++ b/src/ReactiveUI/ReactiveCommand/ReactiveCommand.cs
@@ -59,10 +59,6 @@ namespace ReactiveUI;
 /// </code>
 /// </para>
 /// </remarks>
-#if NET6_0_OR_GREATER
-[RequiresDynamicCode("The method uses reflection and will not work in AOT environments.")]
-[RequiresUnreferencedCode("The method uses reflection and will not work in AOT environments.")]
-#endif
 public static class ReactiveCommand
 {
     /// <summary>
@@ -75,6 +71,10 @@ public static class ReactiveCommand
     /// The <c>ReactiveCommand</c> instance.
     /// </returns>
     /// <exception cref="System.ArgumentNullException">execute.</exception>
+#if NET6_0_OR_GREATER
+    [RequiresDynamicCode("The method uses reflection and will not work in AOT environments.")]
+    [RequiresUnreferencedCode("The method uses reflection and will not work in AOT environments.")]
+#endif
     public static ReactiveCommand<Unit, Unit> Create(
         Action execute,
         IObservable<bool>? canExecute = null,
@@ -106,6 +106,10 @@ public static class ReactiveCommand
     /// The <c>ReactiveCommand</c> instance.
     /// </returns>
     /// <exception cref="System.ArgumentNullException">execute.</exception>
+#if NET6_0_OR_GREATER
+    [RequiresDynamicCode("The method uses reflection and will not work in AOT environments.")]
+    [RequiresUnreferencedCode("The method uses reflection and will not work in AOT environments.")]
+#endif
     public static ReactiveCommand<Unit, Unit> CreateRunInBackground(
         Action execute,
         IObservable<bool>? canExecute = null,
@@ -129,6 +133,10 @@ public static class ReactiveCommand
     /// The <c>ReactiveCommand</c> instance.
     /// </returns>
     /// <exception cref="System.ArgumentNullException">execute.</exception>
+#if NET6_0_OR_GREATER
+    [RequiresDynamicCode("The method uses reflection and will not work in AOT environments.")]
+    [RequiresUnreferencedCode("The method uses reflection and will not work in AOT environments.")]
+#endif
     public static ReactiveCommand<Unit, TResult> Create<TResult>(
         Func<TResult> execute,
         IObservable<bool>? canExecute = null,
@@ -161,6 +169,10 @@ public static class ReactiveCommand
     /// The <c>ReactiveCommand</c> instance.
     /// </returns>
     /// <exception cref="System.ArgumentNullException">execute.</exception>
+#if NET6_0_OR_GREATER
+    [RequiresDynamicCode("The method uses reflection and will not work in AOT environments.")]
+    [RequiresUnreferencedCode("The method uses reflection and will not work in AOT environments.")]
+#endif
     public static ReactiveCommand<Unit, TResult> CreateRunInBackground<TResult>(
         Func<TResult> execute,
         IObservable<bool>? canExecute = null,
@@ -183,6 +195,10 @@ public static class ReactiveCommand
     /// The <c>ReactiveCommand</c> instance.
     /// </returns>
     /// <exception cref="System.ArgumentNullException">execute.</exception>
+#if NET6_0_OR_GREATER
+    [RequiresDynamicCode("The method uses reflection and will not work in AOT environments.")]
+    [RequiresUnreferencedCode("The method uses reflection and will not work in AOT environments.")]
+#endif
     public static ReactiveCommand<TParam, Unit> Create<TParam>(
         Action<TParam> execute,
         IObservable<bool>? canExecute = null,
@@ -215,6 +231,10 @@ public static class ReactiveCommand
     /// The <c>ReactiveCommand</c> instance.
     /// </returns>
     /// <exception cref="System.ArgumentNullException">execute.</exception>
+#if NET6_0_OR_GREATER
+    [RequiresDynamicCode("The method uses reflection and will not work in AOT environments.")]
+    [RequiresUnreferencedCode("The method uses reflection and will not work in AOT environments.")]
+#endif
     public static ReactiveCommand<TParam, Unit> CreateRunInBackground<TParam>(
         Action<TParam> execute,
         IObservable<bool>? canExecute = null,
@@ -239,6 +259,10 @@ public static class ReactiveCommand
     /// The <c>ReactiveCommand</c> instance.
     /// </returns>
     /// <exception cref="System.ArgumentNullException">execute.</exception>
+#if NET6_0_OR_GREATER
+    [RequiresDynamicCode("The method uses reflection and will not work in AOT environments.")]
+    [RequiresUnreferencedCode("The method uses reflection and will not work in AOT environments.")]
+#endif
     public static ReactiveCommand<TParam, TResult> Create<TParam, TResult>(
         Func<TParam, TResult> execute,
         IObservable<bool>? canExecute = null,
@@ -272,6 +296,10 @@ public static class ReactiveCommand
     /// The <c>ReactiveCommand</c> instance.
     /// </returns>
     /// <exception cref="System.ArgumentNullException">execute.</exception>
+#if NET6_0_OR_GREATER
+    [RequiresDynamicCode("The method uses reflection and will not work in AOT environments.")]
+    [RequiresUnreferencedCode("The method uses reflection and will not work in AOT environments.")]
+#endif
     public static ReactiveCommand<TParam, TResult> CreateRunInBackground<TParam, TResult>(
         Func<TParam, TResult> execute,
         IObservable<bool>? canExecute = null,
@@ -305,6 +333,10 @@ public static class ReactiveCommand
     /// <typeparam name="TResult">
     /// The type of the command's result.
     /// </typeparam>
+#if NET6_0_OR_GREATER
+    [RequiresDynamicCode("The method uses reflection and will not work in AOT environments.")]
+    [RequiresUnreferencedCode("The method uses reflection and will not work in AOT environments.")]
+#endif
     public static CombinedReactiveCommand<TParam, TResult> CreateCombined<TParam, TResult>(
         IEnumerable<ReactiveCommandBase<TParam, TResult>> childCommands,
         IObservable<bool>? canExecute = null,
@@ -333,6 +365,10 @@ public static class ReactiveCommand
     /// <typeparam name="TResult">
     /// The type of the command's result.
     /// </typeparam>
+#if NET6_0_OR_GREATER
+    [RequiresDynamicCode("The method uses reflection and will not work in AOT environments.")]
+    [RequiresUnreferencedCode("The method uses reflection and will not work in AOT environments.")]
+#endif
     public static ReactiveCommand<Unit, TResult> CreateFromObservable<TResult>(
         Func<IObservable<TResult>> execute,
         IObservable<bool>? canExecute = null,
@@ -367,6 +403,10 @@ public static class ReactiveCommand
     /// <typeparam name="TResult">
     /// The type of the command's result.
     /// </typeparam>
+#if NET6_0_OR_GREATER
+    [RequiresDynamicCode("The method uses reflection and will not work in AOT environments.")]
+    [RequiresUnreferencedCode("The method uses reflection and will not work in AOT environments.")]
+#endif
     public static ReactiveCommand<TParam, TResult> CreateFromObservable<TParam, TResult>(
         Func<TParam, IObservable<TResult>> execute,
         IObservable<bool>? canExecute = null,
@@ -398,6 +438,10 @@ public static class ReactiveCommand
     /// <typeparam name="TResult">
     /// The type of the command's result.
     /// </typeparam>
+#if NET6_0_OR_GREATER
+    [RequiresDynamicCode("The method uses reflection and will not work in AOT environments.")]
+    [RequiresUnreferencedCode("The method uses reflection and will not work in AOT environments.")]
+#endif
     public static ReactiveCommand<Unit, TResult> CreateFromTask<TResult>(
         Func<Task<TResult>> execute,
         IObservable<bool>? canExecute = null,
@@ -426,6 +470,10 @@ public static class ReactiveCommand
     /// <typeparam name="TResult">
     /// The type of the command's result.
     /// </typeparam>
+#if NET6_0_OR_GREATER
+    [RequiresDynamicCode("The method uses reflection and will not work in AOT environments.")]
+    [RequiresUnreferencedCode("The method uses reflection and will not work in AOT environments.")]
+#endif
     public static ReactiveCommand<Unit, TResult> CreateFromTask<TResult>(
         Func<CancellationToken, Task<TResult>> execute,
         IObservable<bool>? canExecute = null,
@@ -451,6 +499,10 @@ public static class ReactiveCommand
     /// <returns>
     /// The <c>ReactiveCommand</c> instance.
     /// </returns>
+#if NET6_0_OR_GREATER
+    [RequiresDynamicCode("The method uses reflection and will not work in AOT environments.")]
+    [RequiresUnreferencedCode("The method uses reflection and will not work in AOT environments.")]
+#endif
     public static ReactiveCommand<Unit, Unit> CreateFromTask(
         Func<Task> execute,
         IObservable<bool>? canExecute = null,
@@ -476,6 +528,10 @@ public static class ReactiveCommand
     /// <returns>
     /// The <c>ReactiveCommand</c> instance.
     /// </returns>
+#if NET6_0_OR_GREATER
+    [RequiresDynamicCode("The method uses reflection and will not work in AOT environments.")]
+    [RequiresUnreferencedCode("The method uses reflection and will not work in AOT environments.")]
+#endif
     public static ReactiveCommand<Unit, Unit> CreateFromTask(
         Func<CancellationToken, Task> execute,
         IObservable<bool>? canExecute = null,
@@ -507,6 +563,10 @@ public static class ReactiveCommand
     /// <typeparam name="TResult">
     /// The type of the command's result.
     /// </typeparam>
+#if NET6_0_OR_GREATER
+    [RequiresDynamicCode("The method uses reflection and will not work in AOT environments.")]
+    [RequiresUnreferencedCode("The method uses reflection and will not work in AOT environments.")]
+#endif
     public static ReactiveCommand<TParam, TResult> CreateFromTask<TParam, TResult>(
         Func<TParam, Task<TResult>> execute,
         IObservable<bool>? canExecute = null,
@@ -541,6 +601,10 @@ public static class ReactiveCommand
     /// <typeparam name="TResult">
     /// The type of the command's result.
     /// </typeparam>
+#if NET6_0_OR_GREATER
+    [RequiresDynamicCode("The method uses reflection and will not work in AOT environments.")]
+    [RequiresUnreferencedCode("The method uses reflection and will not work in AOT environments.")]
+#endif
     public static ReactiveCommand<TParam, TResult> CreateFromTask<TParam, TResult>(
         Func<TParam, CancellationToken, Task<TResult>> execute,
         IObservable<bool>? canExecute = null,
@@ -572,6 +636,10 @@ public static class ReactiveCommand
     /// <typeparam name="TParam">
     /// The type of the parameter passed through to command execution.
     /// </typeparam>
+#if NET6_0_OR_GREATER
+    [RequiresDynamicCode("The method uses reflection and will not work in AOT environments.")]
+    [RequiresUnreferencedCode("The method uses reflection and will not work in AOT environments.")]
+#endif
     public static ReactiveCommand<TParam, Unit> CreateFromTask<TParam>(
         Func<TParam, Task> execute,
         IObservable<bool>? canExecute = null,
@@ -603,6 +671,10 @@ public static class ReactiveCommand
     /// <typeparam name="TParam">
     /// The type of the parameter passed through to command execution.
     /// </typeparam>
+#if NET6_0_OR_GREATER
+    [RequiresDynamicCode("The method uses reflection and will not work in AOT environments.")]
+    [RequiresUnreferencedCode("The method uses reflection and will not work in AOT environments.")]
+#endif
     public static ReactiveCommand<TParam, Unit> CreateFromTask<TParam>(
         Func<TParam, CancellationToken, Task> execute,
         IObservable<bool>? canExecute = null,
@@ -628,6 +700,10 @@ public static class ReactiveCommand
     /// The <c>ReactiveCommand</c> instance.
     /// </returns>
     /// <exception cref="System.ArgumentNullException">execute.</exception>
+#if NET6_0_OR_GREATER
+    [RequiresDynamicCode("The method uses reflection and will not work in AOT environments.")]
+    [RequiresUnreferencedCode("The method uses reflection and will not work in AOT environments.")]
+#endif
     internal static ReactiveCommand<TParam, TResult> CreateFromObservableCancellable<TParam, TResult>(
         Func<IObservable<(IObservable<TResult> Result, Action Cancel)>> execute,
         IObservable<bool>? canExecute = null,
@@ -662,6 +738,10 @@ public static class ReactiveCommand
     /// <typeparam name="TResult">
     /// The type of the command's result.
     /// </typeparam>
+#if NET6_0_OR_GREATER
+    [RequiresDynamicCode("The method uses reflection and will not work in AOT environments.")]
+    [RequiresUnreferencedCode("The method uses reflection and will not work in AOT environments.")]
+#endif
     internal static ReactiveCommand<TParam, TResult> CreateFromObservableCancellable<TParam, TResult>(
         Func<TParam, IObservable<(IObservable<TResult> Result, Action Cancel)>> execute,
         IObservable<bool>? canExecute = null,
@@ -696,10 +776,6 @@ public static class ReactiveCommand
                     "StyleCop.CSharp.MaintainabilityRules",
                     "SA1402:FileMayOnlyContainASingleType",
                     Justification = "Same class just generic.")]
-#if NET6_0_OR_GREATER
-[RequiresDynamicCode("The method uses reflection and will not work in AOT environments.")]
-[RequiresUnreferencedCode("The method uses reflection and will not work in AOT environments.")]
-#endif
 public class ReactiveCommand<TParam, TResult> : ReactiveCommandBase<TParam, TResult>
 {
     private readonly IObservable<bool> _canExecute;
@@ -726,6 +802,10 @@ public class ReactiveCommand<TParam, TResult> : ReactiveCommandBase<TParam, TRes
     /// execute.
     /// </exception>
     /// <exception cref="ArgumentNullException">Thrown if any dependent parameters are null.</exception>
+#if NET6_0_OR_GREATER
+    [RequiresDynamicCode("The method uses reflection and will not work in AOT environments.")]
+    [RequiresUnreferencedCode("The method uses reflection and will not work in AOT environments.")]
+#endif
     protected internal ReactiveCommand(
         Func<TParam, IObservable<(IObservable<TResult> Result, Action Cancel)>> execute,
         IObservable<bool>? canExecute,
@@ -780,6 +860,10 @@ public class ReactiveCommand<TParam, TResult> : ReactiveCommandBase<TParam, TRes
     /// execute.
     /// </exception>
     /// <exception cref="ArgumentNullException">Thrown if any dependent parameters are null.</exception>
+#if NET6_0_OR_GREATER
+    [RequiresDynamicCode("The method uses reflection and will not work in AOT environments.")]
+    [RequiresUnreferencedCode("The method uses reflection and will not work in AOT environments.")]
+#endif
     protected internal ReactiveCommand(
         Func<TParam, IObservable<TResult>> execute,
         IObservable<bool>? canExecute,

--- a/src/ReactiveUI/Registration/Registrations.cs
+++ b/src/ReactiveUI/Registration/Registrations.cs
@@ -13,10 +13,6 @@ namespace ReactiveUI;
 /// To get these registrations after the main ReactiveUI Initialization use the
 /// DependencyResolverMixins.InitializeReactiveUI() extension method.
 /// </summary>
-#if NET6_0_OR_GREATER
-[RequiresDynamicCode("The method uses reflection and will not work in AOT environments.")]
-[RequiresUnreferencedCode("The method uses reflection and will not work in AOT environments.")]
-#endif
 public class Registrations : IWantsToRegisterStuff
 {
     /// <inheritdoc/>

--- a/src/ReactiveUI/RxApp.cs
+++ b/src/ReactiveUI/RxApp.cs
@@ -239,6 +239,9 @@ public static class RxApp
         set => _unitTestMainThreadScheduler = value;
     }
 
+    /// <summary>
+    /// Set up default initializations.
+    /// </summary>
     [MethodImpl(MethodImplOptions.NoOptimization)]
     internal static void EnsureInitialized()
     {

--- a/src/ReactiveUI/View/DefaultViewLocator.cs
+++ b/src/ReactiveUI/View/DefaultViewLocator.cs
@@ -12,10 +12,6 @@ namespace ReactiveUI;
 /// Default implementation for <see cref="IViewLocator"/>. The default <see cref="ViewModelToViewFunc"/>
 /// behavior is to replace instances of "View" with "ViewMode" in the Fully Qualified Name of the ViewModel type.
 /// </summary>
-#if NET6_0_OR_GREATER
-[RequiresDynamicCode("The method uses reflection and will not work in AOT environments.")]
-[RequiresUnreferencedCode("The method uses reflection and will not work in AOT environments.")]
-#endif
 public sealed class DefaultViewLocator : IViewLocator
 {
     /// <summary>
@@ -131,6 +127,10 @@ public sealed class DefaultViewLocator : IViewLocator
         return null;
     }
 
+#if NET6_0_OR_GREATER
+    [RequiresDynamicCode("The method uses reflection and will not work in AOT environments.")]
+    [RequiresUnreferencedCode("The method uses reflection and will not work in AOT environments.")]
+#endif
     private static Type? ToggleViewModelType(Type viewModelType)
     {
         var viewModelTypeName = viewModelType.AssemblyQualifiedName;
@@ -180,7 +180,8 @@ public sealed class DefaultViewLocator : IViewLocator
     }
 
 #if NET6_0_OR_GREATER
-    [RequiresDynamicCode("The method is used to resolve views for view models.")]
+    [RequiresDynamicCode("The method uses reflection and will not work in AOT environments.")]
+    [RequiresUnreferencedCode("The method uses reflection and will not work in AOT environments.")]
 #endif
     private IViewFor? AttemptViewResolutionFor(Type? viewModelType, string? contract)
     {
@@ -208,6 +209,10 @@ public sealed class DefaultViewLocator : IViewLocator
         return AttemptViewResolution(proposedViewTypeName, contract);
     }
 
+#if NET6_0_OR_GREATER
+    [RequiresDynamicCode("The method uses reflection and will not work in AOT environments.")]
+    [RequiresUnreferencedCode("The method uses reflection and will not work in AOT environments.")]
+#endif
     private IViewFor? AttemptViewResolution(string? viewTypeName, string? contract)
     {
         try


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

update

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

Some AOT markup is applied to broadly

**What is the new behavior?**
<!-- If this is a feature change -->

Added [RequiresDynamicCode] and [RequiresUnreferencedCode] attributes to methods and interfaces that use reflection and are not compatible with AOT environments in .NET 6 or greater. This change improves compatibility and provides clearer warnings for developers targeting AOT scenarios.

**What might this PR break?**

AOT requirements updated

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

