### PR TITLE
chore(renovate): group related dependency cohorts

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,56 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "extends": ["local>reactiveui/.github:renovate"]
+    "extends": [
+        "local>reactiveui/.github:renovate"
+    ],
+    "packageRules": [
+        {
+            "description": "Analyzer packages all gate the build through the same warnings-as-errors pass, so landing them separately just means several red CI runs in a row. Move them in one PR.",
+            "matchManagers": [
+                "nuget"
+            ],
+            "groupName": "analyzers",
+            "matchPackageNames": [
+                "/^Roslynator\\./",
+                "/^SonarAnalyzer\\./",
+                "/Sharp\\.Analyzers$/",
+                "/^Microsoft\\.CodeAnalysis\\.(Public|Banned)ApiAnalyzers$/"
+            ]
+        },
+        {
+            "description": "The shared preset blocks major bumps for Microsoft.CodeAnalysis.* to hold the compiler API at its current band. The public/banned API analyzers ship on their own line and are not part of that toolchain, so allow their majors.",
+            "matchManagers": [
+                "nuget"
+            ],
+            "matchPackageNames": [
+                "/^Microsoft\\.CodeAnalysis\\.(Public|Banned)ApiAnalyzers$/"
+            ],
+            "matchUpdateTypes": [
+                "major"
+            ],
+            "enabled": true
+        },
+        {
+            "description": "Packaging, versioning and symbol tooling. These affect how the package is produced, never the shipped API, so they are safe to move as one.",
+            "matchManagers": [
+                "nuget"
+            ],
+            "groupName": "build tooling",
+            "matchPackageNames": [
+                "/^MinVer$/",
+                "/^Microsoft\\.SourceLink\\./"
+            ]
+        },
+        {
+            "description": "Test and benchmark helpers that sit outside the framework cohorts the shared preset already groups.",
+            "matchManagers": [
+                "nuget"
+            ],
+            "groupName": "test tooling",
+            "matchPackageNames": [
+                "/^BenchmarkDotNet(\\.|$)/",
+                "/^Mocks\\.Maui$/"
+            ]
+        }
+    ]
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Chore - Renovate configuration only. No product code, no build files, no dependency versions change.

## What is the new behavior?

Adds repo-specific grouping on top of the shared `reactiveui/.github` preset so related packages arrive as one reviewable PR:

- `analyzers`
- `build tooling`
- `test tooling`


- The shared preset holds all of `Microsoft.CodeAnalysis.*` on its current major to pin the compiler API. `PublicApiAnalyzers` and `BannedApiAnalyzers` ship on their own release line and are not part of that toolchain, so their majors are allowed through again. The compiler-API pin is unaffected.

## What is the current behavior?

These packages are ungrouped, so each one opens its own PR even when it only makes sense to bump them together.

## What might this PR break?

Nothing at build time - this file only affects how Renovate batches its own PRs. Any currently-open Renovate PR whose group name changes will be closed and reopened under the new branch name.

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [ ] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information

Validated with `renovate-config-validator`. Every pattern was checked against this repo's actual package list (no dead rules), and the merged preset+repo rule set was resolved through Renovate's `applyPackageRules` engine to confirm each package lands in the intended group.
