### PR TITLE
Call WithCoreServices and add platform converters

### DIFF
--- a/src/ReactiveUI.AndroidX/Builder/AndroidXReactiveUIBuilderExtensions.cs
+++ b/src/ReactiveUI.AndroidX/Builder/AndroidXReactiveUIBuilderExtensions.cs
@@ -32,7 +32,7 @@ public static class AndroidXReactiveUIBuilderExtensions
             throw new ArgumentNullException(nameof(builder));
         }
 
-        return builder
+        return ((IReactiveUIBuilder)builder.WithCoreServices())
             .WithMainThreadScheduler(HandlerScheduler.MainThreadScheduler)
             .WithTaskPoolScheduler(TaskPoolScheduler.Default)
             .WithPlatformModule<AndroidX.Registrations>();

--- a/src/ReactiveUI.Blazor/Builder/BlazorReactiveUIBuilderExtensions.cs
+++ b/src/ReactiveUI.Blazor/Builder/BlazorReactiveUIBuilderExtensions.cs
@@ -38,7 +38,7 @@ public static class BlazorReactiveUIBuilderExtensions
             throw new ArgumentNullException(nameof(builder));
         }
 
-        return builder
+        return ((IReactiveUIBuilder)builder.WithCoreServices())
             .WithBlazorScheduler()
             .WithTaskPoolScheduler(TaskPoolScheduler.Default)
             .WithPlatformModule<Blazor.Registrations>();

--- a/src/ReactiveUI.Maui/Builder/MauiReactiveUIBuilderExtensions.cs
+++ b/src/ReactiveUI.Maui/Builder/MauiReactiveUIBuilderExtensions.cs
@@ -5,6 +5,8 @@
 
 using Microsoft.Maui.Dispatching;
 using Microsoft.Maui.Hosting;
+using ReactiveUI.Helpers;
+using ReactiveUI.Maui;
 
 namespace ReactiveUI.Builder;
 
@@ -68,10 +70,11 @@ public static partial class MauiReactiveUIBuilderExtensions
             throw new ArgumentNullException(nameof(builder));
         }
 
-        return builder
+        return ((IReactiveUIBuilder)builder.WithCoreServices())
             .WithMauiScheduler(dispatcher)
             .WithTaskPoolScheduler(TaskPoolScheduler.Default)
             .WithPlatformModule<Maui.Registrations>()
+            .WithMauiConverters()
             .WithPlatformServices();
     }
 
@@ -129,6 +132,26 @@ public static partial class MauiReactiveUIBuilderExtensions
         builder.WithTaskPoolScheduler(TaskPoolScheduler.Default);
         var scheduler = ResolveMainThreadScheduler(dispatcher);
         return builder.WithMainThreadScheduler(scheduler);
+    }
+
+    /// <summary>
+    /// Registers Maui-specific converters to the ConverterService.
+    /// </summary>
+    /// <param name="builder">The builder instance.</param>
+    /// <returns>The builder instance for chaining.</returns>
+    /// <remarks>
+    /// This method registers Maui-specific converters (<see cref="BooleanToVisibilityTypeConverter"/>,
+    /// <see cref="VisibilityToBooleanTypeConverter"/>) and the <see cref="ComponentModelFallbackConverter"/>
+    /// to the <c>ConverterService</c> so they are available when using the builder pattern.
+    /// </remarks>
+    public static IReactiveUIBuilder WithMauiConverters(this IReactiveUIBuilder builder)
+    {
+        ArgumentExceptionHelper.ThrowIfNull(builder);
+
+        return builder
+            .WithConverter(new BooleanToVisibilityTypeConverter())
+            .WithConverter(new VisibilityToBooleanTypeConverter())
+            .WithFallbackConverter(new ComponentModelFallbackConverter());
     }
 
     private static IScheduler ResolveMainThreadScheduler(IDispatcher? dispatcher)

--- a/src/ReactiveUI.WinUI/Builder/WinUIReactiveUIBuilderExtensions.cs
+++ b/src/ReactiveUI.WinUI/Builder/WinUIReactiveUIBuilderExtensions.cs
@@ -27,21 +27,44 @@ public static class WinUIReactiveUIBuilderExtensions
     {
         ArgumentExceptionHelper.ThrowIfNull(builder);
 
-        return builder
+        return ((IReactiveUIBuilder)builder.WithCoreServices())
             .WithWinUIScheduler()
             .WithTaskPoolScheduler(TaskPoolScheduler.Default)
+            .WithWinUIConverters()
             .WithPlatformModule<WinUI.Registrations>();
     }
 
     /// <summary>
-    /// Withes the win UI scheduler.
+    /// Configures the builder to use the WinUI main thread scheduler for reactive operations.
     /// </summary>
-    /// <param name="builder">The builder.</param>
-    /// <returns>The builder instance for chaining.</returns>
+    /// <remarks>Use this method when building reactive applications targeting WinUI to ensure that main
+    /// thread operations are scheduled appropriately for the WinUI environment.</remarks>
+    /// <param name="builder">The builder to configure with the WinUI main thread scheduler. Cannot be null.</param>
+    /// <returns>The same builder instance configured to use the WinUI main thread scheduler.</returns>
     public static IReactiveUIBuilder WithWinUIScheduler(this IReactiveUIBuilder builder)
     {
         ArgumentExceptionHelper.ThrowIfNull(builder);
 
         return builder.WithMainThreadScheduler(WinUIMainThreadScheduler);
+    }
+
+    /// <summary>
+    /// Registers WinUI-specific converters to the ConverterService.
+    /// </summary>
+    /// <param name="builder">The builder instance.</param>
+    /// <returns>The builder instance for chaining.</returns>
+    /// <remarks>
+    /// This method registers WinUI-specific converters (<see cref="BooleanToVisibilityTypeConverter"/>,
+    /// <see cref="VisibilityToBooleanTypeConverter"/>) and the <see cref="ComponentModelFallbackConverter"/>
+    /// to the <c>ConverterService</c> so they are available when using the builder pattern.
+    /// </remarks>
+    public static IReactiveUIBuilder WithWinUIConverters(this IReactiveUIBuilder builder)
+    {
+        ArgumentExceptionHelper.ThrowIfNull(builder);
+
+        return builder
+            .WithConverter(new BooleanToVisibilityTypeConverter())
+            .WithConverter(new VisibilityToBooleanTypeConverter())
+            .WithFallbackConverter(new ComponentModelFallbackConverter());
     }
 }

--- a/src/tests/ReactiveUI.Blazor.Tests/BlazorReactiveUIBuilderExtensionsTests.cs
+++ b/src/tests/ReactiveUI.Blazor.Tests/BlazorReactiveUIBuilderExtensionsTests.cs
@@ -165,7 +165,7 @@ public class BlazorReactiveUIBuilderExtensionsTests
         public Splat.Builder.IAppBuilder UsingModule<T>(T registrationModule)
             where T : Splat.Builder.IModule => throw new NotImplementedException();
 
-        public Splat.Builder.IAppBuilder WithCoreServices() => throw new NotImplementedException();
+        public Splat.Builder.IAppBuilder WithCoreServices() => this;
 
         public Splat.Builder.IAppBuilder WithCustomRegistration(Action<IMutableDependencyResolver> configureAction) => throw new NotImplementedException();
 


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

update

**What is the new behavior?**
<!-- If this is a feature change -->

Ensure core services are initialized before configuring platform-specific builders by calling WithCoreServices() (cast back to IReactiveUIBuilder) in AndroidX, Blazor, MAUI and WinUI builder extensions. Add MAUI and WinUI converter registration helpers (WithMauiConverters and WithWinUIConverters) that register BooleanToVisibilityTypeConverter, VisibilityToBooleanTypeConverter and ComponentModelFallbackConverter via the builder's WithConverter/WithFallbackConverter APIs. Also add required using directives for MAUI and update WinUI scheduler XML docs; null checks use ArgumentExceptionHelper.ThrowIfNull.

**What might this PR break?**

If a user has called WithCoreServices() already in code they should clean up the existing source to remove this unless a custom configuration has been made.

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

