### PR TITLE
chore(deps): bump NuGet dependencies and drop EOL net9 MAUI targets

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -88,10 +88,11 @@
     <ReactiveUITestTargets>net8.0-windows10.0.19041.0;net9.0-windows10.0.19041.0;net10.0-windows10.0.19041.0;net11.0-windows10.0.19041.0</ReactiveUITestTargets>
 
     <!--    <ReactiveUIMauiTestTargets Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(ReactiveUIMauiWindowsTargets)</ReactiveUIMauiTestTargets>-->
-    <ReactiveUIMauiTestTargets>$(ReactiveUIMauiTestTargets);net9.0;net10.0</ReactiveUIMauiTestTargets>
+    <ReactiveUIMauiTestTargets>$(ReactiveUIMauiTestTargets);net10.0</ReactiveUIMauiTestTargets>
 
+    <!-- MAUI net9 heads (Android/Apple/plain) are EOL; MAUI targets net10+ only. Windows/WinUI3 targets keep net9 elsewhere. -->
     <ReactiveMauiTargets>$(ReactiveUIMauiWindowsTargets)</ReactiveMauiTargets>
-    <ReactiveMauiTargets>$(ReactiveMauiTargets);net9.0;net10.0;$(ReactiveUIAndroidTargets)</ReactiveMauiTargets>
+    <ReactiveMauiTargets>$(ReactiveMauiTargets);net10.0;$(ReactiveUIAndroidTargets)</ReactiveMauiTargets>
     <ReactiveMauiTargets Condition="$([MSBuild]::IsOsPlatform('Windows')) or $([MSBuild]::IsOsPlatform('OSX'))">$(ReactiveMauiTargets);$(ReactiveUIAppleTargets)</ReactiveMauiTargets>
 
     <!-- Modern targets for tests and benchmarks (no netstandard) -->

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -6,13 +6,12 @@
 
   <PropertyGroup Label="Shared Version Variables">
     <SplatVersion>20.0.0</SplatVersion>
-    <PrimitivesVersion>5.8.0</PrimitivesVersion>
-    <TUnitVersion>1.57.0</TUnitVersion>
+    <PrimitivesVersion>6.0.0</PrimitivesVersion>
+    <TUnitVersion>1.58.0</TUnitVersion>
     <XamarinAndroidXLifecycleLiveDataVersion>2.11.0.1</XamarinAndroidXLifecycleLiveDataVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="Framework-Aligned Versions">
-    <MauiVersion Condition="$(TargetFramework.StartsWith('net9'))">9.0.120</MauiVersion>
     <MauiVersion Condition="$(TargetFramework.StartsWith('net10'))">10.0.80</MauiVersion>
     <MauiVersion Condition="$(TargetFramework.StartsWith('net11'))">11.0.0-preview.5.26304.4</MauiVersion>
 
@@ -50,7 +49,7 @@
   </ItemGroup>
 
   <ItemGroup Label="Rx Ecosystem">
-    <PackageVersion Include="DynamicData" Version="9.4.31"/>
+    <PackageVersion Include="DynamicData" Version="9.4.33"/>
     <PackageVersion Include="Reactive.Wasm" Version="3.0.1"/>
     <PackageVersion Include="Splat" Version="$(SplatVersion)"/>
     <PackageVersion Include="Splat.Autofac" Version="$(SplatVersion)"/>
@@ -80,10 +79,10 @@
   <ItemGroup Label="Analyzers">
     <PackageVersion Include="StyleSharp.Analyzers" Version="3.13.4"/>
     <PackageVersion Include="Roslynator.Analyzers" Version="4.15.0"/>
-    <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.27.0.140913"/>
-    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0"/>
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.3.0"/>
-    <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="5.0.0-1.25277.114"/>
+    <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.28.0.143324"/>
+    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.6.0"/>
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.6.0"/>
+    <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="5.6.0"/>
   </ItemGroup>
 
   <ItemGroup Label="Build / SourceLink / Versioning">


### PR DESCRIPTION
## What kind of change does this PR introduce?

Build / dependency maintenance:

- Bumps NuGet package versions to latest (verified against nuget.org).
- Drops the end-of-life net9 MAUI target frameworks.

## What is the new behavior?

**Package bumps**

| Package | From | To |
| --- | --- | --- |
| ReactiveUI.Primitives family | 5.8.0 | 6.0.0 |
| DynamicData | 9.4.31 | 9.4.33 |
| TUnit / TUnit.Core | 1.57.0 | 1.58.0 |
| SonarAnalyzer.CSharp | 10.27.0.140913 | 10.28.0.143324 |
| Microsoft.CodeAnalysis.Analyzers | 5.3.0 | 5.6.0 |
| Microsoft.CodeAnalysis.CSharp.Workspaces | 5.3.0 | 5.6.0 |
| Microsoft.CodeAnalysis.PublicApiAnalyzers | 5.0.0-1.25277.114 | 5.6.0 |

**MAUI net9 targets removed**

- The net9 MAUI heads (plain net9.0, and Android/Apple) are dropped; MAUI now builds net10+ only.
- Per the .NET MAUI support policy, .NET 9 MAUI reached end of support on 12 May 2026: https://dotnet.microsoft.com/en-us/platform/support/policy/maui
- The dead net9 MauiVersion pin (9.0.120) was removed from central package management.

## What is the current behavior?

- Package versions were one or more releases behind latest on the packages listed above.
- The MAUI projects (ReactiveUI.Maui, ReactiveUI.Maui.Reactive) and their test projects still multi-targeted a net9 MAUI head that is now out of support.

## What might this PR break?

- Consumers building the ReactiveUI.Maui packages against net9 MAUI must move to net10+. .NET 9 MAUI is already out of support (12 May 2026), so this only removes an unsupported target.
- Windows / WinUI3 targets are unaffected: the net9-windows target frameworks remain in place (WinUI3 is not part of the MAUI net9 removal).
- Android MAUI (net10/net11) and Apple MAUI (net10/net11) were already free of net9 and are unchanged.
- ReactiveUI.Primitives 6.0.0 is a major bump; core library builds clean and the full ReactiveUI.Tests suite passes on net10.0 (1966 tests, 0 failures).

## Checklist

- [x] I have read the Contribute guide
- [ ] Tests have been added or updated (not applicable; dependency and targeting maintenance)
- [ ] Docs have been added or updated (not applicable)
- [x] Changes target the `main` branch
- [x] PR title follows Conventional Commits

## Additional information

- Framework-aligned bands were already at their latest per-TFM patch and are unchanged: MAUI net10 (10.0.80) / net11 preview, ASP.NET Core (net8 8.0.28 / net9 9.0.17 / net10 10.0.9 / netstandard 3.1.32), and System.Text.Json / System.Collections.Immutable / Microsoft.Extensions.DependencyModel / Microsoft.Data.Sqlite.Core at 10.0.9.
- Deliberately stayed on the stable channel where only newer prereleases exist: System.Reactive and Microsoft.Reactive.Testing (7.0-rc), MinVer (8.0-rc), Microsoft.SourceLink.GitHub (11.0-preview), bunit (2.8-preview), BenchmarkDotNet (0.16-preview), and Microsoft.Windows.CsWinRT (already on a 2.3.0 prerelease pin; the 3.0-preview major was not adopted).
- Verification (Linux, net10.0): core ReactiveUI builds with 0 warnings; ReactiveUI.Tests builds with 0 warnings and all 1966 tests pass. Windows-only TFMs are validated by CI.
