### PR TITLE
Add platform-specific main thread schedulers for MAUI

### DIFF
--- a/src/ReactiveUI.Maui/Builder/MauiReactiveUIBuilderExtensions.cs
+++ b/src/ReactiveUI.Maui/Builder/MauiReactiveUIBuilderExtensions.cs
@@ -86,6 +86,11 @@ public static class MauiReactiveUIBuilderExtensions
 
         builder.WithTaskPoolScheduler(TaskPoolScheduler.Default);
 
+        if (ModeDetector.InUnitTestRunner())
+        {
+            return builder.WithMainThreadScheduler(RxApp.UnitTestMainThreadScheduler);
+        }
+
 #if ANDROID
         return builder.WithMainThreadScheduler(AndroidMainThreadScheduler);
 #elif MACCATALYST || IOS || MACOS || TVOS

--- a/src/ReactiveUI/RxApp.cs
+++ b/src/ReactiveUI/RxApp.cs
@@ -238,7 +238,7 @@ public static class RxApp
         }
     }
 
-    private static IScheduler UnitTestMainThreadScheduler
+    internal static IScheduler UnitTestMainThreadScheduler
     {
         get => _unitTestMainThreadScheduler ??= CurrentThreadScheduler.Instance;
 


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Fixes #4185 

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

#4185

**What is the new behavior?**
<!-- If this is a feature change -->

Introduces AndroidMainThreadScheduler and AppleMainThreadScheduler properties for platform-specific main thread scheduling. Updates WithMauiScheduler to use the appropriate scheduler based on the target platform, improving UI thread handling for Android, iOS, macOS, and Mac Catalyst.

**What might this PR break?**

Resolves a threading issue with Maui

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

