### PR TITLE
fix(wpf): resolve XAML namespace under REACTIVE_SHIM in AutoDataTemplateBindingHook

### DIFF
--- a/src/ReactiveUI.Wpf.Shared/Common/AutoDataTemplateBindingHook.cs
+++ b/src/ReactiveUI.Wpf.Shared/Common/AutoDataTemplateBindingHook.cs
@@ -22,8 +22,20 @@ public class AutoDataTemplateBindingHook : IPropertyBindingHook
     /// <summary>Gets the default item template.</summary>
     public static Lazy<DataTemplate> DefaultItemTemplate { get; } = new(static () =>
     {
+        // The clr-namespace in the inline XAML template must match the namespace
+        // this type is actually compiled into. Under REACTIVE_SHIM the shared
+        // source is recompiled into the ReactiveUI.Reactive namespace (see the
+        // conditional namespace above), so the XAML must reference that namespace
+        // too — otherwise XamlReader.Parse throws a XamlObjectReaderException
+        // because '{clr-namespace:ReactiveUI;assembly=ReactiveUI.Wpf.Reactive}'
+        // cannot resolve ViewModelViewHost. See issue #4398.
+#if REACTIVE_SHIM
+        const string XamlClrNamespace = "clr-namespace:ReactiveUI.Reactive";
+#else
+        const string XamlClrNamespace = "clr-namespace:ReactiveUI";
+#endif
         const string Template = "<DataTemplate xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation' " +
-                                "xmlns:xaml='clr-namespace:ReactiveUI;assembly=__ASSEMBLYNAME__'> " +
+                                "xmlns:xaml='" + XamlClrNamespace + ";assembly=__ASSEMBLYNAME__'> " +
                                 "<xaml:ViewModelViewHost ViewModel=\"{Binding Mode=OneWay}\" VerticalContentAlignment=\"Stretch\" HorizontalContentAlignment=\"Stretch\" IsTabStop=\"False\" />" +
                                 "</DataTemplate>";
 

--- a/src/tests/ReactiveUI.Wpf.Tests/Wpf/AutoDataTemplateBindingHookTest.cs
+++ b/src/tests/ReactiveUI.Wpf.Tests/Wpf/AutoDataTemplateBindingHookTest.cs
@@ -21,6 +21,29 @@ public class AutoDataTemplateBindingHookTest
     public async Task DefaultItemTemplate_IsNotNull() =>
         await Assert.That(AutoDataTemplateBindingHook.DefaultItemTemplate.Value).IsNotNull();
 
+#if REACTIVE_SHIM
+    /// <summary>
+    /// Under REACTIVE_SHIM the shared source is recompiled into the
+    /// ReactiveUI.Reactive namespace, so the inline XAML template's
+    /// clr-namespace must also be ReactiveUI.Reactive. If it is left hardcoded
+    /// to ReactiveUI, XamlReader.Parse throws a XamlObjectReaderException
+    /// because ViewModelViewHost cannot be resolved in the ReactiveUI.Wpf.Reactive
+    /// assembly. This regression test forces the lazy template to materialize and
+    /// asserts it loads without throwing. See issue #4398.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task DefaultItemTemplate_LoadsUnderReactiveShim()
+    {
+        // Materializing the lazy value must not throw. Before the fix this threw
+        // System.Xaml.XamlObjectReaderException: Cannot create unknown type
+        // '{clr-namespace:ReactiveUI;assembly=ReactiveUI.Wpf.Reactive}ViewModelViewHost'.
+        DataTemplate? template = null;
+        await Assert.That(() => template = AutoDataTemplateBindingHook.DefaultItemTemplate.Value).ThrowsNothing();
+        await Assert.That(template).IsNotNull();
+    }
+#endif
+
     /// <summary>A null view-property accessor throws.</summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Test]


### PR DESCRIPTION
## Summary

Fixes #4398 — `AutoDataTemplateBindingHook` throws a `XamlObjectReaderException` in the `ReactiveUI.Wpf.Reactive` (shim) build because its inline `DataTemplate` XAML references the wrong namespace.

## Root cause

`src/ReactiveUI.Wpf.Shared/Common/AutoDataTemplateBindingHook.cs` is **shared source** compiled into two assemblies:

| Build | Project | `REACTIVE_SHIM` | C# namespace |
|---|---|---|---|
| lean | `ReactiveUI.Wpf` | undefined | `ReactiveUI` |
| shim | `ReactiveUI.Wpf.Reactive` | defined | `ReactiveUI.Reactive` |

The file already conditionally sets the **C# namespace** at the top:

```csharp
#if REACTIVE_SHIM
namespace ReactiveUI.Reactive;
#else
namespace ReactiveUI;
#endif
```

…but the inline `DataTemplate` XAML string hardcodes `clr-namespace:ReactiveUI`:

```csharp
const string Template = "<DataTemplate xmlns='...' xmlns:xaml='clr-namespace:ReactiveUI;assembly=__ASSEMBLYNAME__'> ...";
```

In the shim build, `ViewModelViewHost` actually lives in `ReactiveUI.Reactive`, so `XamlReader.Parse` can't resolve `{clr-namespace:ReactiveUI;assembly=ReactiveUI.Wpf.Reactive}ViewModelViewHost` and throws — exactly the exception in the issue.

## The fix

Make the XAML `clr-namespace` conditional on `REACTIVE_SHIM`, mirroring the existing namespace block:

```csharp
#if REACTIVE_SHIM
const string XamlClrNamespace = "clr-namespace:ReactiveUI.Reactive";
#else
const string XamlClrNamespace = "clr-namespace:ReactiveUI";
#endif
const string Template = "<DataTemplate ... xmlns:xaml='" + XamlClrNamespace + ";assembly=__ASSEMBLYNAME__'> ...";
```

The `const string` concatenation stays a compile-time constant, so the template remains a `const`. The lean build is byte-for-byte unchanged (`XamlClrNamespace` resolves to the same `clr-namespace:ReactiveUI`); the shim build now resolves `ViewModelViewHost` correctly.

## Test

Added `DefaultItemTemplate_LoadsUnderReactiveShim` to `src/tests/ReactiveUI.Wpf.Tests/Wpf/AutoDataTemplateBindingHookTest.cs`, guarded by `#if REACTIVE_SHIM`.

The test file is cross-included into the `ReactiveUI.Wpf.Tests.Reactive` project via the csproj wildcard `<Compile Include="..\ReactiveUI.Wpf.Tests\Wpf\**\*.cs" .../>`, so the conditional test compiles **only** in the shim test project — i.e. only where the bug manifests. It materializes the lazy `DefaultItemTemplate.Value` (which threw `XamlObjectReaderException` before the fix) and asserts the parse completes without throwing:

```csharp
#if REACTIVE_SHIM
[Test]
public async Task DefaultItemTemplate_LoadsUnderReactiveShim()
{
    DataTemplate? template = null;
    await Assert.That(() => template = AutoDataTemplateBindingHook.DefaultItemTemplate.Value).ThrowsNothing();
    await Assert.That(template).IsNotNull();
}
#endif
```

This fails before the fix (the lazy `.Value` throws) and passes after. The existing `DefaultItemTemplate_IsNotNull` test continues to cover the lean build.

## Scope

- `src/ReactiveUI.Wpf.Shared/Common/AutoDataTemplateBindingHook.cs` — conditional `clr-namespace`
- `src/tests/ReactiveUI.Wpf.Tests/Wpf/AutoDataTemplateBindingHookTest.cs` — one guarded regression test

No changes to `ExecuteHook`, binding logic, or any other platform.

## Out of scope (flagging for maintainers)

`src/ReactiveUI.Maui/Common/AutoDataTemplateBindingHook.cs` has the same hardcoded `clr-namespace:ReactiveUI` pattern, but for the Maui host (different namespace handling, no `assembly=` suffix in its template). I deliberately left it untouched to keep this PR scoped to the reported WPF issue and because I haven't verified the Maui namespace resolution path. Worth a separate look — happy to follow up if you'd like.

## AI usage

An AI assistant was used to help locate the relevant code and draft this change. I have reviewed and understand every line of the diff, and I am the sole author of this contribution.

## CLA

This is a .NET Foundation project; if a CLA is required, please point me to the sign-in flow and I'll complete it before merge.

Fixes #4398