### PR TITLE
fix(testing): restore .NET Framework targets for the testing packages

### DIFF
--- a/src/ReactiveUI.Testing.Reactive/PublicAPI/net462/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Testing.Reactive/PublicAPI/net462/PublicAPI.Shipped.txt
@@ -1,0 +1,64 @@
+#nullable enable
+ReactiveUI.Testing.AppBuilderTestBase
+ReactiveUI.Testing.AppBuilderTestBase.AppBuilderTestBase() -> void
+ReactiveUI.Testing.IBuilder
+ReactiveUI.Testing.IBuilderExtensions
+ReactiveUI.Testing.IBuilderExtensions.extension<TBuilder>(TBuilder)
+ReactiveUI.Testing.IBuilderExtensions.extension<TBuilder>(TBuilder).With<TField>(out TField field, TField value) -> TBuilder
+ReactiveUI.Testing.IBuilderExtensions.extension<TBuilder>(TBuilder).With<TField>(ref System.Collections.Generic.List<TField>? field, System.Collections.Generic.IEnumerable<TField>! values) -> TBuilder
+ReactiveUI.Testing.IBuilderExtensions.extension<TBuilder>(TBuilder).With<TField>(ref System.Collections.Generic.List<TField>? field, TField value) -> TBuilder
+ReactiveUI.Testing.IBuilderExtensions.extension<TBuilder>(TBuilder).With<TKey, TField>(ref System.Collections.Generic.Dictionary<TKey, TField>! dictionary, System.Collections.Generic.IDictionary<TKey, TField>! keyValuePair) -> TBuilder
+ReactiveUI.Testing.IBuilderExtensions.extension<TBuilder>(TBuilder).With<TKey, TField>(ref System.Collections.Generic.Dictionary<TKey, TField>! dictionary, System.Collections.Generic.KeyValuePair<TKey, TField> keyValuePair) -> TBuilder
+ReactiveUI.Testing.IBuilderExtensions.extension<TBuilder>(TBuilder).With<TKey, TField>(ref System.Collections.Generic.Dictionary<TKey, TField>! dictionary, TKey key, TField value) -> TBuilder
+ReactiveUI.Testing.MessageBusExtensions
+ReactiveUI.Testing.MessageBusExtensions.extension(ReactiveUI.Reactive.IMessageBus!)
+ReactiveUI.Testing.MessageBusExtensions.extension(ReactiveUI.Reactive.IMessageBus!).With(System.Action! block) -> void
+ReactiveUI.Testing.MessageBusExtensions.extension(ReactiveUI.Reactive.IMessageBus!).With<TRet>(System.Func<TRet>! block) -> TRet
+ReactiveUI.Testing.MessageBusExtensions.extension(ReactiveUI.Reactive.IMessageBus!).WithMessageBus() -> System.IDisposable!
+ReactiveUI.Testing.RxTest
+ReactiveUI.Testing.SchedulerExtensions
+ReactiveUI.Testing.SchedulerExtensions.extension<T>(T)
+ReactiveUI.Testing.SchedulerExtensions.extension<T>(T).With(System.Action<T>! block) -> void
+ReactiveUI.Testing.SchedulerExtensions.extension<T>(T).With<TRet>(System.Func<T, TRet>! block) -> TRet
+ReactiveUI.Testing.SchedulerExtensions.extension<T>(T).WithAsync(System.Func<T, System.Threading.Tasks.Task!>! block) -> System.Threading.Tasks.Task!
+ReactiveUI.Testing.SchedulerExtensions.extension<T>(T).WithAsync<TRet>(System.Func<T, System.Threading.Tasks.Task<TRet>!>! block) -> System.Threading.Tasks.Task<TRet>!
+ReactiveUI.Testing.TestSchedulerExtensions
+ReactiveUI.Testing.TestSchedulerExtensions.extension(Microsoft.Reactive.Testing.TestScheduler!)
+ReactiveUI.Testing.TestSchedulerExtensions.extension(Microsoft.Reactive.Testing.TestScheduler!).AdvanceByMs(double milliseconds) -> void
+ReactiveUI.Testing.TestSchedulerExtensions.extension(Microsoft.Reactive.Testing.TestScheduler!).AdvanceToMs(double milliseconds) -> void
+ReactiveUI.Testing.TestSequencer
+ReactiveUI.Testing.TestSequencer.AdvancePhaseAsync() -> System.Threading.Tasks.Task!
+ReactiveUI.Testing.TestSequencer.AdvancePhaseAsync(string! comment) -> System.Threading.Tasks.Task!
+ReactiveUI.Testing.TestSequencer.CompletedPhases.get -> long
+ReactiveUI.Testing.TestSequencer.CurrentPhase.get -> long
+ReactiveUI.Testing.TestSequencer.Dispose() -> void
+ReactiveUI.Testing.TestSequencer.TestSequencer() -> void
+static ReactiveUI.Testing.AppBuilderTestBase.RunAppBuilderTestAsync(System.Action! testBody) -> System.Threading.Tasks.Task!
+static ReactiveUI.Testing.AppBuilderTestBase.RunAppBuilderTestAsync(System.Func<System.Threading.Tasks.Task!>! testBody) -> System.Threading.Tasks.Task!
+static ReactiveUI.Testing.IBuilderExtensions.With<TBuilder, TField>(this TBuilder builder, out TField field, TField value) -> TBuilder
+static ReactiveUI.Testing.IBuilderExtensions.With<TBuilder, TField>(this TBuilder builder, ref System.Collections.Generic.List<TField>? field, System.Collections.Generic.IEnumerable<TField>! values) -> TBuilder
+static ReactiveUI.Testing.IBuilderExtensions.With<TBuilder, TField>(this TBuilder builder, ref System.Collections.Generic.List<TField>? field, TField value) -> TBuilder
+static ReactiveUI.Testing.IBuilderExtensions.With<TBuilder, TKey, TField>(this TBuilder builder, ref System.Collections.Generic.Dictionary<TKey, TField>! dictionary, System.Collections.Generic.IDictionary<TKey, TField>! keyValuePair) -> TBuilder
+static ReactiveUI.Testing.IBuilderExtensions.With<TBuilder, TKey, TField>(this TBuilder builder, ref System.Collections.Generic.Dictionary<TKey, TField>! dictionary, System.Collections.Generic.KeyValuePair<TKey, TField> keyValuePair) -> TBuilder
+static ReactiveUI.Testing.IBuilderExtensions.With<TBuilder, TKey, TField>(this TBuilder builder, ref System.Collections.Generic.Dictionary<TKey, TField>! dictionary, TKey key, TField value) -> TBuilder
+static ReactiveUI.Testing.MessageBusExtensions.With(this ReactiveUI.Reactive.IMessageBus! messageBus, System.Action! block) -> void
+static ReactiveUI.Testing.MessageBusExtensions.With<TRet>(this ReactiveUI.Reactive.IMessageBus! messageBus, System.Func<TRet>! block) -> TRet
+static ReactiveUI.Testing.MessageBusExtensions.WithMessageBus(this ReactiveUI.Reactive.IMessageBus! messageBus) -> System.IDisposable!
+static ReactiveUI.Testing.RxTest.AppBuilderTestAsync(System.Func<System.Threading.Tasks.Task!>! testBody) -> System.Threading.Tasks.Task!
+static ReactiveUI.Testing.RxTest.AppBuilderTestAsync(System.Func<System.Threading.Tasks.Task!>! testBody, int maxWaitMs) -> System.Threading.Tasks.Task!
+static ReactiveUI.Testing.SchedulerExtensions.With<T, TRet>(this T scheduler, System.Func<T, TRet>! block) -> TRet
+static ReactiveUI.Testing.SchedulerExtensions.With<T>(this T scheduler, System.Action<T>! block) -> void
+static ReactiveUI.Testing.SchedulerExtensions.WithAsync<T, TRet>(this T scheduler, System.Func<T, System.Threading.Tasks.Task<TRet>!>! block) -> System.Threading.Tasks.Task<TRet>!
+static ReactiveUI.Testing.SchedulerExtensions.WithAsync<T>(this T scheduler, System.Func<T, System.Threading.Tasks.Task!>! block) -> System.Threading.Tasks.Task!
+static ReactiveUI.Testing.SchedulerExtensions.WithScheduler(System.Reactive.Concurrency.IScheduler! scheduler) -> System.IDisposable!
+static ReactiveUI.Testing.TestSchedulerExtensions.AdvanceByMs(this Microsoft.Reactive.Testing.TestScheduler! scheduler, double milliseconds) -> void
+static ReactiveUI.Testing.TestSchedulerExtensions.AdvanceToMs(this Microsoft.Reactive.Testing.TestScheduler! scheduler, double milliseconds) -> void
+static ReactiveUI.Testing.TestSchedulerExtensions.FromTimeSpan(System.TimeSpan span) -> long
+static ReactiveUI.Testing.TestSchedulerExtensions.OnCompletedAt<T>(double milliseconds) -> Microsoft.Reactive.Testing.Recorded<System.Reactive.Notification<T>!>
+static ReactiveUI.Testing.TestSchedulerExtensions.OnErrorAt<T>(double milliseconds, System.Exception! ex) -> Microsoft.Reactive.Testing.Recorded<System.Reactive.Notification<T>!>
+static ReactiveUI.Testing.TestSchedulerExtensions.OnNextAt<T>(double milliseconds, T value) -> Microsoft.Reactive.Testing.Recorded<System.Reactive.Notification<T>!>
+static ReactiveUI.Testing.TestSchedulerExtensions.extension(Microsoft.Reactive.Testing.TestScheduler!).FromTimeSpan(System.TimeSpan span) -> long
+static ReactiveUI.Testing.TestSchedulerExtensions.extension(Microsoft.Reactive.Testing.TestScheduler!).OnCompletedAt<T>(double milliseconds) -> Microsoft.Reactive.Testing.Recorded<System.Reactive.Notification<T>!>
+static ReactiveUI.Testing.TestSchedulerExtensions.extension(Microsoft.Reactive.Testing.TestScheduler!).OnErrorAt<T>(double milliseconds, System.Exception! ex) -> Microsoft.Reactive.Testing.Recorded<System.Reactive.Notification<T>!>
+static ReactiveUI.Testing.TestSchedulerExtensions.extension(Microsoft.Reactive.Testing.TestScheduler!).OnNextAt<T>(double milliseconds, T value) -> Microsoft.Reactive.Testing.Recorded<System.Reactive.Notification<T>!>
+virtual ReactiveUI.Testing.TestSequencer.Dispose(bool disposing) -> void

--- a/src/ReactiveUI.Testing.Reactive/PublicAPI/net462/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Testing.Reactive/PublicAPI/net462/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/ReactiveUI.Testing.Reactive/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Testing.Reactive/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -1,0 +1,64 @@
+#nullable enable
+ReactiveUI.Testing.AppBuilderTestBase
+ReactiveUI.Testing.AppBuilderTestBase.AppBuilderTestBase() -> void
+ReactiveUI.Testing.IBuilder
+ReactiveUI.Testing.IBuilderExtensions
+ReactiveUI.Testing.IBuilderExtensions.extension<TBuilder>(TBuilder)
+ReactiveUI.Testing.IBuilderExtensions.extension<TBuilder>(TBuilder).With<TField>(out TField field, TField value) -> TBuilder
+ReactiveUI.Testing.IBuilderExtensions.extension<TBuilder>(TBuilder).With<TField>(ref System.Collections.Generic.List<TField>? field, System.Collections.Generic.IEnumerable<TField>! values) -> TBuilder
+ReactiveUI.Testing.IBuilderExtensions.extension<TBuilder>(TBuilder).With<TField>(ref System.Collections.Generic.List<TField>? field, TField value) -> TBuilder
+ReactiveUI.Testing.IBuilderExtensions.extension<TBuilder>(TBuilder).With<TKey, TField>(ref System.Collections.Generic.Dictionary<TKey, TField>! dictionary, System.Collections.Generic.IDictionary<TKey, TField>! keyValuePair) -> TBuilder
+ReactiveUI.Testing.IBuilderExtensions.extension<TBuilder>(TBuilder).With<TKey, TField>(ref System.Collections.Generic.Dictionary<TKey, TField>! dictionary, System.Collections.Generic.KeyValuePair<TKey, TField> keyValuePair) -> TBuilder
+ReactiveUI.Testing.IBuilderExtensions.extension<TBuilder>(TBuilder).With<TKey, TField>(ref System.Collections.Generic.Dictionary<TKey, TField>! dictionary, TKey key, TField value) -> TBuilder
+ReactiveUI.Testing.MessageBusExtensions
+ReactiveUI.Testing.MessageBusExtensions.extension(ReactiveUI.Reactive.IMessageBus!)
+ReactiveUI.Testing.MessageBusExtensions.extension(ReactiveUI.Reactive.IMessageBus!).With(System.Action! block) -> void
+ReactiveUI.Testing.MessageBusExtensions.extension(ReactiveUI.Reactive.IMessageBus!).With<TRet>(System.Func<TRet>! block) -> TRet
+ReactiveUI.Testing.MessageBusExtensions.extension(ReactiveUI.Reactive.IMessageBus!).WithMessageBus() -> System.IDisposable!
+ReactiveUI.Testing.RxTest
+ReactiveUI.Testing.SchedulerExtensions
+ReactiveUI.Testing.SchedulerExtensions.extension<T>(T)
+ReactiveUI.Testing.SchedulerExtensions.extension<T>(T).With(System.Action<T>! block) -> void
+ReactiveUI.Testing.SchedulerExtensions.extension<T>(T).With<TRet>(System.Func<T, TRet>! block) -> TRet
+ReactiveUI.Testing.SchedulerExtensions.extension<T>(T).WithAsync(System.Func<T, System.Threading.Tasks.Task!>! block) -> System.Threading.Tasks.Task!
+ReactiveUI.Testing.SchedulerExtensions.extension<T>(T).WithAsync<TRet>(System.Func<T, System.Threading.Tasks.Task<TRet>!>! block) -> System.Threading.Tasks.Task<TRet>!
+ReactiveUI.Testing.TestSchedulerExtensions
+ReactiveUI.Testing.TestSchedulerExtensions.extension(Microsoft.Reactive.Testing.TestScheduler!)
+ReactiveUI.Testing.TestSchedulerExtensions.extension(Microsoft.Reactive.Testing.TestScheduler!).AdvanceByMs(double milliseconds) -> void
+ReactiveUI.Testing.TestSchedulerExtensions.extension(Microsoft.Reactive.Testing.TestScheduler!).AdvanceToMs(double milliseconds) -> void
+ReactiveUI.Testing.TestSequencer
+ReactiveUI.Testing.TestSequencer.AdvancePhaseAsync() -> System.Threading.Tasks.Task!
+ReactiveUI.Testing.TestSequencer.AdvancePhaseAsync(string! comment) -> System.Threading.Tasks.Task!
+ReactiveUI.Testing.TestSequencer.CompletedPhases.get -> long
+ReactiveUI.Testing.TestSequencer.CurrentPhase.get -> long
+ReactiveUI.Testing.TestSequencer.Dispose() -> void
+ReactiveUI.Testing.TestSequencer.TestSequencer() -> void
+static ReactiveUI.Testing.AppBuilderTestBase.RunAppBuilderTestAsync(System.Action! testBody) -> System.Threading.Tasks.Task!
+static ReactiveUI.Testing.AppBuilderTestBase.RunAppBuilderTestAsync(System.Func<System.Threading.Tasks.Task!>! testBody) -> System.Threading.Tasks.Task!
+static ReactiveUI.Testing.IBuilderExtensions.With<TBuilder, TField>(this TBuilder builder, out TField field, TField value) -> TBuilder
+static ReactiveUI.Testing.IBuilderExtensions.With<TBuilder, TField>(this TBuilder builder, ref System.Collections.Generic.List<TField>? field, System.Collections.Generic.IEnumerable<TField>! values) -> TBuilder
+static ReactiveUI.Testing.IBuilderExtensions.With<TBuilder, TField>(this TBuilder builder, ref System.Collections.Generic.List<TField>? field, TField value) -> TBuilder
+static ReactiveUI.Testing.IBuilderExtensions.With<TBuilder, TKey, TField>(this TBuilder builder, ref System.Collections.Generic.Dictionary<TKey, TField>! dictionary, System.Collections.Generic.IDictionary<TKey, TField>! keyValuePair) -> TBuilder
+static ReactiveUI.Testing.IBuilderExtensions.With<TBuilder, TKey, TField>(this TBuilder builder, ref System.Collections.Generic.Dictionary<TKey, TField>! dictionary, System.Collections.Generic.KeyValuePair<TKey, TField> keyValuePair) -> TBuilder
+static ReactiveUI.Testing.IBuilderExtensions.With<TBuilder, TKey, TField>(this TBuilder builder, ref System.Collections.Generic.Dictionary<TKey, TField>! dictionary, TKey key, TField value) -> TBuilder
+static ReactiveUI.Testing.MessageBusExtensions.With(this ReactiveUI.Reactive.IMessageBus! messageBus, System.Action! block) -> void
+static ReactiveUI.Testing.MessageBusExtensions.With<TRet>(this ReactiveUI.Reactive.IMessageBus! messageBus, System.Func<TRet>! block) -> TRet
+static ReactiveUI.Testing.MessageBusExtensions.WithMessageBus(this ReactiveUI.Reactive.IMessageBus! messageBus) -> System.IDisposable!
+static ReactiveUI.Testing.RxTest.AppBuilderTestAsync(System.Func<System.Threading.Tasks.Task!>! testBody) -> System.Threading.Tasks.Task!
+static ReactiveUI.Testing.RxTest.AppBuilderTestAsync(System.Func<System.Threading.Tasks.Task!>! testBody, int maxWaitMs) -> System.Threading.Tasks.Task!
+static ReactiveUI.Testing.SchedulerExtensions.With<T, TRet>(this T scheduler, System.Func<T, TRet>! block) -> TRet
+static ReactiveUI.Testing.SchedulerExtensions.With<T>(this T scheduler, System.Action<T>! block) -> void
+static ReactiveUI.Testing.SchedulerExtensions.WithAsync<T, TRet>(this T scheduler, System.Func<T, System.Threading.Tasks.Task<TRet>!>! block) -> System.Threading.Tasks.Task<TRet>!
+static ReactiveUI.Testing.SchedulerExtensions.WithAsync<T>(this T scheduler, System.Func<T, System.Threading.Tasks.Task!>! block) -> System.Threading.Tasks.Task!
+static ReactiveUI.Testing.SchedulerExtensions.WithScheduler(System.Reactive.Concurrency.IScheduler! scheduler) -> System.IDisposable!
+static ReactiveUI.Testing.TestSchedulerExtensions.AdvanceByMs(this Microsoft.Reactive.Testing.TestScheduler! scheduler, double milliseconds) -> void
+static ReactiveUI.Testing.TestSchedulerExtensions.AdvanceToMs(this Microsoft.Reactive.Testing.TestScheduler! scheduler, double milliseconds) -> void
+static ReactiveUI.Testing.TestSchedulerExtensions.FromTimeSpan(System.TimeSpan span) -> long
+static ReactiveUI.Testing.TestSchedulerExtensions.OnCompletedAt<T>(double milliseconds) -> Microsoft.Reactive.Testing.Recorded<System.Reactive.Notification<T>!>
+static ReactiveUI.Testing.TestSchedulerExtensions.OnErrorAt<T>(double milliseconds, System.Exception! ex) -> Microsoft.Reactive.Testing.Recorded<System.Reactive.Notification<T>!>
+static ReactiveUI.Testing.TestSchedulerExtensions.OnNextAt<T>(double milliseconds, T value) -> Microsoft.Reactive.Testing.Recorded<System.Reactive.Notification<T>!>
+static ReactiveUI.Testing.TestSchedulerExtensions.extension(Microsoft.Reactive.Testing.TestScheduler!).FromTimeSpan(System.TimeSpan span) -> long
+static ReactiveUI.Testing.TestSchedulerExtensions.extension(Microsoft.Reactive.Testing.TestScheduler!).OnCompletedAt<T>(double milliseconds) -> Microsoft.Reactive.Testing.Recorded<System.Reactive.Notification<T>!>
+static ReactiveUI.Testing.TestSchedulerExtensions.extension(Microsoft.Reactive.Testing.TestScheduler!).OnErrorAt<T>(double milliseconds, System.Exception! ex) -> Microsoft.Reactive.Testing.Recorded<System.Reactive.Notification<T>!>
+static ReactiveUI.Testing.TestSchedulerExtensions.extension(Microsoft.Reactive.Testing.TestScheduler!).OnNextAt<T>(double milliseconds, T value) -> Microsoft.Reactive.Testing.Recorded<System.Reactive.Notification<T>!>
+virtual ReactiveUI.Testing.TestSequencer.Dispose(bool disposing) -> void

--- a/src/ReactiveUI.Testing.Reactive/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Testing.Reactive/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/ReactiveUI.Testing.Reactive/PublicAPI/net481/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Testing.Reactive/PublicAPI/net481/PublicAPI.Shipped.txt
@@ -1,0 +1,64 @@
+#nullable enable
+ReactiveUI.Testing.AppBuilderTestBase
+ReactiveUI.Testing.AppBuilderTestBase.AppBuilderTestBase() -> void
+ReactiveUI.Testing.IBuilder
+ReactiveUI.Testing.IBuilderExtensions
+ReactiveUI.Testing.IBuilderExtensions.extension<TBuilder>(TBuilder)
+ReactiveUI.Testing.IBuilderExtensions.extension<TBuilder>(TBuilder).With<TField>(out TField field, TField value) -> TBuilder
+ReactiveUI.Testing.IBuilderExtensions.extension<TBuilder>(TBuilder).With<TField>(ref System.Collections.Generic.List<TField>? field, System.Collections.Generic.IEnumerable<TField>! values) -> TBuilder
+ReactiveUI.Testing.IBuilderExtensions.extension<TBuilder>(TBuilder).With<TField>(ref System.Collections.Generic.List<TField>? field, TField value) -> TBuilder
+ReactiveUI.Testing.IBuilderExtensions.extension<TBuilder>(TBuilder).With<TKey, TField>(ref System.Collections.Generic.Dictionary<TKey, TField>! dictionary, System.Collections.Generic.IDictionary<TKey, TField>! keyValuePair) -> TBuilder
+ReactiveUI.Testing.IBuilderExtensions.extension<TBuilder>(TBuilder).With<TKey, TField>(ref System.Collections.Generic.Dictionary<TKey, TField>! dictionary, System.Collections.Generic.KeyValuePair<TKey, TField> keyValuePair) -> TBuilder
+ReactiveUI.Testing.IBuilderExtensions.extension<TBuilder>(TBuilder).With<TKey, TField>(ref System.Collections.Generic.Dictionary<TKey, TField>! dictionary, TKey key, TField value) -> TBuilder
+ReactiveUI.Testing.MessageBusExtensions
+ReactiveUI.Testing.MessageBusExtensions.extension(ReactiveUI.Reactive.IMessageBus!)
+ReactiveUI.Testing.MessageBusExtensions.extension(ReactiveUI.Reactive.IMessageBus!).With(System.Action! block) -> void
+ReactiveUI.Testing.MessageBusExtensions.extension(ReactiveUI.Reactive.IMessageBus!).With<TRet>(System.Func<TRet>! block) -> TRet
+ReactiveUI.Testing.MessageBusExtensions.extension(ReactiveUI.Reactive.IMessageBus!).WithMessageBus() -> System.IDisposable!
+ReactiveUI.Testing.RxTest
+ReactiveUI.Testing.SchedulerExtensions
+ReactiveUI.Testing.SchedulerExtensions.extension<T>(T)
+ReactiveUI.Testing.SchedulerExtensions.extension<T>(T).With(System.Action<T>! block) -> void
+ReactiveUI.Testing.SchedulerExtensions.extension<T>(T).With<TRet>(System.Func<T, TRet>! block) -> TRet
+ReactiveUI.Testing.SchedulerExtensions.extension<T>(T).WithAsync(System.Func<T, System.Threading.Tasks.Task!>! block) -> System.Threading.Tasks.Task!
+ReactiveUI.Testing.SchedulerExtensions.extension<T>(T).WithAsync<TRet>(System.Func<T, System.Threading.Tasks.Task<TRet>!>! block) -> System.Threading.Tasks.Task<TRet>!
+ReactiveUI.Testing.TestSchedulerExtensions
+ReactiveUI.Testing.TestSchedulerExtensions.extension(Microsoft.Reactive.Testing.TestScheduler!)
+ReactiveUI.Testing.TestSchedulerExtensions.extension(Microsoft.Reactive.Testing.TestScheduler!).AdvanceByMs(double milliseconds) -> void
+ReactiveUI.Testing.TestSchedulerExtensions.extension(Microsoft.Reactive.Testing.TestScheduler!).AdvanceToMs(double milliseconds) -> void
+ReactiveUI.Testing.TestSequencer
+ReactiveUI.Testing.TestSequencer.AdvancePhaseAsync() -> System.Threading.Tasks.Task!
+ReactiveUI.Testing.TestSequencer.AdvancePhaseAsync(string! comment) -> System.Threading.Tasks.Task!
+ReactiveUI.Testing.TestSequencer.CompletedPhases.get -> long
+ReactiveUI.Testing.TestSequencer.CurrentPhase.get -> long
+ReactiveUI.Testing.TestSequencer.Dispose() -> void
+ReactiveUI.Testing.TestSequencer.TestSequencer() -> void
+static ReactiveUI.Testing.AppBuilderTestBase.RunAppBuilderTestAsync(System.Action! testBody) -> System.Threading.Tasks.Task!
+static ReactiveUI.Testing.AppBuilderTestBase.RunAppBuilderTestAsync(System.Func<System.Threading.Tasks.Task!>! testBody) -> System.Threading.Tasks.Task!
+static ReactiveUI.Testing.IBuilderExtensions.With<TBuilder, TField>(this TBuilder builder, out TField field, TField value) -> TBuilder
+static ReactiveUI.Testing.IBuilderExtensions.With<TBuilder, TField>(this TBuilder builder, ref System.Collections.Generic.List<TField>? field, System.Collections.Generic.IEnumerable<TField>! values) -> TBuilder
+static ReactiveUI.Testing.IBuilderExtensions.With<TBuilder, TField>(this TBuilder builder, ref System.Collections.Generic.List<TField>? field, TField value) -> TBuilder
+static ReactiveUI.Testing.IBuilderExtensions.With<TBuilder, TKey, TField>(this TBuilder builder, ref System.Collections.Generic.Dictionary<TKey, TField>! dictionary, System.Collections.Generic.IDictionary<TKey, TField>! keyValuePair) -> TBuilder
+static ReactiveUI.Testing.IBuilderExtensions.With<TBuilder, TKey, TField>(this TBuilder builder, ref System.Collections.Generic.Dictionary<TKey, TField>! dictionary, System.Collections.Generic.KeyValuePair<TKey, TField> keyValuePair) -> TBuilder
+static ReactiveUI.Testing.IBuilderExtensions.With<TBuilder, TKey, TField>(this TBuilder builder, ref System.Collections.Generic.Dictionary<TKey, TField>! dictionary, TKey key, TField value) -> TBuilder
+static ReactiveUI.Testing.MessageBusExtensions.With(this ReactiveUI.Reactive.IMessageBus! messageBus, System.Action! block) -> void
+static ReactiveUI.Testing.MessageBusExtensions.With<TRet>(this ReactiveUI.Reactive.IMessageBus! messageBus, System.Func<TRet>! block) -> TRet
+static ReactiveUI.Testing.MessageBusExtensions.WithMessageBus(this ReactiveUI.Reactive.IMessageBus! messageBus) -> System.IDisposable!
+static ReactiveUI.Testing.RxTest.AppBuilderTestAsync(System.Func<System.Threading.Tasks.Task!>! testBody) -> System.Threading.Tasks.Task!
+static ReactiveUI.Testing.RxTest.AppBuilderTestAsync(System.Func<System.Threading.Tasks.Task!>! testBody, int maxWaitMs) -> System.Threading.Tasks.Task!
+static ReactiveUI.Testing.SchedulerExtensions.With<T, TRet>(this T scheduler, System.Func<T, TRet>! block) -> TRet
+static ReactiveUI.Testing.SchedulerExtensions.With<T>(this T scheduler, System.Action<T>! block) -> void
+static ReactiveUI.Testing.SchedulerExtensions.WithAsync<T, TRet>(this T scheduler, System.Func<T, System.Threading.Tasks.Task<TRet>!>! block) -> System.Threading.Tasks.Task<TRet>!
+static ReactiveUI.Testing.SchedulerExtensions.WithAsync<T>(this T scheduler, System.Func<T, System.Threading.Tasks.Task!>! block) -> System.Threading.Tasks.Task!
+static ReactiveUI.Testing.SchedulerExtensions.WithScheduler(System.Reactive.Concurrency.IScheduler! scheduler) -> System.IDisposable!
+static ReactiveUI.Testing.TestSchedulerExtensions.AdvanceByMs(this Microsoft.Reactive.Testing.TestScheduler! scheduler, double milliseconds) -> void
+static ReactiveUI.Testing.TestSchedulerExtensions.AdvanceToMs(this Microsoft.Reactive.Testing.TestScheduler! scheduler, double milliseconds) -> void
+static ReactiveUI.Testing.TestSchedulerExtensions.FromTimeSpan(System.TimeSpan span) -> long
+static ReactiveUI.Testing.TestSchedulerExtensions.OnCompletedAt<T>(double milliseconds) -> Microsoft.Reactive.Testing.Recorded<System.Reactive.Notification<T>!>
+static ReactiveUI.Testing.TestSchedulerExtensions.OnErrorAt<T>(double milliseconds, System.Exception! ex) -> Microsoft.Reactive.Testing.Recorded<System.Reactive.Notification<T>!>
+static ReactiveUI.Testing.TestSchedulerExtensions.OnNextAt<T>(double milliseconds, T value) -> Microsoft.Reactive.Testing.Recorded<System.Reactive.Notification<T>!>
+static ReactiveUI.Testing.TestSchedulerExtensions.extension(Microsoft.Reactive.Testing.TestScheduler!).FromTimeSpan(System.TimeSpan span) -> long
+static ReactiveUI.Testing.TestSchedulerExtensions.extension(Microsoft.Reactive.Testing.TestScheduler!).OnCompletedAt<T>(double milliseconds) -> Microsoft.Reactive.Testing.Recorded<System.Reactive.Notification<T>!>
+static ReactiveUI.Testing.TestSchedulerExtensions.extension(Microsoft.Reactive.Testing.TestScheduler!).OnErrorAt<T>(double milliseconds, System.Exception! ex) -> Microsoft.Reactive.Testing.Recorded<System.Reactive.Notification<T>!>
+static ReactiveUI.Testing.TestSchedulerExtensions.extension(Microsoft.Reactive.Testing.TestScheduler!).OnNextAt<T>(double milliseconds, T value) -> Microsoft.Reactive.Testing.Recorded<System.Reactive.Notification<T>!>
+virtual ReactiveUI.Testing.TestSequencer.Dispose(bool disposing) -> void

--- a/src/ReactiveUI.Testing.Reactive/PublicAPI/net481/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Testing.Reactive/PublicAPI/net481/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/ReactiveUI.Testing.Reactive/ReactiveUI.Testing.Reactive.csproj
+++ b/src/ReactiveUI.Testing.Reactive/ReactiveUI.Testing.Reactive.csproj
@@ -4,7 +4,7 @@
          ReactiveUI.Reactive engine (RxSchedulers/MessageBus resolve to ReactiveUI.Reactive.* via the seam
          global usings in Directory.Build.props) and adds the Microsoft.Reactive.Testing TestScheduler helpers.
          The ReactiveUI.Testing namespace itself does not flip; nesting + global usings line up the engine types. -->
-    <TargetFrameworks>$(ReactiveUIModernTargets)</TargetFrameworks>
+    <TargetFrameworks>$(ReactiveUIModernTargets);$(ReactiveUIFrameworkTargets)</TargetFrameworks>
     <AssemblyName>ReactiveUI.Testing.Reactive</AssemblyName>
     <RootNamespace>ReactiveUI.Testing</RootNamespace>
     <IsTestProject>false</IsTestProject>

--- a/src/ReactiveUI.Testing/PublicAPI/net462/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Testing/PublicAPI/net462/PublicAPI.Shipped.txt
@@ -1,0 +1,50 @@
+#nullable enable
+ReactiveUI.Testing.AppBuilderTestBase
+ReactiveUI.Testing.AppBuilderTestBase.AppBuilderTestBase() -> void
+ReactiveUI.Testing.IBuilder
+ReactiveUI.Testing.IBuilderExtensions
+ReactiveUI.Testing.IBuilderExtensions.extension<TBuilder>(TBuilder)
+ReactiveUI.Testing.IBuilderExtensions.extension<TBuilder>(TBuilder).With<TField>(out TField field, TField value) -> TBuilder
+ReactiveUI.Testing.IBuilderExtensions.extension<TBuilder>(TBuilder).With<TField>(ref System.Collections.Generic.List<TField>? field, System.Collections.Generic.IEnumerable<TField>! values) -> TBuilder
+ReactiveUI.Testing.IBuilderExtensions.extension<TBuilder>(TBuilder).With<TField>(ref System.Collections.Generic.List<TField>? field, TField value) -> TBuilder
+ReactiveUI.Testing.IBuilderExtensions.extension<TBuilder>(TBuilder).With<TKey, TField>(ref System.Collections.Generic.Dictionary<TKey, TField>! dictionary, System.Collections.Generic.IDictionary<TKey, TField>! keyValuePair) -> TBuilder
+ReactiveUI.Testing.IBuilderExtensions.extension<TBuilder>(TBuilder).With<TKey, TField>(ref System.Collections.Generic.Dictionary<TKey, TField>! dictionary, System.Collections.Generic.KeyValuePair<TKey, TField> keyValuePair) -> TBuilder
+ReactiveUI.Testing.IBuilderExtensions.extension<TBuilder>(TBuilder).With<TKey, TField>(ref System.Collections.Generic.Dictionary<TKey, TField>! dictionary, TKey key, TField value) -> TBuilder
+ReactiveUI.Testing.MessageBusExtensions
+ReactiveUI.Testing.MessageBusExtensions.extension(ReactiveUI.IMessageBus!)
+ReactiveUI.Testing.MessageBusExtensions.extension(ReactiveUI.IMessageBus!).With(System.Action! block) -> void
+ReactiveUI.Testing.MessageBusExtensions.extension(ReactiveUI.IMessageBus!).With<TRet>(System.Func<TRet>! block) -> TRet
+ReactiveUI.Testing.MessageBusExtensions.extension(ReactiveUI.IMessageBus!).WithMessageBus() -> System.IDisposable!
+ReactiveUI.Testing.RxTest
+ReactiveUI.Testing.SchedulerExtensions
+ReactiveUI.Testing.SchedulerExtensions.extension<T>(T)
+ReactiveUI.Testing.SchedulerExtensions.extension<T>(T).With(System.Action<T>! block) -> void
+ReactiveUI.Testing.SchedulerExtensions.extension<T>(T).With<TRet>(System.Func<T, TRet>! block) -> TRet
+ReactiveUI.Testing.SchedulerExtensions.extension<T>(T).WithAsync(System.Func<T, System.Threading.Tasks.Task!>! block) -> System.Threading.Tasks.Task!
+ReactiveUI.Testing.SchedulerExtensions.extension<T>(T).WithAsync<TRet>(System.Func<T, System.Threading.Tasks.Task<TRet>!>! block) -> System.Threading.Tasks.Task<TRet>!
+ReactiveUI.Testing.TestSequencer
+ReactiveUI.Testing.TestSequencer.AdvancePhaseAsync() -> System.Threading.Tasks.Task!
+ReactiveUI.Testing.TestSequencer.AdvancePhaseAsync(string! comment) -> System.Threading.Tasks.Task!
+ReactiveUI.Testing.TestSequencer.CompletedPhases.get -> long
+ReactiveUI.Testing.TestSequencer.CurrentPhase.get -> long
+ReactiveUI.Testing.TestSequencer.Dispose() -> void
+ReactiveUI.Testing.TestSequencer.TestSequencer() -> void
+static ReactiveUI.Testing.AppBuilderTestBase.RunAppBuilderTestAsync(System.Action! testBody) -> System.Threading.Tasks.Task!
+static ReactiveUI.Testing.AppBuilderTestBase.RunAppBuilderTestAsync(System.Func<System.Threading.Tasks.Task!>! testBody) -> System.Threading.Tasks.Task!
+static ReactiveUI.Testing.IBuilderExtensions.With<TBuilder, TField>(this TBuilder builder, out TField field, TField value) -> TBuilder
+static ReactiveUI.Testing.IBuilderExtensions.With<TBuilder, TField>(this TBuilder builder, ref System.Collections.Generic.List<TField>? field, System.Collections.Generic.IEnumerable<TField>! values) -> TBuilder
+static ReactiveUI.Testing.IBuilderExtensions.With<TBuilder, TField>(this TBuilder builder, ref System.Collections.Generic.List<TField>? field, TField value) -> TBuilder
+static ReactiveUI.Testing.IBuilderExtensions.With<TBuilder, TKey, TField>(this TBuilder builder, ref System.Collections.Generic.Dictionary<TKey, TField>! dictionary, System.Collections.Generic.IDictionary<TKey, TField>! keyValuePair) -> TBuilder
+static ReactiveUI.Testing.IBuilderExtensions.With<TBuilder, TKey, TField>(this TBuilder builder, ref System.Collections.Generic.Dictionary<TKey, TField>! dictionary, System.Collections.Generic.KeyValuePair<TKey, TField> keyValuePair) -> TBuilder
+static ReactiveUI.Testing.IBuilderExtensions.With<TBuilder, TKey, TField>(this TBuilder builder, ref System.Collections.Generic.Dictionary<TKey, TField>! dictionary, TKey key, TField value) -> TBuilder
+static ReactiveUI.Testing.MessageBusExtensions.With(this ReactiveUI.IMessageBus! messageBus, System.Action! block) -> void
+static ReactiveUI.Testing.MessageBusExtensions.With<TRet>(this ReactiveUI.IMessageBus! messageBus, System.Func<TRet>! block) -> TRet
+static ReactiveUI.Testing.MessageBusExtensions.WithMessageBus(this ReactiveUI.IMessageBus! messageBus) -> System.IDisposable!
+static ReactiveUI.Testing.RxTest.AppBuilderTestAsync(System.Func<System.Threading.Tasks.Task!>! testBody) -> System.Threading.Tasks.Task!
+static ReactiveUI.Testing.RxTest.AppBuilderTestAsync(System.Func<System.Threading.Tasks.Task!>! testBody, int maxWaitMs) -> System.Threading.Tasks.Task!
+static ReactiveUI.Testing.SchedulerExtensions.With<T, TRet>(this T scheduler, System.Func<T, TRet>! block) -> TRet
+static ReactiveUI.Testing.SchedulerExtensions.With<T>(this T scheduler, System.Action<T>! block) -> void
+static ReactiveUI.Testing.SchedulerExtensions.WithAsync<T, TRet>(this T scheduler, System.Func<T, System.Threading.Tasks.Task<TRet>!>! block) -> System.Threading.Tasks.Task<TRet>!
+static ReactiveUI.Testing.SchedulerExtensions.WithAsync<T>(this T scheduler, System.Func<T, System.Threading.Tasks.Task!>! block) -> System.Threading.Tasks.Task!
+static ReactiveUI.Testing.SchedulerExtensions.WithScheduler(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> System.IDisposable!
+virtual ReactiveUI.Testing.TestSequencer.Dispose(bool disposing) -> void

--- a/src/ReactiveUI.Testing/PublicAPI/net462/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Testing/PublicAPI/net462/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/ReactiveUI.Testing/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Testing/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -1,0 +1,50 @@
+#nullable enable
+ReactiveUI.Testing.AppBuilderTestBase
+ReactiveUI.Testing.AppBuilderTestBase.AppBuilderTestBase() -> void
+ReactiveUI.Testing.IBuilder
+ReactiveUI.Testing.IBuilderExtensions
+ReactiveUI.Testing.IBuilderExtensions.extension<TBuilder>(TBuilder)
+ReactiveUI.Testing.IBuilderExtensions.extension<TBuilder>(TBuilder).With<TField>(out TField field, TField value) -> TBuilder
+ReactiveUI.Testing.IBuilderExtensions.extension<TBuilder>(TBuilder).With<TField>(ref System.Collections.Generic.List<TField>? field, System.Collections.Generic.IEnumerable<TField>! values) -> TBuilder
+ReactiveUI.Testing.IBuilderExtensions.extension<TBuilder>(TBuilder).With<TField>(ref System.Collections.Generic.List<TField>? field, TField value) -> TBuilder
+ReactiveUI.Testing.IBuilderExtensions.extension<TBuilder>(TBuilder).With<TKey, TField>(ref System.Collections.Generic.Dictionary<TKey, TField>! dictionary, System.Collections.Generic.IDictionary<TKey, TField>! keyValuePair) -> TBuilder
+ReactiveUI.Testing.IBuilderExtensions.extension<TBuilder>(TBuilder).With<TKey, TField>(ref System.Collections.Generic.Dictionary<TKey, TField>! dictionary, System.Collections.Generic.KeyValuePair<TKey, TField> keyValuePair) -> TBuilder
+ReactiveUI.Testing.IBuilderExtensions.extension<TBuilder>(TBuilder).With<TKey, TField>(ref System.Collections.Generic.Dictionary<TKey, TField>! dictionary, TKey key, TField value) -> TBuilder
+ReactiveUI.Testing.MessageBusExtensions
+ReactiveUI.Testing.MessageBusExtensions.extension(ReactiveUI.IMessageBus!)
+ReactiveUI.Testing.MessageBusExtensions.extension(ReactiveUI.IMessageBus!).With(System.Action! block) -> void
+ReactiveUI.Testing.MessageBusExtensions.extension(ReactiveUI.IMessageBus!).With<TRet>(System.Func<TRet>! block) -> TRet
+ReactiveUI.Testing.MessageBusExtensions.extension(ReactiveUI.IMessageBus!).WithMessageBus() -> System.IDisposable!
+ReactiveUI.Testing.RxTest
+ReactiveUI.Testing.SchedulerExtensions
+ReactiveUI.Testing.SchedulerExtensions.extension<T>(T)
+ReactiveUI.Testing.SchedulerExtensions.extension<T>(T).With(System.Action<T>! block) -> void
+ReactiveUI.Testing.SchedulerExtensions.extension<T>(T).With<TRet>(System.Func<T, TRet>! block) -> TRet
+ReactiveUI.Testing.SchedulerExtensions.extension<T>(T).WithAsync(System.Func<T, System.Threading.Tasks.Task!>! block) -> System.Threading.Tasks.Task!
+ReactiveUI.Testing.SchedulerExtensions.extension<T>(T).WithAsync<TRet>(System.Func<T, System.Threading.Tasks.Task<TRet>!>! block) -> System.Threading.Tasks.Task<TRet>!
+ReactiveUI.Testing.TestSequencer
+ReactiveUI.Testing.TestSequencer.AdvancePhaseAsync() -> System.Threading.Tasks.Task!
+ReactiveUI.Testing.TestSequencer.AdvancePhaseAsync(string! comment) -> System.Threading.Tasks.Task!
+ReactiveUI.Testing.TestSequencer.CompletedPhases.get -> long
+ReactiveUI.Testing.TestSequencer.CurrentPhase.get -> long
+ReactiveUI.Testing.TestSequencer.Dispose() -> void
+ReactiveUI.Testing.TestSequencer.TestSequencer() -> void
+static ReactiveUI.Testing.AppBuilderTestBase.RunAppBuilderTestAsync(System.Action! testBody) -> System.Threading.Tasks.Task!
+static ReactiveUI.Testing.AppBuilderTestBase.RunAppBuilderTestAsync(System.Func<System.Threading.Tasks.Task!>! testBody) -> System.Threading.Tasks.Task!
+static ReactiveUI.Testing.IBuilderExtensions.With<TBuilder, TField>(this TBuilder builder, out TField field, TField value) -> TBuilder
+static ReactiveUI.Testing.IBuilderExtensions.With<TBuilder, TField>(this TBuilder builder, ref System.Collections.Generic.List<TField>? field, System.Collections.Generic.IEnumerable<TField>! values) -> TBuilder
+static ReactiveUI.Testing.IBuilderExtensions.With<TBuilder, TField>(this TBuilder builder, ref System.Collections.Generic.List<TField>? field, TField value) -> TBuilder
+static ReactiveUI.Testing.IBuilderExtensions.With<TBuilder, TKey, TField>(this TBuilder builder, ref System.Collections.Generic.Dictionary<TKey, TField>! dictionary, System.Collections.Generic.IDictionary<TKey, TField>! keyValuePair) -> TBuilder
+static ReactiveUI.Testing.IBuilderExtensions.With<TBuilder, TKey, TField>(this TBuilder builder, ref System.Collections.Generic.Dictionary<TKey, TField>! dictionary, System.Collections.Generic.KeyValuePair<TKey, TField> keyValuePair) -> TBuilder
+static ReactiveUI.Testing.IBuilderExtensions.With<TBuilder, TKey, TField>(this TBuilder builder, ref System.Collections.Generic.Dictionary<TKey, TField>! dictionary, TKey key, TField value) -> TBuilder
+static ReactiveUI.Testing.MessageBusExtensions.With(this ReactiveUI.IMessageBus! messageBus, System.Action! block) -> void
+static ReactiveUI.Testing.MessageBusExtensions.With<TRet>(this ReactiveUI.IMessageBus! messageBus, System.Func<TRet>! block) -> TRet
+static ReactiveUI.Testing.MessageBusExtensions.WithMessageBus(this ReactiveUI.IMessageBus! messageBus) -> System.IDisposable!
+static ReactiveUI.Testing.RxTest.AppBuilderTestAsync(System.Func<System.Threading.Tasks.Task!>! testBody) -> System.Threading.Tasks.Task!
+static ReactiveUI.Testing.RxTest.AppBuilderTestAsync(System.Func<System.Threading.Tasks.Task!>! testBody, int maxWaitMs) -> System.Threading.Tasks.Task!
+static ReactiveUI.Testing.SchedulerExtensions.With<T, TRet>(this T scheduler, System.Func<T, TRet>! block) -> TRet
+static ReactiveUI.Testing.SchedulerExtensions.With<T>(this T scheduler, System.Action<T>! block) -> void
+static ReactiveUI.Testing.SchedulerExtensions.WithAsync<T, TRet>(this T scheduler, System.Func<T, System.Threading.Tasks.Task<TRet>!>! block) -> System.Threading.Tasks.Task<TRet>!
+static ReactiveUI.Testing.SchedulerExtensions.WithAsync<T>(this T scheduler, System.Func<T, System.Threading.Tasks.Task!>! block) -> System.Threading.Tasks.Task!
+static ReactiveUI.Testing.SchedulerExtensions.WithScheduler(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> System.IDisposable!
+virtual ReactiveUI.Testing.TestSequencer.Dispose(bool disposing) -> void

--- a/src/ReactiveUI.Testing/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Testing/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/ReactiveUI.Testing/PublicAPI/net481/PublicAPI.Shipped.txt
+++ b/src/ReactiveUI.Testing/PublicAPI/net481/PublicAPI.Shipped.txt
@@ -1,0 +1,50 @@
+#nullable enable
+ReactiveUI.Testing.AppBuilderTestBase
+ReactiveUI.Testing.AppBuilderTestBase.AppBuilderTestBase() -> void
+ReactiveUI.Testing.IBuilder
+ReactiveUI.Testing.IBuilderExtensions
+ReactiveUI.Testing.IBuilderExtensions.extension<TBuilder>(TBuilder)
+ReactiveUI.Testing.IBuilderExtensions.extension<TBuilder>(TBuilder).With<TField>(out TField field, TField value) -> TBuilder
+ReactiveUI.Testing.IBuilderExtensions.extension<TBuilder>(TBuilder).With<TField>(ref System.Collections.Generic.List<TField>? field, System.Collections.Generic.IEnumerable<TField>! values) -> TBuilder
+ReactiveUI.Testing.IBuilderExtensions.extension<TBuilder>(TBuilder).With<TField>(ref System.Collections.Generic.List<TField>? field, TField value) -> TBuilder
+ReactiveUI.Testing.IBuilderExtensions.extension<TBuilder>(TBuilder).With<TKey, TField>(ref System.Collections.Generic.Dictionary<TKey, TField>! dictionary, System.Collections.Generic.IDictionary<TKey, TField>! keyValuePair) -> TBuilder
+ReactiveUI.Testing.IBuilderExtensions.extension<TBuilder>(TBuilder).With<TKey, TField>(ref System.Collections.Generic.Dictionary<TKey, TField>! dictionary, System.Collections.Generic.KeyValuePair<TKey, TField> keyValuePair) -> TBuilder
+ReactiveUI.Testing.IBuilderExtensions.extension<TBuilder>(TBuilder).With<TKey, TField>(ref System.Collections.Generic.Dictionary<TKey, TField>! dictionary, TKey key, TField value) -> TBuilder
+ReactiveUI.Testing.MessageBusExtensions
+ReactiveUI.Testing.MessageBusExtensions.extension(ReactiveUI.IMessageBus!)
+ReactiveUI.Testing.MessageBusExtensions.extension(ReactiveUI.IMessageBus!).With(System.Action! block) -> void
+ReactiveUI.Testing.MessageBusExtensions.extension(ReactiveUI.IMessageBus!).With<TRet>(System.Func<TRet>! block) -> TRet
+ReactiveUI.Testing.MessageBusExtensions.extension(ReactiveUI.IMessageBus!).WithMessageBus() -> System.IDisposable!
+ReactiveUI.Testing.RxTest
+ReactiveUI.Testing.SchedulerExtensions
+ReactiveUI.Testing.SchedulerExtensions.extension<T>(T)
+ReactiveUI.Testing.SchedulerExtensions.extension<T>(T).With(System.Action<T>! block) -> void
+ReactiveUI.Testing.SchedulerExtensions.extension<T>(T).With<TRet>(System.Func<T, TRet>! block) -> TRet
+ReactiveUI.Testing.SchedulerExtensions.extension<T>(T).WithAsync(System.Func<T, System.Threading.Tasks.Task!>! block) -> System.Threading.Tasks.Task!
+ReactiveUI.Testing.SchedulerExtensions.extension<T>(T).WithAsync<TRet>(System.Func<T, System.Threading.Tasks.Task<TRet>!>! block) -> System.Threading.Tasks.Task<TRet>!
+ReactiveUI.Testing.TestSequencer
+ReactiveUI.Testing.TestSequencer.AdvancePhaseAsync() -> System.Threading.Tasks.Task!
+ReactiveUI.Testing.TestSequencer.AdvancePhaseAsync(string! comment) -> System.Threading.Tasks.Task!
+ReactiveUI.Testing.TestSequencer.CompletedPhases.get -> long
+ReactiveUI.Testing.TestSequencer.CurrentPhase.get -> long
+ReactiveUI.Testing.TestSequencer.Dispose() -> void
+ReactiveUI.Testing.TestSequencer.TestSequencer() -> void
+static ReactiveUI.Testing.AppBuilderTestBase.RunAppBuilderTestAsync(System.Action! testBody) -> System.Threading.Tasks.Task!
+static ReactiveUI.Testing.AppBuilderTestBase.RunAppBuilderTestAsync(System.Func<System.Threading.Tasks.Task!>! testBody) -> System.Threading.Tasks.Task!
+static ReactiveUI.Testing.IBuilderExtensions.With<TBuilder, TField>(this TBuilder builder, out TField field, TField value) -> TBuilder
+static ReactiveUI.Testing.IBuilderExtensions.With<TBuilder, TField>(this TBuilder builder, ref System.Collections.Generic.List<TField>? field, System.Collections.Generic.IEnumerable<TField>! values) -> TBuilder
+static ReactiveUI.Testing.IBuilderExtensions.With<TBuilder, TField>(this TBuilder builder, ref System.Collections.Generic.List<TField>? field, TField value) -> TBuilder
+static ReactiveUI.Testing.IBuilderExtensions.With<TBuilder, TKey, TField>(this TBuilder builder, ref System.Collections.Generic.Dictionary<TKey, TField>! dictionary, System.Collections.Generic.IDictionary<TKey, TField>! keyValuePair) -> TBuilder
+static ReactiveUI.Testing.IBuilderExtensions.With<TBuilder, TKey, TField>(this TBuilder builder, ref System.Collections.Generic.Dictionary<TKey, TField>! dictionary, System.Collections.Generic.KeyValuePair<TKey, TField> keyValuePair) -> TBuilder
+static ReactiveUI.Testing.IBuilderExtensions.With<TBuilder, TKey, TField>(this TBuilder builder, ref System.Collections.Generic.Dictionary<TKey, TField>! dictionary, TKey key, TField value) -> TBuilder
+static ReactiveUI.Testing.MessageBusExtensions.With(this ReactiveUI.IMessageBus! messageBus, System.Action! block) -> void
+static ReactiveUI.Testing.MessageBusExtensions.With<TRet>(this ReactiveUI.IMessageBus! messageBus, System.Func<TRet>! block) -> TRet
+static ReactiveUI.Testing.MessageBusExtensions.WithMessageBus(this ReactiveUI.IMessageBus! messageBus) -> System.IDisposable!
+static ReactiveUI.Testing.RxTest.AppBuilderTestAsync(System.Func<System.Threading.Tasks.Task!>! testBody) -> System.Threading.Tasks.Task!
+static ReactiveUI.Testing.RxTest.AppBuilderTestAsync(System.Func<System.Threading.Tasks.Task!>! testBody, int maxWaitMs) -> System.Threading.Tasks.Task!
+static ReactiveUI.Testing.SchedulerExtensions.With<T, TRet>(this T scheduler, System.Func<T, TRet>! block) -> TRet
+static ReactiveUI.Testing.SchedulerExtensions.With<T>(this T scheduler, System.Action<T>! block) -> void
+static ReactiveUI.Testing.SchedulerExtensions.WithAsync<T, TRet>(this T scheduler, System.Func<T, System.Threading.Tasks.Task<TRet>!>! block) -> System.Threading.Tasks.Task<TRet>!
+static ReactiveUI.Testing.SchedulerExtensions.WithAsync<T>(this T scheduler, System.Func<T, System.Threading.Tasks.Task!>! block) -> System.Threading.Tasks.Task!
+static ReactiveUI.Testing.SchedulerExtensions.WithScheduler(ReactiveUI.Primitives.Concurrency.ISequencer! scheduler) -> System.IDisposable!
+virtual ReactiveUI.Testing.TestSequencer.Dispose(bool disposing) -> void

--- a/src/ReactiveUI.Testing/PublicAPI/net481/PublicAPI.Unshipped.txt
+++ b/src/ReactiveUI.Testing/PublicAPI/net481/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/ReactiveUI.Testing/ReactiveUI.Testing.csproj
+++ b/src/ReactiveUI.Testing/ReactiveUI.Testing.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(ReactiveUIModernTargets)</TargetFrameworks>
+    <!-- Matches the .NET Framework reach of the ReactiveUI package this one is used to test. -->
+    <TargetFrameworks>$(ReactiveUIModernTargets);$(ReactiveUIFrameworkTargets)</TargetFrameworks>
     <AssemblyName>ReactiveUI.Testing</AssemblyName>
     <RootNamespace>ReactiveUI.Testing</RootNamespace>
     <IsTestProject>false</IsTestProject>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix.

## What is the new behavior?

`ReactiveUI.Testing` and `ReactiveUI.Testing.Reactive` ship `net462`, `net472` and `net481` again, alongside the modern `net8.0` - `net11.0` targets. Verified by packing both projects and listing the package contents:

```
ReactiveUI.Testing.nupkg           ReactiveUI.Testing.Reactive.nupkg
  lib/net462                         lib/net462
  lib/net472                         lib/net472
  lib/net481                         lib/net481
  lib/net8.0 net9.0 net10.0 net11.0  lib/net8.0 net9.0 net10.0 net11.0
```

The .NET Framework public surface is byte-identical to the `net8.0` baseline, so nothing is reduced on the older frameworks.

## What is the current behavior?

Closes #4420

Since v23 both packages set `<TargetFrameworks>$(ReactiveUIModernTargets)</TargetFrameworks>`, which is `net8.0;net9.0;net10.0;net11.0`. The `ReactiveUI` package they exist to test targets `$(ReactiveUIFinalTargetFrameworks)`, which does include `$(ReactiveUIFrameworkTargets)` (`net462;net472;net481`). So a project on .NET Framework could reference ReactiveUI but not its testing helpers.

Note for anyone reading the issue: it points at `ReactiveUITestingTargets` in `Directory.Build.props`. That property is a red herring here - it is consumed only by test projects under `src/tests`, never by the shipped packages. The actual driver was `ReactiveUIModernTargets` in the two csproj files.

## What might this PR break?

- No source changed, and no public API changed on any existing target framework. The four modern TFM baselines regenerate byte-identically.
- The two packages now build three additional target frameworks each, so pack and CI time grow slightly.
- `ReactiveUI.Testing.Reactive` pulls `Microsoft.Reactive.Testing` on the new frameworks; it resolves and compiles clean on all three.

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [x] Tests have been added or updated (for bug fixes / features)
- [x] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information

The PublicAPI baselines for the six new (project, TFM) pairs were produced with the repo's own `tools/generate-publicapi.sh`, which the tooling README already names as the step for "after adding a new target framework to a tracked library". Running it over both projects regenerated all 14 pairs; the eight pre-existing ones came back unchanged, which is the check that the generator is deterministic here and that no existing surface moved.

Verified on Linux:

- `dotnet build reactiveui.slnx -c Release -t:Rebuild` - 0 warnings, 0 errors.
- Both testing projects rebuild clean across all seven target frameworks.
- 4216 tests pass across ReactiveUI.Tests, ReactiveUI.Tests.Reactive, ReactiveUI.Testing.Tests and ReactiveUI.Builder.Tests.
