### PR TITLE
ci(release): add alpha/beta/rc release channel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,17 @@ on:
           - minor
           - major
 
+      channel:
+        description: 'Release channel. none = stable RTM; alpha/beta/rc cut a pre-release (e.g. major + beta -> 6.0.0-beta.1, then 6.0.0-beta.2). Finalise by re-running with the same bump and channel=none.'
+        required: true
+        default: none
+        type: choice
+        options:
+          - none
+          - alpha
+          - beta
+          - rc
+
       sourceRef:
         description: 'Optional git ref (tag/branch/SHA) to release from. Leave blank to release from this branch (normally main).'
         required: false
@@ -29,6 +40,9 @@ jobs:
       solutionFile: reactiveui.slnx
       installWorkloads: true
       bump: ${{ inputs.bump }}
+      # 'none' is the choice-input sentinel for a stable release (choice options
+      # can't be empty); the reusable workflow wants an empty channel for RTM.
+      preRelease: ${{ inputs.channel != 'none' && inputs.channel || '' }}
       ref: ${{ inputs.sourceRef }}
     secrets:
       CERTUM_USER_ID: ${{ secrets.CERTUM_USER_ID }}
@@ -71,3 +85,4 @@ jobs:
       version: ${{ needs.release.outputs.semver2 }}
       tag: ${{ needs.release.outputs.tag }}
       target: ${{ needs.release.outputs.sourceSha }}
+      prerelease: ${{ needs.release.outputs.prerelease == 'true' }}


### PR DESCRIPTION
## What kind of change does this PR introduce?
CI — adds a pre-release channel to the Release dispatch.

## What is the new behavior?
The Release workflow gains a `channel` choice input (`none` / `alpha` / `beta` / `rc`, default `none`), combined with the existing `bump` (major/minor/patch):

- `major` + `beta` → `6.0.0-beta.1`; re-run → `6.0.0-beta.2` (the counter auto-increments from existing `v6.0.0-beta.N` tags)
- switch to `rc` → `6.0.0-rc.1` (per-channel counter; `beta.10` correctly orders above `beta.9`)
- `major` + `none` → finalises `6.0.0` (last stable + bump)

Versions use dotted SemVer 2.0 pre-release form (`-beta.1`), which NuGet orders correctly. Pre-release runs flag the GitHub release with `--prerelease`, so the latest stable stays "Latest".

`channel=none` maps to an empty `preRelease` (choice inputs can't be empty); the work is delegated to the reusable `workflow-common-release` / `workflow-common-create-release` in `reactiveui/actions-common@main`.

## What is the current behavior?
The Release dispatch only exposes `bump` (patch/minor/major) and always cuts a stable RTM version (`vX.Y.Z`). There is no supported way to publish an incrementing alpha/beta/rc pre-release.

## What might this PR break?
None. `channel` defaults to `none`, which reproduces today's stable-release behaviour exactly. Finalising a stable release uses the same "last stable + bump" math as before, so re-select the same `bump` the betas used.

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [ ] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information
Depends on the reusable-workflow side in `reactiveui/actions-common@main` (already merged): `pre-release-id` on `compute-version-and-tag`, `preRelease`/`prerelease` on `workflow-common-release`, and `prerelease` on `workflow-common-create-release`.