### PR TITLE
Refactor WhenAnyValue usage to generic overloads

### DIFF
--- a/src/ReactiveUI.AOTTests/ReactiveUI.AOT.Tests.csproj
+++ b/src/ReactiveUI.AOTTests/ReactiveUI.AOT.Tests.csproj
@@ -9,6 +9,7 @@
     <PublishAot>true</PublishAot>
     <InvariantGlobalization>true</InvariantGlobalization>
     <TrimMode>full</TrimMode>
+    <NoWarn>$(NoWarn);IL2026;IL3050;</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ReactiveUI.AOTTests/StringBasedObservationTests.cs
+++ b/src/ReactiveUI.AOTTests/StringBasedObservationTests.cs
@@ -3,6 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Reactive.Concurrency;
 using System.Reactive.Linq;
 

--- a/src/ReactiveUI.AndroidX/Registrations.cs
+++ b/src/ReactiveUI.AndroidX/Registrations.cs
@@ -17,6 +17,8 @@ public class Registrations : IWantsToRegisterStuff
 #if NET6_0_OR_GREATER
     [RequiresDynamicCode("Register uses methods that require dynamic code generation")]
     [RequiresUnreferencedCode("Register uses methods that may require unreferenced code")]
+    [SuppressMessage("Trimming", "IL2046:'RequiresUnreferencedCodeAttribute' annotations must match across all interface implementations or overrides.", Justification = "Not all paths use reflection")]
+    [SuppressMessage("AOT", "IL3051:'RequiresDynamicCodeAttribute' annotations must match across all interface implementations or overrides.", Justification = "Not all paths use reflection")]
 #endif
     public void Register(Action<Func<object>, Type> registerFunction)
     {

--- a/src/ReactiveUI.Blazor/ReactiveComponentBase.cs
+++ b/src/ReactiveUI.Blazor/ReactiveComponentBase.cs
@@ -92,7 +92,7 @@ public class ReactiveComponentBase<T> : ComponentBase, IViewFor<T>, INotifyPrope
         {
             // The following subscriptions are here because if they are done in OnInitialized, they conflict with certain JavaScript frameworks.
             var viewModelChanged =
-                this.WhenAnyValue(x => x.ViewModel)
+                this.WhenAnyValue<ReactiveComponentBase<T>, T?>(nameof(ViewModel))
                     .WhereNotNull()
                     .Publish()
                     .RefCount(2);

--- a/src/ReactiveUI.Blazor/ReactiveInjectableComponentBase.cs
+++ b/src/ReactiveUI.Blazor/ReactiveInjectableComponentBase.cs
@@ -94,7 +94,7 @@ public class ReactiveInjectableComponentBase<T> : ComponentBase, IViewFor<T>, IN
         {
             // The following subscriptions are here because if they are done in OnInitialized, they conflict with certain JavaScript frameworks.
             var viewModelChanged =
-                this.WhenAnyValue(x => x.ViewModel)
+                this.WhenAnyValue<ReactiveInjectableComponentBase<T>, T?>(nameof(ViewModel))
                     .WhereNotNull()
                     .Publish()
                     .RefCount(2);

--- a/src/ReactiveUI.Blazor/ReactiveLayoutComponentBase.cs
+++ b/src/ReactiveUI.Blazor/ReactiveLayoutComponentBase.cs
@@ -91,7 +91,7 @@ public class ReactiveLayoutComponentBase<T> : LayoutComponentBase, IViewFor<T>, 
         if (isFirstRender)
         {
             var viewModelChanged =
-                this.WhenAnyValue(x => x.ViewModel)
+                this.WhenAnyValue<ReactiveLayoutComponentBase<T>, T?>(nameof(ViewModel))
                     .WhereNotNull()
                     .Publish()
                     .RefCount(2);

--- a/src/ReactiveUI.Blazor/Registrations.cs
+++ b/src/ReactiveUI.Blazor/Registrations.cs
@@ -17,6 +17,8 @@ public class Registrations : IWantsToRegisterStuff
 #if NET6_0_OR_GREATER
     [RequiresDynamicCode("Register uses methods that require dynamic code generation")]
     [RequiresUnreferencedCode("Register uses methods that may require unreferenced code")]
+    [SuppressMessage("Trimming", "IL2046:'RequiresUnreferencedCodeAttribute' annotations must match across all interface implementations or overrides.", Justification = "Not all paths use reflection")]
+    [SuppressMessage("AOT", "IL3051:'RequiresDynamicCodeAttribute' annotations must match across all interface implementations or overrides.", Justification = "Not all paths use reflection")]
 #endif
     public void Register(Action<Func<object>, Type> registerFunction)
     {

--- a/src/ReactiveUI.Builder.WpfApp/ViewModels/ChatRoomViewModel.cs
+++ b/src/ReactiveUI.Builder.WpfApp/ViewModels/ChatRoomViewModel.cs
@@ -33,7 +33,7 @@ public class ChatRoomViewModel : ReactiveObject, IRoutableViewModel
         _room = room;
         _user = user;
 
-        var canSend = this.WhenAnyValue(x => x.MessageText, txt => !string.IsNullOrWhiteSpace(txt));
+        var canSend = this.WhenAnyValue<ChatRoomViewModel, bool, string>(nameof(MessageText), txt => !string.IsNullOrWhiteSpace(txt));
         SendMessage = ReactiveCommand.Create(SendMessageImpl, canSend);
 
         // Observe new incoming messages via MessageBus using the room name as the contract across instances

--- a/src/ReactiveUI.Builder.WpfApp/ViewModels/LobbyViewModel.cs
+++ b/src/ReactiveUI.Builder.WpfApp/ViewModels/LobbyViewModel.cs
@@ -29,7 +29,7 @@ public class LobbyViewModel : ReactiveObject, IRoutableViewModel
         HostScreen = hostScreen;
         UrlPathSegment = "lobby";
 
-        var canCreate = this.WhenAnyValue(x => x.RoomName, rn => !string.IsNullOrWhiteSpace(rn));
+        var canCreate = this.WhenAnyValue<LobbyViewModel, bool, string>(nameof(RoomName), rn => !string.IsNullOrWhiteSpace(rn));
         CreateRoom = ReactiveCommand.Create(CreateRoomImpl, canCreate);
 
         DeleteRoom = ReactiveCommand.Create<ChatRoom>(DeleteRoomImpl);

--- a/src/ReactiveUI.Builder.WpfApp/Views/ChatRoomView.xaml.cs
+++ b/src/ReactiveUI.Builder.WpfApp/Views/ChatRoomView.xaml.cs
@@ -5,6 +5,7 @@
 
 using System.Reactive.Disposables;
 using System.Windows;
+using ReactiveUI.Builder.WpfApp.ViewModels;
 
 namespace ReactiveUI.Builder.WpfApp.Views;
 
@@ -28,7 +29,7 @@ public partial class ChatRoomView : IViewFor<ViewModels.ChatRoomViewModel>
         this.WhenActivated(d =>
         {
             // Map ViewModel to DataContext for XAML bindings like {Binding RoomName}
-            this.WhenAnyValue(v => v.ViewModel).BindTo(this, v => v.DataContext).DisposeWith(d);
+            this.WhenAnyValue<ChatRoomView, ChatRoomViewModel>(nameof(ViewModel)).BindTo(this, v => v.DataContext).DisposeWith(d);
 
             this.Bind(ViewModel, vm => vm.MessageText, v => v.MessageBox.Text).DisposeWith(d);
             this.BindCommand(ViewModel, vm => vm.SendMessage, v => v.SendButton).DisposeWith(d);

--- a/src/ReactiveUI.Builder.WpfApp/Views/LobbyView.xaml.cs
+++ b/src/ReactiveUI.Builder.WpfApp/Views/LobbyView.xaml.cs
@@ -43,7 +43,7 @@ public partial class LobbyView : IViewFor<ViewModels.LobbyViewModel>
             }).DisposeWith(d);
 
             // Delete selected room via Delete button only
-            var selectedRoomStream = this.WhenAnyValue(x => x.RoomsList.SelectedItem)
+            var selectedRoomStream = this.WhenAnyValue<LobbyView, object>(nameof(RoomsList.SelectedItem))
                 .Select(x => x as ChatRoom)
                 .WhereNotNull();
             this.BindCommand(ViewModel, vm => vm.DeleteRoom, v => v.DeleteRoomButton, selectedRoomStream)

--- a/src/ReactiveUI.Drawing/Registrations.cs
+++ b/src/ReactiveUI.Drawing/Registrations.cs
@@ -17,6 +17,8 @@ public class Registrations : IWantsToRegisterStuff
 #if NET6_0_OR_GREATER
     [RequiresDynamicCode("Register uses methods that require dynamic code generation")]
     [RequiresUnreferencedCode("Register uses methods that may require unreferenced code")]
+    [SuppressMessage("Trimming", "IL2046:'RequiresUnreferencedCodeAttribute' annotations must match across all interface implementations or overrides.", Justification = "Not all paths use reflection")]
+    [SuppressMessage("AOT", "IL3051:'RequiresDynamicCodeAttribute' annotations must match across all interface implementations or overrides.", Justification = "Not all paths use reflection")]
 #endif
     public void Register(Action<Func<object>, Type> registerFunction)
     {

--- a/src/ReactiveUI.Maui/ActivationForViewFetcher.cs
+++ b/src/ReactiveUI.Maui/ActivationForViewFetcher.cs
@@ -177,7 +177,7 @@ public class ActivationForViewFetcher : IActivationForViewFetcher
 
         return viewLoaded
                .Merge(viewUnloaded)
-               .Select(b => b ? view.WhenAnyValue(x => x.IsHitTestVisible).SkipWhile(x => !x) : Observables.False)
+               .Select(b => b ? view.WhenAnyValue<FrameworkElement, bool>(nameof(view.IsHitTestVisible)).SkipWhile(x => !x) : Observables.False)
                .Switch()
                .DistinctUntilChanged();
     }

--- a/src/ReactiveUI.Maui/Common/ViewModelViewHost.cs
+++ b/src/ReactiveUI.Maui/Common/ViewModelViewHost.cs
@@ -79,7 +79,7 @@ public partial class ViewModelViewHost : TransitioningContentControl, IViewFor, 
               .DistinctUntilChanged();
 
         var contractChanged = this.WhenAnyObservable(x => x.ViewContractObservable).Do(x => _viewContract = x).StartWith(ViewContract);
-        var viewModelChanged = this.WhenAnyValue(x => x.ViewModel).StartWith(ViewModel);
+        var viewModelChanged = this.WhenAnyValue<ViewModelViewHost, object?>(nameof(ViewModel)).StartWith(ViewModel);
         var vmAndContract = contractChanged
             .CombineLatest(viewModelChanged, (contract, vm) => (ViewModel: vm, Contract: contract));
 

--- a/src/ReactiveUI.Maui/Registrations.cs
+++ b/src/ReactiveUI.Maui/Registrations.cs
@@ -25,6 +25,8 @@ public class Registrations : IWantsToRegisterStuff
 #if NET6_0_OR_GREATER
     [RequiresDynamicCode("Register uses methods that require dynamic code generation")]
     [RequiresUnreferencedCode("Register uses methods that may require unreferenced code")]
+    [SuppressMessage("Trimming", "IL2046:'RequiresUnreferencedCodeAttribute' annotations must match across all interface implementations or overrides.", Justification = "Not all paths use reflection")]
+    [SuppressMessage("AOT", "IL3051:'RequiresDynamicCodeAttribute' annotations must match across all interface implementations or overrides.", Justification = "Not all paths use reflection")]
 #endif
     public void Register(Action<Func<object>, Type> registerFunction)
     {

--- a/src/ReactiveUI.Maui/ViewModelViewHost.cs
+++ b/src/ReactiveUI.Maui/ViewModelViewHost.cs
@@ -69,7 +69,7 @@ public partial class ViewModelViewHost : ContentView, IViewFor
 
         ViewContractObservable = Observable<string>.Default;
 
-        var vmAndContract = this.WhenAnyValue(x => x.ViewModel).CombineLatest(
+        var vmAndContract = this.WhenAnyValue<ViewModelViewHost, object?>(nameof(ViewModel)).CombineLatest(
                                                                               this.WhenAnyObservable(x => x.ViewContractObservable),
                                                                               (vm, contract) => new { ViewModel = vm, Contract = contract, });
 

--- a/src/ReactiveUI.Winforms/Registrations.cs
+++ b/src/ReactiveUI.Winforms/Registrations.cs
@@ -15,6 +15,8 @@ public class Registrations : IWantsToRegisterStuff
 #if NET6_0_OR_GREATER
     [RequiresDynamicCode("Register uses methods that require dynamic code generation")]
     [RequiresUnreferencedCode("Register uses methods that may require unreferenced code")]
+    [SuppressMessage("Trimming", "IL2046:'RequiresUnreferencedCodeAttribute' annotations must match across all interface implementations or overrides.", Justification = "Not all paths use reflection")]
+    [SuppressMessage("AOT", "IL3051:'RequiresDynamicCodeAttribute' annotations must match across all interface implementations or overrides.", Justification = "Not all paths use reflection")]
 #endif
     public void Register(Action<Func<object>, Type> registerFunction)
     {

--- a/src/ReactiveUI.Winforms/ViewModelViewHost.cs
+++ b/src/ReactiveUI.Winforms/ViewModelViewHost.cs
@@ -153,7 +153,7 @@ public partial class ViewModelControlHost : UserControl, IReactiveObject, IViewF
     private IEnumerable<IDisposable> SetupBindings()
     {
         var viewChanges =
-            this.WhenAnyValue(x => x!.Content)
+            this.WhenAnyValue<ViewModelControlHost, object?>(nameof(Content))
                 .WhereNotNull()
                 .OfType<Control>()
                 .Subscribe(x =>
@@ -175,7 +175,7 @@ public partial class ViewModelControlHost : UserControl, IReactiveObject, IViewF
 
         yield return viewChanges!;
 
-        yield return this.WhenAnyValue(x => x.DefaultContent).Subscribe(x =>
+        yield return this.WhenAnyValue<ViewModelControlHost, Control?>(nameof(DefaultContent)).Subscribe(x =>
         {
             if (x is not null)
             {
@@ -186,7 +186,7 @@ public partial class ViewModelControlHost : UserControl, IReactiveObject, IViewF
         ViewContractObservable = Observable.Return(string.Empty);
 
         var vmAndContract =
-            this.WhenAnyValue(x => x.ViewModel)
+            this.WhenAnyValue<ViewModelControlHost, object?>(nameof(ViewModel))
                 .CombineLatest(
                                this.WhenAnyObservable(x => x.ViewContractObservable!),
                                (vm, contract) => new { ViewModel = vm, Contract = contract });

--- a/src/ReactiveUI.Wpf/Common/ViewModelViewHost.cs
+++ b/src/ReactiveUI.Wpf/Common/ViewModelViewHost.cs
@@ -106,7 +106,7 @@ public
               .DistinctUntilChanged();
 
         var contractChanged = this.WhenAnyObservable(x => x.ViewContractObservable).Do(x => _viewContract = x).StartWith(ViewContract);
-        var viewModelChanged = this.WhenAnyValue(x => x.ViewModel).StartWith(ViewModel);
+        var viewModelChanged = this.WhenAnyValue<ViewModelViewHost, object?>(nameof(ViewModel)).StartWith(ViewModel);
         var vmAndContract = contractChanged
             .CombineLatest(viewModelChanged, (contract, vm) => (ViewModel: vm, Contract: contract));
 

--- a/src/ReactiveUI.Wpf/Registrations.cs
+++ b/src/ReactiveUI.Wpf/Registrations.cs
@@ -14,6 +14,8 @@ public class Registrations : IWantsToRegisterStuff
 #if NET6_0_OR_GREATER
     [RequiresDynamicCode("Register uses methods that require dynamic code generation")]
     [RequiresUnreferencedCode("Register uses methods that may require unreferenced code")]
+    [SuppressMessage("Trimming", "IL2046:'RequiresUnreferencedCodeAttribute' annotations must match across all interface implementations or overrides.", Justification = "Not all paths use reflection")]
+    [SuppressMessage("AOT", "IL3051:'RequiresDynamicCodeAttribute' annotations must match across all interface implementations or overrides.", Justification = "Not all paths use reflection")]
 #endif
     public void Register(Action<Func<object>, Type> registerFunction)
     {

--- a/src/ReactiveUI/Platforms/android/PlatformRegistrations.cs
+++ b/src/ReactiveUI/Platforms/android/PlatformRegistrations.cs
@@ -15,6 +15,8 @@ public class PlatformRegistrations : IWantsToRegisterStuff
 #if NET6_0_OR_GREATER
     [RequiresDynamicCode("Platform registration uses ComponentModelTypeConverter and RxApp which require dynamic code generation")]
     [RequiresUnreferencedCode("Platform registration uses ComponentModelTypeConverter and RxApp which may require unreferenced code")]
+    [SuppressMessage("Trimming", "IL2046:'RequiresUnreferencedCodeAttribute' annotations must match across all interface implementations or overrides.", Justification = "Not all paths use reflection")]
+    [SuppressMessage("AOT", "IL3051:'RequiresDynamicCodeAttribute' annotations must match across all interface implementations or overrides.", Justification = "Not all paths use reflection")]
 #endif
     public void Register(Action<Func<object>, Type> registerFunction) // TODO: Create Test
     {

--- a/src/ReactiveUI/Platforms/mac/PlatformRegistrations.cs
+++ b/src/ReactiveUI/Platforms/mac/PlatformRegistrations.cs
@@ -15,6 +15,8 @@ public class PlatformRegistrations : IWantsToRegisterStuff
 #if NET6_0_OR_GREATER
     [RequiresDynamicCode("Platform registration uses ComponentModelTypeConverter and RxApp which require dynamic code generation")]
     [RequiresUnreferencedCode("Platform registration uses ComponentModelTypeConverter and RxApp which may require unreferenced code")]
+    [SuppressMessage("Trimming", "IL2046:'RequiresUnreferencedCodeAttribute' annotations must match across all interface implementations or overrides.", Justification = "Not all paths use reflection")]
+    [SuppressMessage("AOT", "IL3051:'RequiresDynamicCodeAttribute' annotations must match across all interface implementations or overrides.", Justification = "Not all paths use reflection")]
 #endif
     public void Register(Action<Func<object>, Type> registerFunction)
     {

--- a/src/ReactiveUI/Platforms/net/PlatformRegistrations.cs
+++ b/src/ReactiveUI/Platforms/net/PlatformRegistrations.cs
@@ -16,6 +16,8 @@ public class PlatformRegistrations : IWantsToRegisterStuff
 #if NET6_0_OR_GREATER
     [RequiresDynamicCode("Platform registration uses ComponentModelTypeConverter and RxApp which require dynamic code generation")]
     [RequiresUnreferencedCode("Platform registration uses ComponentModelTypeConverter and RxApp which may require unreferenced code")]
+    [SuppressMessage("Trimming", "IL2046:'RequiresUnreferencedCodeAttribute' annotations must match across all interface implementations or overrides.", Justification = "Not all paths use reflection")]
+    [SuppressMessage("AOT", "IL3051:'RequiresDynamicCodeAttribute' annotations must match across all interface implementations or overrides.", Justification = "Not all paths use reflection")]
 #endif
     public void Register(Action<Func<object>, Type> registerFunction)
     {

--- a/src/ReactiveUI/Platforms/uikit-common/PlatformRegistrations.cs
+++ b/src/ReactiveUI/Platforms/uikit-common/PlatformRegistrations.cs
@@ -15,6 +15,8 @@ public class PlatformRegistrations : IWantsToRegisterStuff
 #if NET6_0_OR_GREATER
     [RequiresDynamicCode("Platform registration uses ComponentModelTypeConverter and RxApp which require dynamic code generation")]
     [RequiresUnreferencedCode("Platform registration uses ComponentModelTypeConverter and RxApp which may require unreferenced code")]
+    [SuppressMessage("Trimming", "IL2046:'RequiresUnreferencedCodeAttribute' annotations must match across all interface implementations or overrides.", Justification = "Not all paths use reflection")]
+    [SuppressMessage("AOT", "IL3051:'RequiresDynamicCodeAttribute' annotations must match across all interface implementations or overrides.", Justification = "Not all paths use reflection")]
 #endif
     public void Register(Action<Func<object>, Type> registerFunction)
     {

--- a/src/ReactiveUI/Suspension/SuspensionHostExtensions.cs
+++ b/src/ReactiveUI/Suspension/SuspensionHostExtensions.cs
@@ -50,7 +50,7 @@ public static class SuspensionHostExtensions
     {
         item.ArgumentNullExceptionThrowIfNull(nameof(item));
 
-        return item.WhenAny(suspensionHost => suspensionHost.AppState, observedChange => observedChange.Value)
+        return item.WhenAny<ISuspensionHost, object?, object?>(nameof(item.AppState), observedChange => observedChange.Value)
                    .WhereNotNull()
                    .Cast<T>();
     }


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Update

**What is the new behavior?**
<!-- If this is a feature change -->

Replaces lambda-based WhenAnyValue calls with explicit generic overloads across multiple platforms and components for improved AOT compatibility and clarity. Adds SuppressMessage attributes to registration classes to address trimming and AOT warnings where dynamic code or reflection is not always used. Also updates project file to suppress IL2026 and IL3050 warnings for AOT tests.

**What might this PR break?**

New feature, part of a larger breaking change

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

