### PR TITLE
fix: support .NET Core in winforms activation design mode check

### DIFF
--- a/src/ReactiveUI.Winforms/ActivationForViewFetcher.cs
+++ b/src/ReactiveUI.Winforms/ActivationForViewFetcher.cs
@@ -45,8 +45,7 @@ public class ActivationForViewFetcher : IActivationForViewFetcher, IEnableLogger
                                                                           h => control.VisibleChanged += h,
                                                                           h => control.VisibleChanged -= h);
 
-            var controlActivation = Observable.Merge(handleDestroyed, handleCreated, visibleChanged)
-                                              .DistinctUntilChanged();
+            IObservable<bool> controlActivation;
 
             if (view is Form form)
             {
@@ -58,11 +57,15 @@ public class ActivationForViewFetcher : IActivationForViewFetcher, IEnableLogger
                  },
                  h => form.FormClosed += h,
                  h => form.FormClosed -= h);
-                controlActivation = controlActivation.Merge(formClosed)
-                                                     .DistinctUntilChanged();
+
+                controlActivation = Observable.Merge(handleDestroyed, handleCreated, visibleChanged, formClosed);
+            }
+            else
+            {
+                controlActivation = Observable.Merge(handleDestroyed, handleCreated, visibleChanged);
             }
 
-            return controlActivation.Where(_ => !GetCachedIsDesignMode(control));
+            return controlActivation.DistinctUntilChanged().Where(_ => !GetCachedIsDesignMode(control));
         }
 
         if (view is null)

--- a/src/ReactiveUI.Winforms/ActivationForViewFetcher.cs
+++ b/src/ReactiveUI.Winforms/ActivationForViewFetcher.cs
@@ -26,13 +26,10 @@ public class ActivationForViewFetcher : IActivationForViewFetcher, IEnableLogger
         // Startup: Control.HandleCreated > Control.BindingContextChanged > Form.Load > Control.VisibleChanged > Form.Activated > Form.Shown
         // Shutdown: Form.Closing > Form.FormClosing > Form.Closed > Form.FormClosed > Form.Deactivate
         // https://docs.microsoft.com/en-us/dotnet/framework/winforms/order-of-events-in-windows-forms
+        //
+        // Note: A control is not yet set sited in its constructor. We must delay the design mode check until after one of the events fires.
         if (view is Control control)
         {
-            if (GetCachedIsDesignMode(control))
-            {
-                return Observable<bool>.Empty;
-            }
-
             var handleDestroyed = Observable.FromEvent<EventHandler, bool>(
                                                                            eventHandler => (_, _) => eventHandler(false),
                                                                            h => control.HandleDestroyed += h,
@@ -65,7 +62,7 @@ public class ActivationForViewFetcher : IActivationForViewFetcher, IEnableLogger
                                                      .DistinctUntilChanged();
             }
 
-            return controlActivation;
+            return controlActivation.Where(_ => !GetCachedIsDesignMode(control));
         }
 
         if (view is null)
@@ -86,12 +83,9 @@ public class ActivationForViewFetcher : IActivationForViewFetcher, IEnableLogger
         return Observable<bool>.Empty;
     }
 
-    private static bool GetIsDesignMode(Control control) =>
-        LicenseManager.UsageMode == LicenseUsageMode.Designtime || control.Site?.DesignMode == true || control.Parent?.Site?.DesignMode == true;
-
     private bool GetCachedIsDesignMode(Control control)
     {
-        _isDesignModeCache ??= GetIsDesignMode(control);
+        _isDesignModeCache ??= control.IsAncestorSiteInDesignMode;
 
         return _isDesignModeCache.Value;
     }

--- a/src/ReactiveUI.Winforms/ActivationForViewFetcher.cs
+++ b/src/ReactiveUI.Winforms/ActivationForViewFetcher.cs
@@ -88,7 +88,7 @@ public class ActivationForViewFetcher : IActivationForViewFetcher, IEnableLogger
 
     private bool GetCachedIsDesignMode(Control control)
     {
-        _isDesignModeCache ??= control.IsAncestorSiteInDesignMode;
+        _isDesignModeCache ??= control.GetIsAncestorSiteInDesignMode();
 
         return _isDesignModeCache.Value;
     }

--- a/src/ReactiveUI.Winforms/ControlPolyfills.cs
+++ b/src/ReactiveUI.Winforms/ControlPolyfills.cs
@@ -3,35 +3,29 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-#if !NET6_0_OR_GREATER
-
 namespace ReactiveUI.Winforms;
 
 internal static class ControlPolyfills
 {
-    extension(Control control)
+    public static bool GetIsAncestorSiteInDesignMode(this Control control)
     {
-        public bool IsAncestorSiteInDesignMode
-        {
-            get
-            {
-                ArgumentExceptionHelper.ThrowIfNull(control);
+#if NET6_0_OR_GREATER
+        return control.IsAncestorSiteInDesignMode;
+#else
+        ArgumentExceptionHelper.ThrowIfNull(control);
 
-                if (control.Site is { DesignMode: true })
-                {
-                    return true;
-                }
-                else if (control.Parent is null)
-                {
-                    return false;
-                }
-                else
-                {
-                    return control.Parent.IsAncestorSiteInDesignMode;
-                }
-            }
+        if (control.Site is { DesignMode: true })
+        {
+            return true;
         }
+        else if (control.Parent is null)
+        {
+            return false;
+        }
+        else
+        {
+            return control.Parent.GetIsAncestorSiteInDesignMode();
+        }
+#endif
     }
 }
-
-#endif

--- a/src/ReactiveUI.Winforms/ControlPolyfills.cs
+++ b/src/ReactiveUI.Winforms/ControlPolyfills.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+#if !NET6_0_OR_GREATER
+
+namespace ReactiveUI.Winforms;
+
+internal static class ControlPolyfills
+{
+    extension(Control control)
+    {
+        public bool IsAncestorSiteInDesignMode
+        {
+            get
+            {
+                ArgumentExceptionHelper.ThrowIfNull(control);
+
+                if (control.Site is { DesignMode: true })
+                {
+                    return true;
+                }
+                else if (control.Parent is null)
+                {
+                    return false;
+                }
+                else
+                {
+                    return control.Parent.IsAncestorSiteInDesignMode;
+                }
+            }
+        }
+    }
+}
+
+#endif


### PR DESCRIPTION
## What kind of change does this PR introduce?
1. Delay the design mode check in Winforms activation until after the control is sited.
2. Use `Control.IsAncestorSiteInDesignMode` (polyfilled on older targets) to support deeply nested controls.
3. Remove the `LicenseManager.UsageMode` check because it doesn't work on .NET Core and is no longer needed on .NET Framework after the other fixes.
4. While at it, reduce nesting of RX operators if the control is a `Form`.

## What is the current behavior?
Design mode detection is broken on .NET Core.

1. The detection is done too early. Controls are not yet sited in their constructor, so `control.Site?.DesignMode` is never true.
`LicenseManager` is not supported on .NET Core. `LicenseManager.UsageMode == LicenseUsageMode.Designtime` is always false.

2. Design mode detection does not support deeply nested controls.
Only the current control and its parent are checked for design mode.

## What is the new behavior?
Design mode detection works both on .NET Framework and .NET Core and supports deeply nested controls.

## What might this PR break?
This shouldn't change anything at runtime, only design time.

## Checklist
- [X] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [ ] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features)
- [X] Changes target the `main` branch
- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information
Manually tested on `net481` and `net10.0-windows10.0.19041.0`.

There are still more issues with the Winforms Designer.
Unless you inherit your controls from a base class that ensures ReactiveUI is initialized in its constructor, `WhenActivated` fails to resolve `IActivationForViewFetcher`.
I don't know how to fix this in a way that can be upstreamed.