### PR TITLE
fix(doc): AutoSuspendHelper not known by all target frameworks

### DIFF
--- a/src/ReactiveUI/Platforms/android/AutoSuspendHelper.cs
+++ b/src/ReactiveUI/Platforms/android/AutoSuspendHelper.cs
@@ -88,8 +88,8 @@ public class AutoSuspendHelper : IEnableLogger, IDisposable
     /// Gets or sets the latest bundle.
     /// </summary>
     /// <remarks>
-    /// Updated whenever <see cref="Activity.OnSaveInstanceState"/> runs so callers can detect whether
-    /// <see cref="OnActivityCreated(Activity?, Bundle?)"/> represents a cold launch (<see langword="null"/>) or a
+    /// Updated whenever <see cref="Activity.OnSaveInstanceState(Bundle)"/> runs so callers can detect whether
+    /// <see cref="ObservableLifecycle.OnActivityCreated(Activity?, Bundle?)"/> represents a cold launch (<see langword="null"/>) or a
     /// recreation with persisted state.
     /// </remarks>
     public static Bundle? LatestBundle { get; set; }

--- a/src/ReactiveUI/Platforms/mac/AutoSuspendHelper.cs
+++ b/src/ReactiveUI/Platforms/mac/AutoSuspendHelper.cs
@@ -84,7 +84,7 @@ public class AutoSuspendHelper : IEnableLogger, IDisposable
     /// <param name="sender">The sender.</param>
     /// <returns>The termination reply from the application.</returns>
     /// <remarks>
-    /// Delays the OS shutdown until <see cref="RxApp.SuspensionHost.ShouldPersistState"/> subscribers finish writing
+    /// Delays the OS shutdown until <see cref="ISuspensionHost.ShouldPersistState"/> subscribers finish writing
     /// <see cref="ISuspensionHost.AppState"/>, replying with <see cref="NSApplication.ReplyToApplicationShouldTerminate(bool)"/>
     /// once persistence completes.
     /// </remarks>

--- a/src/ReactiveUI/Suspension/SuspensionHost.cs
+++ b/src/ReactiveUI/Suspension/SuspensionHost.cs
@@ -12,11 +12,11 @@ namespace ReactiveUI;
 /// <remarks>
 /// <para>
 /// <see cref="SuspensionHost"/> backs <see cref="RxApp.SuspensionHost"/> and provides concrete observables that are wired up
-/// by helpers such as <see cref="AutoSuspendHelper"/>. Platform hosts push their lifecycle notifications into the
-/// <c>ReplaySubject</c> instances exposed here and view models subscribe through <see cref="ISuspensionHost"/>.
+/// by helpers such as <c>AutoSuspendHelper</c>. Platform hosts push their lifecycle notifications into the
+/// <see cref="ReplaySubject{T}"/> instances exposed here and view models subscribe through <see cref="ISuspensionHost"/>.
 /// </para>
 /// <para>
-/// Consumers rarely instantiate this type directly; instead call <c>RxApp.SuspensionHost</c> to access the singleton. The
+/// Consumers rarely instantiate this type directly; instead call <see cref="RxApp.SuspensionHost"/> to access the singleton. The
 /// object is intentionally thread-safe via <see cref="ReplaySubject{T}"/> so events raised prior to subscription are
 /// replayed to late subscribers.
 /// </para>

--- a/src/ReactiveUI/Suspension/SuspensionHostExtensions.cs
+++ b/src/ReactiveUI/Suspension/SuspensionHostExtensions.cs
@@ -12,7 +12,7 @@ namespace ReactiveUI;
 /// <para>
 /// These helpers provide strongly-typed access to the current application state and wire up the
 /// <see cref="ISuspensionDriver"/> responsible for persisting it. They are typically invoked from platform bootstrap
-/// classes after registering an <see cref="AutoSuspendHelper"/>.
+/// classes after registering an <c>AutoSuspendHelper</c>.
 /// </para>
 /// </remarks>
 public static class SuspensionHostExtensions


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bug fix



**What is the current behavior?**
See #4244 



**What is the new behavior?**
Build generates no warnings



**What might this PR break?**
Nothing


**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
AutoSuspendHelper symbol is only existing for target frameworks which include a src/ReactiveUI/Platforms/.../AutoSuspendHelper.cs class.

In order to hide this warning for all other platforms, the `<c>...</c>` syntax is used instead of a `<see cref="..."/>`.

This PR also fixes an ambigous reference issue as there are two overloads of `Activity.OnSaveInstanceState`