### PR TITLE
Adding ReactiveOwningComponentBase

### DIFF
--- a/src/ReactiveUI.Blazor/ReactiveOwningComponentBase.cs
+++ b/src/ReactiveUI.Blazor/ReactiveOwningComponentBase.cs
@@ -20,7 +20,6 @@ public class ReactiveOwningComponentBase<T> : OwningComponentBase<T>, IViewFor<T
     private readonly Subject<Unit> _deactivateSubject = new();
     private readonly CompositeDisposable _compositeDisposable = [];
 
-    private bool _disposedValue; // To detect redundant calls
     private T? _viewModel;
 
     /// <inheritdoc />
@@ -116,22 +115,17 @@ public class ReactiveOwningComponentBase<T> : OwningComponentBase<T>, IViewFor<T
     /// Invokes the property changed event.
     /// </summary>
     /// <param name="propertyName">The name of the changed property.</param>
-    protected virtual void OnPropertyChanged([CallerMemberName]string? propertyName = null) =>
+    protected virtual void OnPropertyChanged([CallerMemberName] string? propertyName = null) =>
         PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
 
     /// <inheritdoc />
     protected override void Dispose(bool disposing)
     {
-        if (!_disposedValue)
+        if (disposing)
         {
-            if (disposing)
-            {
-                _initSubject.Dispose();
-                _compositeDisposable.Dispose();
-                _deactivateSubject.OnNext(Unit.Default);
-            }
-
-            _disposedValue = true;
+            _initSubject.Dispose();
+            _compositeDisposable.Dispose();
+            _deactivateSubject.OnNext(Unit.Default);
         }
     }
 }


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
This PR adds a `ReactiveOwningComponentBase<T>` to the ReactiveUI.Blazor project, as requested in #3001.



**What is the current behavior?**
There is currently no reactive base component that combines `OwningComponentBase<T>` with ReactiveUI’s `IViewFor<T>` / activation support in `ReactiveUI.Blazor`.



**What is the new behavior?**
Blazor components can derive from `ReactiveOwningComponentBase<T>` to:

- use an owning DI scope via `OwningComponentBase<T>`,
- expose a reactive `ViewModel` property,
- participate in activation (`ICanActivate`) and automatically call `StateHasChanged` on `INotifyPropertyChanged` changes.



**What might this PR break?**
No breaking changes are expected. The PR only introduces a new base class and does not modify existing public APIs or behavior.


**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
Fixes #3001.