### PR TITLE
fix(activation)!: let .Reactive blocks use System.Reactive DisposeWith

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -6,16 +6,16 @@
 
   <PropertyGroup Label="Shared Version Variables">
     <SplatVersion>21.0.0</SplatVersion>
-    <PrimitivesVersion>7.2.0</PrimitivesVersion>
-    <TUnitVersion>1.63.0</TUnitVersion>
+    <PrimitivesVersion>7.3.0</PrimitivesVersion>
+    <TUnitVersion>1.65.68</TUnitVersion>
     <!-- StyleSharp.Analyzers, PerformanceSharp.Analyzers and SecuritySharp.Analyzers ship from the
          same release pipeline and always share a version. -->
-    <RoslynCommonAnalyzersVersion>3.45.0</RoslynCommonAnalyzersVersion>
+    <RoslynCommonAnalyzersVersion>3.46.0</RoslynCommonAnalyzersVersion>
     <XamarinAndroidXLifecycleLiveDataVersion>2.11.0.1</XamarinAndroidXLifecycleLiveDataVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="Framework-Aligned Versions">
-    <MauiVersion Condition="$(TargetFramework.StartsWith('net10'))">10.0.90</MauiVersion>
+    <MauiVersion Condition="$(TargetFramework.StartsWith('net10'))">10.0.100</MauiVersion>
     <MauiVersion Condition="$(TargetFramework.StartsWith('net11'))">11.0.0-preview.7.26406.9</MauiVersion>
 
     <AspNetVersion Condition="$(TargetFramework.StartsWith('netstandard'))">3.1.32</AspNetVersion>
@@ -32,11 +32,11 @@
     <MicrosoftExtensionsVersion>10.0.11</MicrosoftExtensionsVersion>
     <MicrosoftExtensionsVersion Condition="$(TargetFramework.StartsWith('net11'))">11.0.0-preview.7.26381.103</MicrosoftExtensionsVersion>
 
-    <XamlBehaviorsWpfVersion Condition="$(TargetFramework.StartsWith('net4'))">1.1.142</XamlBehaviorsWpfVersion>
-    <XamlBehaviorsWpfVersion Condition="$(TargetFramework.StartsWith('net8'))">1.1.142</XamlBehaviorsWpfVersion>
-    <XamlBehaviorsWpfVersion Condition="$(TargetFramework.StartsWith('net9'))">1.1.142</XamlBehaviorsWpfVersion>
-    <XamlBehaviorsWpfVersion Condition="$(TargetFramework.StartsWith('net10'))">1.1.142</XamlBehaviorsWpfVersion>
-    <XamlBehaviorsWpfVersion Condition="$(TargetFramework.StartsWith('net11'))">1.1.142</XamlBehaviorsWpfVersion>
+    <XamlBehaviorsWpfVersion Condition="$(TargetFramework.StartsWith('net4'))">1.1.158</XamlBehaviorsWpfVersion>
+    <XamlBehaviorsWpfVersion Condition="$(TargetFramework.StartsWith('net8'))">1.1.158</XamlBehaviorsWpfVersion>
+    <XamlBehaviorsWpfVersion Condition="$(TargetFramework.StartsWith('net9'))">1.1.158</XamlBehaviorsWpfVersion>
+    <XamlBehaviorsWpfVersion Condition="$(TargetFramework.StartsWith('net10'))">1.1.158</XamlBehaviorsWpfVersion>
+    <XamlBehaviorsWpfVersion Condition="$(TargetFramework.StartsWith('net11'))">1.1.158</XamlBehaviorsWpfVersion>
   </PropertyGroup>
 
   <ItemGroup Label="ReactiveUI Primitives">
@@ -75,8 +75,8 @@
     <PackageVersion Include="TUnit" Version="$(TUnitVersion)"/>
     <PackageVersion Include="TUnit.Core" Version="$(TUnitVersion)"/>
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.9.0"/>
-    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.10.0"/>
-    <PackageVersion Include="Microsoft.Testing.Platform.MSBuild" Version="2.3.3"/>
+    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.11.0"/>
+    <PackageVersion Include="Microsoft.Testing.Platform.MSBuild" Version="2.4.0"/>
     <PackageVersion Include="Microsoft.Reactive.Testing" Version="7.0.0"/>
     <PackageVersion Include="System.Reactive" Version="7.0.0"/>
     <PackageVersion Include="Mocks.Maui" Version="1.2.5"/>
@@ -143,8 +143,8 @@
   </ItemGroup>
 
   <ItemGroup Label="Platform - Android (Fragment / Collection / SavedState / Preference)">
-    <PackageVersion Include="Xamarin.AndroidX.Fragment" Version="1.8.9.3"/>
-    <PackageVersion Include="Xamarin.AndroidX.Fragment.Ktx" Version="1.8.9.4"/>
+    <PackageVersion Include="Xamarin.AndroidX.Fragment" Version="1.9.0"/>
+    <PackageVersion Include="Xamarin.AndroidX.Fragment.Ktx" Version="1.9.0"/>
     <PackageVersion Include="Xamarin.AndroidX.Collection.Jvm" Version="1.6.0.1"/>
     <PackageVersion Include="Xamarin.AndroidX.Collection.Ktx" Version="1.6.0.1"/>
     <PackageVersion Include="Xamarin.AndroidX.SavedState" Version="1.5.0.1"/>

--- a/src/ReactiveShim.props
+++ b/src/ReactiveShim.props
@@ -44,6 +44,9 @@
          Signal.* factories. The shared source constructs these directly in place of in-repo sink forks; only
          the seam-neutral (both-leaf) concretes are named so the .Reactive leaf below stays buildable. -->
     <Using Include="ReactiveUI.Primitives.Advanced" />
+    <!-- The disposal container WhenActivated hands to an activation block. Lean has nothing to interop with,
+         so it is the plain MultipleDisposable; the .Reactive leaf rebinds it below. -->
+    <Using Include="ReactiveUI.Primitives.Disposables.MultipleDisposable" Alias="ActivationDisposables"/>
   </ItemGroup>
 
   <!-- Reactive seam: the *.Reactive leaves recompile the shared ReactiveUI source against System.Reactive's
@@ -70,6 +73,14 @@
     <!-- Reactive-shim counterpart of the lean leaf's ReactiveUI.Primitives.Advanced import: the same
          seam-neutral concrete signal classes, flipped to the ReactiveUI.Primitives.Reactive.Advanced namespace. -->
     <Using Include="ReactiveUI.Primitives.Reactive.Advanced" />
+    <!-- Activation seam: a System.Reactive consumer writes DisposeWith against CompositeDisposable, which
+         MultipleDisposable is not, so a block given one cannot use the fluent helpers it already has
+         (see reactiveui/ReactiveUI#4434). ContainerDisposable is a MultipleDisposable that converts to a
+         CompositeDisposable it owns, so the block gets a container both sides accept. This has to replace
+         the lean binding rather than add an overload: Action<T> is contravariant, so an added
+         Action<ContainerDisposable> loses overload resolution to the existing Action<MultipleDisposable>
+         and an untyped lambda would still bind to the one that does not convert. -->
+    <Using Include="ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable" Alias="ActivationDisposables"/>
   </ItemGroup>
 
   <!-- Reactive seam, platform leaves: the apple/android reactive main-thread sequencers

--- a/src/ReactiveUI.Reactive/PublicAPI/net10.0-android36.0/PublicAPI.txt
+++ b/src/ReactiveUI.Reactive/PublicAPI/net10.0-android36.0/PublicAPI.txt
@@ -1545,7 +1545,7 @@ namespace ReactiveUI.Reactive
             public System.IDisposable WhenActivated() { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
             public System.IDisposable WhenActivated(System.Action<System.Action<System.IDisposable>> block) { }
@@ -1555,9 +1555,9 @@ namespace ReactiveUI.Reactive
             public System.IDisposable WhenActivated(System.IObservable<object?> viewModelChanged) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block, ReactiveUI.IViewFor? view) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block, ReactiveUI.IViewFor? view) { }
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block, System.IObservable<object?> viewModelChanged) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block, System.IObservable<object?> viewModelChanged) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
             public System.IDisposable WhenActivated(System.Action<System.Action<System.IDisposable>> block, ReactiveUI.IViewFor view) { }
@@ -1569,7 +1569,7 @@ namespace ReactiveUI.Reactive
         }
         extension(ReactiveUI.Reactive.IActivatableViewModel item)
         {
-            public void WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block) { }
+            public void WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block) { }
             public void WhenActivated(System.Action<System.Action<System.IDisposable>> block) { }
             public void WhenActivated(System.Func<System.Collections.Generic.IEnumerable<System.IDisposable>> block) { }
         }

--- a/src/ReactiveUI.Reactive/PublicAPI/net10.0-ios/PublicAPI.txt
+++ b/src/ReactiveUI.Reactive/PublicAPI/net10.0-ios/PublicAPI.txt
@@ -2223,7 +2223,7 @@ namespace ReactiveUI.Reactive
             public System.IDisposable WhenActivated() { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
             public System.IDisposable WhenActivated(System.Action<System.Action<System.IDisposable>> block) { }
@@ -2233,9 +2233,9 @@ namespace ReactiveUI.Reactive
             public System.IDisposable WhenActivated(System.IObservable<object?> viewModelChanged) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block, ReactiveUI.IViewFor? view) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block, ReactiveUI.IViewFor? view) { }
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block, System.IObservable<object?> viewModelChanged) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block, System.IObservable<object?> viewModelChanged) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
             public System.IDisposable WhenActivated(System.Action<System.Action<System.IDisposable>> block, ReactiveUI.IViewFor view) { }
@@ -2247,7 +2247,7 @@ namespace ReactiveUI.Reactive
         }
         extension(ReactiveUI.Reactive.IActivatableViewModel item)
         {
-            public void WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block) { }
+            public void WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block) { }
             public void WhenActivated(System.Action<System.Action<System.IDisposable>> block) { }
             public void WhenActivated(System.Func<System.Collections.Generic.IEnumerable<System.IDisposable>> block) { }
         }

--- a/src/ReactiveUI.Reactive/PublicAPI/net10.0-maccatalyst/PublicAPI.txt
+++ b/src/ReactiveUI.Reactive/PublicAPI/net10.0-maccatalyst/PublicAPI.txt
@@ -2223,7 +2223,7 @@ namespace ReactiveUI.Reactive
             public System.IDisposable WhenActivated() { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
             public System.IDisposable WhenActivated(System.Action<System.Action<System.IDisposable>> block) { }
@@ -2233,9 +2233,9 @@ namespace ReactiveUI.Reactive
             public System.IDisposable WhenActivated(System.IObservable<object?> viewModelChanged) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block, ReactiveUI.IViewFor? view) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block, ReactiveUI.IViewFor? view) { }
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block, System.IObservable<object?> viewModelChanged) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block, System.IObservable<object?> viewModelChanged) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
             public System.IDisposable WhenActivated(System.Action<System.Action<System.IDisposable>> block, ReactiveUI.IViewFor view) { }
@@ -2247,7 +2247,7 @@ namespace ReactiveUI.Reactive
         }
         extension(ReactiveUI.Reactive.IActivatableViewModel item)
         {
-            public void WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block) { }
+            public void WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block) { }
             public void WhenActivated(System.Action<System.Action<System.IDisposable>> block) { }
             public void WhenActivated(System.Func<System.Collections.Generic.IEnumerable<System.IDisposable>> block) { }
         }

--- a/src/ReactiveUI.Reactive/PublicAPI/net10.0-macos/PublicAPI.txt
+++ b/src/ReactiveUI.Reactive/PublicAPI/net10.0-macos/PublicAPI.txt
@@ -1624,7 +1624,7 @@ namespace ReactiveUI.Reactive
             public System.IDisposable WhenActivated() { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
             public System.IDisposable WhenActivated(System.Action<System.Action<System.IDisposable>> block) { }
@@ -1634,9 +1634,9 @@ namespace ReactiveUI.Reactive
             public System.IDisposable WhenActivated(System.IObservable<object?> viewModelChanged) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block, ReactiveUI.IViewFor? view) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block, ReactiveUI.IViewFor? view) { }
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block, System.IObservable<object?> viewModelChanged) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block, System.IObservable<object?> viewModelChanged) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
             public System.IDisposable WhenActivated(System.Action<System.Action<System.IDisposable>> block, ReactiveUI.IViewFor view) { }
@@ -1648,7 +1648,7 @@ namespace ReactiveUI.Reactive
         }
         extension(ReactiveUI.Reactive.IActivatableViewModel item)
         {
-            public void WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block) { }
+            public void WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block) { }
             public void WhenActivated(System.Action<System.Action<System.IDisposable>> block) { }
             public void WhenActivated(System.Func<System.Collections.Generic.IEnumerable<System.IDisposable>> block) { }
         }

--- a/src/ReactiveUI.Reactive/PublicAPI/net10.0-tvos/PublicAPI.txt
+++ b/src/ReactiveUI.Reactive/PublicAPI/net10.0-tvos/PublicAPI.txt
@@ -2223,7 +2223,7 @@ namespace ReactiveUI.Reactive
             public System.IDisposable WhenActivated() { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
             public System.IDisposable WhenActivated(System.Action<System.Action<System.IDisposable>> block) { }
@@ -2233,9 +2233,9 @@ namespace ReactiveUI.Reactive
             public System.IDisposable WhenActivated(System.IObservable<object?> viewModelChanged) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block, ReactiveUI.IViewFor? view) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block, ReactiveUI.IViewFor? view) { }
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block, System.IObservable<object?> viewModelChanged) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block, System.IObservable<object?> viewModelChanged) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
             public System.IDisposable WhenActivated(System.Action<System.Action<System.IDisposable>> block, ReactiveUI.IViewFor view) { }
@@ -2247,7 +2247,7 @@ namespace ReactiveUI.Reactive
         }
         extension(ReactiveUI.Reactive.IActivatableViewModel item)
         {
-            public void WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block) { }
+            public void WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block) { }
             public void WhenActivated(System.Action<System.Action<System.IDisposable>> block) { }
             public void WhenActivated(System.Func<System.Collections.Generic.IEnumerable<System.IDisposable>> block) { }
         }

--- a/src/ReactiveUI.Reactive/PublicAPI/net10.0-windows10.0.19041.0/PublicAPI.txt
+++ b/src/ReactiveUI.Reactive/PublicAPI/net10.0-windows10.0.19041.0/PublicAPI.txt
@@ -1256,7 +1256,7 @@ namespace ReactiveUI.Reactive
             public System.IDisposable WhenActivated() { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
             public System.IDisposable WhenActivated(System.Action<System.Action<System.IDisposable>> block) { }
@@ -1266,9 +1266,9 @@ namespace ReactiveUI.Reactive
             public System.IDisposable WhenActivated(System.IObservable<object?> viewModelChanged) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block, ReactiveUI.IViewFor? view) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block, ReactiveUI.IViewFor? view) { }
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block, System.IObservable<object?> viewModelChanged) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block, System.IObservable<object?> viewModelChanged) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
             public System.IDisposable WhenActivated(System.Action<System.Action<System.IDisposable>> block, ReactiveUI.IViewFor view) { }
@@ -1280,7 +1280,7 @@ namespace ReactiveUI.Reactive
         }
         extension(ReactiveUI.Reactive.IActivatableViewModel item)
         {
-            public void WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block) { }
+            public void WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block) { }
             public void WhenActivated(System.Action<System.Action<System.IDisposable>> block) { }
             public void WhenActivated(System.Func<System.Collections.Generic.IEnumerable<System.IDisposable>> block) { }
         }

--- a/src/ReactiveUI.Reactive/PublicAPI/net10.0/PublicAPI.txt
+++ b/src/ReactiveUI.Reactive/PublicAPI/net10.0/PublicAPI.txt
@@ -1255,7 +1255,7 @@ namespace ReactiveUI.Reactive
             public System.IDisposable WhenActivated() { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
             public System.IDisposable WhenActivated(System.Action<System.Action<System.IDisposable>> block) { }
@@ -1265,9 +1265,9 @@ namespace ReactiveUI.Reactive
             public System.IDisposable WhenActivated(System.IObservable<object?> viewModelChanged) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block, ReactiveUI.IViewFor? view) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block, ReactiveUI.IViewFor? view) { }
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block, System.IObservable<object?> viewModelChanged) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block, System.IObservable<object?> viewModelChanged) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
             public System.IDisposable WhenActivated(System.Action<System.Action<System.IDisposable>> block, ReactiveUI.IViewFor view) { }
@@ -1279,7 +1279,7 @@ namespace ReactiveUI.Reactive
         }
         extension(ReactiveUI.Reactive.IActivatableViewModel item)
         {
-            public void WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block) { }
+            public void WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block) { }
             public void WhenActivated(System.Action<System.Action<System.IDisposable>> block) { }
             public void WhenActivated(System.Func<System.Collections.Generic.IEnumerable<System.IDisposable>> block) { }
         }

--- a/src/ReactiveUI.Reactive/PublicAPI/net11.0-android37/PublicAPI.txt
+++ b/src/ReactiveUI.Reactive/PublicAPI/net11.0-android37/PublicAPI.txt
@@ -1545,7 +1545,7 @@ namespace ReactiveUI.Reactive
             public System.IDisposable WhenActivated() { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
             public System.IDisposable WhenActivated(System.Action<System.Action<System.IDisposable>> block) { }
@@ -1555,9 +1555,9 @@ namespace ReactiveUI.Reactive
             public System.IDisposable WhenActivated(System.IObservable<object?> viewModelChanged) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block, ReactiveUI.IViewFor? view) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block, ReactiveUI.IViewFor? view) { }
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block, System.IObservable<object?> viewModelChanged) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block, System.IObservable<object?> viewModelChanged) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
             public System.IDisposable WhenActivated(System.Action<System.Action<System.IDisposable>> block, ReactiveUI.IViewFor view) { }
@@ -1569,7 +1569,7 @@ namespace ReactiveUI.Reactive
         }
         extension(ReactiveUI.Reactive.IActivatableViewModel item)
         {
-            public void WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block) { }
+            public void WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block) { }
             public void WhenActivated(System.Action<System.Action<System.IDisposable>> block) { }
             public void WhenActivated(System.Func<System.Collections.Generic.IEnumerable<System.IDisposable>> block) { }
         }

--- a/src/ReactiveUI.Reactive/PublicAPI/net11.0-ios/PublicAPI.txt
+++ b/src/ReactiveUI.Reactive/PublicAPI/net11.0-ios/PublicAPI.txt
@@ -2223,7 +2223,7 @@ namespace ReactiveUI.Reactive
             public System.IDisposable WhenActivated() { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
             public System.IDisposable WhenActivated(System.Action<System.Action<System.IDisposable>> block) { }
@@ -2233,9 +2233,9 @@ namespace ReactiveUI.Reactive
             public System.IDisposable WhenActivated(System.IObservable<object?> viewModelChanged) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block, ReactiveUI.IViewFor? view) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block, ReactiveUI.IViewFor? view) { }
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block, System.IObservable<object?> viewModelChanged) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block, System.IObservable<object?> viewModelChanged) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
             public System.IDisposable WhenActivated(System.Action<System.Action<System.IDisposable>> block, ReactiveUI.IViewFor view) { }
@@ -2247,7 +2247,7 @@ namespace ReactiveUI.Reactive
         }
         extension(ReactiveUI.Reactive.IActivatableViewModel item)
         {
-            public void WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block) { }
+            public void WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block) { }
             public void WhenActivated(System.Action<System.Action<System.IDisposable>> block) { }
             public void WhenActivated(System.Func<System.Collections.Generic.IEnumerable<System.IDisposable>> block) { }
         }

--- a/src/ReactiveUI.Reactive/PublicAPI/net11.0-maccatalyst/PublicAPI.txt
+++ b/src/ReactiveUI.Reactive/PublicAPI/net11.0-maccatalyst/PublicAPI.txt
@@ -2223,7 +2223,7 @@ namespace ReactiveUI.Reactive
             public System.IDisposable WhenActivated() { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
             public System.IDisposable WhenActivated(System.Action<System.Action<System.IDisposable>> block) { }
@@ -2233,9 +2233,9 @@ namespace ReactiveUI.Reactive
             public System.IDisposable WhenActivated(System.IObservable<object?> viewModelChanged) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block, ReactiveUI.IViewFor? view) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block, ReactiveUI.IViewFor? view) { }
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block, System.IObservable<object?> viewModelChanged) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block, System.IObservable<object?> viewModelChanged) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
             public System.IDisposable WhenActivated(System.Action<System.Action<System.IDisposable>> block, ReactiveUI.IViewFor view) { }
@@ -2247,7 +2247,7 @@ namespace ReactiveUI.Reactive
         }
         extension(ReactiveUI.Reactive.IActivatableViewModel item)
         {
-            public void WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block) { }
+            public void WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block) { }
             public void WhenActivated(System.Action<System.Action<System.IDisposable>> block) { }
             public void WhenActivated(System.Func<System.Collections.Generic.IEnumerable<System.IDisposable>> block) { }
         }

--- a/src/ReactiveUI.Reactive/PublicAPI/net11.0-macos/PublicAPI.txt
+++ b/src/ReactiveUI.Reactive/PublicAPI/net11.0-macos/PublicAPI.txt
@@ -1624,7 +1624,7 @@ namespace ReactiveUI.Reactive
             public System.IDisposable WhenActivated() { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
             public System.IDisposable WhenActivated(System.Action<System.Action<System.IDisposable>> block) { }
@@ -1634,9 +1634,9 @@ namespace ReactiveUI.Reactive
             public System.IDisposable WhenActivated(System.IObservable<object?> viewModelChanged) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block, ReactiveUI.IViewFor? view) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block, ReactiveUI.IViewFor? view) { }
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block, System.IObservable<object?> viewModelChanged) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block, System.IObservable<object?> viewModelChanged) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
             public System.IDisposable WhenActivated(System.Action<System.Action<System.IDisposable>> block, ReactiveUI.IViewFor view) { }
@@ -1648,7 +1648,7 @@ namespace ReactiveUI.Reactive
         }
         extension(ReactiveUI.Reactive.IActivatableViewModel item)
         {
-            public void WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block) { }
+            public void WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block) { }
             public void WhenActivated(System.Action<System.Action<System.IDisposable>> block) { }
             public void WhenActivated(System.Func<System.Collections.Generic.IEnumerable<System.IDisposable>> block) { }
         }

--- a/src/ReactiveUI.Reactive/PublicAPI/net11.0-tvos/PublicAPI.txt
+++ b/src/ReactiveUI.Reactive/PublicAPI/net11.0-tvos/PublicAPI.txt
@@ -2223,7 +2223,7 @@ namespace ReactiveUI.Reactive
             public System.IDisposable WhenActivated() { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
             public System.IDisposable WhenActivated(System.Action<System.Action<System.IDisposable>> block) { }
@@ -2233,9 +2233,9 @@ namespace ReactiveUI.Reactive
             public System.IDisposable WhenActivated(System.IObservable<object?> viewModelChanged) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block, ReactiveUI.IViewFor? view) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block, ReactiveUI.IViewFor? view) { }
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block, System.IObservable<object?> viewModelChanged) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block, System.IObservable<object?> viewModelChanged) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
             public System.IDisposable WhenActivated(System.Action<System.Action<System.IDisposable>> block, ReactiveUI.IViewFor view) { }
@@ -2247,7 +2247,7 @@ namespace ReactiveUI.Reactive
         }
         extension(ReactiveUI.Reactive.IActivatableViewModel item)
         {
-            public void WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block) { }
+            public void WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block) { }
             public void WhenActivated(System.Action<System.Action<System.IDisposable>> block) { }
             public void WhenActivated(System.Func<System.Collections.Generic.IEnumerable<System.IDisposable>> block) { }
         }

--- a/src/ReactiveUI.Reactive/PublicAPI/net11.0-windows10.0.19041.0/PublicAPI.txt
+++ b/src/ReactiveUI.Reactive/PublicAPI/net11.0-windows10.0.19041.0/PublicAPI.txt
@@ -1256,7 +1256,7 @@ namespace ReactiveUI.Reactive
             public System.IDisposable WhenActivated() { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
             public System.IDisposable WhenActivated(System.Action<System.Action<System.IDisposable>> block) { }
@@ -1266,9 +1266,9 @@ namespace ReactiveUI.Reactive
             public System.IDisposable WhenActivated(System.IObservable<object?> viewModelChanged) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block, ReactiveUI.IViewFor? view) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block, ReactiveUI.IViewFor? view) { }
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block, System.IObservable<object?> viewModelChanged) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block, System.IObservable<object?> viewModelChanged) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
             public System.IDisposable WhenActivated(System.Action<System.Action<System.IDisposable>> block, ReactiveUI.IViewFor view) { }
@@ -1280,7 +1280,7 @@ namespace ReactiveUI.Reactive
         }
         extension(ReactiveUI.Reactive.IActivatableViewModel item)
         {
-            public void WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block) { }
+            public void WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block) { }
             public void WhenActivated(System.Action<System.Action<System.IDisposable>> block) { }
             public void WhenActivated(System.Func<System.Collections.Generic.IEnumerable<System.IDisposable>> block) { }
         }

--- a/src/ReactiveUI.Reactive/PublicAPI/net11.0/PublicAPI.txt
+++ b/src/ReactiveUI.Reactive/PublicAPI/net11.0/PublicAPI.txt
@@ -1255,7 +1255,7 @@ namespace ReactiveUI.Reactive
             public System.IDisposable WhenActivated() { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
             public System.IDisposable WhenActivated(System.Action<System.Action<System.IDisposable>> block) { }
@@ -1265,9 +1265,9 @@ namespace ReactiveUI.Reactive
             public System.IDisposable WhenActivated(System.IObservable<object?> viewModelChanged) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block, ReactiveUI.IViewFor? view) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block, ReactiveUI.IViewFor? view) { }
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block, System.IObservable<object?> viewModelChanged) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block, System.IObservable<object?> viewModelChanged) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
             public System.IDisposable WhenActivated(System.Action<System.Action<System.IDisposable>> block, ReactiveUI.IViewFor view) { }
@@ -1279,7 +1279,7 @@ namespace ReactiveUI.Reactive
         }
         extension(ReactiveUI.Reactive.IActivatableViewModel item)
         {
-            public void WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block) { }
+            public void WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block) { }
             public void WhenActivated(System.Action<System.Action<System.IDisposable>> block) { }
             public void WhenActivated(System.Func<System.Collections.Generic.IEnumerable<System.IDisposable>> block) { }
         }

--- a/src/ReactiveUI.Reactive/PublicAPI/net462/PublicAPI.txt
+++ b/src/ReactiveUI.Reactive/PublicAPI/net462/PublicAPI.txt
@@ -1113,16 +1113,16 @@ namespace ReactiveUI.Reactive
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
             public System.IDisposable WhenActivated() { }
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block) { }
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
             public System.IDisposable WhenActivated(System.Action<System.Action<System.IDisposable>> block) { }
             public System.IDisposable WhenActivated(System.Func<System.Collections.Generic.IEnumerable<System.IDisposable>> block) { }
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
             public System.IDisposable WhenActivated(System.IObservable<object?> viewModelChanged) { }
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block, ReactiveUI.IViewFor? view) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block, ReactiveUI.IViewFor? view) { }
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block, System.IObservable<object?> viewModelChanged) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block, System.IObservable<object?> viewModelChanged) { }
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
             public System.IDisposable WhenActivated(System.Action<System.Action<System.IDisposable>> block, ReactiveUI.IViewFor view) { }
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
@@ -1132,7 +1132,7 @@ namespace ReactiveUI.Reactive
         }
         extension(ReactiveUI.Reactive.IActivatableViewModel item)
         {
-            public void WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block) { }
+            public void WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block) { }
             public void WhenActivated(System.Action<System.Action<System.IDisposable>> block) { }
             public void WhenActivated(System.Func<System.Collections.Generic.IEnumerable<System.IDisposable>> block) { }
         }

--- a/src/ReactiveUI.Reactive/PublicAPI/net472/PublicAPI.txt
+++ b/src/ReactiveUI.Reactive/PublicAPI/net472/PublicAPI.txt
@@ -1113,16 +1113,16 @@ namespace ReactiveUI.Reactive
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
             public System.IDisposable WhenActivated() { }
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block) { }
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
             public System.IDisposable WhenActivated(System.Action<System.Action<System.IDisposable>> block) { }
             public System.IDisposable WhenActivated(System.Func<System.Collections.Generic.IEnumerable<System.IDisposable>> block) { }
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
             public System.IDisposable WhenActivated(System.IObservable<object?> viewModelChanged) { }
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block, ReactiveUI.IViewFor? view) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block, ReactiveUI.IViewFor? view) { }
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block, System.IObservable<object?> viewModelChanged) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block, System.IObservable<object?> viewModelChanged) { }
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
             public System.IDisposable WhenActivated(System.Action<System.Action<System.IDisposable>> block, ReactiveUI.IViewFor view) { }
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
@@ -1132,7 +1132,7 @@ namespace ReactiveUI.Reactive
         }
         extension(ReactiveUI.Reactive.IActivatableViewModel item)
         {
-            public void WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block) { }
+            public void WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block) { }
             public void WhenActivated(System.Action<System.Action<System.IDisposable>> block) { }
             public void WhenActivated(System.Func<System.Collections.Generic.IEnumerable<System.IDisposable>> block) { }
         }

--- a/src/ReactiveUI.Reactive/PublicAPI/net481/PublicAPI.txt
+++ b/src/ReactiveUI.Reactive/PublicAPI/net481/PublicAPI.txt
@@ -1113,16 +1113,16 @@ namespace ReactiveUI.Reactive
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
             public System.IDisposable WhenActivated() { }
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block) { }
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
             public System.IDisposable WhenActivated(System.Action<System.Action<System.IDisposable>> block) { }
             public System.IDisposable WhenActivated(System.Func<System.Collections.Generic.IEnumerable<System.IDisposable>> block) { }
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
             public System.IDisposable WhenActivated(System.IObservable<object?> viewModelChanged) { }
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block, ReactiveUI.IViewFor? view) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block, ReactiveUI.IViewFor? view) { }
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block, System.IObservable<object?> viewModelChanged) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block, System.IObservable<object?> viewModelChanged) { }
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
             public System.IDisposable WhenActivated(System.Action<System.Action<System.IDisposable>> block, ReactiveUI.IViewFor view) { }
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
@@ -1132,7 +1132,7 @@ namespace ReactiveUI.Reactive
         }
         extension(ReactiveUI.Reactive.IActivatableViewModel item)
         {
-            public void WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block) { }
+            public void WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block) { }
             public void WhenActivated(System.Action<System.Action<System.IDisposable>> block) { }
             public void WhenActivated(System.Func<System.Collections.Generic.IEnumerable<System.IDisposable>> block) { }
         }

--- a/src/ReactiveUI.Reactive/PublicAPI/net8.0-windows10.0.19041.0/PublicAPI.txt
+++ b/src/ReactiveUI.Reactive/PublicAPI/net8.0-windows10.0.19041.0/PublicAPI.txt
@@ -1256,7 +1256,7 @@ namespace ReactiveUI.Reactive
             public System.IDisposable WhenActivated() { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
             public System.IDisposable WhenActivated(System.Action<System.Action<System.IDisposable>> block) { }
@@ -1266,9 +1266,9 @@ namespace ReactiveUI.Reactive
             public System.IDisposable WhenActivated(System.IObservable<object?> viewModelChanged) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block, ReactiveUI.IViewFor? view) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block, ReactiveUI.IViewFor? view) { }
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block, System.IObservable<object?> viewModelChanged) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block, System.IObservable<object?> viewModelChanged) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
             public System.IDisposable WhenActivated(System.Action<System.Action<System.IDisposable>> block, ReactiveUI.IViewFor view) { }
@@ -1280,7 +1280,7 @@ namespace ReactiveUI.Reactive
         }
         extension(ReactiveUI.Reactive.IActivatableViewModel item)
         {
-            public void WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block) { }
+            public void WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block) { }
             public void WhenActivated(System.Action<System.Action<System.IDisposable>> block) { }
             public void WhenActivated(System.Func<System.Collections.Generic.IEnumerable<System.IDisposable>> block) { }
         }

--- a/src/ReactiveUI.Reactive/PublicAPI/net8.0/PublicAPI.txt
+++ b/src/ReactiveUI.Reactive/PublicAPI/net8.0/PublicAPI.txt
@@ -1255,7 +1255,7 @@ namespace ReactiveUI.Reactive
             public System.IDisposable WhenActivated() { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
             public System.IDisposable WhenActivated(System.Action<System.Action<System.IDisposable>> block) { }
@@ -1265,9 +1265,9 @@ namespace ReactiveUI.Reactive
             public System.IDisposable WhenActivated(System.IObservable<object?> viewModelChanged) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block, ReactiveUI.IViewFor? view) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block, ReactiveUI.IViewFor? view) { }
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block, System.IObservable<object?> viewModelChanged) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block, System.IObservable<object?> viewModelChanged) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
             public System.IDisposable WhenActivated(System.Action<System.Action<System.IDisposable>> block, ReactiveUI.IViewFor view) { }
@@ -1279,7 +1279,7 @@ namespace ReactiveUI.Reactive
         }
         extension(ReactiveUI.Reactive.IActivatableViewModel item)
         {
-            public void WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block) { }
+            public void WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block) { }
             public void WhenActivated(System.Action<System.Action<System.IDisposable>> block) { }
             public void WhenActivated(System.Func<System.Collections.Generic.IEnumerable<System.IDisposable>> block) { }
         }

--- a/src/ReactiveUI.Reactive/PublicAPI/net9.0-windows10.0.19041.0/PublicAPI.txt
+++ b/src/ReactiveUI.Reactive/PublicAPI/net9.0-windows10.0.19041.0/PublicAPI.txt
@@ -1256,7 +1256,7 @@ namespace ReactiveUI.Reactive
             public System.IDisposable WhenActivated() { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
             public System.IDisposable WhenActivated(System.Action<System.Action<System.IDisposable>> block) { }
@@ -1266,9 +1266,9 @@ namespace ReactiveUI.Reactive
             public System.IDisposable WhenActivated(System.IObservable<object?> viewModelChanged) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block, ReactiveUI.IViewFor? view) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block, ReactiveUI.IViewFor? view) { }
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block, System.IObservable<object?> viewModelChanged) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block, System.IObservable<object?> viewModelChanged) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
             public System.IDisposable WhenActivated(System.Action<System.Action<System.IDisposable>> block, ReactiveUI.IViewFor view) { }
@@ -1280,7 +1280,7 @@ namespace ReactiveUI.Reactive
         }
         extension(ReactiveUI.Reactive.IActivatableViewModel item)
         {
-            public void WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block) { }
+            public void WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block) { }
             public void WhenActivated(System.Action<System.Action<System.IDisposable>> block) { }
             public void WhenActivated(System.Func<System.Collections.Generic.IEnumerable<System.IDisposable>> block) { }
         }

--- a/src/ReactiveUI.Reactive/PublicAPI/net9.0/PublicAPI.txt
+++ b/src/ReactiveUI.Reactive/PublicAPI/net9.0/PublicAPI.txt
@@ -1255,7 +1255,7 @@ namespace ReactiveUI.Reactive
             public System.IDisposable WhenActivated() { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
             public System.IDisposable WhenActivated(System.Action<System.Action<System.IDisposable>> block) { }
@@ -1265,9 +1265,9 @@ namespace ReactiveUI.Reactive
             public System.IDisposable WhenActivated(System.IObservable<object?> viewModelChanged) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block, ReactiveUI.IViewFor? view) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block, ReactiveUI.IViewFor? view) { }
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block, System.IObservable<object?> viewModelChanged) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block, System.IObservable<object?> viewModelChanged) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
             public System.IDisposable WhenActivated(System.Action<System.Action<System.IDisposable>> block, ReactiveUI.IViewFor view) { }
@@ -1279,7 +1279,7 @@ namespace ReactiveUI.Reactive
         }
         extension(ReactiveUI.Reactive.IActivatableViewModel item)
         {
-            public void WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block) { }
+            public void WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block) { }
             public void WhenActivated(System.Action<System.Action<System.IDisposable>> block) { }
             public void WhenActivated(System.Func<System.Collections.Generic.IEnumerable<System.IDisposable>> block) { }
         }

--- a/src/ReactiveUI.Shared/Activation/ViewForMixins.cs
+++ b/src/ReactiveUI.Shared/Activation/ViewForMixins.cs
@@ -140,30 +140,30 @@ public static class ViewForMixins
         /// Activates the specified view and executes the provided block when the view is activated, managing disposables
         /// for the activation lifecycle.
         /// </summary>
-        /// <param name="block">An action that receives a MultipleDisposable to which activation-related disposables should be added.</param>
+        /// <param name="block">An action that receives an <see cref="ActivationDisposables"/> to which activation-related disposables should be added.</param>
         /// <returns>An IDisposable that deactivates the view and disposes of all registered disposables when disposed.</returns>
         [RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public IDisposable WhenActivated(
-            Action<MultipleDisposable> block) =>
+            Action<ActivationDisposables> block) =>
             item.WhenActivated(block, (IViewFor?)null);
 
         /// <summary>
         /// Activates the specified view and executes the provided block when the view is activated, managing disposables
         /// for the activation lifecycle.
         /// </summary>
-        /// <param name="block">An action that receives a MultipleDisposable to which activation-related disposables should be added.</param>
+        /// <param name="block">An action that receives an <see cref="ActivationDisposables"/> to which activation-related disposables should be added.</param>
         /// <param name="view">An optional IViewFor instance representing the view context. If null, the item itself is used as the view.</param>
         /// <returns>An IDisposable that deactivates the view and disposes of all registered disposables when disposed.</returns>
         [RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public IDisposable WhenActivated(
-            Action<MultipleDisposable> block,
+            Action<ActivationDisposables> block,
             IViewFor? view) =>
             item.WhenActivated(
                 () =>
                 {
-                    MultipleDisposable d = [];
+                    ActivationDisposables d = [];
                     block(d);
                     return [d];
                 },
@@ -243,21 +243,21 @@ public static class ViewForMixins
         /// Registers a block of activation logic to be executed when the view is activated, forwarding
         /// <see cref="IActivatableViewModel"/> activation using a caller-supplied ViewModel-change signal.
         /// </summary>
-        /// <param name="block">An action that receives a <see cref="MultipleDisposable"/> to which activation-related disposables can be added.</param>
+        /// <param name="block">An action that receives an <see cref="ActivationDisposables"/> to which activation-related disposables can be added.</param>
         /// <param name="viewModelChanged">An observable that emits the view's ViewModel whenever it changes (including its current value).</param>
         /// <returns>An <see cref="IDisposable"/> that deactivates the view and disposes the registered resources when disposed.</returns>
-        /// <remarks>This is the trim- and AOT-safe counterpart to the reflected <c>WhenActivated(Action&lt;MultipleDisposable&gt;, IViewFor)</c>
+        /// <remarks>This is the trim- and AOT-safe counterpart to the reflected <c>WhenActivated(Action&lt;ActivationDisposables&gt;, IViewFor)</c>
         /// overload; the <paramref name="viewModelChanged"/> observable replaces reflection-based ViewModel discovery. Produce it with a
         /// reflection-free source such as the source-generated <c>WhenAnyValue</c> or a hand-written
         /// <see cref="System.ComponentModel.INotifyPropertyChanged"/> subscription.</remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public IDisposable WhenActivated(
-            Action<MultipleDisposable> block,
+            Action<ActivationDisposables> block,
             IObservable<object?> viewModelChanged) =>
             item.WhenActivated(
                 () =>
                 {
-                    MultipleDisposable d = [];
+                    ActivationDisposables d = [];
                     block(d);
                     return [d];
                 },
@@ -329,19 +329,19 @@ public static class ViewForMixins
         /// Registers a block of code to be executed when the specified view model is activated, and ensures that any
         /// disposables created within the block are disposed when the view model is deactivated.
         /// </summary>
-        /// <param name="block">An action that receives a <see cref="MultipleDisposable"/> to which disposables can be added for automatic
+        /// <param name="block">An action that receives an <see cref="ActivationDisposables"/> to which disposables can be added for automatic
         /// cleanup upon deactivation. Cannot be null.</param>
         /// <remarks>Use this method to manage subscriptions or other resources that should be tied to the
-        /// activation lifecycle of the view model. All disposables added to the provided <see cref="MultipleDisposable"/>
+        /// activation lifecycle of the view model. All disposables added to the provided <see cref="ActivationDisposables"/>
         /// will be disposed automatically when the view model is deactivated.</remarks>
         public void
-            WhenActivated(Action<MultipleDisposable> block)
+            WhenActivated(Action<ActivationDisposables> block)
         {
             ArgumentExceptionHelper.ThrowIfNull(item);
 
             item.Activator.AddActivationBlock(() =>
             {
-                MultipleDisposable d = [];
+                ActivationDisposables d = [];
                 block(d);
                 return [d];
             });

--- a/src/ReactiveUI.Wpf.Reactive/PublicAPI/net10.0-windows10.0.19041.0/PublicAPI.txt
+++ b/src/ReactiveUI.Wpf.Reactive/PublicAPI/net10.0-windows10.0.19041.0/PublicAPI.txt
@@ -165,13 +165,13 @@ namespace ReactiveUI.Reactive
             public System.IDisposable WhenActivated() { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             public System.IDisposable WhenActivated(System.Action<System.Action<System.IDisposable>> block) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             public System.IDisposable WhenActivated(System.Func<System.Collections.Generic.IEnumerable<System.IDisposable>> block) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block, ReactiveUI.IViewFor? view) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block, ReactiveUI.IViewFor? view) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             public System.IDisposable WhenActivated(System.Action<System.Action<System.IDisposable>> block, ReactiveUI.IViewFor view) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]

--- a/src/ReactiveUI.Wpf.Reactive/PublicAPI/net11.0-windows10.0.19041.0/PublicAPI.txt
+++ b/src/ReactiveUI.Wpf.Reactive/PublicAPI/net11.0-windows10.0.19041.0/PublicAPI.txt
@@ -165,13 +165,13 @@ namespace ReactiveUI.Reactive
             public System.IDisposable WhenActivated() { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             public System.IDisposable WhenActivated(System.Action<System.Action<System.IDisposable>> block) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             public System.IDisposable WhenActivated(System.Func<System.Collections.Generic.IEnumerable<System.IDisposable>> block) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block, ReactiveUI.IViewFor? view) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block, ReactiveUI.IViewFor? view) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             public System.IDisposable WhenActivated(System.Action<System.Action<System.IDisposable>> block, ReactiveUI.IViewFor view) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]

--- a/src/ReactiveUI.Wpf.Reactive/PublicAPI/net462/PublicAPI.txt
+++ b/src/ReactiveUI.Wpf.Reactive/PublicAPI/net462/PublicAPI.txt
@@ -162,10 +162,10 @@ namespace ReactiveUI.Reactive
             public bool GetIsDesignMode() { }
             public System.IDisposable WhenActivated() { }
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block) { }
             public System.IDisposable WhenActivated(System.Action<System.Action<System.IDisposable>> block) { }
             public System.IDisposable WhenActivated(System.Func<System.Collections.Generic.IEnumerable<System.IDisposable>> block) { }
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block, ReactiveUI.IViewFor? view) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block, ReactiveUI.IViewFor? view) { }
             public System.IDisposable WhenActivated(System.Action<System.Action<System.IDisposable>> block, ReactiveUI.IViewFor view) { }
             public System.IDisposable WhenActivated(System.Func<System.Collections.Generic.IEnumerable<System.IDisposable>> block, ReactiveUI.IViewFor? view) { }
         }

--- a/src/ReactiveUI.Wpf.Reactive/PublicAPI/net472/PublicAPI.txt
+++ b/src/ReactiveUI.Wpf.Reactive/PublicAPI/net472/PublicAPI.txt
@@ -162,10 +162,10 @@ namespace ReactiveUI.Reactive
             public bool GetIsDesignMode() { }
             public System.IDisposable WhenActivated() { }
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block) { }
             public System.IDisposable WhenActivated(System.Action<System.Action<System.IDisposable>> block) { }
             public System.IDisposable WhenActivated(System.Func<System.Collections.Generic.IEnumerable<System.IDisposable>> block) { }
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block, ReactiveUI.IViewFor? view) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block, ReactiveUI.IViewFor? view) { }
             public System.IDisposable WhenActivated(System.Action<System.Action<System.IDisposable>> block, ReactiveUI.IViewFor view) { }
             public System.IDisposable WhenActivated(System.Func<System.Collections.Generic.IEnumerable<System.IDisposable>> block, ReactiveUI.IViewFor? view) { }
         }

--- a/src/ReactiveUI.Wpf.Reactive/PublicAPI/net481/PublicAPI.txt
+++ b/src/ReactiveUI.Wpf.Reactive/PublicAPI/net481/PublicAPI.txt
@@ -162,10 +162,10 @@ namespace ReactiveUI.Reactive
             public bool GetIsDesignMode() { }
             public System.IDisposable WhenActivated() { }
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block) { }
             public System.IDisposable WhenActivated(System.Action<System.Action<System.IDisposable>> block) { }
             public System.IDisposable WhenActivated(System.Func<System.Collections.Generic.IEnumerable<System.IDisposable>> block) { }
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block, ReactiveUI.IViewFor? view) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block, ReactiveUI.IViewFor? view) { }
             public System.IDisposable WhenActivated(System.Action<System.Action<System.IDisposable>> block, ReactiveUI.IViewFor view) { }
             public System.IDisposable WhenActivated(System.Func<System.Collections.Generic.IEnumerable<System.IDisposable>> block, ReactiveUI.IViewFor? view) { }
         }

--- a/src/ReactiveUI.Wpf.Reactive/PublicAPI/net8.0-windows10.0.19041.0/PublicAPI.txt
+++ b/src/ReactiveUI.Wpf.Reactive/PublicAPI/net8.0-windows10.0.19041.0/PublicAPI.txt
@@ -165,13 +165,13 @@ namespace ReactiveUI.Reactive
             public System.IDisposable WhenActivated() { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             public System.IDisposable WhenActivated(System.Action<System.Action<System.IDisposable>> block) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             public System.IDisposable WhenActivated(System.Func<System.Collections.Generic.IEnumerable<System.IDisposable>> block) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block, ReactiveUI.IViewFor? view) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block, ReactiveUI.IViewFor? view) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             public System.IDisposable WhenActivated(System.Action<System.Action<System.IDisposable>> block, ReactiveUI.IViewFor view) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]

--- a/src/ReactiveUI.Wpf.Reactive/PublicAPI/net9.0-windows10.0.19041.0/PublicAPI.txt
+++ b/src/ReactiveUI.Wpf.Reactive/PublicAPI/net9.0-windows10.0.19041.0/PublicAPI.txt
@@ -165,13 +165,13 @@ namespace ReactiveUI.Reactive
             public System.IDisposable WhenActivated() { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             public System.IDisposable WhenActivated(System.Action<System.Action<System.IDisposable>> block) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             public System.IDisposable WhenActivated(System.Func<System.Collections.Generic.IEnumerable<System.IDisposable>> block) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
-            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Disposables.MultipleDisposable> block, ReactiveUI.IViewFor? view) { }
+            public System.IDisposable WhenActivated(System.Action<ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable> block, ReactiveUI.IViewFor? view) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
             public System.IDisposable WhenActivated(System.Action<System.Action<System.IDisposable>> block, ReactiveUI.IViewFor view) { }
             [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]

--- a/src/ReactiveUI.Wpf.Shared/WpfViewForMixins.cs
+++ b/src/ReactiveUI.Wpf.Shared/WpfViewForMixins.cs
@@ -96,14 +96,14 @@ public static class WpfViewForMixins
         /// <returns>An <see cref="IDisposable"/> that unregisters the activation logic.</returns>
         [RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public IDisposable WhenActivated(Action<MultipleDisposable> block) => item.WhenActivated(block, null);
+        public IDisposable WhenActivated(Action<ActivationDisposables> block) => item.WhenActivated(block, null);
 
         /// <summary>Activates the specified WPF view and manages the provided disposables for the duration of the activation lifecycle.</summary>
         /// <param name="block">An action that receives a composite disposable for activation-related resources.</param>
         /// <param name="view">An optional view instance to use for view model activation.</param>
         /// <returns>An <see cref="IDisposable"/> that unregisters the activation logic.</returns>
         [RequiresUnreferencedCode("Evaluates expression-based member chains via reflection; members may be trimmed.")]
-        public IDisposable WhenActivated(Action<MultipleDisposable> block, IViewFor? view)
+        public IDisposable WhenActivated(Action<ActivationDisposables> block, IViewFor? view)
         {
             ArgumentExceptionHelper.ThrowIfNull(item);
             ArgumentExceptionHelper.ThrowIfNull(block);
@@ -113,7 +113,7 @@ public static class WpfViewForMixins
                 : ((IActivatableView)item).WhenActivated(
                     () =>
                     {
-                        MultipleDisposable d = [];
+                        ActivationDisposables d = [];
                         block(d);
                         return [d];
                     },

--- a/src/tests/ReactiveUI.Tests/Activation/ActivatingViewTests.cs
+++ b/src/tests/ReactiveUI.Tests/Activation/ActivatingViewTests.cs
@@ -250,7 +250,7 @@ public class ActivatingViewTests
 
     /// <summary>Provides a no-op activation callback for overload selection in tests.</summary>
     /// <param name="_">The activation-scoped disposable container.</param>
-    private static void NoopActivation(MultipleDisposable _)
+    private static void NoopActivation(ActivationDisposables _)
     {
         // Intentionally empty.
     }

--- a/src/tests/ReactiveUI.Tests/Activation/ViewForMixinsTests.cs
+++ b/src/tests/ReactiveUI.Tests/Activation/ViewForMixinsTests.cs
@@ -6,6 +6,8 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 #if REACTIVE_SHIM
+using System.Reactive.Disposables;
+using System.Reactive.Disposables.Fluent;
 using ReactiveUI.Reactive.Builder;
 #else
 using ReactiveUI.Builder;
@@ -100,11 +102,11 @@ public class ViewForMixinsTests
         }
     }
 
-    /// <summary>The <c>Action&lt;MultipleDisposable&gt;</c> view-model overload runs the block on activation and disposes the
-    /// composite on deactivation.</summary>
+    /// <summary>The <c>Action&lt;ActivationDisposables&gt;</c> view-model overload runs the block on activation and disposes the
+    /// container on deactivation.</summary>
     /// <returns>A <see cref="Task" /> representing the asynchronous operation.</returns>
     [Test]
-    public async Task ViewModelWhenActivatedMultipleDisposableOverloadActivatesAndDeactivates()
+    public async Task ViewModelWhenActivatedActivationDisposablesOverloadActivatesAndDeactivates()
     {
         var activations = 0;
         var deactivations = new StrongBox<int>();
@@ -205,11 +207,11 @@ public class ViewForMixinsTests
         }
     }
 
-    /// <summary>The trim-safe <c>Action&lt;MultipleDisposable&gt;</c> overload activates the view block and forwards ViewModel
+    /// <summary>The trim-safe <c>Action&lt;ActivationDisposables&gt;</c> overload activates the view block and forwards ViewModel
     /// activation using the supplied observable.</summary>
     /// <returns>A <see cref="Task" /> representing the asynchronous operation.</returns>
     [Test]
-    public async Task ViewWhenActivatedWithViewModelChangedMultipleDisposableOverloadActivatesView()
+    public async Task ViewWhenActivatedWithViewModelChangedActivationDisposablesOverloadActivatesView()
     {
         using (WithActivatingViewFetcher())
         {
@@ -302,6 +304,53 @@ public class ViewForMixinsTests
             await Assert.That(viewModel.IsActiveCount).IsEqualTo(0);
         }
     }
+
+#if REACTIVE_SHIM
+    /// <summary>The container handed to a view-model activation block is usable as a System.Reactive
+    /// <see cref="CompositeDisposable"/>, and what is registered through the composite is disposed on deactivation.</summary>
+    /// <returns>A <see cref="Task" /> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task ViewModelWhenActivatedContainerIsUsableAsCompositeDisposable()
+    {
+        var deactivations = new StrongBox<int>();
+        var viewModel = new ActivatableViewModelMock();
+
+        viewModel.WhenActivated(d =>
+        {
+            CompositeDisposable composite = d;
+            composite.Add(Scope.Create(deactivations, static box => box.Value++));
+        });
+
+        _ = viewModel.Activator.Activate();
+        await Assert.That(deactivations.Value).IsEqualTo(0);
+
+        viewModel.Activator.Deactivate();
+        await Assert.That(deactivations.Value).IsEqualTo(1);
+    }
+
+    /// <summary>System.Reactive's fluent <c>DisposeWith</c> accepts the container a view activation block is given, so a
+    /// consumer keeps the disposal idiom it already has instead of converting by hand.</summary>
+    /// <returns>A <see cref="Task" /> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task ViewWhenActivatedContainerAcceptsSystemReactiveDisposeWith()
+    {
+        using (WithActivatingViewFetcher())
+        {
+            var viewModel = new ActivatingViewModel();
+            var view = new ActivatingView { ViewModel = viewModel };
+            var deactivations = new StrongBox<int>();
+
+            using var activation = view.WhenActivated(d =>
+                Scope.Create(deactivations, static box => box.Value++).DisposeWith(d));
+
+            view.Loaded.OnNext(RxVoid.Default);
+            await Assert.That(deactivations.Value).IsEqualTo(0);
+
+            view.Unloaded.OnNext(RxVoid.Default);
+            await Assert.That(deactivations.Value).IsEqualTo(1);
+        }
+    }
+#endif
 
     /// <summary>Builds a dependency resolver scope with a registered <see cref="ActivatingViewFetcher"/>.</summary>
     /// <returns>A disposable that restores the previous resolver when disposed.</returns>

--- a/src/tests/ReactiveUI.Wpf.Tests/Wpf/WpfActivationForViewFetcherTest.cs
+++ b/src/tests/ReactiveUI.Wpf.Tests/Wpf/WpfActivationForViewFetcherTest.cs
@@ -91,7 +91,7 @@ public class WpfActivationForViewFetcherTest
             var disposables = new MultipleDisposable(
                 view.WhenActivated(static () => [Scope.Empty]),
                 view.WhenActivated(static (Action<IDisposable> _) => { }),
-                view.WhenActivated(static (MultipleDisposable _) => { }),
+                view.WhenActivated(static (ActivationDisposables _) => { }),
                 view.WhenActivated(static () => [Scope.Empty], view),
                 view.WhenActivated(static (Action<IDisposable> _) => { }, view));
 
@@ -127,7 +127,7 @@ public class WpfActivationForViewFetcherTest
                     return [Scope.Empty];
                 }),
                 view.WhenActivated((Action<IDisposable> _) => activationCount++),
-                view.WhenActivated((MultipleDisposable _) => activationCount++),
+                view.WhenActivated((ActivationDisposables _) => activationCount++),
                 view.WhenActivated(
                     () =>
                     {
@@ -269,7 +269,7 @@ public class WpfActivationForViewFetcherTest
                 new FrameworkPropertyMetadata(true));
 
         /// <summary>Initializes a new instance of the <see cref="DesignModeActivatableUserControl"/> class.</summary>
-        public DesignModeActivatableUserControl() => ActivationDisposable = this.WhenActivated(static (MultipleDisposable _) => { });
+        public DesignModeActivatableUserControl() => ActivationDisposable = this.WhenActivated(static (ActivationDisposables _) => { });
 
         /// <summary>Gets the disposable returned by the activation subscription.</summary>
         public IDisposable ActivationDisposable { get; }

--- a/src/tests/ReactiveUI.Wpf.Tests/Xaml/PropertyBindingTest.cs
+++ b/src/tests/ReactiveUI.Wpf.Tests/Xaml/PropertyBindingTest.cs
@@ -759,19 +759,22 @@ public partial class PropertyBindingTest
         await Assert.That(dis.IsDisposed).IsTrue();
     }
 
-    /// <summary>Verifies that one-way binding with a hint tolerates a null disposal container.</summary>
+    /// <summary>Verifies that registering a one-way binding into a null disposal container is rejected.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Test]
-    public void OneWayBindWithHintTestDisposeWithNullContainerIsSafe()
+    public async Task OneWayBindWithHintTestDisposeWithNullContainerThrows()
     {
         MultipleDisposable? dis = null;
         var vm = new PropertyBindViewModel();
         var view = new PropertyBindView { ViewModel = vm };
         var fixture = new PropertyBinderImplementation();
+        var binding = fixture.OneWayBind(vm, view, static x => x.JustABoolean, static v => v.SomeTextBox.Visibility, BooleanToVisibilityHint.Inverse);
 
-        // DisposeWith(MultipleDisposable) is a null-safe no-op in ReactiveUI.Primitives (disposables?.Add(...)),
-        // so binding against a null container neither throws nor loses the binding — the live binding is returned.
-        var binding = fixture.OneWayBind(vm, view, static x => x.JustABoolean, static v => v.SomeTextBox.Visibility, BooleanToVisibilityHint.Inverse).DisposeWith(dis!);
+        // DisposeWith validates the container, so a null one is an argument error rather than a registration
+        // that silently disappears and leaks the binding.
+        var ex = await Assert.That(() => binding.DisposeWith(dis!)).Throws<ArgumentNullException>();
 
+        await Assert.That(ex).IsNotNull();
         binding.Dispose();
     }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix, plus a dependency refresh.

## What is the new behavior?

**On the `*.Reactive` leaves, the container `WhenActivated` hands to an activation block is usable as a System.Reactive `CompositeDisposable`.**

- **A block can keep the disposal idiom a System.Reactive consumer already has.** `subscription.DisposeWith(d)` against `System.Reactive.Disposables.Fluent` compiles, and the subscription is disposed on deactivation.
- **The block parameter is bound through a seam alias, `ActivationDisposables`.** It resolves to `MultipleDisposable` on the lean leaves and to `ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable` on `*.Reactive`, which converts to a `CompositeDisposable` it owns and disposes.
- **Both the `IActivatableView` and `IActivatableViewModel` overloads are covered**, in the core mixins and the WPF ones.

**Dependencies move to their current releases.** ReactiveUI.Primitives goes to 7.3.0, which is what supplies `ContainerDisposable`; TUnit, the analyzer set, MAUI, Xaml.Behaviors, the Microsoft.Testing packages and AndroidX Fragment come along with it.

## What is the current behavior?

Closes #4434

- `WhenActivated` hands every leaf a `MultipleDisposable`. System.Reactive's fluent `DisposeWith` takes a `CompositeDisposable`, so a `*.Reactive` consumer gets `CS1503` with no overload to fall back to.
- Adding a `WhenActivated(Action<ContainerDisposable>)` overload does not fix that. `Action<T>` is contravariant, so `Action<MultipleDisposable>` wins as the better conversion target and an untyped `d => ...` still binds to the parameter that does not convert. The parameter has to be replaced rather than overloaded.

## What might this PR break?

- **Binary breaking on the `*.Reactive` packages only.** `WhenActivated(Action<MultipleDisposable>)` becomes `WhenActivated(Action<ContainerDisposable>)`, so compiled consumers must recompile. Source that passes an untyped `d => ...` lambda is unaffected, and the lean packages are unchanged.
- **`DisposeWith(null)` now throws.** ReactiveUI.Primitives 7.3.0 validates the container instead of treating null as a silent no-op, so a registration that previously vanished is now an `ArgumentNullException`.

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [x] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information

Most of the diff is regenerated public-API baselines. The authored changes are:

- `src/ReactiveShim.props` - the `ActivationDisposables` alias on both sides of the seam
- `src/ReactiveUI.Shared/Activation/ViewForMixins.cs`
- `src/ReactiveUI.Wpf.Shared/WpfViewForMixins.cs`
- `src/Directory.Packages.props`
- four test files under `src/tests`
