### PR TITLE
Add NonParallelizable attribute to tests

### DIFF
--- a/src/ReactiveUI.Tests/Locator/DefaultViewLocatorTests.cs
+++ b/src/ReactiveUI.Tests/Locator/DefaultViewLocatorTests.cs
@@ -9,6 +9,7 @@ namespace ReactiveUI.Tests;
 /// Tests for the default view locators.
 /// </summary>
 [TestFixture]
+[NonParallelizable]
 public partial class DefaultViewLocatorTests
 {
     /// <summary>


### PR DESCRIPTION
Some of the UI tests fail based on accessing static classes. 
