### PR TITLE
fix: Winforms design mode detection regressed

### DIFF
--- a/src/ReactiveUI.Winforms/ActivationForViewFetcher.cs
+++ b/src/ReactiveUI.Winforms/ActivationForViewFetcher.cs
@@ -30,19 +30,16 @@ public class ActivationForViewFetcher : IActivationForViewFetcher, IEnableLogger
     {
         switch (view)
         {
-            // Startup: Control.HandleCreated > Control.BindingContextChanged > Form.Load > Control.VisibleChanged > Form.Activated > Form.Shown
-            // Shutdown: Form.Closing > Form.FormClosing > Form.Closed > Form.FormClosed > Form.Deactivate
-            // https://docs.microsoft.com/en-us/dotnet/framework/winforms/order-of-events-in-windows-forms
-            case Control control when GetCachedIsDesignMode(control):
-                break;
             case Control control:
-                return GetActivationForControl(control);
+                // We are very likely being called from control's constructor, which means control.Site is not yet set.
+                // We must delay the design mode check until after one of the activation events fires.
+                return new WhereObservable<bool>(GetActivationForControl(control), _ => !GetCachedIsDesignMode(control));
 
             case null:
                 {
                     this.Log().Warn(
-                                    CultureInfo.InvariantCulture,
-                                    "Expected a view of type System.Windows.Forms.Control it was null");
+                        CultureInfo.InvariantCulture,
+                        "Expected a view of type System.Windows.Forms.Control it was null");
                     break;
                 }
 
@@ -65,6 +62,9 @@ public class ActivationForViewFetcher : IActivationForViewFetcher, IEnableLogger
     /// <returns>An observable that signals when the control is activated and deactivated.</returns>
     private static MergedDistinctObservable<bool> GetActivationForControl(Control control)
     {
+        // Startup: Control.HandleCreated > Control.BindingContextChanged > Form.Load > Control.VisibleChanged > Form.Activated > Form.Shown
+        // Shutdown: Form.Closing > Form.FormClosing > Form.Closed > Form.FormClosed > Form.Deactivate
+        // https://docs.microsoft.com/en-us/dotnet/framework/winforms/order-of-events-in-windows-forms
         var handleDestroyed = new FromEventObservable<bool>(onNext =>
         {
             void Handler(object? sender, EventArgs e) => onNext(false);

--- a/src/ReactiveUI.Winforms/ReactiveUI.Winforms.csproj
+++ b/src/ReactiveUI.Winforms/ReactiveUI.Winforms.csproj
@@ -27,6 +27,7 @@
     <Compile Include="..\Shared\Platform\EmptyObservable.cs" Link="Shared\Platform\EmptyObservable.cs"/>
     <Compile Include="..\Shared\Platform\ReturnObservable.cs" Link="Shared\Platform\ReturnObservable.cs"/>
     <Compile Include="..\Shared\Platform\StartWithObservable.cs" Link="Shared\Platform\StartWithObservable.cs"/>
+    <Compile Include="..\Shared\Platform\WhereObservable.cs" Link="Shared\Platform\WhereObservable.cs"/>
     <Compile Include="..\Shared\Platform\CombineLatestSink.cs" Link="Shared\Platform\CombineLatestSink.cs"/>
     <Compile Include="..\ReactiveUI\Polyfills\**\*.cs" Link="Polyfills\%(RecursiveDir)%(Filename)%(Extension)"/>
   </ItemGroup>

--- a/src/tests/ReactiveUI.WinForms.Tests/winforms/ActivationTests.cs
+++ b/src/tests/ReactiveUI.WinForms.Tests/winforms/ActivationTests.cs
@@ -149,4 +149,35 @@ public class ActivationTests
         parent.Close();
         await Assert.That(userControlDeActivateCount).IsEqualTo(ExpectedSecondCount);
     }
+
+    /// <summary>
+    /// Tests that view activation is skipped in design mode.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task ActivationIsSkippedInDesignMode()
+    {
+        using var control = new DesignModeTestControl
+        {
+            Site = new DesignModeSite(),
+        };
+
+        _ = control.Handle;
+
+        await Assert.That(control.Activated).IsFalse();
+    }
+
+    /// <summary>
+    /// Tests that view activation is not skipped outside of design mode.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task ActivationIsNotSkippedNotInDesignMode()
+    {
+        using var control = new DesignModeTestControl();
+
+        _ = control.Handle;
+
+        await Assert.That(control.Activated).IsTrue();
+    }
 }

--- a/src/tests/ReactiveUI.WinForms.Tests/winforms/Mocks/DesignModeSite.cs
+++ b/src/tests/ReactiveUI.WinForms.Tests/winforms/Mocks/DesignModeSite.cs
@@ -1,0 +1,22 @@
+// Copyright (c) 2009-2026 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.ComponentModel;
+
+namespace ReactiveUI.WinForms.Tests.Winforms.Mocks
+{
+    internal sealed class DesignModeSite : ISite
+    {
+        public IComponent Component { get; } = new Component();
+
+        public IContainer? Container => null;
+
+        public bool DesignMode => true;
+
+        public string? Name { get; set; }
+
+        public object? GetService(Type serviceType) => null;
+    }
+}

--- a/src/tests/ReactiveUI.WinForms.Tests/winforms/Mocks/DesignModeTestControl.cs
+++ b/src/tests/ReactiveUI.WinForms.Tests/winforms/Mocks/DesignModeTestControl.cs
@@ -1,0 +1,23 @@
+// Copyright (c) 2009-2026 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Windows.Forms;
+
+namespace ReactiveUI.WinForms.Tests.Winforms.Mocks
+{
+    internal sealed class DesignModeTestControl : Control, IActivatableView
+    {
+        public DesignModeTestControl()
+        {
+            this.WhenActivated(() =>
+            {
+                Activated = true;
+                return [];
+            });
+        }
+
+        public bool Activated { get; private set; }
+    }
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?
Fix #4368 and add a regression test.

## What is the new behavior?
See description of #4358.

## What is the current behavior?
See description of #4358.

## What might this PR break?
See description of #4358.

## Checklist
- [X] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [X] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features)
- [X] Changes target the `main` branch
- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information
In the original PR I didn't add a regression test because we can't run the Winforms designer in a test.
However, it turns out it's actually really easy to mock a site in design mode.