### PR TITLE
Fixes 4331 Handle null load state; add tests

### DIFF
--- a/src/ReactiveUI/Suspension/SuspensionHostExtensions.cs
+++ b/src/ReactiveUI/Suspension/SuspensionHostExtensions.cs
@@ -284,15 +284,19 @@ public static class SuspensionHostExtensions
             return Observable.Return(Unit.Default);
         }
 
+        object? loadedState;
+
         try
         {
-            item.AppState = _suspensionDriver.LoadState().Wait();
+            loadedState = _suspensionDriver.LoadState().Wait();
         }
         catch (Exception ex)
         {
             item.Log().Warn(ex, "Failed to restore app state from storage, creating from scratch");
-            item.AppState = item.CreateNewAppState?.Invoke();
+            loadedState = null;
         }
+
+        item.AppState = loadedState ?? item.CreateNewAppState?.Invoke();
 
         return Observable.Return(Unit.Default);
     }
@@ -321,15 +325,19 @@ public static class SuspensionHostExtensions
             return Observable.Return(Unit.Default);
         }
 
+        TAppState? loadedState;
+
         try
         {
-            item.AppStateValue = _suspensionDriver.LoadState(typeInfo).Wait();
+            loadedState = _suspensionDriver.LoadState(typeInfo).Wait();
         }
         catch (Exception ex)
         {
             item.Log().Warn(ex, "Failed to restore app state from storage, creating from scratch");
-            item.AppStateValue = item.CreateNewAppStateTyped?.Invoke();
+            loadedState = null;
         }
+
+        item.AppStateValue = loadedState ?? item.CreateNewAppStateTyped?.Invoke();
 
         return Observable.Return(Unit.Default);
     }

--- a/src/tests/ReactiveUI.Test.Utilities/SuspensionHost/SuspensionHostTestExecutor.cs
+++ b/src/tests/ReactiveUI.Test.Utilities/SuspensionHost/SuspensionHostTestExecutor.cs
@@ -5,6 +5,8 @@
 
 using System.Reactive;
 
+using ReactiveUI.Tests.Utilities.AppBuilder;
+
 namespace ReactiveUI.Tests.Utilities.SuspensionHost;
 
 /// <summary>
@@ -17,13 +19,13 @@ namespace ReactiveUI.Tests.Utilities.SuspensionHost;
 /// - SuspensionHostExtensions.SuspensionDriver
 /// Tests using this executor should be marked with [NotInParallel] due to static state modifications.
 /// </remarks>
-public class SuspensionHostTestExecutor : ITestExecutor
+public class SuspensionHostTestExecutor : AppBuilderTestExecutor
 {
     private Func<IObservable<Unit>>? _previousEnsureLoadAppStateFunc;
     private ISuspensionDriver? _previousSuspensionDriver;
 
     /// <inheritdoc/>
-    public virtual async ValueTask ExecuteTest(TestContext context, Func<ValueTask> testAction)
+    public override async ValueTask ExecuteTest(TestContext context, Func<ValueTask> testAction)
     {
         ArgumentNullException.ThrowIfNull(testAction);
 
@@ -31,7 +33,7 @@ public class SuspensionHostTestExecutor : ITestExecutor
 
         try
         {
-            await testAction();
+            await base.ExecuteTest(context, testAction);
         }
         finally
         {

--- a/src/tests/ReactiveUI.Tests/Suspension/SuspensionHostExtensionsAotTests.cs
+++ b/src/tests/ReactiveUI.Tests/Suspension/SuspensionHostExtensionsAotTests.cs
@@ -70,6 +70,36 @@ public partial class SuspensionHostExtensionsAotTests
     }
 
     [Test]
+    public async Task GetAppState_Typed_WhenNoPersistedState_CreatesAndStoresNewAppState()
+    {
+        var createdState = new TestAppState { Value = 99 };
+        var createNewAppStateCallCount = 0;
+        using var host = new SuspensionHost<TestAppState>
+        {
+            CreateNewAppStateTyped = () =>
+            {
+                createNewAppStateCallCount++;
+                return createdState;
+            },
+            IsLaunchingNew = Observable.Never<Unit>(),
+            IsResuming = Observable.Never<Unit>(),
+            ShouldPersistState = Observable.Never<IDisposable>(),
+            ShouldInvalidateState = Observable.Never<Unit>()
+        };
+
+        var driver = new TestSuspensionDriver<TestAppState>();
+
+        using var disposable = host.SetupDefaultSuspendResume(TestAppStateContext.Default.TestAppState, driver);
+
+        var state = host.GetAppState();
+
+        await Assert.That(state).IsSameReferenceAs(createdState);
+        await Assert.That(host.AppStateValue).IsSameReferenceAs(createdState);
+        await Assert.That(createNewAppStateCallCount).IsEqualTo(1);
+        await Assert.That(driver.LoadStateCallCount).IsEqualTo(1);
+    }
+
+    [Test]
     public async Task ObserveAppState_Typed_EmitsCurrentValueImmediately()
     {
         var state = new TestAppState { Value = 42 };

--- a/src/tests/ReactiveUI.Tests/SuspensionHostExtensionsTests.cs
+++ b/src/tests/ReactiveUI.Tests/SuspensionHostExtensionsTests.cs
@@ -125,6 +125,36 @@ public class SuspensionHostExtensionsTests
     }
 
     [Test]
+    public async Task GetAppState_WhenNoPersistedState_CreatesAndStoresNewAppState()
+    {
+        var createdState = new DummyAppState();
+        var createNewAppStateCallCount = 0;
+        using var host = new SuspensionHost
+        {
+            CreateNewAppState = () =>
+            {
+                createNewAppStateCallCount++;
+                return createdState;
+            },
+            IsLaunchingNew = Observable.Never<Unit>(),
+            IsResuming = Observable.Never<Unit>(),
+            ShouldPersistState = Observable.Never<IDisposable>(),
+            ShouldInvalidateState = Observable.Never<Unit>()
+        };
+
+        var driver = new TestSuspensionDriver { ReturnNullOnLoad = true };
+
+        using var disposable = host.SetupDefaultSuspendResume(driver);
+
+        var state = host.GetAppState<DummyAppState>();
+
+        await Assert.That(state).IsSameReferenceAs(createdState);
+        await Assert.That(host.AppState).IsSameReferenceAs(createdState);
+        await Assert.That(createNewAppStateCallCount).IsEqualTo(1);
+        await Assert.That(driver.LoadStateCallCount).IsEqualTo(1);
+    }
+
+    [Test]
     public async Task EnsureLoadAppState_WithExistingAppState_DoesNotLoad()
     {
         var existingState = new DummyAppState();
@@ -475,6 +505,8 @@ public class SuspensionHostExtensionsTests
 
         public bool ShouldThrowOnLoad { get; set; }
 
+        public bool ReturnNullOnLoad { get; set; }
+
         public object? StateToLoad { get; set; }
 
         public IObservable<Unit> InvalidateState()
@@ -495,6 +527,11 @@ public class SuspensionHostExtensionsTests
                 return Observable.Throw<object?>(
                     new InvalidOperationException("Failed to load state"),
                     ImmediateScheduler.Instance);
+            }
+
+            if (ReturnNullOnLoad)
+            {
+                return Observable.Return<object?>(null, ImmediateScheduler.Instance);
             }
 
             return Observable.Return(StateToLoad ?? new DummyAppState(), ImmediateScheduler.Instance);


### PR DESCRIPTION
<!-- Please be sure to read our [Contribute guide](https://www.reactiveui.net/contribute/index.html) before opening a PR. -->

## What kind of change does this PR introduce?
<!-- Bug fix, feature, docs update, refactor, ci, ... -->
Fix
## What is the current behavior?
<!-- You can also link to an open issue here. Use "Closes #123" to auto-close on merge. -->

Closes #4331

## What is the new behavior?
<!-- If this is a feature change -->

Do not assign a potentially-null loaded state directly to AppState/AppStateValue. 

Capture the result of ISuspensionDriver.LoadState into a local (object? / TAppState?) and assign item.AppState/item.AppStateValue to the loaded value or fallback to CreateNewAppState/CreateNewAppStateTyped. 

Add tests in SuspensionHostExtensionsTests and SuspensionHostExtensionsAotTests that verify GetAppState creates and stores a new app state when no persisted state exists. 

Add ReturnNullOnLoad to TestSuspensionDriver to simulate drivers returning null. 

Change SuspensionHostTestExecutor to inherit from AppBuilderTestExecutor and delegate ExecuteTest to the base implementation (and add the required using). 

These changes ensure null-returning drivers are handled safely and covered by tests.

## What might this PR break?

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [x] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information
