### PR TITLE
refactor: consolidate duplicated reactive plumbing

### DIFF
--- a/src/ReactiveUI.Maui/Common/RoutedViewHost.cs
+++ b/src/ReactiveUI.Maui/Common/RoutedViewHost.cs
@@ -12,7 +12,6 @@ using ReactiveUI.Reactive.Maui.Internal;
 #else
 using ReactiveUI.Maui.Internal;
 #endif
-using ReactiveUI.Primitives;
 using Splat;
 
 #if REACTIVE_SHIM
@@ -58,78 +57,24 @@ public partial class RoutedViewHost : TransitioningContentControl, IActivatableV
         HorizontalContentAlignment = HorizontalAlignment.Stretch;
         VerticalContentAlignment = VerticalAlignment.Stretch;
 
-        var platform = AppLocator.Current.GetService<IPlatformOperations>();
-        Func<string?> platformGetter = static () => default;
+        var platformGetter = ViewContractObservableHelpers.GetPlatformOrientation(this.Log());
+        ViewContractObservable = ViewContractObservableHelpers.Create(
+            platformGetter,
+            new FromEventObservable<string?>(onNext =>
+            {
+                SizeChangedEventHandler handler = (_, _) => onNext(platformGetter());
+                SizeChanged += handler;
+                return new ActionDisposable(() => SizeChanged -= handler);
+            }));
 
-        if (platform is null)
-        {
-            // NB: This used to be an error but WPF design mode can't read
-            // good or do other stuff good.
-            this.Log().Error(
-                "Couldn't find an IPlatformOperations implementation. Please make sure you have installed the latest "
-                + "version of the ReactiveUI packages for your platform. See https://reactiveui.net/docs/getting-started/installation for guidance.");
-        }
-        else
-        {
-            platformGetter = platform.GetOrientation;
-        }
-
-        ViewContractObservable = ModeDetector.InUnitTestRunner()
-            ? Signal.Silent<string>()
-
-            // Replaces FromEvent(SizeChanged).StartWith(platformGetter()).DistinctUntilChanged().
-            : new StartWithObservable<string?>(
-                    new FromEventObservable<string?>(onNext =>
-                    {
-                        SizeChangedEventHandler handler = (_, _) => onNext(platformGetter());
-                        SizeChanged += handler;
-                        return new ActionDisposable(() => SizeChanged -= handler);
-                    }),
-                    platformGetter())
-                .DistinctUntilChanged();
-
-        // Observe Router property changes using DependencyProperty (AOT-friendly)
-        var routerChanged = MauiReactiveHelpers.CreatePropertyValueObservable(
+        MauiReactiveHelpers.SubscribeRoutedViewHost(
             this,
-            nameof(Router),
-            RouterProperty,
-            () => Router);
-
-        // Observe ViewContractObservable property changes using DependencyProperty (AOT-friendly)
-        var viewContractObservableChanged = MauiReactiveHelpers.CreatePropertyValueObservable(
-            this,
-            nameof(ViewContractObservable),
-            ViewContractObservableProperty,
-            () => ViewContractObservable);
-
-        // Observe current view model from router. Replaces Where(...).SelectMany(r => r.CurrentViewModel).StartWith(null).
-        var currentViewModel = new StartWithObservable<IRoutableViewModel?>(
-            new KeepSignal<RoutingState?>(routerChanged, static router => router is not null)
-                .SelectMany(static router => router!.CurrentViewModel),
-            null);
-
-        // Flatten the ViewContractObservable observable-of-observable.
-        // Replaces SelectMany(x => x ?? Return(null)).Do(x => _viewContract = x).StartWith(ViewContract).
-        var viewContract = new StartWithObservable<string?>(
-            viewContractObservableChanged
-                .SelectMany(static x => x ?? Signal.Emit<string?>(null))
-                .Do(x => _viewContract = x),
-            ViewContract);
-
-        var viewModelAndContract = currentViewModel
-            .CombineLatest(
-                viewContract,
-                static (viewModel, contract) => (viewModel, contract));
-
-        // Subscribe directly without WhenActivated
-        // NB: The DistinctUntilChanged is useful because most views in
-        // WinRT will end up getting here twice - once for configuring
-        // the RoutedViewHost's ViewModel, and once on load via SizeChanged
-        _ = viewModelAndContract.DistinctUntilChanged()
-            .Subscribe(new DelegateObserver<(IRoutableViewModel? viewModel, string? contract)>(
-                ResolveViewForViewModel,
-                RxState.DefaultExceptionHandler.OnNext))
-            .DisposeWith(_subscriptions);
+            (nameof(Router), RouterProperty, () => Router),
+            (nameof(ViewContractObservable), ViewContractObservableProperty, () => ViewContractObservable),
+            () => ViewContract,
+            contract => _viewContract = contract,
+            ResolveViewForViewModel,
+            _subscriptions);
     }
 
     /// <summary>Gets or sets the <see cref="RoutingState"/> of the view model stack.</summary>

--- a/src/ReactiveUI.Maui/Common/RoutedViewHost.cs
+++ b/src/ReactiveUI.Maui/Common/RoutedViewHost.cs
@@ -6,7 +6,6 @@
 #if WINUI_TARGET
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.UI.Xaml;
-using ReactiveUI.Internal;
 #if REACTIVE_SHIM
 using ReactiveUI.Reactive.Maui.Internal;
 #else
@@ -57,18 +56,8 @@ public partial class RoutedViewHost : TransitioningContentControl, IActivatableV
         HorizontalContentAlignment = HorizontalAlignment.Stretch;
         VerticalContentAlignment = VerticalAlignment.Stretch;
 
-        var platformGetter = ViewContractObservableHelpers.GetPlatformOrientation(this.Log());
-        ViewContractObservable = ViewContractObservableHelpers.Create(
-            platformGetter,
-            new FromEventObservable<string?>(onNext =>
-            {
-                SizeChangedEventHandler handler = (_, _) => onNext(platformGetter());
-                SizeChanged += handler;
-                return new ActionDisposable(() => SizeChanged -= handler);
-            }));
-
-        MauiReactiveHelpers.SubscribeRoutedViewHost(
-            this,
+        MauiReactiveHelpers.InitializeRoutedViewHost(
+            (this, this.Log(), observable => ViewContractObservable = observable),
             (nameof(Router), RouterProperty, () => Router),
             (nameof(ViewContractObservable), ViewContractObservableProperty, () => ViewContractObservable),
             () => ViewContract,

--- a/src/ReactiveUI.Maui/Common/RoutedViewHost{TViewModel}.cs
+++ b/src/ReactiveUI.Maui/Common/RoutedViewHost{TViewModel}.cs
@@ -12,7 +12,6 @@ using ReactiveUI.Reactive.Maui.Internal;
 #else
 using ReactiveUI.Maui.Internal;
 #endif
-using ReactiveUI.Primitives;
 using Splat;
 
 #if REACTIVE_SHIM
@@ -60,78 +59,24 @@ public partial class RoutedViewHost<
         HorizontalContentAlignment = HorizontalAlignment.Stretch;
         VerticalContentAlignment = VerticalAlignment.Stretch;
 
-        var platform = AppLocator.Current.GetService<IPlatformOperations>();
-        Func<string?> platformGetter = static () => default;
+        var platformGetter = ViewContractObservableHelpers.GetPlatformOrientation(this.Log());
+        ViewContractObservable = ViewContractObservableHelpers.Create(
+            platformGetter,
+            new FromEventObservable<string?>(onNext =>
+            {
+                SizeChangedEventHandler handler = (_, _) => onNext(platformGetter());
+                SizeChanged += handler;
+                return new ActionDisposable(() => SizeChanged -= handler);
+            }));
 
-        if (platform is null)
-        {
-            // NB: This used to be an error but WPF design mode can't read
-            // good or do other stuff good.
-            this.Log().Error(
-                "Couldn't find an IPlatformOperations implementation. Please make sure you have installed the latest "
-                + "version of the ReactiveUI packages for your platform. See https://reactiveui.net/docs/getting-started/installation for guidance.");
-        }
-        else
-        {
-            platformGetter = platform.GetOrientation;
-        }
-
-        ViewContractObservable = ModeDetector.InUnitTestRunner()
-            ? Signal.Silent<string>()
-
-            // Replaces FromEvent(SizeChanged).StartWith(platformGetter()).DistinctUntilChanged().
-            : new StartWithObservable<string?>(
-                    new FromEventObservable<string?>(onNext =>
-                    {
-                        SizeChangedEventHandler handler = (_, _) => onNext(platformGetter());
-                        SizeChanged += handler;
-                        return new ActionDisposable(() => SizeChanged -= handler);
-                    }),
-                    platformGetter())
-                .DistinctUntilChanged();
-
-        // Observe Router property changes using DependencyProperty (AOT-friendly)
-        var routerChanged = MauiReactiveHelpers.CreatePropertyValueObservable(
+        MauiReactiveHelpers.SubscribeRoutedViewHost(
             this,
-            nameof(Router),
-            RouterProperty,
-            () => Router);
-
-        // Observe ViewContractObservable property changes using DependencyProperty (AOT-friendly)
-        var viewContractObservableChanged = MauiReactiveHelpers.CreatePropertyValueObservable(
-            this,
-            nameof(ViewContractObservable),
-            ViewContractObservableProperty,
-            () => ViewContractObservable);
-
-        // Observe current view model from router. Replaces Where(...).SelectMany(r => r.CurrentViewModel).StartWith(null).
-        var currentViewModel = new StartWithObservable<IRoutableViewModel?>(
-            new KeepSignal<RoutingState?>(routerChanged, static router => router is not null)
-                .SelectMany(static router => router!.CurrentViewModel),
-            null);
-
-        // Flatten the ViewContractObservable observable-of-observable.
-        // Replaces SelectMany(x => x ?? Return(null)).Do(x => _viewContract = x).StartWith(ViewContract).
-        var viewContract = new StartWithObservable<string?>(
-            viewContractObservableChanged
-                .SelectMany(static x => x ?? Signal.Emit<string?>(null))
-                .Do(x => _viewContract = x),
-            ViewContract);
-
-        var viewModelAndContract = currentViewModel
-            .CombineLatest(
-                viewContract,
-                static (viewModel, contract) => (viewModel, contract));
-
-        // Subscribe directly without WhenActivated
-        // NB: The DistinctUntilChanged is useful because most views in
-        // WinRT will end up getting here twice - once for configuring
-        // the RoutedViewHost's ViewModel, and once on load via SizeChanged
-        _ = viewModelAndContract.DistinctUntilChanged()
-            .Subscribe(new DelegateObserver<(IRoutableViewModel? viewModel, string? contract)>(
-                ResolveViewForViewModel,
-                RxState.DefaultExceptionHandler.OnNext))
-            .DisposeWith(_subscriptions);
+            (nameof(Router), RouterProperty, () => Router),
+            (nameof(ViewContractObservable), ViewContractObservableProperty, () => ViewContractObservable),
+            () => ViewContract,
+            contract => _viewContract = contract,
+            ResolveViewForViewModel,
+            _subscriptions);
     }
 
     /// <summary>Gets or sets the <see cref="RoutingState"/> of the view model stack.</summary>
@@ -140,6 +85,12 @@ public partial class RoutedViewHost<
         get => (RoutingState)GetValue(RouterProperty);
         set => SetValue(RouterProperty, value);
     }
+
+    /// <summary>Gets or sets the view locator.</summary>
+    /// <value>
+    /// The view locator.
+    /// </value>
+    public IViewLocator? ViewLocator { get; set; }
 
     /// <summary>Gets or sets the content displayed whenever there is no page currently routed.</summary>
     public object DefaultContent
@@ -168,12 +119,6 @@ public partial class RoutedViewHost<
             ViewContractObservable = Signal.Emit(value);
         }
     }
-
-    /// <summary>Gets or sets the view locator.</summary>
-    /// <value>
-    /// The view locator.
-    /// </value>
-    public IViewLocator? ViewLocator { get; set; }
 
     /// <summary>
     /// Resolves and displays the view for the given view model and contract.

--- a/src/ReactiveUI.Maui/Common/RoutedViewHost{TViewModel}.cs
+++ b/src/ReactiveUI.Maui/Common/RoutedViewHost{TViewModel}.cs
@@ -6,7 +6,6 @@
 #if WINUI_TARGET
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.UI.Xaml;
-using ReactiveUI.Internal;
 #if REACTIVE_SHIM
 using ReactiveUI.Reactive.Maui.Internal;
 #else
@@ -59,18 +58,8 @@ public partial class RoutedViewHost<
         HorizontalContentAlignment = HorizontalAlignment.Stretch;
         VerticalContentAlignment = VerticalAlignment.Stretch;
 
-        var platformGetter = ViewContractObservableHelpers.GetPlatformOrientation(this.Log());
-        ViewContractObservable = ViewContractObservableHelpers.Create(
-            platformGetter,
-            new FromEventObservable<string?>(onNext =>
-            {
-                SizeChangedEventHandler handler = (_, _) => onNext(platformGetter());
-                SizeChanged += handler;
-                return new ActionDisposable(() => SizeChanged -= handler);
-            }));
-
-        MauiReactiveHelpers.SubscribeRoutedViewHost(
-            this,
+        MauiReactiveHelpers.InitializeRoutedViewHost(
+            (this, this.Log(), observable => ViewContractObservable = observable),
             (nameof(Router), RouterProperty, () => Router),
             (nameof(ViewContractObservable), ViewContractObservableProperty, () => ViewContractObservable),
             () => ViewContract,
@@ -79,18 +68,18 @@ public partial class RoutedViewHost<
             _subscriptions);
     }
 
+    /// <summary>Gets or sets the view locator.</summary>
+    /// <value>
+    /// The view locator.
+    /// </value>
+    public IViewLocator? ViewLocator { get; set; }
+
     /// <summary>Gets or sets the <see cref="RoutingState"/> of the view model stack.</summary>
     public RoutingState Router
     {
         get => (RoutingState)GetValue(RouterProperty);
         set => SetValue(RouterProperty, value);
     }
-
-    /// <summary>Gets or sets the view locator.</summary>
-    /// <value>
-    /// The view locator.
-    /// </value>
-    public IViewLocator? ViewLocator { get; set; }
 
     /// <summary>Gets or sets the content displayed whenever there is no page currently routed.</summary>
     public object DefaultContent

--- a/src/ReactiveUI.Maui/Common/ViewModelViewHost.cs
+++ b/src/ReactiveUI.Maui/Common/ViewModelViewHost.cs
@@ -11,7 +11,6 @@ using ReactiveUI.Reactive.Maui.Internal;
 #else
 using ReactiveUI.Maui.Internal;
 #endif
-using ReactiveUI.Primitives;
 using Splat;
 
 #if REACTIVE_SHIM
@@ -58,58 +57,23 @@ public partial class ViewModelViewHost : TransitioningContentControl, IViewFor, 
         Justification = "The single-threaded UI control hands 'this' to MauiReactiveHelpers to observe its own dependency-property changes; it is never published to another thread.")]
     public ViewModelViewHost()
     {
-        var platform = AppLocator.Current.GetService<IPlatformOperations>();
-        Func<string?> platformGetter = static () => default;
+        var platformGetter = ViewContractObservableHelpers.GetPlatformOrientation(this.Log());
+        ViewContractObservable = ViewContractObservableHelpers.Create(
+            platformGetter,
+            new FromEventObservable<string?>(onNext =>
+            {
+                SizeChangedEventHandler handler = (_, _) => onNext(platformGetter());
+                SizeChanged += handler;
+                return new ActionDisposable(() => SizeChanged -= handler);
+            }));
 
-        if (platform is null)
-        {
-            // NB: This used to be an error but WPF design mode can't read
-            // good or do other stuff good.
-            this.Log().Error(
-                "Couldn't find an IPlatformOperations implementation. Please make sure you have installed the latest "
-                + "version of the ReactiveUI packages for your platform. See https://reactiveui.net/docs/getting-started/installation for guidance.");
-        }
-        else
-        {
-            platformGetter = platform.GetOrientation;
-        }
-
-        ViewContractObservable = ModeDetector.InUnitTestRunner()
-            ? Signal.Silent<string>()
-
-            // Replaces FromEvent(SizeChanged).StartWith(platformGetter()).DistinctUntilChanged().
-            : new StartWithObservable<string?>(
-                    new FromEventObservable<string?>(onNext =>
-                    {
-                        SizeChangedEventHandler handler = (_, _) => onNext(platformGetter());
-                        SizeChanged += handler;
-                        return new ActionDisposable(() => SizeChanged -= handler);
-                    }),
-                    platformGetter())
-                .DistinctUntilChanged();
-
-        // Observe ViewModel property changes without expression trees (AOT-friendly)
-        var viewModelChanged = MauiReactiveHelpers.CreatePropertyValueObservable(
+        MauiReactiveHelpers.SubscribeViewModelViewHost(
             this,
-            nameof(ViewModel),
-            ViewModelProperty,
-            () => ViewModel);
-
-        // Combine contract observable (recording the latest contract) with ViewModel changes.
-        var viewModelAndContract = ViewContractObservable.Do(x => _viewContract = x)
-            .CombineLatest(
-                viewModelChanged,
-                static (contract, vm) => (vm, contract));
-
-        // Subscribe directly without WhenActivated
-        _ = new ObserveOnObservable<string?>(ViewContractObservable, RxSchedulers.MainThreadScheduler)
-            .Subscribe(new DelegateObserver<string?>(x => _viewContract = x ?? string.Empty))
-            .DisposeWith(_subscriptions);
-
-        _ = viewModelAndContract.DistinctUntilChanged()
-            .Subscribe(new DelegateObserver<(object? ViewModel, string? Contract)>(
-                x => ResolveViewForViewModel(x.ViewModel, x.Contract)))
-            .DisposeWith(_subscriptions);
+            (nameof(ViewModel), ViewModelProperty, () => ViewModel),
+            ViewContractObservable,
+            contract => _viewContract = contract,
+            ResolveViewForViewModel,
+            _subscriptions);
     }
 
     /// <summary>Gets or sets the view contract observable.</summary>

--- a/src/ReactiveUI.Maui/Common/ViewModelViewHost.cs
+++ b/src/ReactiveUI.Maui/Common/ViewModelViewHost.cs
@@ -5,7 +5,6 @@
 
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.UI.Xaml;
-using ReactiveUI.Internal;
 #if REACTIVE_SHIM
 using ReactiveUI.Reactive.Maui.Internal;
 #else
@@ -57,20 +56,9 @@ public partial class ViewModelViewHost : TransitioningContentControl, IViewFor, 
         Justification = "The single-threaded UI control hands 'this' to MauiReactiveHelpers to observe its own dependency-property changes; it is never published to another thread.")]
     public ViewModelViewHost()
     {
-        var platformGetter = ViewContractObservableHelpers.GetPlatformOrientation(this.Log());
-        ViewContractObservable = ViewContractObservableHelpers.Create(
-            platformGetter,
-            new FromEventObservable<string?>(onNext =>
-            {
-                SizeChangedEventHandler handler = (_, _) => onNext(platformGetter());
-                SizeChanged += handler;
-                return new ActionDisposable(() => SizeChanged -= handler);
-            }));
-
-        MauiReactiveHelpers.SubscribeViewModelViewHost(
-            this,
+        MauiReactiveHelpers.InitializeViewModelViewHost(
+            (this, this.Log(), observable => ViewContractObservable = observable),
             (nameof(ViewModel), ViewModelProperty, () => ViewModel),
-            ViewContractObservable,
             contract => _viewContract = contract,
             ResolveViewForViewModel,
             _subscriptions);

--- a/src/ReactiveUI.Maui/Common/ViewModelViewHost{TViewModel}.cs
+++ b/src/ReactiveUI.Maui/Common/ViewModelViewHost{TViewModel}.cs
@@ -5,7 +5,6 @@
 
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.UI.Xaml;
-using ReactiveUI.Internal;
 #if REACTIVE_SHIM
 using ReactiveUI.Reactive.Maui.Internal;
 #else
@@ -59,30 +58,12 @@ public partial class ViewModelViewHost<
         Justification = "The single-threaded UI control hands 'this' to MauiReactiveHelpers to observe its own dependency-property changes; it is never published to another thread.")]
     public ViewModelViewHost()
     {
-        var platformGetter = ViewContractObservableHelpers.GetPlatformOrientation(this.Log());
-        ViewContractObservable = ViewContractObservableHelpers.Create(
-            platformGetter,
-            new FromEventObservable<string?>(onNext =>
-            {
-                SizeChangedEventHandler handler = (_, _) => onNext(platformGetter());
-                SizeChanged += handler;
-                return new ActionDisposable(() => SizeChanged -= handler);
-            }));
-
-        MauiReactiveHelpers.SubscribeViewModelViewHost(
-            this,
+        MauiReactiveHelpers.InitializeViewModelViewHost(
+            (this, this.Log(), observable => ViewContractObservable = observable),
             (nameof(ViewModel), ViewModelProperty, () => ViewModel),
-            ViewContractObservable,
             contract => _viewContract = contract,
             ResolveViewForViewModel,
             _subscriptions);
-    }
-
-    /// <summary>Gets or sets the view contract observable.</summary>
-    public IObservable<string?> ViewContractObservable
-    {
-        get => (IObservable<string>)GetValue(ViewContractObservableProperty);
-        set => SetValue(ViewContractObservableProperty, value);
     }
 
     /// <summary>Gets or sets the content displayed by default when no content is set.</summary>
@@ -97,6 +78,13 @@ public partial class ViewModelViewHost<
     {
         get => (TViewModel?)GetValue(ViewModelProperty);
         set => SetValue(ViewModelProperty, value);
+    }
+
+    /// <summary>Gets or sets the view contract observable.</summary>
+    public IObservable<string?> ViewContractObservable
+    {
+        get => (IObservable<string>)GetValue(ViewContractObservableProperty);
+        set => SetValue(ViewContractObservableProperty, value);
     }
 
     /// <summary>Gets or sets the ViewModel to display (non-generic interface implementation).</summary>

--- a/src/ReactiveUI.Maui/Common/ViewModelViewHost{TViewModel}.cs
+++ b/src/ReactiveUI.Maui/Common/ViewModelViewHost{TViewModel}.cs
@@ -11,7 +11,6 @@ using ReactiveUI.Reactive.Maui.Internal;
 #else
 using ReactiveUI.Maui.Internal;
 #endif
-using ReactiveUI.Primitives;
 using Splat;
 
 #if REACTIVE_SHIM
@@ -60,58 +59,23 @@ public partial class ViewModelViewHost<
         Justification = "The single-threaded UI control hands 'this' to MauiReactiveHelpers to observe its own dependency-property changes; it is never published to another thread.")]
     public ViewModelViewHost()
     {
-        var platform = AppLocator.Current.GetService<IPlatformOperations>();
-        Func<string?> platformGetter = static () => default;
+        var platformGetter = ViewContractObservableHelpers.GetPlatformOrientation(this.Log());
+        ViewContractObservable = ViewContractObservableHelpers.Create(
+            platformGetter,
+            new FromEventObservable<string?>(onNext =>
+            {
+                SizeChangedEventHandler handler = (_, _) => onNext(platformGetter());
+                SizeChanged += handler;
+                return new ActionDisposable(() => SizeChanged -= handler);
+            }));
 
-        if (platform is null)
-        {
-            // NB: This used to be an error but WPF design mode can't read
-            // good or do other stuff good.
-            this.Log().Error(
-                "Couldn't find an IPlatformOperations implementation. Please make sure you have installed the latest "
-                + "version of the ReactiveUI packages for your platform. See https://reactiveui.net/docs/getting-started/installation for guidance.");
-        }
-        else
-        {
-            platformGetter = platform.GetOrientation;
-        }
-
-        ViewContractObservable = ModeDetector.InUnitTestRunner()
-            ? Signal.Silent<string>()
-
-            // Replaces FromEvent(SizeChanged).StartWith(platformGetter()).DistinctUntilChanged().
-            : new StartWithObservable<string?>(
-                    new FromEventObservable<string?>(onNext =>
-                    {
-                        SizeChangedEventHandler handler = (_, _) => onNext(platformGetter());
-                        SizeChanged += handler;
-                        return new ActionDisposable(() => SizeChanged -= handler);
-                    }),
-                    platformGetter())
-                .DistinctUntilChanged();
-
-        // Observe ViewModel property changes without expression trees (AOT-friendly)
-        var viewModelChanged = MauiReactiveHelpers.CreatePropertyValueObservable(
+        MauiReactiveHelpers.SubscribeViewModelViewHost(
             this,
-            nameof(ViewModel),
-            ViewModelProperty,
-            () => ViewModel);
-
-        // Combine contract observable (recording the latest contract) with ViewModel changes.
-        var viewModelAndContract = ViewContractObservable.Do(x => _viewContract = x)
-            .CombineLatest(
-                viewModelChanged,
-                static (contract, vm) => (vm, contract));
-
-        // Subscribe directly without WhenActivated
-        _ = new ObserveOnObservable<string?>(ViewContractObservable, RxSchedulers.MainThreadScheduler)
-            .Subscribe(new DelegateObserver<string?>(x => _viewContract = x ?? string.Empty))
-            .DisposeWith(_subscriptions);
-
-        _ = viewModelAndContract.DistinctUntilChanged()
-            .Subscribe(new DelegateObserver<(TViewModel? ViewModel, string? Contract)>(
-                x => ResolveViewForViewModel(x.ViewModel, x.Contract)))
-            .DisposeWith(_subscriptions);
+            (nameof(ViewModel), ViewModelProperty, () => ViewModel),
+            ViewContractObservable,
+            contract => _viewContract = contract,
+            ResolveViewForViewModel,
+            _subscriptions);
     }
 
     /// <summary>Gets or sets the view contract observable.</summary>

--- a/src/ReactiveUI.Maui/Internal/MauiReactiveHelpers.cs
+++ b/src/ReactiveUI.Maui/Internal/MauiReactiveHelpers.cs
@@ -9,6 +9,7 @@ using ReactiveUI.Internal;
 #if IS_WINUI
 using Microsoft.UI.Xaml;
 using ReactiveUI.Primitives;
+using Splat;
 #endif
 
 #if REACTIVE_SHIM
@@ -139,6 +140,53 @@ internal static class MauiReactiveHelpers
         });
     }
 
+    /// <summary>Initializes a WinUI routed host and its view-contract subscriptions.</summary>
+    /// <param name="host">The host, logger, and view-contract setter.</param>
+    /// <param name="router">The router property metadata and accessor.</param>
+    /// <param name="viewContractObservable">The view-contract observable property metadata and accessor.</param>
+    /// <param name="getViewContract">Gets the current view contract.</param>
+    /// <param name="setViewContract">Stores the latest view contract.</param>
+    /// <param name="resolveView">Resolves a routed view model and contract.</param>
+    /// <param name="subscriptions">Collects the host subscription.</param>
+    internal static void InitializeRoutedViewHost(
+        (FrameworkElement Source, IFullLogger Logger, Action<IObservable<string?>> SetViewContractObservable) host,
+        (string Name, DependencyProperty Property, Func<RoutingState> GetValue) router,
+        (string Name, DependencyProperty Property, Func<IObservable<string?>> GetValue) viewContractObservable,
+        Func<string?> getViewContract,
+        Action<string?> setViewContract,
+        Action<(IRoutableViewModel? viewModel, string? contract)> resolveView,
+        MultipleDisposable subscriptions)
+    {
+        host.SetViewContractObservable(CreateViewContractObservable(host.Source, host.Logger));
+        SubscribeRoutedViewHost(
+            host.Source,
+            router,
+            viewContractObservable,
+            getViewContract,
+            setViewContract,
+            resolveView,
+            subscriptions);
+    }
+
+    /// <summary>Initializes a WinUI view-model host and its view-contract subscriptions.</summary>
+    /// <typeparam name="TViewModel">The hosted view-model type.</typeparam>
+    /// <param name="host">The host, logger, and view-contract setter.</param>
+    /// <param name="viewModel">The view-model property metadata and accessor.</param>
+    /// <param name="setViewContract">Stores the latest view contract.</param>
+    /// <param name="resolveView">Resolves a view model and contract.</param>
+    /// <param name="subscriptions">Collects the host subscriptions.</param>
+    internal static void InitializeViewModelViewHost<TViewModel>(
+        (FrameworkElement Source, IFullLogger Logger, Action<IObservable<string?>> SetViewContractObservable) host,
+        (string Name, DependencyProperty Property, Func<TViewModel?> GetValue) viewModel,
+        Action<string?> setViewContract,
+        Action<TViewModel?, string?> resolveView,
+        MultipleDisposable subscriptions)
+    {
+        var viewContractObservable = CreateViewContractObservable(host.Source, host.Logger);
+        host.SetViewContractObservable(viewContractObservable);
+        SubscribeViewModelViewHost(host.Source, viewModel, viewContractObservable, setViewContract, resolveView, subscriptions);
+    }
+
     /// <summary>Subscribes a WinUI routed host to its router and view-contract properties.</summary>
     /// <param name="source">The host dependency object.</param>
     /// <param name="router">The router property metadata and accessor.</param>
@@ -215,6 +263,7 @@ internal static class MauiReactiveHelpers
                 pair => resolveView(pair.viewModel, pair.contract)))
             .DisposeWith(subscriptions);
     }
+
 #endif
 
     /// <summary>Wires up activation for a view model that supports activation.</summary>
@@ -237,4 +286,23 @@ internal static class MauiReactiveHelpers
 
         return new MultipleDisposable(activatedSub, deactivatedSub);
     }
+
+#if IS_WINUI
+    /// <summary>Creates a WinUI view-contract stream from platform orientation and size changes.</summary>
+    /// <param name="source">The host element.</param>
+    /// <param name="logger">The host logger.</param>
+    /// <returns>The view-contract stream.</returns>
+    private static IObservable<string?> CreateViewContractObservable(FrameworkElement source, IFullLogger logger)
+    {
+        var platformGetter = ViewContractObservableHelpers.GetPlatformOrientation(logger);
+        return ViewContractObservableHelpers.Create(
+            platformGetter,
+            new FromEventObservable<string?>(onNext =>
+            {
+                SizeChangedEventHandler handler = (_, _) => onNext(platformGetter());
+                source.SizeChanged += handler;
+                return new ActionDisposable(() => source.SizeChanged -= handler);
+            }));
+    }
+#endif
 }

--- a/src/ReactiveUI.Maui/Internal/MauiReactiveHelpers.cs
+++ b/src/ReactiveUI.Maui/Internal/MauiReactiveHelpers.cs
@@ -8,6 +8,7 @@ using ReactiveUI.Internal;
 
 #if IS_WINUI
 using Microsoft.UI.Xaml;
+using ReactiveUI.Primitives;
 #endif
 
 #if REACTIVE_SHIM
@@ -136,6 +137,83 @@ internal static class MauiReactiveHelpers
 
             return new ActionDisposable(() => source.UnregisterPropertyChangedCallback(property, token));
         });
+    }
+
+    /// <summary>Subscribes a WinUI routed host to its router and view-contract properties.</summary>
+    /// <param name="source">The host dependency object.</param>
+    /// <param name="router">The router property metadata and accessor.</param>
+    /// <param name="viewContractObservable">The view-contract observable property metadata and accessor.</param>
+    /// <param name="getViewContract">Gets the current view contract.</param>
+    /// <param name="setViewContract">Stores the latest view contract.</param>
+    /// <param name="resolveView">Resolves a routed view model and contract.</param>
+    /// <param name="subscriptions">Collects the host subscription.</param>
+    internal static void SubscribeRoutedViewHost(
+        DependencyObject source,
+        (string Name, DependencyProperty Property, Func<RoutingState> GetValue) router,
+        (string Name, DependencyProperty Property, Func<IObservable<string?>> GetValue) viewContractObservable,
+        Func<string?> getViewContract,
+        Action<string?> setViewContract,
+        Action<(IRoutableViewModel? viewModel, string? contract)> resolveView,
+        MultipleDisposable subscriptions)
+    {
+        var routerChanged = CreatePropertyValueObservable(source, router.Name, router.Property, router.GetValue);
+        var viewContractObservableChanged = CreatePropertyValueObservable(
+            source,
+            viewContractObservable.Name,
+            viewContractObservable.Property,
+            viewContractObservable.GetValue);
+        var currentViewModel = new StartWithObservable<IRoutableViewModel?>(
+            new KeepSignal<RoutingState?>(routerChanged, static router => router is not null)
+                .SelectMany(static router => router!.CurrentViewModel),
+            null);
+        var viewContract = new StartWithObservable<string?>(
+            viewContractObservableChanged
+                .SelectMany(static observable => observable ?? Signal.Emit<string?>(null))
+                .Do(setViewContract),
+            getViewContract());
+
+        _ = currentViewModel
+            .CombineLatest(viewContract, static (viewModel, contract) => (viewModel, contract))
+            .DistinctUntilChanged()
+            .Subscribe(new DelegateObserver<(IRoutableViewModel? viewModel, string? contract)>(
+                resolveView,
+                RxState.DefaultExceptionHandler.OnNext))
+            .DisposeWith(subscriptions);
+    }
+
+    /// <summary>Subscribes a WinUI view-model host to its view model and contract.</summary>
+    /// <typeparam name="TViewModel">The hosted view-model type.</typeparam>
+    /// <param name="source">The host dependency object.</param>
+    /// <param name="viewModel">The view-model property metadata and accessor.</param>
+    /// <param name="viewContractObservable">The view-contract observable.</param>
+    /// <param name="setViewContract">Stores the latest view contract.</param>
+    /// <param name="resolveView">Resolves a view model and contract.</param>
+    /// <param name="subscriptions">Collects the host subscriptions.</param>
+    internal static void SubscribeViewModelViewHost<TViewModel>(
+        DependencyObject source,
+        (string Name, DependencyProperty Property, Func<TViewModel?> GetValue) viewModel,
+        IObservable<string?> viewContractObservable,
+        Action<string?> setViewContract,
+        Action<TViewModel?, string?> resolveView,
+        MultipleDisposable subscriptions)
+    {
+        var viewModelChanged = CreatePropertyValueObservable(
+            source,
+            viewModel.Name,
+            viewModel.Property,
+            viewModel.GetValue);
+        var viewModelAndContract = viewContractObservable
+            .Do(setViewContract)
+            .CombineLatest(viewModelChanged, static (contract, viewModel) => (viewModel, contract));
+
+        _ = new ObserveOnObservable<string?>(viewContractObservable, RxSchedulers.MainThreadScheduler)
+            .Subscribe(new DelegateObserver<string?>(contract => setViewContract(contract ?? string.Empty)))
+            .DisposeWith(subscriptions);
+        _ = viewModelAndContract
+            .DistinctUntilChanged()
+            .Subscribe(new DelegateObserver<(TViewModel? viewModel, string? contract)>(
+                pair => resolveView(pair.viewModel, pair.contract)))
+            .DisposeWith(subscriptions);
     }
 #endif
 

--- a/src/ReactiveUI.Shared/Bindings/Command/CommandBinderImplementation.cs
+++ b/src/ReactiveUI.Shared/Bindings/Command/CommandBinderImplementation.cs
@@ -79,30 +79,12 @@ public class CommandBinderImplementation : ICommandBinderImplementation
         ArgumentExceptionHelper.ThrowIfNull(viewModelProperty);
         ArgumentExceptionHelper.ThrowIfNull(controlProperty);
 
-        var viewModelExpression = Reflection.Rewrite(viewModelProperty.Body);
-        var controlExpression = Reflection.Rewrite(controlProperty.Body);
         var parameterExpression = Reflection.Rewrite(withParameter.Body);
 
-        var source = new MapSignal<object, TProp>(Reflection.ViewModelWhenAnyValue(viewModel, view, viewModelExpression), static x => (TProp)x!);
-
         // Observe the parameter through the view's current view model (not the originally supplied one) so the
-        // parameter rebinds when the view model instance is replaced, matching the command source above.
+        // parameter rebinds when the view model instance is replaced, matching the command source.
         var parameter = new MapSignal<object, TParam?>(Reflection.ViewModelWhenAnyValue(viewModel, view, parameterExpression), static x => (TParam?)x);
-
-        var bindingDisposable = BindCommandInternal<TView, TProp, TParam, TControl>(
-            source,
-            view,
-            controlExpression,
-            parameter,
-            toEvent);
-
-        return new ReactiveBinding<TView, TProp>(
-            view,
-            controlExpression,
-            viewModelExpression,
-            source,
-            BindingDirection.OneWay,
-            bindingDisposable);
+        return BindCommand(viewModel, view, viewModelProperty, controlProperty, parameter, toEvent);
     }
 
     /// <summary>

--- a/src/ReactiveUI.Shared/Bindings/Command/CommandBinderMixins.cs
+++ b/src/ReactiveUI.Shared/Bindings/Command/CommandBinderMixins.cs
@@ -66,12 +66,8 @@ public static class CommandBinderMixins
             IObservable<TParam?> withParameter)
             where TViewModel : class
             where TProp : ICommand
-            where TControl : class
-        {
-            ValidateBindingArguments(view, propertyName, controlName, withParameter);
-
-            return _binderImplementation.BindCommand(viewModel, view, propertyName, controlName, withParameter);
-        }
+            where TControl : class =>
+            BindCommand(view, viewModel, propertyName, controlName, withParameter, null);
 
         /// <summary>
         /// Binds a command from the view model to a control on the view, enabling the control to execute the command with a
@@ -204,12 +200,8 @@ public static class CommandBinderMixins
             Expression<Func<TViewModel, TParam?>> withParameter)
             where TViewModel : class
             where TProp : ICommand
-            where TControl : class
-        {
-            ValidateBindingArguments(view, propertyName, controlName, withParameter);
-
-            return _binderImplementation.BindCommand(viewModel, view, propertyName, controlName, withParameter);
-        }
+            where TControl : class =>
+            BindCommand(view, viewModel, propertyName, controlName, withParameter, null);
 
         /// <summary>
         /// Binds a command from the view model to a control on the view, enabling the control to execute the command with a

--- a/src/ReactiveUI.Shared/Bindings/Command/CommandBinderMixins.cs
+++ b/src/ReactiveUI.Shared/Bindings/Command/CommandBinderMixins.cs
@@ -68,10 +68,7 @@ public static class CommandBinderMixins
             where TProp : ICommand
             where TControl : class
         {
-            ArgumentExceptionHelper.ThrowIfNull(view);
-            ArgumentExceptionHelper.ThrowIfNull(propertyName);
-            ArgumentExceptionHelper.ThrowIfNull(controlName);
-            ArgumentExceptionHelper.ThrowIfNull(withParameter);
+            ValidateBindingArguments(view, propertyName, controlName, withParameter);
 
             return _binderImplementation.BindCommand(viewModel, view, propertyName, controlName, withParameter);
         }
@@ -114,10 +111,7 @@ public static class CommandBinderMixins
             where TProp : ICommand
             where TControl : class
         {
-            ArgumentExceptionHelper.ThrowIfNull(view);
-            ArgumentExceptionHelper.ThrowIfNull(propertyName);
-            ArgumentExceptionHelper.ThrowIfNull(controlName);
-            ArgumentExceptionHelper.ThrowIfNull(withParameter);
+            ValidateBindingArguments(view, propertyName, controlName, withParameter);
 
             return _binderImplementation.BindCommand(viewModel, view, propertyName, controlName, withParameter, toEvent);
         }
@@ -180,9 +174,7 @@ public static class CommandBinderMixins
             where TProp : ICommand
             where TControl : class
         {
-            ArgumentExceptionHelper.ThrowIfNull(view);
-            ArgumentExceptionHelper.ThrowIfNull(propertyName);
-            ArgumentExceptionHelper.ThrowIfNull(controlName);
+            ValidateBindingArguments(view, propertyName, controlName);
 
             return _binderImplementation.BindCommand(viewModel, view, propertyName, controlName, Signal.None<object?>(), toEvent);
         }
@@ -214,10 +206,7 @@ public static class CommandBinderMixins
             where TProp : ICommand
             where TControl : class
         {
-            ArgumentExceptionHelper.ThrowIfNull(view);
-            ArgumentExceptionHelper.ThrowIfNull(propertyName);
-            ArgumentExceptionHelper.ThrowIfNull(controlName);
-            ArgumentExceptionHelper.ThrowIfNull(withParameter);
+            ValidateBindingArguments(view, propertyName, controlName, withParameter);
 
             return _binderImplementation.BindCommand(viewModel, view, propertyName, controlName, withParameter);
         }
@@ -260,12 +249,31 @@ public static class CommandBinderMixins
             where TProp : ICommand
             where TControl : class
         {
-            ArgumentExceptionHelper.ThrowIfNull(view);
-            ArgumentExceptionHelper.ThrowIfNull(propertyName);
-            ArgumentExceptionHelper.ThrowIfNull(controlName);
-            ArgumentExceptionHelper.ThrowIfNull(withParameter);
+            ValidateBindingArguments(view, propertyName, controlName, withParameter);
 
             return _binderImplementation.BindCommand(viewModel, view, propertyName, controlName, withParameter, toEvent);
         }
+    }
+
+    /// <summary>Validates the arguments shared by command-binding overloads.</summary>
+    /// <param name="view">The view being bound.</param>
+    /// <param name="propertyName">The command property expression.</param>
+    /// <param name="controlName">The control expression.</param>
+    private static void ValidateBindingArguments(object? view, object? propertyName, object? controlName)
+    {
+        ArgumentExceptionHelper.ThrowIfNull(view);
+        ArgumentExceptionHelper.ThrowIfNull(propertyName);
+        ArgumentExceptionHelper.ThrowIfNull(controlName);
+    }
+
+    /// <summary>Validates the arguments shared by parameterized command-binding overloads.</summary>
+    /// <param name="view">The view being bound.</param>
+    /// <param name="propertyName">The command property expression.</param>
+    /// <param name="controlName">The control expression.</param>
+    /// <param name="withParameter">The command parameter source.</param>
+    private static void ValidateBindingArguments(object? view, object? propertyName, object? controlName, object? withParameter)
+    {
+        ValidateBindingArguments(view, propertyName, controlName);
+        ArgumentExceptionHelper.ThrowIfNull(withParameter);
     }
 }

--- a/src/ReactiveUI.Shared/ObservableForProperty/OAPHCreationHelperMixins.cs
+++ b/src/ReactiveUI.Shared/ObservableForProperty/OAPHCreationHelperMixins.cs
@@ -1182,19 +1182,17 @@ public static class OAPHCreationHelperMixins
     private static string GetPropertyName<TObj, TRet>(Expression<Func<TObj, TRet>> property)
     {
         var expression = Reflection.Rewrite(property.Body);
-        var parent = expression.GetParent()
-                     ?? throw new ArgumentException(
-                         "The property expression does not have a valid parent.",
-                         nameof(property));
+        var parent = expression.GetParent();
+        ArgumentExceptionHelper.ThrowIfNull(parent);
+
         if (parent.NodeType != ExpressionType.Parameter)
         {
             throw new ArgumentException("Property expression must be of the form 'x => x.SomeProperty'");
         }
 
-        var memberInfo = expression.GetMemberInfo()
-                         ?? throw new ArgumentException(
-                             "The property expression does not point towards a valid member.",
-                             nameof(property));
+        var memberInfo = expression.GetMemberInfo();
+        ArgumentExceptionHelper.ThrowIfNull(memberInfo);
+
         return expression is IndexExpression ? $"{memberInfo.Name}[]" : memberInfo.Name;
     }
 }

--- a/src/ReactiveUI.Shared/ObservableForProperty/OAPHCreationHelperMixins.cs
+++ b/src/ReactiveUI.Shared/ObservableForProperty/OAPHCreationHelperMixins.cs
@@ -1053,26 +1053,7 @@ public static class OAPHCreationHelperMixins
             ArgumentExceptionHelper.ThrowIfNull(observable);
             ArgumentExceptionHelper.ThrowIfNull(property);
 
-            var expression = Reflection.Rewrite(property.Body);
-
-            var parent = expression.GetParent()
-                         ?? throw new ArgumentException(
-                             "The property expression does not have a valid parent.",
-                             nameof(property));
-            if (parent.NodeType != ExpressionType.Parameter)
-            {
-                throw new ArgumentException("Property expression must be of the form 'x => x.SomeProperty'");
-            }
-
-            var memberInfo = expression.GetMemberInfo()
-                             ?? throw new ArgumentException(
-                                 "The property expression does not point towards a valid member.",
-                                 nameof(property));
-            var name = memberInfo.Name;
-            if (expression is IndexExpression)
-            {
-                name += "[]";
-            }
+            var name = GetPropertyName(property);
 
             return new(
                 observable,
@@ -1111,26 +1092,7 @@ public static class OAPHCreationHelperMixins
             ArgumentExceptionHelper.ThrowIfNull(observable);
             ArgumentExceptionHelper.ThrowIfNull(property);
 
-            var expression = Reflection.Rewrite(property.Body);
-
-            var parent = expression.GetParent()
-                         ?? throw new ArgumentException(
-                             "The property expression does not have a valid parent.",
-                             nameof(property));
-            if (parent.NodeType != ExpressionType.Parameter)
-            {
-                throw new ArgumentException("Property expression must be of the form 'x => x.SomeProperty'");
-            }
-
-            var memberInfo = expression.GetMemberInfo()
-                             ?? throw new ArgumentException(
-                                 "The property expression does not point towards a valid member.",
-                                 nameof(property));
-            var name = memberInfo.Name;
-            if (expression is IndexExpression)
-            {
-                name += "[]";
-            }
+            var name = GetPropertyName(property);
 
             return new(
                 observable,
@@ -1210,5 +1172,29 @@ public static class OAPHCreationHelperMixins
                 deferSubscription,
                 scheduler);
         }
+    }
+
+    /// <summary>Gets the property name represented by a valid property expression.</summary>
+    /// <typeparam name="TObj">The object declaring the property.</typeparam>
+    /// <typeparam name="TRet">The property value type.</typeparam>
+    /// <param name="property">The property expression.</param>
+    /// <returns>The property name used by change notifications.</returns>
+    private static string GetPropertyName<TObj, TRet>(Expression<Func<TObj, TRet>> property)
+    {
+        var expression = Reflection.Rewrite(property.Body);
+        var parent = expression.GetParent()
+                     ?? throw new ArgumentException(
+                         "The property expression does not have a valid parent.",
+                         nameof(property));
+        if (parent.NodeType != ExpressionType.Parameter)
+        {
+            throw new ArgumentException("Property expression must be of the form 'x => x.SomeProperty'");
+        }
+
+        var memberInfo = expression.GetMemberInfo()
+                         ?? throw new ArgumentException(
+                             "The property expression does not point towards a valid member.",
+                             nameof(property));
+        return expression is IndexExpression ? $"{memberInfo.Name}[]" : memberInfo.Name;
     }
 }

--- a/src/ReactiveUI.Shared/ReactiveObject/ReactiveNotificationHelpers.cs
+++ b/src/ReactiveUI.Shared/ReactiveObject/ReactiveNotificationHelpers.cs
@@ -1,0 +1,110 @@
+// Copyright (c) 2009-2026 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.ComponentModel;
+
+#if REACTIVE_SHIM
+namespace ReactiveUI.Reactive;
+#else
+namespace ReactiveUI;
+#endif
+
+/// <summary>Manages notification state shared by reactive object implementations.</summary>
+internal static class ReactiveNotificationHelpers
+{
+    /// <summary>Adds a property-changing event handler.</summary>
+    /// <param name="source">The reactive object owning the event.</param>
+    /// <param name="subscribed">Tracks whether the observable has been initialized.</param>
+    /// <param name="handlers">The event handler store.</param>
+    /// <param name="handler">The handler to add.</param>
+    internal static void AddPropertyChanging(
+        IReactiveObject source,
+        ref bool subscribed,
+        ref PropertyChangingEventHandler? handlers,
+        PropertyChangingEventHandler? handler)
+    {
+        if (!subscribed)
+        {
+            source.SubscribePropertyChangingEvents();
+            subscribed = true;
+        }
+
+        handlers += handler;
+    }
+
+    /// <summary>Adds a property-changed event handler.</summary>
+    /// <param name="source">The reactive object owning the event.</param>
+    /// <param name="subscribed">Tracks whether the observable has been initialized.</param>
+    /// <param name="handlers">The event handler store.</param>
+    /// <param name="handler">The handler to add.</param>
+    internal static void AddPropertyChanged(
+        IReactiveObject source,
+        ref bool subscribed,
+        ref PropertyChangedEventHandler? handlers,
+        PropertyChangedEventHandler? handler)
+    {
+        if (!subscribed)
+        {
+            source.SubscribePropertyChangedEvents();
+            subscribed = true;
+        }
+
+        handlers += handler;
+    }
+
+    /// <summary>Gets the lazily initialized property-changing observable.</summary>
+    /// <param name="source">The reactive object owning the observable.</param>
+    /// <param name="observable">The observable store.</param>
+    /// <returns>The property-changing observable.</returns>
+    internal static IObservable<IReactivePropertyChangedEventArgs<IReactiveObject>> GetChanging(
+        IReactiveObject source,
+        ref IObservable<IReactivePropertyChangedEventArgs<IReactiveObject>>? observable)
+    {
+        var current = Volatile.Read(ref observable);
+        if (current is not null)
+        {
+            return current;
+        }
+
+        _ = Interlocked.CompareExchange(ref observable, source.GetChangingObservable(), null);
+        return Volatile.Read(ref observable)!;
+    }
+
+    /// <summary>Gets the lazily initialized property-changed observable.</summary>
+    /// <param name="source">The reactive object owning the observable.</param>
+    /// <param name="observable">The observable store.</param>
+    /// <returns>The property-changed observable.</returns>
+    internal static IObservable<IReactivePropertyChangedEventArgs<IReactiveObject>> GetChanged(
+        IReactiveObject source,
+        ref IObservable<IReactivePropertyChangedEventArgs<IReactiveObject>>? observable)
+    {
+        var current = Volatile.Read(ref observable);
+        if (current is not null)
+        {
+            return current;
+        }
+
+        _ = Interlocked.CompareExchange(ref observable, source.GetChangedObservable(), null);
+        return Volatile.Read(ref observable)!;
+    }
+
+    /// <summary>Gets the lazily initialized exception observable.</summary>
+    /// <param name="source">The reactive object owning the observable.</param>
+    /// <param name="observable">The observable store.</param>
+    /// <returns>The exception observable.</returns>
+    internal static IObservable<Exception> GetThrownExceptions(
+        IReactiveObject source,
+        ref IObservable<Exception>? observable)
+    {
+        var current = Volatile.Read(ref observable);
+        if (current is not null)
+        {
+            return current;
+        }
+
+        _ = Interlocked.CompareExchange(ref observable, source.GetThrownExceptionsObservable(), null);
+        return Volatile.Read(ref observable)!;
+    }
+}

--- a/src/ReactiveUI.Shared/ReactiveObject/ReactiveObject.cs
+++ b/src/ReactiveUI.Shared/ReactiveObject/ReactiveObject.cs
@@ -32,46 +32,37 @@ public class ReactiveObject : IReactiveNotifyPropertyChanged<IReactiveObject>, I
     /// <summary>Tracks whether PropertyChanged event subscriptions have been initialized.</summary>
     private bool _propertyChangedEventsSubscribed;
 
-    /// <summary>Stores this instance's reactive notification state directly, avoiding a table lookup.</summary>
-    [IgnoreDataMember]
-    [SuppressMessage("Design", "SST1424:Make field readonly", Justification = "Mutated in place through the ref returned by GetReactiveStateSlot.")]
-    private object? _reactiveStateSlot;
-
     /// <summary>Backing handler for the PropertyChanging event.</summary>
     private PropertyChangingEventHandler? _propertyChangingHandler;
 
     /// <summary>Backing handler for the PropertyChanged event.</summary>
     private PropertyChangedEventHandler? _propertyChangedHandler;
 
+    /// <summary>Stores the property-changing observable.</summary>
+    private IObservable<IReactivePropertyChangedEventArgs<IReactiveObject>>? _changing;
+
+    /// <summary>Stores the property-changed observable.</summary>
+    private IObservable<IReactivePropertyChangedEventArgs<IReactiveObject>>? _changed;
+
+    /// <summary>Stores the exception observable.</summary>
+    private IObservable<Exception>? _thrownExceptions;
+
+    /// <summary>Stores this instance's extension state directly, avoiding a table lookup.</summary>
+    [IgnoreDataMember]
+    [SuppressMessage("Design", "SST1424:Make field readonly", Justification = "Mutated in place through the ref returned by GetReactiveStateSlot.")]
+    private object? _reactiveStateSlot;
+
     /// <inheritdoc/>
     public event PropertyChangingEventHandler? PropertyChanging
     {
-        add
-        {
-            if (!_propertyChangingEventsSubscribed)
-            {
-                this.SubscribePropertyChangingEvents();
-                _propertyChangingEventsSubscribed = true;
-            }
-
-            _propertyChangingHandler += value;
-        }
+        add => ReactiveNotificationHelpers.AddPropertyChanging(this, ref _propertyChangingEventsSubscribed, ref _propertyChangingHandler, value);
         remove => _propertyChangingHandler -= value;
     }
 
     /// <inheritdoc/>
     public event PropertyChangedEventHandler? PropertyChanged
     {
-        add
-        {
-            if (!_propertyChangedEventsSubscribed)
-            {
-                this.SubscribePropertyChangedEvents();
-                _propertyChangedEventsSubscribed = true;
-            }
-
-            _propertyChangedHandler += value;
-        }
+        add => ReactiveNotificationHelpers.AddPropertyChanged(this, ref _propertyChangedEventsSubscribed, ref _propertyChangedHandler, value);
         remove => _propertyChangedHandler -= value;
     }
 
@@ -83,8 +74,7 @@ public class ReactiveObject : IReactiveNotifyPropertyChanged<IReactiveObject>, I
     [Display(Order = -1, AutoGenerateField = false, AutoGenerateFilter = false)]
 #endif
     public IObservable<IReactivePropertyChangedEventArgs<IReactiveObject>> Changing =>
-        Volatile.Read(ref field)
-        ?? Interlocked.CompareExchange(ref field, ((IReactiveObject)this).GetChangingObservable(), null) ?? field;
+        ReactiveNotificationHelpers.GetChanging(this, ref _changing);
 
     /// <inheritdoc />
     [IgnoreDataMember]
@@ -94,8 +84,7 @@ public class ReactiveObject : IReactiveNotifyPropertyChanged<IReactiveObject>, I
     [Display(Order = -1, AutoGenerateField = false, AutoGenerateFilter = false)]
 #endif
     public IObservable<IReactivePropertyChangedEventArgs<IReactiveObject>> Changed =>
-        Volatile.Read(ref field)
-        ?? Interlocked.CompareExchange(ref field, ((IReactiveObject)this).GetChangedObservable(), null) ?? field;
+        ReactiveNotificationHelpers.GetChanged(this, ref _changed);
 
     /// <inheritdoc/>
     [IgnoreDataMember]
@@ -105,8 +94,7 @@ public class ReactiveObject : IReactiveNotifyPropertyChanged<IReactiveObject>, I
     [Display(Order = -1, AutoGenerateField = false, AutoGenerateFilter = false)]
 #endif
     public IObservable<Exception> ThrownExceptions =>
-        Volatile.Read(ref field)
-        ?? Interlocked.CompareExchange(ref field, this.GetThrownExceptionsObservable(), null) ?? field;
+        ReactiveNotificationHelpers.GetThrownExceptions(this, ref _thrownExceptions);
 
     /// <inheritdoc/>
     void IReactiveObject.RaisePropertyChanging(PropertyChangingEventArgs args) =>

--- a/src/ReactiveUI.Shared/ReactiveObject/ReactiveRecord.cs
+++ b/src/ReactiveUI.Shared/ReactiveObject/ReactiveRecord.cs
@@ -37,36 +37,27 @@ public abstract record ReactiveRecord : IReactiveNotifyPropertyChanged<IReactive
     /// <summary>Backing event store for property-changed notifications.</summary>
     private PropertyChangedEventHandler? _propertyChangedHandler;
 
+    /// <summary>Stores the property-changing observable.</summary>
+    private IObservable<IReactivePropertyChangedEventArgs<IReactiveObject>>? _changing;
+
+    /// <summary>Stores the property-changed observable.</summary>
+    private IObservable<IReactivePropertyChangedEventArgs<IReactiveObject>>? _changed;
+
+    /// <summary>Stores the exception observable.</summary>
+    private IObservable<Exception>? _thrownExceptions;
+
     /// <inheritdoc/>
     public event PropertyChangingEventHandler? PropertyChanging
     {
-        add
-        {
-            if (!_propertyChangingEventsSubscribed)
-            {
-                this.SubscribePropertyChangingEvents();
-                _propertyChangingEventsSubscribed = true;
-            }
-
-            _propertyChangingHandler += value;
-        }
-        remove => _propertyChangingHandler -= value;
+        add => AddPropertyChanging(value);
+        remove => RemovePropertyChanging(value);
     }
 
     /// <inheritdoc/>
     public event PropertyChangedEventHandler? PropertyChanged
     {
-        add
-        {
-            if (!_propertyChangedEventsSubscribed)
-            {
-                this.SubscribePropertyChangedEvents();
-                _propertyChangedEventsSubscribed = true;
-            }
-
-            _propertyChangedHandler += value;
-        }
-        remove => _propertyChangedHandler -= value;
+        add => AddPropertyChanged(value);
+        remove => RemovePropertyChanged(value);
     }
 
     /// <inheritdoc />
@@ -76,9 +67,7 @@ public abstract record ReactiveRecord : IReactiveNotifyPropertyChanged<IReactive
     [Browsable(false)]
     [Display(Order = -1, AutoGenerateField = false, AutoGenerateFilter = false)]
 #endif
-    public IObservable<IReactivePropertyChangedEventArgs<IReactiveObject>> Changing =>
-        Volatile.Read(ref field)
-        ?? Interlocked.CompareExchange(ref field, ((IReactiveObject)this).GetChangingObservable(), null) ?? field;
+    public IObservable<IReactivePropertyChangedEventArgs<IReactiveObject>> Changing => GetChanging();
 
     /// <inheritdoc />
     [IgnoreDataMember]
@@ -87,9 +76,7 @@ public abstract record ReactiveRecord : IReactiveNotifyPropertyChanged<IReactive
     [Browsable(false)]
     [Display(Order = -1, AutoGenerateField = false, AutoGenerateFilter = false)]
 #endif
-    public IObservable<IReactivePropertyChangedEventArgs<IReactiveObject>> Changed =>
-        Volatile.Read(ref field)
-        ?? Interlocked.CompareExchange(ref field, ((IReactiveObject)this).GetChangedObservable(), null) ?? field;
+    public IObservable<IReactivePropertyChangedEventArgs<IReactiveObject>> Changed => GetChanged();
 
     /// <inheritdoc/>
     [IgnoreDataMember]
@@ -98,11 +85,7 @@ public abstract record ReactiveRecord : IReactiveNotifyPropertyChanged<IReactive
     [Browsable(false)]
     [Display(Order = -1, AutoGenerateField = false, AutoGenerateFilter = false)]
 #endif
-    public IObservable<Exception> ThrownExceptions => Volatile.Read(ref field)
-                                                      ?? Interlocked.CompareExchange(
-                                                          ref field,
-                                                          this.GetThrownExceptionsObservable(),
-                                                          null) ?? field;
+    public IObservable<Exception> ThrownExceptions => GetThrownExceptions();
 
     /// <inheritdoc/>
     void IReactiveObject.RaisePropertyChanging(PropertyChangingEventArgs args) =>
@@ -122,4 +105,37 @@ public abstract record ReactiveRecord : IReactiveNotifyPropertyChanged<IReactive
     /// <summary>Delays notifications until the return IDisposable is disposed.</summary>
     /// <returns>A disposable which when disposed will send delayed notifications.</returns>
     public IDisposable DelayChangeNotifications() => IReactiveObjectExtensions.DelayChangeNotifications(this);
+
+    /// <summary>Adds a property-changing event handler.</summary>
+    /// <param name="handler">The handler to add.</param>
+    private void AddPropertyChanging(PropertyChangingEventHandler? handler) =>
+        ReactiveNotificationHelpers.AddPropertyChanging(this, ref _propertyChangingEventsSubscribed, ref _propertyChangingHandler, handler);
+
+    /// <summary>Removes a property-changing event handler.</summary>
+    /// <param name="handler">The handler to remove.</param>
+    private void RemovePropertyChanging(PropertyChangingEventHandler? handler) => _propertyChangingHandler -= handler;
+
+    /// <summary>Adds a property-changed event handler.</summary>
+    /// <param name="handler">The handler to add.</param>
+    private void AddPropertyChanged(PropertyChangedEventHandler? handler) =>
+        ReactiveNotificationHelpers.AddPropertyChanged(this, ref _propertyChangedEventsSubscribed, ref _propertyChangedHandler, handler);
+
+    /// <summary>Removes a property-changed event handler.</summary>
+    /// <param name="handler">The handler to remove.</param>
+    private void RemovePropertyChanged(PropertyChangedEventHandler? handler) => _propertyChangedHandler -= handler;
+
+    /// <summary>Gets the property-changing observable.</summary>
+    /// <returns>The property-changing observable.</returns>
+    private IObservable<IReactivePropertyChangedEventArgs<IReactiveObject>> GetChanging() =>
+        ReactiveNotificationHelpers.GetChanging(this, ref _changing);
+
+    /// <summary>Gets the property-changed observable.</summary>
+    /// <returns>The property-changed observable.</returns>
+    private IObservable<IReactivePropertyChangedEventArgs<IReactiveObject>> GetChanged() =>
+        ReactiveNotificationHelpers.GetChanged(this, ref _changed);
+
+    /// <summary>Gets the exception observable.</summary>
+    /// <returns>The exception observable.</returns>
+    private IObservable<Exception> GetThrownExceptions() =>
+        ReactiveNotificationHelpers.GetThrownExceptions(this, ref _thrownExceptions);
 }

--- a/src/ReactiveUI.WinUI.Reactive/ReactiveUI.WinUI.Reactive.csproj
+++ b/src/ReactiveUI.WinUI.Reactive/ReactiveUI.WinUI.Reactive.csproj
@@ -59,5 +59,6 @@
     <Compile Include="..\Shared\DelegateObserver.cs" Link="Shared\DelegateObserver.cs"/>
     <Compile Include="..\Shared\Platform\FromEventObservable.cs" Link="Shared\Platform\FromEventObservable.cs"/>
     <Compile Include="..\Shared\Platform\ObserveOnObservable.cs" Link="Shared\Platform\ObserveOnObservable.cs"/>
+    <Compile Include="..\Shared\ViewContractObservableHelpers.cs" Link="Shared\ViewContractObservableHelpers.cs"/>
   </ItemGroup>
 </Project>

--- a/src/ReactiveUI.WinUI/ReactiveUI.WinUI.csproj
+++ b/src/ReactiveUI.WinUI/ReactiveUI.WinUI.csproj
@@ -44,5 +44,6 @@
     <Compile Include="..\Shared\DelegateObserver.cs" Link="Shared\DelegateObserver.cs"/>
     <Compile Include="..\Shared\Platform\FromEventObservable.cs" Link="Shared\Platform\FromEventObservable.cs"/>
     <Compile Include="..\Shared\Platform\ObserveOnObservable.cs" Link="Shared\Platform\ObserveOnObservable.cs"/>
+    <Compile Include="..\Shared\ViewContractObservableHelpers.cs" Link="Shared\ViewContractObservableHelpers.cs"/>
   </ItemGroup>
 </Project>

--- a/src/ReactiveUI.Wpf.Reactive/ReactiveUI.Wpf.Reactive.csproj
+++ b/src/ReactiveUI.Wpf.Reactive/ReactiveUI.Wpf.Reactive.csproj
@@ -53,6 +53,7 @@
     <Compile Include="..\Shared\Platform\FromEventObservable.cs" Link="Shared\Platform\FromEventObservable.cs"/>
     <Compile Include="..\Shared\Platform\ObserveOnObservable.cs" Link="Shared\Platform\ObserveOnObservable.cs"/>
     <Compile Include="..\Shared\Platform\IdleTimeoutObservable.cs" Link="Shared\Platform\IdleTimeoutObservable.cs"/>
+    <Compile Include="..\Shared\ViewContractObservableHelpers.cs" Link="Shared\ViewContractObservableHelpers.cs"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ReactiveUI.Wpf.Shared/Common/RoutedViewHost.cs
+++ b/src/ReactiveUI.Wpf.Shared/Common/RoutedViewHost.cs
@@ -65,34 +65,15 @@ public
         HorizontalContentAlignment = HorizontalAlignment.Stretch;
         VerticalContentAlignment = VerticalAlignment.Stretch;
 
-        var platform = AppLocator.Current.GetService<IPlatformOperations>();
-        Func<string?> platformGetter = static () => null;
-
-        if (platform is null)
-        {
-            // NB: This used to be an error but WPF design mode can't read
-            // good or do other stuff good.
-            this.Log().Error(
-                "Couldn't find an IPlatformOperations implementation. Please make sure you have installed "
-                + "the latest version of the ReactiveUI packages for your platform. "
-                + "See https://reactiveui.net/docs/getting-started/installation for guidance.");
-        }
-        else
-        {
-            platformGetter = platform.GetOrientation;
-        }
-
-        ViewContractObservable = ModeDetector.InUnitTestRunner()
-            ? Signal.Silent<string?>()
-            : new StartWithObservable<string?>(
-                new FromEventObservable<string?>(onNext =>
-                {
-                    SizeChangedEventHandler handler = (_, _) => onNext(platformGetter());
-                    SizeChanged += handler;
-                    return new ActionDisposable(() => SizeChanged -= handler);
-                }),
-                platformGetter())
-                .DistinctUntilChanged();
+        var platformGetter = ViewContractObservableHelpers.GetPlatformOrientation(this.Log());
+        ViewContractObservable = ViewContractObservableHelpers.Create(
+            platformGetter,
+            new FromEventObservable<string?>(onNext =>
+            {
+                SizeChangedEventHandler handler = (_, _) => onNext(platformGetter());
+                SizeChanged += handler;
+                return new ActionDisposable(() => SizeChanged -= handler);
+            }));
 
         IRoutableViewModel? currentViewModel = null;
         var viewModelAndContract = new StartWithObservable<IRoutableViewModel?>(

--- a/src/ReactiveUI.Wpf.Shared/Common/ViewModelViewHost.cs
+++ b/src/ReactiveUI.Wpf.Shared/Common/ViewModelViewHost.cs
@@ -64,34 +64,15 @@ public
     /// <summary>Initializes a new instance of the <see cref="ViewModelViewHost"/> class.</summary>
     public ViewModelViewHost()
     {
-        var platform = AppLocator.Current.GetService<IPlatformOperations>();
-        Func<string?> platformGetter = static () => null;
-
-        if (platform is null)
-        {
-            // NB: This used to be an error but WPF design mode can't read
-            // good or do other stuff good.
-            this.Log().Error(
-                "Couldn't find an IPlatformOperations implementation. Please make sure you have installed "
-                + "the latest version of the ReactiveUI packages for your platform. "
-                + "See https://reactiveui.net/docs/getting-started/installation for guidance.");
-        }
-        else
-        {
-            platformGetter = platform.GetOrientation;
-        }
-
-        ViewContractObservable = ModeDetector.InUnitTestRunner()
-            ? Signal.Silent<string?>()
-            : new StartWithObservable<string?>(
-                new FromEventObservable<string?>(onNext =>
-                {
-                    SizeChangedEventHandler handler = (_, _) => onNext(platformGetter());
-                    SizeChanged += handler;
-                    return new ActionDisposable(() => SizeChanged -= handler);
-                }),
-                platformGetter())
-                .DistinctUntilChanged();
+        var platformGetter = ViewContractObservableHelpers.GetPlatformOrientation(this.Log());
+        ViewContractObservable = ViewContractObservableHelpers.Create(
+            platformGetter,
+            new FromEventObservable<string?>(onNext =>
+            {
+                SizeChangedEventHandler handler = (_, _) => onNext(platformGetter());
+                SizeChanged += handler;
+                return new ActionDisposable(() => SizeChanged -= handler);
+            }));
 
         var contractChanged = new StartWithObservable<string?>(
             this.WhenAnyObservable(x => x.ViewContractObservable).Do(x => _viewContract = x),

--- a/src/ReactiveUI.Wpf/ReactiveUI.Wpf.csproj
+++ b/src/ReactiveUI.Wpf/ReactiveUI.Wpf.csproj
@@ -49,6 +49,7 @@
     <Compile Include="..\Shared\Platform\FromEventObservable.cs" Link="Shared\Platform\FromEventObservable.cs"/>
     <Compile Include="..\Shared\Platform\ObserveOnObservable.cs" Link="Shared\Platform\ObserveOnObservable.cs"/>
     <Compile Include="..\Shared\Platform\IdleTimeoutObservable.cs" Link="Shared\Platform\IdleTimeoutObservable.cs"/>
+    <Compile Include="..\Shared\ViewContractObservableHelpers.cs" Link="Shared\ViewContractObservableHelpers.cs"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Shared/ViewContractObservableHelpers.cs
+++ b/src/Shared/ViewContractObservableHelpers.cs
@@ -1,0 +1,46 @@
+// Copyright (c) 2009-2026 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using ReactiveUI.Primitives;
+using Splat;
+
+#if REACTIVE_SHIM
+namespace ReactiveUI.Reactive;
+#else
+namespace ReactiveUI;
+#endif
+
+/// <summary>Creates the view-contract streams shared by platform view hosts.</summary>
+internal static class ViewContractObservableHelpers
+{
+    /// <summary>Gets the platform orientation callback used by a view host.</summary>
+    /// <param name="logger">The host logger.</param>
+    /// <returns>The platform orientation callback.</returns>
+    internal static Func<string?> GetPlatformOrientation(IFullLogger logger)
+    {
+        var platform = AppLocator.Current.GetService<IPlatformOperations>();
+        if (platform is null)
+        {
+            logger.Error(
+                "Couldn't find an IPlatformOperations implementation. Please make sure you have installed "
+                + "the latest version of the ReactiveUI packages for your platform. "
+                + "See https://reactiveui.net/docs/getting-started/installation for guidance.");
+            return static () => null;
+        }
+
+        return platform.GetOrientation;
+    }
+
+    /// <summary>Creates a contract stream from platform orientation and host size changes.</summary>
+    /// <param name="platformGetter">Gets the current platform orientation.</param>
+    /// <param name="sizeChanges">Signals the current orientation after a host size change.</param>
+    /// <returns>The view-contract stream.</returns>
+    internal static IObservable<string?> Create(
+        Func<string?> platformGetter,
+        IObservable<string?> sizeChanges) =>
+        ModeDetector.InUnitTestRunner()
+            ? Signal.Silent<string?>()
+            : new StartWithObservable<string?>(sizeChanges, platformGetter()).DistinctUntilChanged();
+}

--- a/src/tests/ReactiveUI.Tests/CommandBinding/CommandBindingTests.cs
+++ b/src/tests/ReactiveUI.Tests/CommandBinding/CommandBindingTests.cs
@@ -25,6 +25,22 @@ namespace ReactiveUI.Tests.CommandBinding;
 [TestExecutor<CommandBindingExecutorTests>]
 public class CommandBindingTests
 {
+    /// <summary>The event used by the fake control command bindings.</summary>
+    private const string ClickEvent = "Click";
+
+    /// <summary>The command-parameter source shapes exposed by the binding mixins.</summary>
+    public enum ParameterSource
+    {
+        /// <summary>No command parameter.</summary>
+        None,
+
+        /// <summary>An observable command parameter.</summary>
+        Observable,
+
+        /// <summary>A view-model expression command parameter.</summary>
+        Expression
+    }
+
     /// <summary>Verifies that the command binder binds a command to a control event so the command executes when the event is raised.</summary>
     /// <returns>A <see cref="Task" /> representing the asynchronous operation.</returns>
     [Test]
@@ -40,7 +56,7 @@ public class CommandBindingTests
             vm => vm.Command,
             v => v.Control,
             Signal.Emit((object?)null),
-            "Click");
+            ClickEvent);
 
         await Assert.That(disp).IsNotNull();
 
@@ -71,6 +87,43 @@ public class CommandBindingTests
 
         await Assert.That(disp).IsNotNull();
         await Assert.That(FakeCustomBinder.BindCalled).IsTrue();
+    }
+
+    /// <summary>Verifies that each parameter-source extension overload creates an executable binding.</summary>
+    /// <param name="parameterSource">The command-parameter source shape to bind.</param>
+    /// <returns>A <see cref="Task" /> representing the asynchronous operation.</returns>
+    [Test]
+    [Arguments(ParameterSource.None)]
+    [Arguments(ParameterSource.Observable)]
+    [Arguments(ParameterSource.Expression)]
+    public async Task BindCommand_ParameterSource_CreatesExecutableBinding(ParameterSource parameterSource)
+    {
+        var viewModel = new FakeViewModel();
+        var view = new FakeView { ViewModel = viewModel };
+        var executed = false;
+        _ = viewModel.Command.Subscribe(_ => executed = true);
+
+        using var binding = parameterSource switch
+        {
+            ParameterSource.None => view.BindCommand(viewModel, model => model.Command, target => target.Control, ClickEvent),
+            ParameterSource.Observable => view.BindCommand(
+                viewModel,
+                model => model.Command,
+                target => target.Control,
+                Signal.Emit<RxVoid?>(default),
+                ClickEvent),
+            ParameterSource.Expression => view.BindCommand(
+                viewModel,
+                model => model.Command,
+                target => target.Control,
+                model => model.Parameter,
+                ClickEvent),
+            _ => throw new ArgumentOutOfRangeException(nameof(parameterSource), parameterSource, null)
+        };
+
+        view.Control.RaiseClick();
+
+        await Assert.That(executed).IsTrue();
     }
 
     /// <summary>Provides test execution support for command binding scenarios using the ReactiveUI framework.</summary>
@@ -201,5 +254,8 @@ public class CommandBindingTests
     {
         /// <summary>Gets the command under test.</summary>
         public ReactiveCommand<RxVoid, RxVoid> Command { get; } = ReactiveCommand.Create(static () => { });
+
+        /// <summary>Gets the expression-backed command parameter.</summary>
+        public RxVoid Parameter => default;
     }
 }

--- a/src/tests/ReactiveUI.Tests/CommandBinding/CommandBindingTests.cs
+++ b/src/tests/ReactiveUI.Tests/CommandBinding/CommandBindingTests.cs
@@ -110,14 +110,12 @@ public class CommandBindingTests
                 viewModel,
                 model => model.Command,
                 target => target.Control,
-                Signal.Emit<RxVoid?>(default),
-                ClickEvent),
+                Signal.Emit<RxVoid?>(default)),
             ParameterSource.Expression => view.BindCommand(
                 viewModel,
                 model => model.Command,
                 target => target.Control,
-                model => model.Parameter,
-                ClickEvent),
+                model => model.Parameter),
             _ => throw new ArgumentOutOfRangeException(nameof(parameterSource), parameterSource, null)
         };
 

--- a/src/tests/ReactiveUI.Tests/ObservableForProperty/OaphCreationHelperMixinTest.cs
+++ b/src/tests/ReactiveUI.Tests/ObservableForProperty/OaphCreationHelperMixinTest.cs
@@ -220,6 +220,39 @@ public class OaphCreationHelperMixinTest
             .Throws<ArgumentNullException>();
     }
 
+    /// <summary>Tests that a static expression is rejected because it has no object parent.</summary>
+    /// <returns>A <see cref="Task" /> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task ToProperty_WithStaticExpression_ThrowsOnMissingParent()
+    {
+        var source = new TestReactiveObject();
+
+        await Assert.That(() => Signal.Emit(TestText).ToProperty(source, static _ => TestReactiveObject.StaticProperty))
+            .Throws<ArgumentException>();
+    }
+
+    /// <summary>Tests that a nested property expression is rejected because its parent is not the lambda parameter.</summary>
+    /// <returns>A <see cref="Task" /> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task ToProperty_WithNestedExpression_ThrowsOnNonParameterParent()
+    {
+        var source = new TestReactiveObject();
+
+        await Assert.That(() => Signal.Emit(TestText).ToProperty(source, static value => value.Nested.TestProperty))
+            .Throws<ArgumentException>();
+    }
+
+    /// <summary>Tests that an array index expression is rejected because it has no member metadata.</summary>
+    /// <returns>A <see cref="Task" /> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task ToProperty_WithArrayIndexExpression_ThrowsOnMissingMember()
+    {
+        var source = new TestReactiveObject();
+
+        await Assert.That(() => Signal.Emit(TestText).ToProperty(source, static value => value.Values[0]))
+            .Throws<ArgumentException>();
+    }
+
     /// <summary>Tests that ToProperty with Expression and initial value creates a helper with initial value.</summary>
     /// <returns>A <see cref="Task" /> representing the asynchronous operation.</returns>
     [Test]
@@ -415,6 +448,15 @@ public class OaphCreationHelperMixinTest
     /// <summary>Test reactive object for testing.</summary>
     private sealed class TestReactiveObject : ReactiveObject
     {
+        /// <summary>Gets a static value used to create a parentless expression.</summary>
+        public static string StaticProperty => TestText;
+
+        /// <summary>Gets a nested object used to create a non-direct expression.</summary>
+        public TestReactiveObject Nested => this;
+
+        /// <summary>Gets values used to create an array index expression.</summary>
+        public string[] Values { get; } = [TestText];
+
         /// <summary>Gets or sets the test property.</summary>
         public string? TestProperty
         {

--- a/src/tests/ReactiveUI.Tests/ReactiveObjects/ReactiveNotificationHelpersTests.cs
+++ b/src/tests/ReactiveUI.Tests/ReactiveObjects/ReactiveNotificationHelpersTests.cs
@@ -1,0 +1,118 @@
+// Copyright (c) 2009-2026 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.ComponentModel;
+
+namespace ReactiveUI.Tests.ReactiveObjects;
+
+/// <summary>Tests for <see cref="ReactiveNotificationHelpers"/>.</summary>
+public class ReactiveNotificationHelpersTests
+{
+    /// <summary>The number of handlers registered in combination tests.</summary>
+    private const int ExpectedHandlerCalls = 2;
+
+    /// <summary>Verifies that property-changing handlers are initialized and retained.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task AddPropertyChanging_NewHandlers_InitializesAndCombinesHandlers()
+    {
+        var source = new TestReactiveObject();
+        var subscribed = false;
+        PropertyChangingEventHandler? handlers = null;
+        var calls = 0;
+
+        ReactiveNotificationHelpers.AddPropertyChanging(source, ref subscribed, ref handlers, (_, _) => calls++);
+        ReactiveNotificationHelpers.AddPropertyChanging(source, ref subscribed, ref handlers, (_, _) => calls++);
+        handlers?.Invoke(source, new PropertyChangingEventArgs(nameof(TestReactiveObject.Value)));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(subscribed).IsTrue();
+            await Assert.That(calls).IsEqualTo(ExpectedHandlerCalls);
+        }
+    }
+
+    /// <summary>Verifies that property-changed handlers are initialized and retained.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task AddPropertyChanged_NewHandlers_InitializesAndCombinesHandlers()
+    {
+        var source = new TestReactiveObject();
+        var subscribed = false;
+        PropertyChangedEventHandler? handlers = null;
+        var calls = 0;
+
+        ReactiveNotificationHelpers.AddPropertyChanged(source, ref subscribed, ref handlers, (_, _) => calls++);
+        ReactiveNotificationHelpers.AddPropertyChanged(source, ref subscribed, ref handlers, (_, _) => calls++);
+        handlers?.Invoke(source, new PropertyChangedEventArgs(nameof(TestReactiveObject.Value)));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(subscribed).IsTrue();
+            await Assert.That(calls).IsEqualTo(ExpectedHandlerCalls);
+        }
+    }
+
+    /// <summary>Verifies that the property-changing observable is cached after its first creation.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task GetChanging_RepeatedCalls_ReturnsCachedObservable()
+    {
+        var source = new TestReactiveObject();
+        IObservable<IReactivePropertyChangedEventArgs<IReactiveObject>>? observable = null;
+
+        var first = ReactiveNotificationHelpers.GetChanging(source, ref observable);
+        var second = ReactiveNotificationHelpers.GetChanging(source, ref observable);
+
+        await Assert.That(second).IsSameReferenceAs(first);
+    }
+
+    /// <summary>Verifies that the property-changed observable is cached after its first creation.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task GetChanged_RepeatedCalls_ReturnsCachedObservable()
+    {
+        var source = new TestReactiveObject();
+        IObservable<IReactivePropertyChangedEventArgs<IReactiveObject>>? observable = null;
+
+        var first = ReactiveNotificationHelpers.GetChanged(source, ref observable);
+        var second = ReactiveNotificationHelpers.GetChanged(source, ref observable);
+
+        await Assert.That(second).IsSameReferenceAs(first);
+    }
+
+    /// <summary>Verifies that the exception observable is cached after its first creation.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task GetThrownExceptions_RepeatedCalls_ReturnsCachedObservable()
+    {
+        var source = new TestReactiveObject();
+        IObservable<Exception>? observable = null;
+
+        var first = ReactiveNotificationHelpers.GetThrownExceptions(source, ref observable);
+        var second = ReactiveNotificationHelpers.GetThrownExceptions(source, ref observable);
+
+        await Assert.That(second).IsSameReferenceAs(first);
+    }
+
+    /// <summary>Minimal reactive object used to exercise helper-owned state.</summary>
+    private sealed class TestReactiveObject : IReactiveObject
+    {
+        /// <inheritdoc/>
+        public event PropertyChangingEventHandler? PropertyChanging;
+
+        /// <inheritdoc/>
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        /// <summary>Gets or sets the test value.</summary>
+        public int Value { get; set; }
+
+        /// <inheritdoc/>
+        public void RaisePropertyChanging(PropertyChangingEventArgs args) => PropertyChanging?.Invoke(this, args);
+
+        /// <inheritdoc/>
+        public void RaisePropertyChanged(PropertyChangedEventArgs args) => PropertyChanged?.Invoke(this, args);
+    }
+}

--- a/src/tests/ReactiveUI.Wpf.Tests/Wpf/ViewContractObservableHelpersTests.cs
+++ b/src/tests/ReactiveUI.Wpf.Tests/Wpf/ViewContractObservableHelpersTests.cs
@@ -1,0 +1,76 @@
+// Copyright (c) 2009-2026 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Splat;
+using TUnit.Core.Executors;
+using TUnit.Core.Interfaces;
+
+namespace ReactiveUI.Tests.Wpf;
+
+/// <summary>Tests for <see cref="ViewContractObservableHelpers"/>.</summary>
+public class ViewContractObservableHelpersTests
+{
+    /// <summary>The initial orientation returned by the platform.</summary>
+    private const string Portrait = "portrait";
+
+    /// <summary>The changed orientation emitted by the host.</summary>
+    private const string Landscape = "landscape";
+
+    /// <summary>The runtime size-change signals, including a consecutive duplicate.</summary>
+    private static readonly string?[] RuntimeSignals = [Portrait, Landscape, Landscape];
+
+    /// <summary>The distinct runtime contracts expected from the helper.</summary>
+    private static readonly string?[] ExpectedRuntimeContracts = [Portrait, Landscape];
+
+    /// <summary>Verifies that test mode suppresses platform view-contract signals.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task Create_TestMode_ReturnsSilentObservable()
+    {
+        var values = ViewContractObservableHelpers.Create(static () => Portrait, Signal.Emit<string?>(Landscape)).Collect();
+
+        await Assert.That(values).IsEmpty();
+    }
+
+    /// <summary>Verifies that runtime mode starts with the current orientation and removes consecutive duplicates.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    [TestExecutor<RuntimeModeTestExecutor>]
+    public async Task Create_RuntimeMode_StartsWithOrientationAndRemovesDuplicates()
+    {
+        var values = ViewContractObservableHelpers.Create(
+                static () => Portrait,
+                Signal.FromEnumerable(RuntimeSignals))
+            .Collect();
+
+        await Assert.That(values).IsEquivalentTo(ExpectedRuntimeContracts);
+    }
+
+    /// <summary>Runs a test with runtime mode enabled and restores test mode afterward.</summary>
+    public sealed class RuntimeModeTestExecutor : ITestExecutor
+    {
+        /// <inheritdoc/>
+        public async ValueTask ExecuteTest(TestContext context, Func<ValueTask> action)
+        {
+            ModeDetector.OverrideModeDetector(new FixedModeDetector(false));
+            try
+            {
+                await action();
+            }
+            finally
+            {
+                ModeDetector.OverrideModeDetector(new FixedModeDetector(true));
+            }
+        }
+    }
+
+    /// <summary>Returns a fixed unit-test mode value.</summary>
+    /// <param name="isTestMode">The mode value to return.</param>
+    private sealed class FixedModeDetector(bool isTestMode) : IModeDetector
+    {
+        /// <inheritdoc/>
+        public bool? InUnitTestRunner() => isTestMode;
+    }
+}

--- a/src/tests/ReactiveUI.Wpf.Tests/Wpf/ViewContractObservableHelpersTests.cs
+++ b/src/tests/ReactiveUI.Wpf.Tests/Wpf/ViewContractObservableHelpersTests.cs
@@ -3,6 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using ReactiveUI.Tests.Utilities.Logging;
 using Splat;
 using TUnit.Core.Executors;
 using TUnit.Core.Interfaces;
@@ -48,6 +49,37 @@ public class ViewContractObservableHelpersTests
         await Assert.That(values).IsEquivalentTo(ExpectedRuntimeContracts);
     }
 
+    /// <summary>Verifies that the registered platform orientation callback is returned.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    [TestExecutor<LoggingRegistrationExecutor>]
+    public async Task GetPlatformOrientation_RegisteredPlatform_ReturnsPlatformCallback()
+    {
+        AppLocator.CurrentMutable.RegisterConstant<IPlatformOperations>(new FixedPlatformOperations());
+
+        var getOrientation = ViewContractObservableHelpers.GetPlatformOrientation(new LoggerHost().Log());
+
+        await Assert.That(getOrientation()).IsEqualTo(Landscape);
+    }
+
+    /// <summary>Verifies that a missing platform is logged and represented by a null orientation callback.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    [TestExecutor<LoggingRegistrationExecutor>]
+    public async Task GetPlatformOrientation_MissingPlatform_LogsErrorAndReturnsNullCallback()
+    {
+        var logger = TestContext.Current?.GetTestLogger()
+                     ?? throw new InvalidOperationException("The logging executor did not provide a test logger.");
+
+        var getOrientation = ViewContractObservableHelpers.GetPlatformOrientation(new LoggerHost().Log());
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(getOrientation()).IsNull();
+            await Assert.That(logger.Messages.Exists(static message => message.logLevel == LogLevel.Error)).IsTrue();
+        }
+    }
+
     /// <summary>Runs a test with runtime mode enabled and restores test mode afterward.</summary>
     public sealed class RuntimeModeTestExecutor : ITestExecutor
     {
@@ -73,4 +105,14 @@ public class ViewContractObservableHelpersTests
         /// <inheritdoc/>
         public bool? InUnitTestRunner() => isTestMode;
     }
+
+    /// <summary>Returns a fixed platform orientation.</summary>
+    private sealed class FixedPlatformOperations : IPlatformOperations
+    {
+        /// <inheritdoc/>
+        public string GetOrientation() => Landscape;
+    }
+
+    /// <summary>Provides a logging category for helper tests.</summary>
+    private sealed class LoggerHost : IEnableLogger;
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Refactor.

## What is the new behavior?

Reactive notification initialization, view-contract streams, WinUI host subscriptions, command-binding validation, and observable-property expression validation now reuse shared helpers. Runtime behavior and the public API remain unchanged.

## What is the current behavior?

Equivalent implementation blocks are repeated across reactive objects, WPF and WinUI hosts, command-binding overloads, and observable-property helpers. SonarCloud reports those blocks as duplicated new code.

## What might this PR break?

None expected. The shared source remains linked into the same WPF and WinUI target-framework paths.

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [ ] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information

Verification:

- `dotnet build reactiveui.slnx -c Release --no-restore` (0 warnings, 0 errors)
- `dotnet test --solution reactiveui.slnx -c Release --no-build` (33,404 passed, 0 failed, 0 skipped)
