### PR TITLE
chore(deps): update NuGet dependencies to latest

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -6,14 +6,14 @@
 
   <PropertyGroup Label="Shared Version Variables">
     <SplatVersion>20.0.0</SplatVersion>
-    <PrimitivesVersion>5.7.0</PrimitivesVersion>
-    <TUnitVersion>1.56.25</TUnitVersion>
-    <XamarinAndroidXLifecycleLiveDataVersion>2.10.0.2</XamarinAndroidXLifecycleLiveDataVersion>
+    <PrimitivesVersion>5.8.0</PrimitivesVersion>
+    <TUnitVersion>1.57.0</TUnitVersion>
+    <XamarinAndroidXLifecycleLiveDataVersion>2.11.0.1</XamarinAndroidXLifecycleLiveDataVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="Framework-Aligned Versions">
     <MauiVersion Condition="$(TargetFramework.StartsWith('net9'))">9.0.120</MauiVersion>
-    <MauiVersion Condition="$(TargetFramework.StartsWith('net10'))">10.0.71</MauiVersion>
+    <MauiVersion Condition="$(TargetFramework.StartsWith('net10'))">10.0.80</MauiVersion>
     <MauiVersion Condition="$(TargetFramework.StartsWith('net11'))">11.0.0-preview.5.26304.4</MauiVersion>
 
     <AspNetVersion Condition="$(TargetFramework.StartsWith('netstandard'))">3.1.32</AspNetVersion>
@@ -61,8 +61,8 @@
   </ItemGroup>
 
   <ItemGroup Label="Akavache">
-    <PackageVersion Include="Akavache.Sqlite3" Version="12.0.12"/>
-    <PackageVersion Include="Akavache.SystemTextJson" Version="12.0.12"/>
+    <PackageVersion Include="Akavache.Sqlite3" Version="12.1.1"/>
+    <PackageVersion Include="Akavache.SystemTextJson" Version="12.1.1"/>
   </ItemGroup>
 
   <ItemGroup Label="Testing">
@@ -100,7 +100,7 @@
   </ItemGroup>
 
   <ItemGroup Label="Platform - Windows / WinUI / WPF">
-    <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.1839"/>
+    <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.2270"/>
     <PackageVersion Include="Microsoft.Windows.CsWinRT" Version="2.3.0-prerelease.251115.2"/>
     <PackageVersion Include="Microsoft.Xaml.Behaviors.Wpf" Version="$(XamlBehaviorsWpfVersion)"/>
   </ItemGroup>
@@ -132,13 +132,13 @@
   </ItemGroup>
 
   <ItemGroup Label="Platform - Android (Fragment / Collection / SavedState / Preference)">
-    <PackageVersion Include="Xamarin.AndroidX.Fragment" Version="1.8.9.2"/>
-    <PackageVersion Include="Xamarin.AndroidX.Fragment.Ktx" Version="1.8.9.2"/>
-    <PackageVersion Include="Xamarin.AndroidX.Collection.Jvm" Version="1.6.0"/>
-    <PackageVersion Include="Xamarin.AndroidX.Collection.Ktx" Version="1.6.0"/>
-    <PackageVersion Include="Xamarin.AndroidX.SavedState" Version="1.4.0.2"/>
-    <PackageVersion Include="Xamarin.AndroidX.SavedState.SavedState.Ktx" Version="1.4.0.2"/>
-    <PackageVersion Include="Xamarin.AndroidX.Preference" Version="1.2.1.17"/>
+    <PackageVersion Include="Xamarin.AndroidX.Fragment" Version="1.8.9.3"/>
+    <PackageVersion Include="Xamarin.AndroidX.Fragment.Ktx" Version="1.8.9.4"/>
+    <PackageVersion Include="Xamarin.AndroidX.Collection.Jvm" Version="1.6.0.1"/>
+    <PackageVersion Include="Xamarin.AndroidX.Collection.Ktx" Version="1.6.0.1"/>
+    <PackageVersion Include="Xamarin.AndroidX.SavedState" Version="1.5.0.1"/>
+    <PackageVersion Include="Xamarin.AndroidX.SavedState.SavedState.Ktx" Version="1.5.0.1"/>
+    <PackageVersion Include="Xamarin.AndroidX.Preference" Version="1.2.1.18"/>
   </ItemGroup>
 
   <ItemGroup Label="Platform - WinUI (non-MAUI only)" Condition="'$(UseMaui)' != 'true'">


### PR DESCRIPTION
## What kind of change does this PR introduce?
Build / dependency maintenance — bumps centrally managed NuGet packages to their latest stable versions on nuget.org.

## What is the new behavior?
Updated `src/Directory.Packages.props`:

- ReactiveUI.Primitives 5.7.0 → 5.8.0
- TUnit 1.56.25 → 1.57.0
- Akavache.Sqlite3 / Akavache.SystemTextJson 12.0.12 → 12.1.1
- Microsoft.Maui.Controls (net10) 10.0.71 → 10.0.80
- Microsoft.Windows.SDK.BuildTools 10.0.28000.1839 → 10.0.28000.2270
- Xamarin.AndroidX.Lifecycle.* 2.10.0.2 → 2.11.0.1
- Xamarin.AndroidX.Fragment 1.8.9.2 → 1.8.9.3 (Fragment.Ktx → 1.8.9.4 to satisfy Preference's transitive constraint)
- Xamarin.AndroidX.Collection.Jvm / Collection.Ktx 1.6.0 → 1.6.0.1
- Xamarin.AndroidX.SavedState.* 1.4.0.2 → 1.5.0.1
- Xamarin.AndroidX.Preference 1.2.1.17 → 1.2.1.18

The multi-TFM / framework-aligned version pattern is preserved (per-band MAUI/AspNet/STJ conditions are untouched; only the net10 MAUI band moved to its latest patch). Packages already at their latest stable (Splat, DynamicData, System.Reactive, bunit, analyzers, etc.) were left unchanged, as were intentional prereleases (CsWinRT 2.3.0-prerelease, PublicApiAnalyzers 5.0.0 preview). GitHub Actions were checked: `download-artifact@v8` and `setup-dotnet@v5` already track the latest major; SHA-pinned actions are intentionally pinned.

## What is the current behavior?
Dependencies were one or more patch/minor releases behind the latest on nuget.org.

## What might this PR break?
None expected. Verified locally on Linux with clean builds (0 warnings/errors) of the core library (net8.0), the main test suite (TUnit 1.57.0), ReactiveUI.AndroidX (net10/net11-android), and ReactiveUI.Maui (net9/net10/net11 + android + windows). Windows/Apple-only TFMs are covered by CI, which is authoritative.

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [ ] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)