### PR TITLE
fix(blazor): migrate to ReactiveUI.Primitives.Blazor

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -5,12 +5,12 @@
   </PropertyGroup>
 
   <PropertyGroup Label="Shared Version Variables">
-    <SplatVersion>20.2.0</SplatVersion>
-    <PrimitivesVersion>7.1.1</PrimitivesVersion>
+    <SplatVersion>21.0.0</SplatVersion>
+    <PrimitivesVersion>7.2.0</PrimitivesVersion>
     <TUnitVersion>1.63.0</TUnitVersion>
     <!-- StyleSharp.Analyzers, PerformanceSharp.Analyzers and SecuritySharp.Analyzers ship from the
          same release pipeline and always share a version. -->
-    <RoslynCommonAnalyzersVersion>3.43.2</RoslynCommonAnalyzersVersion>
+    <RoslynCommonAnalyzersVersion>3.45.0</RoslynCommonAnalyzersVersion>
     <XamarinAndroidXLifecycleLiveDataVersion>2.11.0.1</XamarinAndroidXLifecycleLiveDataVersion>
   </PropertyGroup>
 
@@ -19,17 +19,17 @@
     <MauiVersion Condition="$(TargetFramework.StartsWith('net11'))">11.0.0-preview.7.26406.9</MauiVersion>
 
     <AspNetVersion Condition="$(TargetFramework.StartsWith('netstandard'))">3.1.32</AspNetVersion>
-    <AspNetVersion Condition="$(TargetFramework.StartsWith('net8'))">8.0.29</AspNetVersion>
-    <AspNetVersion Condition="$(TargetFramework.StartsWith('net9'))">9.0.18</AspNetVersion>
-    <AspNetVersion Condition="$(TargetFramework.StartsWith('net10'))">10.0.10</AspNetVersion>
+    <AspNetVersion Condition="$(TargetFramework.StartsWith('net8'))">8.0.30</AspNetVersion>
+    <AspNetVersion Condition="$(TargetFramework.StartsWith('net9'))">9.0.19</AspNetVersion>
+    <AspNetVersion Condition="$(TargetFramework.StartsWith('net10'))">10.0.11</AspNetVersion>
     <AspNetVersion Condition="$(TargetFramework.StartsWith('net11'))">11.0.0-preview.7.26381.103</AspNetVersion>
 
-    <SystemTextJsonVersion>10.0.10</SystemTextJsonVersion>
+    <SystemTextJsonVersion>10.0.11</SystemTextJsonVersion>
     <SystemTextJsonVersion Condition="$(TargetFramework.StartsWith('net11'))">11.0.0-preview.7.26381.103</SystemTextJsonVersion>
 
     <!-- Microsoft.Extensions.* and the runtime data packages track the framework: stable 10.0.x for
          net8/9/10, the net11 preview on net11 so the net11 ReactiveUI.Primitives assemblies resolve. -->
-    <MicrosoftExtensionsVersion>10.0.10</MicrosoftExtensionsVersion>
+    <MicrosoftExtensionsVersion>10.0.11</MicrosoftExtensionsVersion>
     <MicrosoftExtensionsVersion Condition="$(TargetFramework.StartsWith('net11'))">11.0.0-preview.7.26381.103</MicrosoftExtensionsVersion>
 
     <XamlBehaviorsWpfVersion Condition="$(TargetFramework.StartsWith('net4'))">1.1.142</XamlBehaviorsWpfVersion>
@@ -58,7 +58,6 @@
 
   <ItemGroup Label="Rx Ecosystem">
     <PackageVersion Include="DynamicData" Version="9.4.33"/>
-    <PackageVersion Include="Reactive.Wasm" Version="3.0.1"/>
     <PackageVersion Include="Splat" Version="$(SplatVersion)"/>
     <PackageVersion Include="Splat.Autofac" Version="$(SplatVersion)"/>
     <PackageVersion Include="Splat.Drawing" Version="$(SplatVersion)"/>
@@ -122,6 +121,8 @@
 
   <ItemGroup Label="Platform - Blazor / ASP.NET">
     <PackageVersion Include="Microsoft.AspNetCore.Components" Version="$(AspNetVersion)"/>
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.11"/>
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.11"/>
   </ItemGroup>
 
   <ItemGroup Label="Legacy Compat Shims">

--- a/src/ReactiveUI.Blazor.Reactive/ReactiveUI.Blazor.Reactive.csproj
+++ b/src/ReactiveUI.Blazor.Reactive/ReactiveUI.Blazor.Reactive.csproj
@@ -14,9 +14,10 @@
   <ItemGroup>
     <Using Include="ReactiveUI.Internal"/>
     <Using Include="ReactiveUI.Primitives.Disposables"/>
+    <Using Include="ReactiveUI.Primitives.Reactive.Concurrency"/>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Reactive.Wasm"/>
+    <PackageReference Include="ReactiveUI.Primitives.Blazor.Reactive"/>
     <PackageReference Include="Microsoft.AspNetCore.Components"/>
   </ItemGroup>
   <!-- The same ReactiveUI.Blazor source the lean package ships, recompiled here under REACTIVE_SHIM. -->

--- a/src/ReactiveUI.Blazor/Builder/BlazorReactiveUIBuilderExtensions.cs
+++ b/src/ReactiveUI.Blazor/Builder/BlazorReactiveUIBuilderExtensions.cs
@@ -14,21 +14,22 @@ namespace ReactiveUI.Builder;
 [SuppressMessage("ReSharper", "InconsistentNaming", Justification = "ReactiveUI is the name of the product.")]
 public static class BlazorReactiveUIBuilderExtensions
 {
-    /// <summary>Gets the blazor main thread scheduler.</summary>
+    /// <summary>Gets the Blazor Server scheduler.</summary>
     /// <value>
-    /// The blazor main thread scheduler.
+    /// A current-thread scheduler. Renderer-affine work remains component-scoped and is marshalled through
+    /// <c>ComponentBase.InvokeAsync</c> because Blazor Server has one renderer dispatcher per circuit.
     /// </value>
     public static ISequencer BlazorMainThreadScheduler { get; } = Sequencer.CurrentThread;
 
-    /// <summary>Gets the blazor wasm scheduler.</summary>
+    /// <summary>Gets the browser WebAssembly event-loop scheduler.</summary>
     /// <value>
-    /// The blazor wasm scheduler.
+    /// The Primitives scheduler that yields work through the WebAssembly event loop without creating threads.
     /// </value>
     public static ISequencer BlazorWasmScheduler { get; } =
 #if REACTIVE_SHIM
         WasmScheduler.Default;
 #else
-        Sequencer.CurrentThread;
+        WasmSequencer.Default;
 #endif
 
     /// <summary>Provides ReactiveUI builder extension methods for Blazor.</summary>
@@ -53,7 +54,7 @@ public static class BlazorReactiveUIBuilderExtensions
         {
             ArgumentExceptionHelper.ThrowIfNull(builder);
 
-            return builder
+            return ((IReactiveUIBuilder)builder.WithCoreServices())
                 .WithBlazorWasmScheduler()
                 .WithTaskPoolScheduler(TaskPoolSequencer.Default)
                 .WithPlatformModule<Blazor.Registrations>();

--- a/src/ReactiveUI.Blazor/ReactiveUI.Blazor.csproj
+++ b/src/ReactiveUI.Blazor/ReactiveUI.Blazor.csproj
@@ -10,7 +10,7 @@
     <Using Include="ReactiveUI.Primitives.Disposables"/>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Reactive.Wasm"/>
+    <PackageReference Include="ReactiveUI.Primitives.Blazor"/>
     <PackageReference Include="Microsoft.AspNetCore.Components"/>
   </ItemGroup>
   <ItemGroup>

--- a/src/examples/ReactiveUI.Builder.BlazorWasm/App.razor
+++ b/src/examples/ReactiveUI.Builder.BlazorWasm/App.razor
@@ -1,0 +1,6 @@
+<PageTitle>ReactiveUI Blazor WebAssembly</PageTitle>
+
+<main>
+    <h1>ReactiveUI Blazor WebAssembly</h1>
+    <SchedulerProbe />
+</main>

--- a/src/examples/ReactiveUI.Builder.BlazorWasm/Components/SchedulerProbe.razor
+++ b/src/examples/ReactiveUI.Builder.BlazorWasm/Components/SchedulerProbe.razor
@@ -1,0 +1,37 @@
+@inherits ReactiveComponentBase<SchedulerProbeViewModel>
+
+<section>
+    <p id="scheduler-status">@ViewModel?.Status</p>
+    <button id="scheduler-probe" @onclick="Schedule">Schedule through ReactiveUI</button>
+</section>
+
+@code {
+    private IDisposable? _execution;
+
+    protected override void OnInitialized()
+    {
+        ViewModel = new();
+        base.OnInitialized();
+    }
+
+    private void Schedule()
+    {
+        if (ViewModel is not { } viewModel)
+        {
+            return;
+        }
+
+        _execution?.Dispose();
+        _execution = viewModel.Run.Execute().Subscribe();
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _execution?.Dispose();
+        }
+
+        base.Dispose(disposing);
+    }
+}

--- a/src/examples/ReactiveUI.Builder.BlazorWasm/Program.cs
+++ b/src/examples/ReactiveUI.Builder.BlazorWasm/Program.cs
@@ -6,23 +6,30 @@
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using ReactiveUI.Builder;
-using ReactiveUI.Builder.BlazorWasm;
 
-var builder = WebAssemblyHostBuilder.CreateDefault(args);
-
-builder.RootComponents.Add<App>("#app");
-
-builder.RootComponents.Add<HeadOutlet>("head::after");
-
-_ = RxAppBuilder.CreateReactiveUIBuilder()
-    .WithBlazorWasm()
-    .BuildApp();
-
-await builder.Build().RunAsync();
+namespace ReactiveUI.Builder.BlazorWasm;
 
 /// <summary>The host type generated for the example's top-level statements.</summary>
-internal sealed partial class Program
+internal static class Program
 {
     /// <summary>Gets the assembly containing the WebAssembly example.</summary>
     internal static System.Reflection.Assembly HostAssembly => typeof(Program).Assembly;
+
+    /// <summary>The main entry point for the WebAssembly example.</summary>
+    /// <param name="args">The command-line arguments.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    internal static async Task Main(string[] args)
+    {
+        var builder = WebAssemblyHostBuilder.CreateDefault(args);
+
+        builder.RootComponents.Add<App>("#app");
+
+        builder.RootComponents.Add<HeadOutlet>("head::after");
+
+        _ = RxAppBuilder.CreateReactiveUIBuilder()
+            .WithBlazorWasm()
+            .BuildApp();
+
+        await builder.Build().RunAsync();
+    }
 }

--- a/src/examples/ReactiveUI.Builder.BlazorWasm/Program.cs
+++ b/src/examples/ReactiveUI.Builder.BlazorWasm/Program.cs
@@ -1,0 +1,28 @@
+// Copyright (c) 2009-2026 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+using ReactiveUI.Builder;
+using ReactiveUI.Builder.BlazorWasm;
+
+var builder = WebAssemblyHostBuilder.CreateDefault(args);
+
+builder.RootComponents.Add<App>("#app");
+
+builder.RootComponents.Add<HeadOutlet>("head::after");
+
+_ = RxAppBuilder.CreateReactiveUIBuilder()
+    .WithBlazorWasm()
+    .BuildApp();
+
+await builder.Build().RunAsync();
+
+/// <summary>The host type generated for the example's top-level statements.</summary>
+internal sealed partial class Program
+{
+    /// <summary>Gets the assembly containing the WebAssembly example.</summary>
+    internal static System.Reflection.Assembly HostAssembly => typeof(Program).Assembly;
+}

--- a/src/examples/ReactiveUI.Builder.BlazorWasm/Properties/launchSettings.json
+++ b/src/examples/ReactiveUI.Builder.BlazorWasm/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "ReactiveUI.Builder.BlazorWasm": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:57237;http://localhost:57238"
+    }
+  }
+}

--- a/src/examples/ReactiveUI.Builder.BlazorWasm/ReactiveUI.Builder.BlazorWasm.csproj
+++ b/src/examples/ReactiveUI.Builder.BlazorWasm/ReactiveUI.Builder.BlazorWasm.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <DefaultPackageDescription>Blazor WebAssembly example app for ReactiveUI Builder.</DefaultPackageDescription>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Components" VersionOverride="10.0.11"/>
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly"/>
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" PrivateAssets="all"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\ReactiveUI.Blazor\ReactiveUI.Blazor.csproj"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="ReactiveUI.Primitives"/>
+    <Using Include="ReactiveUI.Primitives.Disposables"/>
+  </ItemGroup>
+</Project>

--- a/src/examples/ReactiveUI.Builder.BlazorWasm/ViewModels/SchedulerProbeViewModel.cs
+++ b/src/examples/ReactiveUI.Builder.BlazorWasm/ViewModels/SchedulerProbeViewModel.cs
@@ -1,0 +1,49 @@
+// Copyright (c) 2009-2026 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+using ReactiveUI.Builder;
+
+namespace ReactiveUI.Builder.BlazorWasm.ViewModels;
+
+/// <summary>View model that verifies work executes through the configured browser event-loop scheduler.</summary>
+[DebuggerDisplay("{Status}")]
+public sealed class SchedulerProbeViewModel : ReactiveObject
+{
+    /// <summary>Initializes a new instance of the <see cref="SchedulerProbeViewModel"/> class.</summary>
+    public SchedulerProbeViewModel() => Run = ReactiveCommand.CreateFromTask(ScheduleAsync);
+
+    /// <summary>Gets the command that schedules a browser event-loop callback.</summary>
+    public ReactiveCommand<RxVoid, RxVoid> Run { get; }
+
+    /// <summary>Gets the current scheduler verification status.</summary>
+    public string Status
+    {
+        get;
+        private set => this.RaiseAndSetIfChanged(ref field, value);
+    } = "Ready";
+
+    /// <summary>Schedules work through ReactiveUI's configured main scheduler.</summary>
+    /// <returns>A task that completes after the event-loop callback runs.</returns>
+    private async Task ScheduleAsync()
+    {
+        var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var scheduled = RxSchedulers.MainThreadScheduler.Schedule(
+            completion,
+            static (_, source) =>
+            {
+                source.SetResult();
+                return EmptyDisposable.Instance;
+            });
+
+        await completion.Task;
+
+        Status = ReferenceEquals(
+            RxSchedulers.MainThreadScheduler,
+            BlazorReactiveUIBuilderExtensions.BlazorWasmScheduler)
+            ? "WASM scheduler executed successfully"
+            : "Unexpected scheduler configured";
+    }
+}

--- a/src/examples/ReactiveUI.Builder.BlazorWasm/_Imports.razor
+++ b/src/examples/ReactiveUI.Builder.BlazorWasm/_Imports.razor
@@ -1,0 +1,7 @@
+@using System.Net.Http
+@using Microsoft.AspNetCore.Components
+@using Microsoft.AspNetCore.Components.Web
+@using ReactiveUI.Blazor
+@using ReactiveUI.Builder.BlazorWasm
+@using ReactiveUI.Builder.BlazorWasm.Components
+@using ReactiveUI.Builder.BlazorWasm.ViewModels

--- a/src/examples/ReactiveUI.Builder.BlazorWasm/wwwroot/index.html
+++ b/src/examples/ReactiveUI.Builder.BlazorWasm/wwwroot/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <base href="/" />
+    <title>ReactiveUI Blazor WebAssembly</title>
+</head>
+<body>
+    <div id="app">Loading...</div>
+    <script src="_framework/blazor.webassembly.js"></script>
+</body>
+</html>

--- a/src/reactiveui.slnx
+++ b/src/reactiveui.slnx
@@ -11,6 +11,7 @@
     </Folder>
     <Folder Name="/Examples/">
         <Project Path="examples/ReactiveUI.Builder.BlazorServer/ReactiveUI.Builder.BlazorServer.csproj" Id="5d87db90-4f69-470e-8c4f-4e68516ee3fb" />
+        <Project Path="examples/ReactiveUI.Builder.BlazorWasm/ReactiveUI.Builder.BlazorWasm.csproj" />
         <Project Path="examples/ReactiveUI.Builder.WpfApp/ReactiveUI.Builder.WpfApp.csproj" />
         <Project Path="examples/ReactiveUI.Samples.Wpf/ReactiveUI.Samples.Wpf.csproj" />
         <Project Path="examples/ReactiveUI.Samples.Winforms/ReactiveUI.Samples.Winforms.csproj" />
@@ -35,6 +36,7 @@
     <Folder Name="/Tests/">
         <Project Path="tests/ReactiveUI.AOTTests/ReactiveUI.AOT.Tests.csproj" />
         <Project Path="tests/ReactiveUI.Blazor.Tests/ReactiveUI.Blazor.Tests.csproj" />
+        <Project Path="tests/ReactiveUI.Blazor.Tests.Reactive/ReactiveUI.Blazor.Tests.Reactive.csproj" />
         <Project Path="tests/ReactiveUI.Builder.Maui.Tests/ReactiveUI.Builder.Maui.Tests.csproj" />
         <Project Path="tests/ReactiveUI.Builder.Tests/ReactiveUI.Builder.Tests.csproj" />
         <Project Path="tests/ReactiveUI.Maui.Tests/ReactiveUI.Maui.Tests.csproj" />

--- a/src/tests/ReactiveUI.Blazor.Tests.Reactive/ReactiveUI.Blazor.Tests.Reactive.csproj
+++ b/src/tests/ReactiveUI.Blazor.Tests.Reactive/ReactiveUI.Blazor.Tests.Reactive.csproj
@@ -1,0 +1,25 @@
+<!--
+ Copyright (c) 2026 .NET Foundation and Contributors. All rights reserved.
+ Licensed to the .NET Foundation under one or more agreements.
+ The .NET Foundation licenses this file to you under the MIT license.
+ See the LICENSE file in the project root for full license information.
+-->
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>$(ReactiveUIModernTargets)</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+    <AssemblyName>ReactiveUI.Blazor.Tests.Reactive</AssemblyName>
+    <RootNamespace>ReactiveUI.Blazor.Tests</RootNamespace>
+    <IsTestProject>true</IsTestProject>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\ReactiveUI.Blazor.Reactive\ReactiveUI.Blazor.Reactive.csproj"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="ReactiveUI.Primitives.Reactive.Concurrency"/>
+    <Compile Include="..\ReactiveUI.Blazor.Tests\BlazorReactiveUIBuilderExtensionsTests.cs" Link="BlazorReactiveUIBuilderExtensionsTests.cs"/>
+  </ItemGroup>
+</Project>

--- a/src/tests/ReactiveUI.Blazor.Tests/BlazorReactiveUIBuilderExtensionsTests.cs
+++ b/src/tests/ReactiveUI.Blazor.Tests/BlazorReactiveUIBuilderExtensionsTests.cs
@@ -4,7 +4,11 @@
 // See the LICENSE file in the project root for full license information.
 
 using System.Diagnostics.CodeAnalysis;
+#if REACTIVE_SHIM
+using ReactiveUI.Reactive.Builder;
+#else
 using ReactiveUI.Builder;
+#endif
 using Splat;
 
 namespace ReactiveUI.Blazor.Tests;
@@ -14,6 +18,17 @@ public class BlazorReactiveUIBuilderExtensionsTests
 {
     /// <summary>The expected <see cref="ArgumentException.ParamName"/> for the builder argument.</summary>
     private const string BuilderParameterName = "builder";
+
+    /// <summary>The maximum time to wait for asynchronous scheduler work.</summary>
+    private const int SchedulerTimeoutSeconds = 5;
+
+    /// <summary>Gets the expected scheduler for the active lean or reactive compilation seam.</summary>
+    private static ISequencer ExpectedBlazorWasmScheduler =>
+#if REACTIVE_SHIM
+        WasmScheduler.Default;
+#else
+        WasmSequencer.Default;
+#endif
 
     /// <summary>Verifies that BlazorMainThreadScheduler returns the current-thread sequencer.</summary>
     /// <returns>A Task representing the asynchronous test operation.</returns>
@@ -25,7 +40,27 @@ public class BlazorReactiveUIBuilderExtensionsTests
     /// <returns>A Task representing the asynchronous test operation.</returns>
     [Test]
     public async Task BlazorWasmScheduler_ReturnsConfiguredSequencer() =>
-        await Assert.That(BlazorReactiveUIBuilderExtensions.BlazorWasmScheduler).IsSameReferenceAs(BlazorReactiveUIBuilderExtensions.BlazorWasmScheduler);
+        await Assert.That(BlazorReactiveUIBuilderExtensions.BlazorWasmScheduler).IsSameReferenceAs(ExpectedBlazorWasmScheduler);
+
+    /// <summary>Verifies that the WASM scheduler executes work through its event-loop queue.</summary>
+    /// <returns>A Task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task BlazorWasmScheduler_ExecutesScheduledWork()
+    {
+        var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        using var scheduled = BlazorReactiveUIBuilderExtensions.BlazorWasmScheduler.Schedule(
+            completion,
+            static (_, source) =>
+            {
+                source.SetResult();
+                return EmptyDisposable.Instance;
+            });
+
+        await completion.Task.WaitAsync(TimeSpan.FromSeconds(SchedulerTimeoutSeconds));
+
+        await Assert.That(completion.Task.IsCompletedSuccessfully).IsTrue();
+    }
 
     /// <summary>Verifies that WithBlazor calls WithBlazorScheduler and WithPlatformModule.</summary>
     /// <returns>A Task representing the asynchronous test operation.</returns>
@@ -37,9 +72,39 @@ public class BlazorReactiveUIBuilderExtensionsTests
         var result = builder.WithBlazor();
 
         await Assert.That(result).IsSameReferenceAs(builder);
+        await Assert.That(builder.CoreServicesSet).IsTrue();
         await Assert.That(builder.MainThreadSchedulerSet).IsTrue();
         await Assert.That(builder.MainThreadScheduler).IsSameReferenceAs(Sequencer.CurrentThread);
+        await Assert.That(builder.TaskPoolScheduler).IsSameReferenceAs(TaskPoolSequencer.Default);
         await Assert.That(builder.PlatformModuleCalled).IsTrue();
+    }
+
+    /// <summary>Verifies that WithBlazorWasm configures core services and the WASM scheduler.</summary>
+    /// <returns>A Task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WithBlazorWasm_ConfiguresCoreServicesSchedulersAndPlatformModule()
+    {
+        var builder = new TestReactiveUIBuilder();
+
+        var result = builder.WithBlazorWasm();
+
+        await Assert.That(result).IsSameReferenceAs(builder);
+        await Assert.That(builder.CoreServicesSet).IsTrue();
+        await Assert.That(builder.MainThreadScheduler).IsSameReferenceAs(BlazorReactiveUIBuilderExtensions.BlazorWasmScheduler);
+        await Assert.That(builder.TaskPoolScheduler).IsSameReferenceAs(TaskPoolSequencer.Default);
+        await Assert.That(builder.PlatformModuleCalled).IsTrue();
+    }
+
+    /// <summary>Verifies that WithBlazorWasm throws ArgumentNullException when builder is null.</summary>
+    /// <returns>A Task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WithBlazorWasm_ThrowsArgumentNullException_WhenBuilderIsNull()
+    {
+        IReactiveUIBuilder? builder = null;
+
+        var exception = await Assert.That(() => builder!.WithBlazorWasm()).Throws<ArgumentNullException>();
+        await Assert.That(exception).IsNotNull();
+        await Assert.That(exception.ParamName).IsEqualTo(BuilderParameterName);
     }
 
     /// <summary>Verifies that WithBlazor throws ArgumentNullException when builder is null.</summary>
@@ -115,6 +180,12 @@ public class BlazorReactiveUIBuilderExtensionsTests
         /// <summary>Gets a value indicating whether the main thread scheduler was set.</summary>
         public bool MainThreadSchedulerSet { get; private set; }
 
+        /// <summary>Gets a value indicating whether core services were configured.</summary>
+        public bool CoreServicesSet { get; private set; }
+
+        /// <summary>Gets the task-pool scheduler that was set on the builder.</summary>
+        public ISequencer? TaskPoolScheduler { get; private set; }
+
         /// <summary>Gets a value indicating whether the platform module registration was called.</summary>
         public bool PlatformModuleCalled { get; private set; }
 
@@ -154,7 +225,11 @@ public class BlazorReactiveUIBuilderExtensionsTests
             where T : Splat.Builder.IModule => throw new NotSupportedException();
 
         /// <inheritdoc/>
-        public Splat.Builder.IAppBuilder WithCoreServices() => this;
+        public Splat.Builder.IAppBuilder WithCoreServices()
+        {
+            CoreServicesSet = true;
+            return this;
+        }
 
         /// <inheritdoc/>
         public Splat.Builder.IAppBuilder WithCustomRegistration(Action<IMutableDependencyResolver> configureAction) =>
@@ -246,6 +321,7 @@ public class BlazorReactiveUIBuilderExtensionsTests
         public IReactiveUIBuilder WithTaskPoolScheduler(ISequencer scheduler, bool setRxApp)
         {
             ArgumentNullException.ThrowIfNull(scheduler);
+            TaskPoolScheduler = scheduler;
             return this;
         }
 

--- a/src/tests/ReactiveUI.Builder.Tests/Platforms/Blazor/ReactiveUIBuilderBlazorTests.cs
+++ b/src/tests/ReactiveUI.Builder.Tests/Platforms/Blazor/ReactiveUIBuilderBlazorTests.cs
@@ -38,6 +38,26 @@ public class ReactiveUIBuilderBlazorTests
         await Assert.That(platformOperations).IsNotNull();
     }
 
+    /// <summary>Verifies that the Blazor Server builder configures both scheduler slots.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    [TestExecutor<WithBlazorExecutor>]
+    public async Task WithBlazor_Should_Configure_Server_Schedulers()
+    {
+        await Assert.That(RxSchedulers.MainThreadScheduler).IsSameReferenceAs(Sequencer.CurrentThread);
+        await Assert.That(RxSchedulers.TaskpoolScheduler).IsSameReferenceAs(TaskPoolSequencer.Default);
+    }
+
+    /// <summary>Verifies that the Blazor WebAssembly builder configures both scheduler slots.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    [TestExecutor<WithBlazorWasmExecutor>]
+    public async Task WithBlazorWasm_Should_Configure_WebAssembly_Schedulers()
+    {
+        await Assert.That(RxSchedulers.MainThreadScheduler).IsSameReferenceAs(BlazorReactiveUIBuilderExtensions.BlazorWasmScheduler);
+        await Assert.That(RxSchedulers.TaskpoolScheduler).IsSameReferenceAs(TaskPoolSequencer.Default);
+    }
+
     /// <summary>Executor that builds the app with Blazor platform services registered.</summary>
     internal sealed class WithBlazorExecutor : BuilderTestExecutorBase
     {
@@ -47,5 +67,15 @@ public class ReactiveUIBuilderBlazorTests
                 .WithCoreServices())
             .WithBlazor()
             .BuildApp();
+    }
+
+    /// <summary>Executor that builds the app with Blazor WebAssembly platform services registered.</summary>
+    internal sealed class WithBlazorWasmExecutor : BuilderTestExecutorBase
+    {
+        /// <inheritdoc/>
+        protected override void ConfigureBuilder() =>
+            RxAppBuilder.CreateReactiveUIBuilder()
+                .WithBlazorWasm()
+                .BuildApp();
     }
 }

--- a/src/tests/ReactiveUI.Builder.Tests/ReactiveUI.Builder.Tests.csproj
+++ b/src/tests/ReactiveUI.Builder.Tests/ReactiveUI.Builder.Tests.csproj
@@ -23,7 +23,7 @@
     <Compile Remove="Platforms\**\*.cs"/>
     <None Include="Platforms\**\*.cs"/>
   </ItemGroup>
-  <ItemGroup Condition="$(TargetFramework.EndsWith('net8.0')) or $(TargetFramework.EndsWith('net9.0')) or $(TargetFramework.EndsWith('net8.0'))">
+  <ItemGroup Condition="$(TargetFramework.StartsWith('net8.0')) or $(TargetFramework.StartsWith('net9.0')) or $(TargetFramework.StartsWith('net10.0')) or $(TargetFramework.StartsWith('net11.0'))">
     <Compile Include="Platforms\Blazor\**\*.cs"/>
     <ProjectReference Include="..\..\ReactiveUI.Blazor\ReactiveUI.Blazor.csproj"/>
   </ItemGroup>


### PR DESCRIPTION
## What kind of change does this PR introduce?

This is a Blazor scheduler and dependency compatibility fix. It migrates the Blazor packages from `Reactive.Wasm` to `ReactiveUI.Primitives.Blazor` and its System.Reactive variant, aligns required servicing dependencies, and adds lean/reactive regression coverage plus a runnable WebAssembly example.

closes #4430 

## What is the new behavior?

- Blazor WebAssembly uses `WasmSequencer.Default` in the lean package and `WasmScheduler.Default` in the System.Reactive package.
- Blazor Server retains the current-thread fallback; renderer-affine work remains component-scoped through `ComponentBase.InvokeAsync`, avoiding an invalid process-wide renderer dispatcher.
- `WithBlazorWasm()` consistently configures core services, the WASM main scheduler, the task-pool scheduler, and Blazor platform registrations.
- ASP.NET, `Microsoft.Extensions.*`, `System.Text.Json`, and WebAssembly package versions satisfy the `ReactiveUI.Primitives 7.2.0` servicing floors.
- A Blazor WebAssembly scheduler-probe example and reactive Blazor test project validate both package seams.

## What is the current behavior?

The Blazor projects depend on the removed `Reactive.Wasm` package and do not provide equivalent lean/reactive validation. After updating to `ReactiveUI.Primitives 7.2.0`, lower central ASP.NET, `System.Collections.Immutable`, and `System.Text.Json` pins cause package-downgrade restore failures.

## Checklist

- [x] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the main branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information

Root-cause fixes were made without adding warning suppressions, `NoWarn`, pragmas, warning demotion, or analyzer exclusions.

Validation completed:

- Full solution restore and build: 0 warnings, 0 errors
- `ReactiveUI.Blazor.Tests`: 38/38 passed
- `ReactiveUI.Blazor.Tests.Reactive`: 11/11 passed
- `ReactiveUI.Splat.Tests`: 6/6 passed
- `ReactiveUI.Tests`: 2,024/2,024 passed
- `ReactiveUI.Tests.Reactive`: 2,024/2,024 passed
- `ReactiveUI.Builder.Tests`: 187/187 passed
- `BlazorReactiveUIBuilderExtensions`: 100% line coverage in lean and reactive reports
- `git diff --check`: clean