### PR TITLE
Fix Blazor activation render ordering and update dependencies

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -42,8 +42,8 @@
 
   <PropertyGroup Condition="'$(IsTestProject)' == 'true'">
     <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
-    <TUnitImplicitUsings>false</TUnitImplicitUsings>
-    <TUnitAssertionsImplicitUsings>false</TUnitAssertionsImplicitUsings>
+    <TUnitImplicitUsings>true</TUnitImplicitUsings>
+    <TUnitAssertionsImplicitUsings>true</TUnitAssertionsImplicitUsings>
     <NoWarn>$(NoWarn);CS4014</NoWarn>
   </PropertyGroup>
 

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -5,35 +5,35 @@
   </PropertyGroup>
   <PropertyGroup>
     <SplatVersion>19.3.1</SplatVersion>
-    <TUnitVersion>1.17.54</TUnitVersion>
+    <TUnitVersion>1.24.18</TUnitVersion>
     <XamarinAndroidXCoreVersion>1.17.0</XamarinAndroidXCoreVersion>
-    <XamarinAndroidXLifecycleLiveDataVersion>2.10.0.1</XamarinAndroidXLifecycleLiveDataVersion>
-    <MauiVersion Condition="$(TargetFramework.StartsWith('net10'))">10.0.41</MauiVersion>
+    <XamarinAndroidXLifecycleLiveDataVersion>2.10.0.2</XamarinAndroidXLifecycleLiveDataVersion>
+    <MauiVersion Condition="$(TargetFramework.StartsWith('net10'))">10.0.51</MauiVersion>
     <MauiVersion Condition="$(TargetFramework.StartsWith('net9'))">9.0.120</MauiVersion>
-    <XamlBehaviorsWpfVersion Condition="$(TargetFramework.StartsWith('net4'))">1.1.141</XamlBehaviorsWpfVersion>
-    <XamlBehaviorsWpfVersion Condition="$(TargetFramework.StartsWith('net8'))">1.1.135</XamlBehaviorsWpfVersion>
-    <XamlBehaviorsWpfVersion Condition="$(TargetFramework.StartsWith('net9'))">1.1.141</XamlBehaviorsWpfVersion>
-    <XamlBehaviorsWpfVersion Condition="$(TargetFramework.StartsWith('net10'))">1.1.141</XamlBehaviorsWpfVersion>
-    <AspNetVersion Condition="$(TargetFramework.StartsWith('net10'))">10.0.3</AspNetVersion>
-    <AspNetVersion Condition="$(TargetFramework.StartsWith('net9'))">9.0.13</AspNetVersion>
-    <AspNetVersion Condition="$(TargetFramework.StartsWith('net8'))">8.0.24</AspNetVersion>
+    <XamlBehaviorsWpfVersion Condition="$(TargetFramework.StartsWith('net4'))">1.1.142</XamlBehaviorsWpfVersion>
+    <XamlBehaviorsWpfVersion Condition="$(TargetFramework.StartsWith('net8'))">1.1.142</XamlBehaviorsWpfVersion>
+    <XamlBehaviorsWpfVersion Condition="$(TargetFramework.StartsWith('net9'))">1.1.142</XamlBehaviorsWpfVersion>
+    <XamlBehaviorsWpfVersion Condition="$(TargetFramework.StartsWith('net10'))">1.1.142</XamlBehaviorsWpfVersion>
+    <AspNetVersion Condition="$(TargetFramework.StartsWith('net10'))">10.0.5</AspNetVersion>
+    <AspNetVersion Condition="$(TargetFramework.StartsWith('net9'))">9.0.14</AspNetVersion>
+    <AspNetVersion Condition="$(TargetFramework.StartsWith('net8'))">8.0.25</AspNetVersion>
     <AspNetVersion Condition="$(TargetFramework.StartsWith('netstandard'))">3.1.32</AspNetVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Akavache.Sqlite3" Version="11.5.1" />
     <PackageVersion Include="Akavache.SystemTextJson" Version="11.5.1" />
-    <PackageVersion Include="bunit" Version="2.6.2" />
+    <PackageVersion Include="bunit" Version="2.7.2" />
     <PackageVersion Include="DynamicData" Version="9.4.31" />
     <PackageVersion Include="JetBrains.DotMemoryUnit" Version="3.2.20220510" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.0.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="10.0.3" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.4.1" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.5.2" />
     <PackageVersion Include="Microsoft.Testing.Platform.MSBuild" Version="2.1.0" />
     <PackageVersion Include="Microsoft.Reactive.Testing" Version="6.1.0" />
     <PackageVersion Include="System.Reactive" Version="6.1.0" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.103" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.201" />
     <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.7705" />
     <PackageVersion Include="Microsoft.Xaml.Behaviors.Wpf" Version="$(XamlBehaviorsWpfVersion)" />
     <PackageVersion Include="Mocks.Maui" Version="1.2.5" />
@@ -54,7 +54,7 @@
     <PackageVersion Include="System.Text.Json" Version="10.0.3" />
     <PackageVersion Include="TUnit" Version="$(TUnitVersion)" />
     <PackageVersion Include="TUnit.Core" Version="$(TUnitVersion)" />
-    <PackageVersion Include="Verify.TUnit" Version="31.13.2" />
+    <PackageVersion Include="Verify.TUnit" Version="31.14.0" />
     <PackageVersion Include="Microsoft.Windows.CsWinRT" Version="2.3.0-prerelease.251115.2" />
     <PackageVersion Include="Microsoft.AspNetCore.Components" Version="$(AspNetVersion)" />
     <PackageVersion Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
@@ -72,13 +72,13 @@
     <PackageVersion Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="$(XamarinAndroidXLifecycleLiveDataVersion)" />
     <PackageVersion Include="Xamarin.AndroidX.Lifecycle.LiveData.Core.Ktx" Version="$(XamarinAndroidXLifecycleLiveDataVersion)" />
     <!-- Fragment/Collection/SavedState to match their latest constraints -->
-    <PackageVersion Include="Xamarin.AndroidX.Fragment" Version="1.8.9.1" />
-    <PackageVersion Include="Xamarin.AndroidX.Fragment.Ktx" Version="1.8.9.1" />
-    <PackageVersion Include="Xamarin.AndroidX.Collection.Jvm" Version="1.5.0.4" />
-    <PackageVersion Include="Xamarin.AndroidX.Collection.Ktx" Version="1.5.0.4" />
-    <PackageVersion Include="Xamarin.AndroidX.SavedState" Version="1.4.0.1" />
-    <PackageVersion Include="Xamarin.AndroidX.SavedState.SavedState.Ktx" Version="1.4.0.1" />
-    <PackageVersion Include="Xamarin.AndroidX.Preference" Version="1.2.1.16" />
+    <PackageVersion Include="Xamarin.AndroidX.Fragment" Version="1.8.9.2" />
+    <PackageVersion Include="Xamarin.AndroidX.Fragment.Ktx" Version="1.8.9.2" />
+    <PackageVersion Include="Xamarin.AndroidX.Collection.Jvm" Version="1.5.0.5" />
+    <PackageVersion Include="Xamarin.AndroidX.Collection.Ktx" Version="1.5.0.5" />
+    <PackageVersion Include="Xamarin.AndroidX.SavedState" Version="1.4.0.2" />
+    <PackageVersion Include="Xamarin.AndroidX.SavedState.SavedState.Ktx" Version="1.4.0.2" />
+    <PackageVersion Include="Xamarin.AndroidX.Preference" Version="1.2.1.17" />
   </ItemGroup>
   <ItemGroup Condition="'$(UseMaui)' != 'true'">
     <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.8.260317003" />

--- a/src/ReactiveUI.Blazor/ReactiveComponentBase.cs
+++ b/src/ReactiveUI.Blazor/ReactiveComponentBase.cs
@@ -105,6 +105,10 @@ public class ReactiveComponentBase<T> : ComponentBase, IViewFor<T>, INotifyPrope
                 h => PropertyChanged -= h,
                 nameof(ViewModel),
                 () => InvokeAsync(StateHasChanged));
+
+            // Re-render to pick up any property changes that occurred during activation (OnInitialized)
+            // before these subscriptions were wired.
+            InvokeAsync(StateHasChanged);
         }
 
         base.OnAfterRender(firstRender);

--- a/src/ReactiveUI.Blazor/ReactiveInjectableComponentBase.cs
+++ b/src/ReactiveUI.Blazor/ReactiveInjectableComponentBase.cs
@@ -108,6 +108,10 @@ public class ReactiveInjectableComponentBase<T> : ComponentBase, IViewFor<T>, IN
                 h => PropertyChanged -= h,
                 nameof(ViewModel),
                 () => InvokeAsync(StateHasChanged));
+
+            // Re-render to pick up any property changes that occurred during activation (OnInitialized)
+            // before these subscriptions were wired.
+            InvokeAsync(StateHasChanged);
         }
 
         base.OnAfterRender(firstRender);

--- a/src/ReactiveUI.Blazor/ReactiveLayoutComponentBase.cs
+++ b/src/ReactiveUI.Blazor/ReactiveLayoutComponentBase.cs
@@ -104,6 +104,10 @@ public class ReactiveLayoutComponentBase<T> : LayoutComponentBase, IViewFor<T>, 
                 h => PropertyChanged -= h,
                 nameof(ViewModel),
                 () => InvokeAsync(StateHasChanged));
+
+            // Re-render to pick up any property changes that occurred during activation (OnInitialized)
+            // before these subscriptions were wired.
+            InvokeAsync(StateHasChanged);
         }
 
         base.OnAfterRender(firstRender);

--- a/src/ReactiveUI.Blazor/ReactiveOwningComponentBase.cs
+++ b/src/ReactiveUI.Blazor/ReactiveOwningComponentBase.cs
@@ -103,6 +103,10 @@ public class ReactiveOwningComponentBase<T> : OwningComponentBase<T>, IViewFor<T
                 h => PropertyChanged -= h,
                 nameof(ViewModel),
                 () => InvokeAsync(StateHasChanged));
+
+            // Re-render to pick up any property changes that occurred during activation (OnInitialized)
+            // before these subscriptions were wired.
+            InvokeAsync(StateHasChanged);
         }
 
         base.OnAfterRender(firstRender);

--- a/src/tests/ReactiveUI.Blazor.Tests/ReactiveComponentBaseTests.cs
+++ b/src/tests/ReactiveUI.Blazor.Tests/ReactiveComponentBaseTests.cs
@@ -26,7 +26,7 @@ public class ReactiveComponentBaseTests : BunitContext
         var cut = Render<TestComponent>(parameters => parameters.Add(p => p.ViewModel, viewModel));
 
         // Initial render should have occurred once.
-        await Assert.That(cut.Instance.RenderCount).IsEqualTo(1);
+        await Assert.That(cut.Instance.RenderCount).IsEqualTo(2);
 
         // Change a property on the ViewModel to trigger a notification.
         viewModel.SomeProperty = "Changed";
@@ -48,7 +48,7 @@ public class ReactiveComponentBaseTests : BunitContext
         var viewModel1 = new TestViewModel();
         var cut = Render<TestComponent>(parameters => parameters.Add(p => p.ViewModel, viewModel1));
 
-        await Assert.That(cut.Instance.RenderCount).IsEqualTo(1);
+        await Assert.That(cut.Instance.RenderCount).IsEqualTo(2);
 
         var viewModel2 = new TestViewModel();
         cut.Render(parameters => parameters.Add(p => p.ViewModel, viewModel2));

--- a/src/tests/ReactiveUI.Blazor.Tests/ReactiveInjectableComponentBaseTests.cs
+++ b/src/tests/ReactiveUI.Blazor.Tests/ReactiveInjectableComponentBaseTests.cs
@@ -29,7 +29,7 @@ public class ReactiveInjectableComponentBaseTests : BunitContext
 
         // Verify injection was successful.
         await Assert.That(cut.Instance.ViewModel).IsEqualTo(viewModel);
-        await Assert.That(cut.Instance.RenderCount).IsEqualTo(1);
+        await Assert.That(cut.Instance.RenderCount).IsEqualTo(2);
 
         // Trigger a change to verify the component is listening.
         viewModel.SomeProperty = "Changed";

--- a/src/tests/ReactiveUI.Blazor.Tests/ReactiveLayoutComponentBaseTests.cs
+++ b/src/tests/ReactiveUI.Blazor.Tests/ReactiveLayoutComponentBaseTests.cs
@@ -21,7 +21,7 @@ public class ReactiveLayoutComponentBaseTests : BunitContext
         var viewModel = new TestViewModel();
         var cut = Render<TestLayoutComponent>(parameters => parameters.Add(p => p.ViewModel, viewModel));
 
-        await Assert.That(cut.Instance.RenderCount).IsEqualTo(1);
+        await Assert.That(cut.Instance.RenderCount).IsEqualTo(2);
 
         viewModel.SomeProperty = "Changed";
 

--- a/src/tests/ReactiveUI.Blazor.Tests/ReactiveOwningComponentBaseTests.cs
+++ b/src/tests/ReactiveUI.Blazor.Tests/ReactiveOwningComponentBaseTests.cs
@@ -27,7 +27,7 @@ public class ReactiveOwningComponentBaseTests : BunitContext
 
         var cut = Render<TestOwningComponent>(parameters => parameters.Add(p => p.ViewModel, viewModel));
 
-        await Assert.That(cut.Instance.RenderCount).IsEqualTo(1);
+        await Assert.That(cut.Instance.RenderCount).IsEqualTo(2);
 
         viewModel.SomeProperty = "Changed";
 

--- a/src/tests/ReactiveUI.Tests/Suspension/SuspensionHostGenericTests.cs
+++ b/src/tests/ReactiveUI.Tests/Suspension/SuspensionHostGenericTests.cs
@@ -362,7 +362,7 @@ public class SuspensionHostGenericTests
 
         untypedHost.CreateNewAppState = null;
 
-        await Assert.That(host.CreateNewAppStateTyped).IsNull();
+        await Assert.That(host.CreateNewAppStateTyped is null).IsTrue();
     }
 
     [Test]


### PR DESCRIPTION
## What changed for end users

Blazor components (ReactiveComponentBase, ReactiveInjectableComponentBase, ReactiveLayoutComponentBase, ReactiveOwningComponentBase) had a lifecycle ordering bug where property changes made during `WhenActivated` were not reflected in the UI. This happened because:

1. `WhenActivated` fires during `OnInitialized` -- your Rx chains execute and set reactive properties
2. Blazor renders the component
3. ViewModel change subscriptions are wired in `OnAfterRender` -- too late to catch changes from step 1

The fix adds a `StateHasChanged()` call after wiring subscriptions in `OnAfterRender` so the component re-renders with the latest state from activation. This results in one additional render cycle on first load but ensures the UI is always consistent.

Fixes #4317

## Dependency updates

| Package | From | To |
|---------|------|----|
| TUnit | 1.17.54 | 1.24.18 |
| bunit | 2.6.2 | 2.7.2 |
| Microsoft.SourceLink.GitHub | 10.0.103 | 10.0.201 |
| Microsoft.AspNetCore.Components (net8) | 8.0.24 | 8.0.25 |
| Microsoft.AspNetCore.Components (net9) | 9.0.13 | 9.0.14 |
| Microsoft.AspNetCore.Components (net10) | 10.0.3 | 10.0.5 |
| Microsoft.Testing.Extensions.CodeCoverage | 18.4.1 | 18.5.2 |
| Verify.TUnit | 31.13.2 | 31.14.0 |
| Microsoft.Xaml.Behaviors.Wpf | 1.1.135/1.1.141 | 1.1.142 |
| Microsoft.Maui.Controls (net10 only) | 10.0.41 | 10.0.51 |
| Xamarin.AndroidX.Preference | 1.2.1.16 | 1.2.1.17 |
| Xamarin.AndroidX.Lifecycle.LiveData | 2.10.0.1 | 2.10.0.2 |
| Xamarin.AndroidX.Fragment | 1.8.9.1 | 1.8.9.2 |
| Xamarin.AndroidX.Collection.Jvm | 1.5.0.4 | 1.5.0.5 |
| Xamarin.AndroidX.SavedState | 1.4.0.1 | 1.4.0.2 |

TUnit implicit usings were enabled to match TUnit 1.24 requirements. One test assertion was updated for TUnit 1.24 compatibility (nullable Func evaluation change).

## Test plan

- [x] All 12,514 tests pass across net8.0, net9.0, net10.0
- [x] Full solution build succeeds with 0 warnings, 0 errors
- [x] Blazor test render counts updated to reflect the additional activation render