### PR TITLE
Ensure Splat initialization in builder and tests

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -4,7 +4,7 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <PropertyGroup>
-    <SplatVersion>15.5.3</SplatVersion>
+    <SplatVersion>16.0.1</SplatVersion>
     <XamarinAndroidXCoreVersion>1.13.1.4</XamarinAndroidXCoreVersion>
     <XamarinAndroidXLifecycleLiveDataVersion>2.8.4.1</XamarinAndroidXLifecycleLiveDataVersion>
   </PropertyGroup>

--- a/src/ReactiveUI.AOTTests/ViewLocatorAOTMappingTests.cs
+++ b/src/ReactiveUI.AOTTests/ViewLocatorAOTMappingTests.cs
@@ -13,6 +13,14 @@ namespace ReactiveUI.AOTTests;
 public class ViewLocatorAOTMappingTests
 {
     /// <summary>
+    /// Initializes a new instance of the <see cref="ViewLocatorAOTMappingTests"/> class.
+    /// </summary>
+    public ViewLocatorAOTMappingTests()
+    {
+        RxApp.EnsureInitialized();
+    }
+
+    /// <summary>
     /// Map/Resolve with contract and default fallback works.
     /// </summary>
     [Fact]

--- a/src/ReactiveUI.Builder.Maui.Tests/ReactiveUIBuilderMauiTests.cs
+++ b/src/ReactiveUI.Builder.Maui.Tests/ReactiveUIBuilderMauiTests.cs
@@ -31,7 +31,6 @@ public class ReactiveUIBuilderMauiTests
         using var locator = new ModernDependencyResolver();
 
         locator.CreateBuilder()
-               .WithCoreServices()
                .WithMaui()
                .Build();
 

--- a/src/ReactiveUI.Tests/Commands/ReactiveCommandTest.cs
+++ b/src/ReactiveUI.Tests/Commands/ReactiveCommandTest.cs
@@ -18,6 +18,11 @@ namespace ReactiveUI.Tests;
 /// </summary>
 public class ReactiveCommandTest
 {
+    public ReactiveCommandTest()
+    {
+        RxApp.EnsureInitialized();
+    }
+
     /// <summary>
     /// A test that determines whether this instance [can execute changed is available via ICommand].
     /// </summary>

--- a/src/ReactiveUI.Tests/Platforms/winforms/DefaultPropertyBindingTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/winforms/DefaultPropertyBindingTests.cs
@@ -18,6 +18,14 @@ namespace ReactiveUI.Tests.Winforms;
 public class DefaultPropertyBindingTests
 {
     /// <summary>
+    /// Initializes a new instance of the <see cref="DefaultPropertyBindingTests"/> class.
+    /// </summary>
+    public DefaultPropertyBindingTests()
+    {
+        RxApp.EnsureInitialized();
+    }
+
+    /// <summary>
     /// Tests Winforms creates observable for property works for textboxes.
     /// </summary>
     [Fact]

--- a/src/ReactiveUI.Tests/Platforms/wpf/ReactiveUIBuilderWpfTests.cs
+++ b/src/ReactiveUI.Tests/Platforms/wpf/ReactiveUIBuilderWpfTests.cs
@@ -14,6 +14,14 @@ namespace ReactiveUI.Tests.Platforms.Wpf;
 public class ReactiveUIBuilderWpfTests
 {
     /// <summary>
+    /// Initializes a new instance of the <see cref="ReactiveUIBuilderWpfTests"/> class.
+    /// </summary>
+    public ReactiveUIBuilderWpfTests()
+    {
+        RxApp.EnsureInitialized();
+    }
+
+    /// <summary>
     /// Test that WPF services can be registered using the builder.
     /// </summary>
     [Fact]

--- a/src/ReactiveUI/Builder/ReactiveUIBuilder.cs
+++ b/src/ReactiveUI/Builder/ReactiveUIBuilder.cs
@@ -38,6 +38,8 @@ public sealed class ReactiveUIBuilder(IMutableDependencyResolver resolver) : App
             return this;
         }
 
+        _resolver.InitializeSplat();
+
         // Immediately register the core ReactiveUI services into the provided resolver.
         var registrations = new Registrations();
 #pragma warning disable IL2067 // Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.

--- a/src/ReactiveUI/Mixins/ReactiveUIBuilderExtensions.cs
+++ b/src/ReactiveUI/Mixins/ReactiveUIBuilderExtensions.cs
@@ -26,6 +26,7 @@ public static class ReactiveUIBuilderExtensions
     public static AppBuilder CreateBuilder(this IMutableDependencyResolver resolver)
     {
         resolver.ArgumentNullExceptionThrowIfNull(nameof(resolver));
+        resolver.InitializeSplat();
         var builder = new Builder.ReactiveUIBuilder(resolver);
 
         // Queue core registrations by default so Build() always provides the basics

--- a/src/ReactiveUI/RxApp.cs
+++ b/src/ReactiveUI/RxApp.cs
@@ -84,6 +84,7 @@ public static class RxApp
 #if !PORTABLE
         _taskpoolScheduler = TaskPoolScheduler.Default;
 #endif
+        Locator.CurrentMutable.InitializeSplat();
 
         if (!AppBuilder.UsingBuilder)
         {
@@ -94,6 +95,7 @@ public static class RxApp
                     return;
                 }
 
+                Locator.CurrentMutable.InitializeSplat();
                 Locator.CurrentMutable.InitializeReactiveUI(PlatformRegistrationManager.NamespacesToRegister);
             });
         }


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

update, feature

**What is the new behavior?**
<!-- If this is a feature change -->

Added calls to InitializeSplat in ReactiveUIBuilder, builder extension, and RxApp static constructor to ensure Splat services are registered before core ReactiveUI services. Updated test classes to call RxApp.EnsureInitialized in constructors for consistent initialization. Also updated Splat package version in Directory.Packages.props.

**What might this PR break?**

Part of a major update for V21

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

