### PR TITLE
fix(build): hold the coverage collector at 18.10.0

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -75,7 +75,12 @@
     <PackageVersion Include="TUnit" Version="$(TUnitVersion)"/>
     <PackageVersion Include="TUnit.Core" Version="$(TUnitVersion)"/>
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.9.0"/>
-    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.11.0"/>
+    <!-- Held at 18.10.0. On 18.11.0 the collector's SharedBufferReconciler takes a cross-process mutex
+         while finishing a session, and a solution-wide run has many hosts holding it in turn: when one
+         exits still owning it the next waiter gets an AbandonedMutexException that the collector does not
+         handle, so a test host that passed every test aborts (SIGABRT) and the run reports exit code 7.
+         It lands on whichever assembly loses the race, which is why it shows up on the macOS leg. -->
+    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.10.0"/>
     <PackageVersion Include="Microsoft.Testing.Platform.MSBuild" Version="2.4.0"/>
     <PackageVersion Include="Microsoft.Reactive.Testing" Version="7.0.0"/>
     <PackageVersion Include="System.Reactive" Version="7.0.0"/>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Build fix. One version pin, no product or test source changes.

## What is the new behavior?

**A solution-wide run finishes cleanly, and the coverage it reports is complete again.**

- `Microsoft.Testing.Extensions.CodeCoverage` is held at 18.10.0.
- Union coverage over a full `dotnet test --solution --coverage` run, same commit, only the collector version differing:

  | collector | exit | line coverage | branch coverage |
  | --- | --- | --- | --- |
  | 18.10.0 | 0 | 12820/13537 = **94.703%** | 1051/1334 = **78.786%** |
  | 18.11.0 | 7 | 12097/13537 = **89.362%** | 1005/1334 = **75.337%** |

  The aborting host never reconciles its buffers, so its data is dropped and the reported number silently falls by about 5.3 points of line coverage. The pin recovers it.
- The pin carries a comment describing the failure, so the next bump gets checked against it rather than taken on trust.

## What is the current behavior?

A test host that has run every test successfully aborts during session teardown, and the run reports exit code 7:

```
Unhandled exception. System.Threading.AbandonedMutexException: The wait completed due to an abandoned mutex.
   at Microsoft.CodeCoverage.Core.Threading.Mutex.WaitOne(TimeSpan timeout)
   at Microsoft.CodeCoverage.Instrumentation.SharedBufferReconciler.Reconcile(...)
   at Microsoft.Testing.Extensions.CodeCoverage.TestingPlatformCoverageDynamicTestSessionLifetimeHandler.OnTestSessionFinishingAsync(...)
```

`SharedBufferReconciler` waits on a cross-process mutex to reconcile coverage buffers. A solution-wide run passes that mutex between many concurrently running hosts, so when one exits while still owning it the next waiter is handed an `AbandonedMutexException`, which the collector does not handle. The exception goes unhandled, the process aborts with SIGABRT, and the platform maps that to exit code 7.

It lands on whichever assembly loses the race rather than on a particular test, which is why a single arbitrary assembly went red while its near-identical sibling passed in the same run. All 34300 tests pass either way; the crash is purely in teardown.

18.11.0 is the newest published version, so there is no later release to move forward to.

## What might this PR break?

- Nothing shipped. `Microsoft.Testing.Extensions.CodeCoverage` is test-only tooling and is not a dependency of any published package.
- Coverage collection is unchanged in shape; 18.10.0 emits the same cobertura the CI coverage job already consumes, and reports more of it.
- `Microsoft.Testing.Platform.MSBuild` deliberately stays at 2.4.0. It appears in the stack only as the calling frame; the defect is in the collector.

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [ ] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information

The crash needs the whole solution running concurrently, not one assembly: looping a single test project 25 times never reproduced it, while a full `--coverage` solution run reproduced exit 7 on Linux as well. It is a race across hosts, not something specific to the macOS runner.

The stack is not visible through `--log-failed`, which shows only the runner's exit code; it is in the full job log.
