### PR TITLE
Fix 3921 Support inherited DependencyProperty lookup

### DIFF
--- a/src/ReactiveUI.Wpf/Binding/ValidationBindingWpf.cs
+++ b/src/ReactiveUI.Wpf/Binding/ValidationBindingWpf.cs
@@ -3,6 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.ComponentModel;
 using System.Linq.Expressions;
 using System.Windows;
 using System.Windows.Data;
@@ -221,6 +222,17 @@ internal class ValidationBindingWpf<TView, TViewModel, TVProp, TVMProp> : IReact
         if (element is null || string.IsNullOrEmpty(name))
         {
             return null;
+        }
+
+        if (element is DependencyObject dependencyObject)
+        {
+            var targetType = dependencyObject.DependencyObjectType.SystemType;
+            var descriptor = DependencyPropertyDescriptor.FromName(name, targetType, targetType);
+
+            if (descriptor?.DependencyProperty is not null)
+            {
+                return descriptor.DependencyProperty;
+            }
         }
 
         return EnumerateDependencyProperties(element)

--- a/src/tests/ReactiveUI.Wpf.Tests/Wpf/ValidationBindingWpfTest.cs
+++ b/src/tests/ReactiveUI.Wpf.Tests/Wpf/ValidationBindingWpfTest.cs
@@ -5,6 +5,8 @@
 
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Data;
 
 using ReactiveUI.Wpf.Binding;
 
@@ -187,6 +189,36 @@ public class ValidationBindingWpfTest
 
         await Assert.That(result).IsNotNull();
         await Assert.That(result!.Name).IsEqualTo("Text");
+    }
+
+    /// <summary>
+    /// Tests that GetDependencyProperty finds dependency properties inherited from base controls.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task GetDependencyProperty_FindsInheritedPropertyByName()
+    {
+        var comboBox = new ComboBox();
+
+        var result = ValidationBindingWpf<TestView, TestViewModel, Control, string>.GetDependencyProperty(comboBox, nameof(Selector.SelectedValue));
+
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result).IsSameReferenceAs(Selector.SelectedValueProperty);
+    }
+
+    /// <summary>
+    /// Tests that GetDependencyProperty finds dependency properties inherited by TextBox.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task GetDependencyProperty_FindsInheritedTextBoxBasePropertyByName()
+    {
+        var textBox = new TextBox();
+
+        var result = ValidationBindingWpf<TestView, TestViewModel, Control, string>.GetDependencyProperty(textBox, nameof(TextBoxBase.IsReadOnly));
+
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result).IsSameReferenceAs(TextBoxBase.IsReadOnlyProperty);
     }
 
     /// <summary>
@@ -373,6 +405,25 @@ public class ValidationBindingWpfTest
         {
             await Assert.That(ex.ParamName).IsEqualTo("viewProperty");
         }
+    }
+
+    /// <summary>
+    /// Tests that BindWithValidation supports ComboBox.SelectedValue.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task BindWithValidation_BindsComboBoxSelectedValue()
+    {
+        var view = new TestViewWithComboBox();
+        var viewModel = new TestViewModel { SelectedValue = "initial" };
+        view.ViewModel = viewModel;
+
+        using var binding = view.BindWithValidation(viewModel, vm => vm.SelectedValue, v => v.MyComboBox.SelectedValue);
+
+        var bindingExpression = BindingOperations.GetBindingExpression(view.MyComboBox, Selector.SelectedValueProperty);
+
+        await Assert.That(bindingExpression).IsNotNull();
+        await Assert.That(bindingExpression!.ParentBinding.Path.Path).IsEqualTo("SelectedValue");
     }
 
     /// <summary>
@@ -645,10 +696,30 @@ public class ValidationBindingWpfTest
         public TextBox MyTextBox { get; }
     }
 
+    private class TestViewWithComboBox : StackPanel, IViewFor<TestViewModel>
+    {
+        public TestViewWithComboBox()
+        {
+            MyComboBox = new ComboBox { Name = "MyComboBox" };
+            Children.Add(MyComboBox);
+        }
+
+        public TestViewModel? ViewModel { get; set; }
+
+        object? IViewFor.ViewModel
+        {
+            get => ViewModel;
+            set => ViewModel = value as TestViewModel;
+        }
+
+        public ComboBox MyComboBox { get; }
+    }
+
     private class TestViewModel : ReactiveObject
     {
         private string? _testProperty;
         private NestedTestObject? _nestedObject;
+        private string? _selectedValue;
 
         public string? TestProperty
         {
@@ -660,6 +731,12 @@ public class ValidationBindingWpfTest
         {
             get => _nestedObject;
             set => this.RaiseAndSetIfChanged(ref _nestedObject, value);
+        }
+
+        public string? SelectedValue
+        {
+            get => _selectedValue;
+            set => this.RaiseAndSetIfChanged(ref _selectedValue, value);
         }
     }
 


### PR DESCRIPTION
<!-- Please be sure to read our [Contribute guide](https://www.reactiveui.net/contribute/index.html) before opening a PR. -->

## What kind of change does this PR introduce?
<!-- Bug fix, feature, docs update, refactor, ci, ... -->
Fix
## What is the current behavior?
<!-- You can also link to an open issue here. Use "Closes #123" to auto-close on merge. -->
Closes #3921 
## What is the new behavior?
<!-- If this is a feature change -->

Use DependencyPropertyDescriptor.FromName to resolve dependency properties declared on base control types (via DependencyObjectType.SystemType) and return the descriptor's DependencyProperty when found; fall back to existing enumeration otherwise. 

Add System.ComponentModel using and unit tests covering inherited property lookup (Selector.SelectedValue, TextBoxBase.IsReadOnly) and a BindWithValidation test for ComboBox.SelectedValue, plus a small TestViewWithComboBox and SelectedValue on the test view model.

## What might this PR break?

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [x] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information
