### PR TITLE
Fix TFMs missing for ReactiveUI.Testing

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -81,7 +81,7 @@
 
     <!-- Final target frameworks for tests/benchmarks (modern .NET only, with platform-specific additions) -->
     <ReactiveUIFinalModernTargetFrameworks>$(ReactiveUIModernTargets)</ReactiveUIFinalModernTargetFrameworks>
-    <ReactiveUIFinalModernTargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(ReactiveUIFrameworkTargets);$(ReactiveUIWindowsTargets)</ReactiveUIFinalModernTargetFrameworks>
+    <ReactiveUIFinalModernTargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(ReactiveUIFinalModernTargetFrameworks);$(ReactiveUIFrameworkTargets);$(ReactiveUIWindowsTargets)</ReactiveUIFinalModernTargetFrameworks>
   </PropertyGroup>
   
   <PropertyGroup>


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here. -->

ReactiveUI.Testing is missing `net8.0` and newer Target Frameworks

**What is the new behavior?**
<!-- If this is a feature change -->

ReactiveUI.Testing is now including the correct target frameworks

**What might this PR break?**



**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

ReactiveUIFinalModernTargetFrameworks was missing the initial value there was set on the variable and just overwriting it with new values, but only when building on Windows.

I've update the variant that is used with running on windows to include `$(ReactiveUIFinalModernTargetFrameworks)` similar to the other definitions.