### PR TITLE
build: update PublicApiSharp.Analyzers to 1.0.7

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -91,7 +91,7 @@
     <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.31.0.145097"/>
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.6.0"/>
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.6.0"/>
-    <PackageVersion Include="PublicApiSharp.Analyzers" Version="1.0.5"/>
+    <PackageVersion Include="PublicApiSharp.Analyzers" Version="1.0.7"/>
   </ItemGroup>
 
   <ItemGroup Label="Build / SourceLink / Versioning">


### PR DESCRIPTION
## What kind of change does this PR introduce?

Build.

## What is the new behavior?

`PublicApiSharp.Analyzers` moves to 1.0.7.

- 1.0.7 fixes the enum-member comparison, so a public enum whose baseline is already correct no longer reports PAS0003.
- No baseline is regenerated. A full `dotnet build reactiveui.slnx -c Release -t:Rebuild` produces no PAS diagnostics of any ID, so all 232 baselines still match byte-for-byte.

## What is the current behavior?

`PublicApiSharp.Analyzers` 1.0.5, as introduced by #4428. This PR targets that branch, because `main` has no reference to the package at all.

1.0.6 was tried first and is unusable here: it renders enum members with their trailing separator but parses the baseline without it, so every public enum member fails.

```
error PAS0003: 'Refresh = 4,' differs from the baseline;
  baseline declares 'Refresh = 4' but the API is 'Refresh = 4,'
```

That was 10 members across the three public enums in `ReactiveUI.Core`, over 26 target frameworks - 130 errors - and no baseline could satisfy it. `dotnet format analyzers` wrote zero changes (the fixer agreed the file was already correct), and hand-editing the baseline to the comma-less form the message asks for made it unparseable with `PAS0005: Syntax error, ',' expected`.

## What might this PR break?

- None. No product code and no public API changed, and no baseline file changed.

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [ ] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features)
- [ ] Changes target the `main` branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information

Verified on Linux, so the Apple target framework baselines were not exercised; everything Linux can compile, including the Windows target frameworks via `EnableWindowsTargeting`, is green. The full solution rebuild reports 0 errors. The only warnings come from `examples/ReactiveUI.Samples.Maui` - un-IDed JNI registration notices emitted by `Xamarin.Android.Common.targets` - and are unrelated to this change.
