### PR TITLE
Fix for 4280 interaction async handler scheduling

### DIFF
--- a/src/ReactiveUI/Interactions/Interaction.cs
+++ b/src/ReactiveUI/Interactions/Interaction.cs
@@ -87,11 +87,13 @@ public class Interaction<TInput, TOutput>(IScheduler? handlerScheduler = null) :
     {
         ArgumentExceptionHelper.ThrowIfNull(handler);
 
-        return RegisterHandler(interaction =>
+        IObservable<Unit> ContentHandler(IInteractionContext<TInput, TOutput> interaction)
         {
             handler(interaction);
             return Observables.Unit;
-        });
+        }
+
+        return RegisterHandlerCore(ContentHandler);
     }
 
     /// <inheritdoc />
@@ -99,7 +101,15 @@ public class Interaction<TInput, TOutput>(IScheduler? handlerScheduler = null) :
     {
         ArgumentExceptionHelper.ThrowIfNull(handler);
 
-        return RegisterHandler(interaction => handler(interaction).ToObservable());
+        IObservable<Unit> ContentHandler(IInteractionContext<TInput, TOutput> interaction) =>
+            Observable.FromAsync(
+                async () =>
+                {
+                    await YieldToCurrentContext();
+                    await handler(interaction).ConfigureAwait(false);
+                });
+
+        return RegisterHandlerCore(ContentHandler);
     }
 
     /// <inheritdoc />
@@ -107,10 +117,16 @@ public class Interaction<TInput, TOutput>(IScheduler? handlerScheduler = null) :
     {
         ArgumentExceptionHelper.ThrowIfNull(handler);
 
-        IObservable<Unit> ContentHandler(IInteractionContext<TInput, TOutput> context) => handler(context).Select(_ => Unit.Default);
+        IObservable<Unit> ContentHandler(IInteractionContext<TInput, TOutput> context) =>
+            Observable.FromAsync(
+                    async () =>
+                    {
+                        await YieldToCurrentContext();
+                        return handler(context);
+                    })
+                .SelectMany(result => result.Select(_ => Unit.Default));
 
-        AddHandler(ContentHandler);
-        return Disposable.Create(() => RemoveHandler(ContentHandler));
+        return RegisterHandlerCore(ContentHandler);
     }
 
     /// <inheritdoc />
@@ -152,6 +168,27 @@ public class Interaction<TInput, TOutput>(IScheduler? handlerScheduler = null) :
     /// <param name="input">The input that is being passed in.</param>
     /// <returns>The interaction context.</returns>
     protected virtual IOutputContext<TInput, TOutput> GenerateContext(TInput input) => new InteractionContext<TInput, TOutput>(input);
+
+    /// <summary>
+    /// Yields once so asynchronous handlers are not invoked inside the current scheduler trampoline.
+    /// </summary>
+    /// <returns>A task that completes after the current context has yielded.</returns>
+    private static async Task YieldToCurrentContext()
+    {
+        await Task.Yield();
+    }
+
+    /// <summary>
+    /// Registers a normalized interaction handler.
+    /// </summary>
+    /// <param name="contentHandler">The normalized handler.</param>
+    /// <returns>A disposable which unregisters the handler.</returns>
+    private IDisposable RegisterHandlerCore(Func<IInteractionContext<TInput, TOutput>, IObservable<Unit>> contentHandler)
+    {
+        ArgumentExceptionHelper.ThrowIfNull(contentHandler);
+        AddHandler(contentHandler);
+        return Disposable.Create(() => RemoveHandler(contentHandler));
+    }
 
     /// <summary>
     /// Adds a handler delegate to be invoked for interaction contexts.

--- a/src/tests/ReactiveUI.Tests/InteractionsTest.cs
+++ b/src/tests/ReactiveUI.Tests/InteractionsTest.cs
@@ -10,6 +10,7 @@ namespace ReactiveUI.Tests;
 /// <summary>
 ///     Tests interactions.
 /// </summary>
+[NotInParallel]
 public class InteractionsTest
 {
     /// <summary>
@@ -23,8 +24,8 @@ public class InteractionsTest
 
         interaction.RegisterHandler(context => { _ = ((InteractionContext<Unit, Unit>)context).GetOutput(); });
 
-        var ex = Assert.Throws<InvalidOperationException>(() => interaction.Handle(Unit.Default).Subscribe());
-        await Assert.That(ex.Message).IsEqualTo("Output has not been set.");
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => interaction.Handle(Unit.Default).ToTask());
+        await Assert.That(ex!.Message).IsEqualTo("Output has not been set.");
     }
 
     /// <summary>
@@ -42,20 +43,21 @@ public class InteractionsTest
             context.SetOutput(Unit.Default);
         });
 
-        var ex = Assert.Throws<InvalidOperationException>(() => interaction.Handle(Unit.Default).Subscribe());
-        await Assert.That(ex.Message).IsEqualTo("Output has already been set.");
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => interaction.Handle(Unit.Default).ToTask());
+        await Assert.That(ex!.Message).IsEqualTo("Output has already been set.");
     }
 
     /// <summary>
     ///     Tests that Handled interactions should not cause exception.
     /// </summary>
+    /// <returns>A <see cref="Task" /> representing the asynchronous operation.</returns>
     [Test]
-    public void HandledInteractionsShouldNotCauseException()
+    public async Task HandledInteractionsShouldNotCauseException()
     {
         var interaction = new Interaction<Unit, bool>();
         interaction.RegisterHandler(static c => c.SetOutput(true));
 
-        interaction.Handle(Unit.Default).FirstAsync().Wait();
+        await interaction.Handle(Unit.Default);
     }
 
     /// <summary>
@@ -95,16 +97,27 @@ public class InteractionsTest
 
         // even though handler B is "slow" (i.e. mimicks waiting for the user), it takes precedence over A, so we expect A to never even be called
         var handler1AWasCalled = false;
+        var handler1BWasSubscribed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var handler1A = interaction.RegisterHandler(x =>
         {
             x.SetOutput("A");
             handler1AWasCalled = true;
         });
         var handler1B = interaction.RegisterHandler(x =>
-            Observables
-                .Unit
-                .Delay(TimeSpan.FromSeconds(1), scheduler)
-                .Do(_ => x.SetOutput("B")));
+        {
+            return Observable.Create<Unit>(
+                observer =>
+                {
+                    var subscription = Observables
+                        .Unit
+                        .Delay(TimeSpan.FromSeconds(1), scheduler)
+                        .Do(_ => x.SetOutput("B"))
+                        .Subscribe(observer);
+
+                    handler1BWasSubscribed.TrySetResult();
+                    return subscription;
+                });
+        });
 
         using (handler1A)
         using (handler1B)
@@ -113,6 +126,7 @@ public class InteractionsTest
                 .Handle(Unit.Default)
                 .ToObservableChangeSet(ImmediateScheduler.Instance).Bind(out var result).Subscribe();
 
+            await handler1BWasSubscribed.Task.WaitAsync(TimeSpan.FromSeconds(5));
             await Assert.That(result).IsEmpty();
             scheduler.AdvanceBy(TimeSpan.FromSeconds(0.5));
             await Assert.That(result).IsEmpty();
@@ -139,12 +153,65 @@ public class InteractionsTest
             return Task.FromResult(true);
         });
 
-        string? result = null;
-        interaction
-            .Handle(Unit.Default)
-            .Subscribe(r => result = r);
+        var result = await interaction.Handle(Unit.Default);
 
         await Assert.That(result).IsEqualTo("result");
+    }
+
+    /// <summary>
+    ///     Tests that task handlers release the current scheduler before invoking user code.
+    /// </summary>
+    /// <returns>A <see cref="Task" /> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task TaskHandlersShouldNotBlockNestedInteractionsBeforeReturningTask()
+    {
+        var parent = new Interaction<Unit, Unit>();
+        var nested = new Interaction<Unit, string>();
+        var nestedHandledBeforeParentReturned = false;
+        string? nestedOutput = null;
+
+        nested.RegisterHandler(context => context.SetOutput("nested"));
+
+        parent.RegisterHandler(context =>
+        {
+            using var nestedSubscription = nested.Handle(Unit.Default).Subscribe(output => nestedOutput = output);
+            nestedHandledBeforeParentReturned = nestedOutput == "nested";
+
+            context.SetOutput(Unit.Default);
+            return Task.CompletedTask;
+        });
+
+        await parent.Handle(Unit.Default);
+
+        await Assert.That(nestedHandledBeforeParentReturned).IsTrue();
+    }
+
+    /// <summary>
+    ///     Tests that observable handlers release the current scheduler before invoking user code.
+    /// </summary>
+    /// <returns>A <see cref="Task" /> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task ObservableHandlersShouldNotBlockNestedInteractionsBeforeReturningObservable()
+    {
+        var parent = new Interaction<Unit, Unit>();
+        var nested = new Interaction<Unit, string>();
+        var nestedHandledBeforeParentReturned = false;
+        string? nestedOutput = null;
+
+        nested.RegisterHandler(context => context.SetOutput("nested"));
+
+        parent.RegisterHandler(context =>
+        {
+            using var nestedSubscription = nested.Handle(Unit.Default).Subscribe(output => nestedOutput = output);
+            nestedHandledBeforeParentReturned = nestedOutput == "nested";
+
+            context.SetOutput(Unit.Default);
+            return Observables.Unit;
+        });
+
+        await parent.Handle(Unit.Default);
+
+        await Assert.That(nestedHandledBeforeParentReturned).IsTrue();
     }
 
     /// <summary>
@@ -174,21 +241,21 @@ public class InteractionsTest
                 using (handler1C)
                 using (Assert.Multiple())
                 {
-                    await Assert.That(interaction.Handle(false).FirstAsync().Wait()).IsEqualTo("C");
-                    await Assert.That(interaction.Handle(true).FirstAsync().Wait()).IsEqualTo("C");
+                    await Assert.That(await interaction.Handle(false)).IsEqualTo("C");
+                    await Assert.That(await interaction.Handle(true)).IsEqualTo("C");
                 }
 
                 using (Assert.Multiple())
                 {
-                    await Assert.That(interaction.Handle(false).FirstAsync().Wait()).IsEqualTo("A");
-                    await Assert.That(interaction.Handle(true).FirstAsync().Wait()).IsEqualTo("B");
+                    await Assert.That(await interaction.Handle(false)).IsEqualTo("A");
+                    await Assert.That(await interaction.Handle(true)).IsEqualTo("B");
                 }
             }
 
             using (Assert.Multiple())
             {
-                await Assert.That(interaction.Handle(false).FirstAsync().Wait()).IsEqualTo("A");
-                await Assert.That(interaction.Handle(true).FirstAsync().Wait()).IsEqualTo("A");
+                await Assert.That(await interaction.Handle(false)).IsEqualTo("A");
+                await Assert.That(await interaction.Handle(true)).IsEqualTo("A");
             }
         }
     }
@@ -207,7 +274,7 @@ public class InteractionsTest
                 .Return(42)
                 .Do(_ => x.SetOutput("result")));
 
-        var result = interaction.Handle(Unit.Default).FirstAsync().Wait();
+        var result = await interaction.Handle(Unit.Default);
         await Assert.That(result).IsEqualTo("result");
     }
 
@@ -222,19 +289,19 @@ public class InteractionsTest
 
         using (interaction.RegisterHandler(static x => x.SetOutput("A")))
         {
-            await Assert.That(interaction.Handle(Unit.Default).FirstAsync().Wait()).IsEqualTo("A");
+            await Assert.That(await interaction.Handle(Unit.Default)).IsEqualTo("A");
             using (interaction.RegisterHandler(static x => x.SetOutput("B")))
             {
-                await Assert.That(interaction.Handle(Unit.Default).FirstAsync().Wait()).IsEqualTo("B");
+                await Assert.That(await interaction.Handle(Unit.Default)).IsEqualTo("B");
                 using (interaction.RegisterHandler(static x => x.SetOutput("C")))
                 {
-                    await Assert.That(interaction.Handle(Unit.Default).FirstAsync().Wait()).IsEqualTo("C");
+                    await Assert.That(await interaction.Handle(Unit.Default)).IsEqualTo("C");
                 }
 
-                await Assert.That(interaction.Handle(Unit.Default).FirstAsync().Wait()).IsEqualTo("B");
+                await Assert.That(await interaction.Handle(Unit.Default)).IsEqualTo("B");
             }
 
-            await Assert.That(interaction.Handle(Unit.Default).FirstAsync().Wait()).IsEqualTo("A");
+            await Assert.That(await interaction.Handle(Unit.Default)).IsEqualTo("A");
         }
     }
 
@@ -261,21 +328,21 @@ public class InteractionsTest
     public async Task UnhandledInteractionsShouldCauseException()
     {
         var interaction = new Interaction<string, Unit>();
-        var ex = Assert.Throws<UnhandledInteractionException<string, Unit>>(() =>
-            interaction.Handle("foo").FirstAsync().Wait());
+        var ex = await Assert.ThrowsAsync<UnhandledInteractionException<string, Unit>>(() =>
+            interaction.Handle("foo").ToTask());
         using (Assert.Multiple())
         {
-            await Assert.That(ex.Interaction).IsSameReferenceAs(interaction);
+            await Assert.That(ex!.Interaction).IsSameReferenceAs(interaction);
             await Assert.That(ex.Input).IsEqualTo("foo");
         }
 
         interaction.RegisterHandler(_ => { });
         interaction.RegisterHandler(_ => { });
-        ex = Assert.Throws<UnhandledInteractionException<string, Unit>>(() =>
-            interaction.Handle("bar").FirstAsync().Wait());
+        ex = await Assert.ThrowsAsync<UnhandledInteractionException<string, Unit>>(() =>
+            interaction.Handle("bar").ToTask());
         using (Assert.Multiple())
         {
-            await Assert.That(ex.Interaction).IsSameReferenceAs(interaction);
+            await Assert.That(ex!.Interaction).IsSameReferenceAs(interaction);
             await Assert.That(ex.Input).IsEqualTo("bar");
         }
     }

--- a/src/tests/ReactiveUI.Tests/InteractionsTest.cs
+++ b/src/tests/ReactiveUI.Tests/InteractionsTest.cs
@@ -65,21 +65,32 @@ public class InteractionsTest
     /// </summary>
     /// <returns>A <see cref="Task" /> representing the asynchronous operation.</returns>
     [Test]
-    [TestExecutor<WithSchedulerExecutor>]
     public async Task HandlersAreExecutedOnHandlerScheduler()
     {
-        var scheduler = TestContext.Current!.GetScheduler();
+        var schedulerThreadId = -1;
+        using var scheduler = new EventLoopScheduler(
+            threadStart =>
+            {
+                var thread = new Thread(threadStart) { IsBackground = true };
+                schedulerThreadId = thread.ManagedThreadId;
+                return thread;
+            });
         var interaction = new Interaction<Unit, string>(scheduler);
+        var handlerThreadId = -1;
 
-        using (interaction.RegisterHandler(x => x.SetOutput("done")))
+        using (interaction.RegisterHandler(x =>
         {
-            var handled = false;
-            interaction
-                .Handle(Unit.Default)
-                .Subscribe(_ => handled = true);
+            handlerThreadId = Environment.CurrentManagedThreadId;
+            x.SetOutput("done");
+        }))
+        {
+            var result = await interaction.Handle(Unit.Default).ToTask().WaitAsync(TimeSpan.FromSeconds(5));
 
-            // With ImmediateScheduler, handlers execute immediately
-            await Assert.That(handled).IsTrue();
+            using (Assert.Multiple())
+            {
+                await Assert.That(result).IsEqualTo("done");
+                await Assert.That(handlerThreadId).IsEqualTo(schedulerThreadId);
+            }
         }
     }
 


### PR DESCRIPTION
<!-- Please be sure to read our [Contribute guide](https://www.reactiveui.net/contribute/index.html) before opening a PR. -->

## What kind of change does this PR introduce?
<!-- Bug fix, feature, docs update, refactor, ci, ... -->
Fix
## What is the current behavior?
<!-- You can also link to an open issue here. Use "Closes #123" to auto-close on merge. -->
Closes #4280 
## What is the new behavior?
<!-- If this is a feature change -->

This pull request refactors the `Interaction` handler registration and execution logic in `ReactiveUI` to improve consistency, reliability, and testability, especially around asynchronous handler scenarios. It introduces a unified handler registration core, ensures asynchronous handlers yield to the current context, and updates tests to use modern async/await patterns. Several new tests are also added to verify scheduler release behavior for both task-based and observable handlers.

**Core handler registration and async context improvements:**

* Introduced a private `RegisterHandlerCore` method to centralize handler registration and disposal logic, replacing duplicated code in `RegisterHandler` overloads. [[1]](diffhunk://#diff-4c32538b51e31225de509d21d08ea6cfd573a7df738530957077df781d5d3ba9L90-R129) [[2]](diffhunk://#diff-4c32538b51e31225de509d21d08ea6cfd573a7df738530957077df781d5d3ba9R172-R192)
* Added a private `YieldToCurrentContext` method to ensure asynchronous handlers (both `Task` and `IObservable`-based) yield execution before invoking user code, preventing scheduler trampoline issues and improving nested interaction support. [[1]](diffhunk://#diff-4c32538b51e31225de509d21d08ea6cfd573a7df738530957077df781d5d3ba9L90-R129) [[2]](diffhunk://#diff-4c32538b51e31225de509d21d08ea6cfd573a7df738530957077df781d5d3ba9R172-R192)

**Test modernization and reliability:**

* Updated all relevant tests in `InteractionsTest.cs` to use `async`/`await` and `ToTask()` instead of synchronous blocking (`Wait()`/`FirstAsync().Wait()`), improving test reliability and better reflecting real-world async usage. [[1]](diffhunk://#diff-f2ed870457c71b058a31b5f78fde682cb52406c51bd54a6626d8f71de439d2ceL26-R28) [[2]](diffhunk://#diff-f2ed870457c71b058a31b5f78fde682cb52406c51bd54a6626d8f71de439d2ceL45-R60) [[3]](diffhunk://#diff-f2ed870457c71b058a31b5f78fde682cb52406c51bd54a6626d8f71de439d2ceL177-R258) [[4]](diffhunk://#diff-f2ed870457c71b058a31b5f78fde682cb52406c51bd54a6626d8f71de439d2ceL210-R277) [[5]](diffhunk://#diff-f2ed870457c71b058a31b5f78fde682cb52406c51bd54a6626d8f71de439d2ceL225-R304) [[6]](diffhunk://#diff-f2ed870457c71b058a31b5f78fde682cb52406c51bd54a6626d8f71de439d2ceL264-R345)
* Marked the `InteractionsTest` class with `[NotInParallel]` to ensure tests are not run in parallel, avoiding flakiness due to shared state.

**Expanded test coverage for async handler behavior:**

* Added tests to verify that both `Task`-based and `IObservable`-based handlers release the current scheduler before executing user code, ensuring nested interactions are not blocked and behave as expected.

**Test improvements for handler precedence and subscription timing:**

* Enhanced tests to more reliably detect when handlers are subscribed and to ensure correct handler precedence, especially in asynchronous scenarios, using `TaskCompletionSource` for precise subscription tracking. [[1]](diffhunk://#diff-f2ed870457c71b058a31b5f78fde682cb52406c51bd54a6626d8f71de439d2ceR100-R120) [[2]](diffhunk://#diff-f2ed870457c71b058a31b5f78fde682cb52406c51bd54a6626d8f71de439d2ceR129)

These changes collectively make handler registration more robust, improve async interaction patterns, and ensure that both the implementation and test suite are future-proof and reliable.
## What might this PR break?

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [x] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information
